### PR TITLE
Update the temporal interpolation in GLASS LAI reader

### DIFF
--- a/lis/dataassim/obs/GLASS_LAI/read_GLASSlai.F90
+++ b/lis/dataassim/obs/GLASS_LAI/read_GLASSlai.F90
@@ -187,17 +187,22 @@ subroutine read_GLASSlai(n, k, OBS_State, OBS_Pert_State)
      endif
   endif
 
-  dataCheck = .false. 
-  if(GLASSlai_struc(n)%tsmooth.eq.1) then 
-     if(GLASSlai_struc(n)%fnd.ne.0) then 
-        dataCheck = .true. 
+  dataCheck = .false.
+  if(alarmCheck) then 
+     if(GLASSlai_struc(n)%tsmooth.eq.1) then 
+        if(GLASSlai_struc(n)%fnd.ne.0) then 
+           dataCheck = .true. 
+           fnd = 1
+        endif
+     else
+        if(fnd.eq.1) then 
+           dataCheck = .true. 
+        endif
      endif
   else
-     if(fnd.eq.1) then 
-        dataCheck = .true. 
-     endif
+     fnd = 0 
+     dataCheck = .false.
   endif
-
   if(dataCheck) then 
         
         !        open(100,file='test_out.bin',form='unformatted')


### PR DESCRIPTION
The GLASS LAI reader segfaults when the 'GLASS LAI apply temporal smoother between 8-day intervals:' option is turned on, due to improper initialization of variables. This updates fixes these errors.

resolves issue #2