### PR TITLE
Expose NROOT in Noah-MP

### DIFF
--- a/lis/surfacemodels/land/noahmp.3.6/NoahMP36_main.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/NoahMP36_main.F90
@@ -237,6 +237,7 @@ subroutine NoahMP36_main(n)
     real                 :: tmp_rsmax          ! maximum stomatal resistance
     real                 :: tmp_rsmin          ! minimum Canopy Resistance [s/m]
     real                 :: tmp_hs             ! parameter used in vapor pressure deficit function 
+    real                 :: tmp_nroot
     ! SY: End PARAMETERS for prescribed VEGETATION evolution in time 
     ! SY: End corresponding to REDPRM
     ! SY: Begin corresponding to read_mp_veg_parameters
@@ -505,6 +506,7 @@ subroutine NoahMP36_main(n)
             tmp_rsmax       = NOAHMP36_struc(n)%noahmp36(t)%rsmax
             tmp_rsmin       = NOAHMP36_struc(n)%noahmp36(t)%rsmin
             tmp_hs          = NOAHMP36_struc(n)%noahmp36(t)%hs
+            tmp_nroot       = NOAHMP36_struc(n)%noahmp36(t)%nroot
             ! SY: End corresponding to REDPRM
             ! SY: Begin corresponding to read_mp_veg_parameters
             tmp_CH2OP       = NOAHMP36_struc(n)%noahmp36(t)%CH2OP
@@ -626,6 +628,7 @@ subroutine NoahMP36_main(n)
                                   tmp_rsmax             , & ! in    - maximum stomatal resistance
                                   tmp_rsmin             , & ! in    - minimum Canopy Resistance [s/m]
                                   tmp_hs                , & ! in    - parameter used in vapor pressure deficit function 
+                                  tmp_nroot             , & ! in    - 
                                   tmp_CH2OP             , & ! in    - maximum intercepted h2o per unit lai+sai [mm]
                                   tmp_DLEAF             , & ! in    - characteristic leaf dimension [m]
                                   tmp_Z0MVT             , & ! in    - momentum roughness length [m]

--- a/lis/surfacemodels/land/noahmp.3.6/NoahMP36_module.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/NoahMP36_module.F90
@@ -596,6 +596,7 @@ module NoahMP36_module
      real               :: rsmax
      real               :: rsmin
      real               :: hs
+     real               :: nroot
      !SY: end vegetation parameters
      !SY: begin soil parameters
      real               :: csoil

--- a/lis/surfacemodels/land/noahmp.3.6/NoahMP36_setup.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/NoahMP36_setup.F90
@@ -239,6 +239,9 @@ subroutine NoahMP36_setup()
             NOAHMP36_struc(n)%noahmp36(t)%rsmax = RSMAX_DATA
             NOAHMP36_struc(n)%noahmp36(t)%rsmin = RSTBL(NOAHMP36_struc(n)%noahmp36(t)%vegetype)
             NOAHMP36_struc(n)%noahmp36(t)%hs = HSTBL(NOAHMP36_struc(n)%noahmp36(t)%vegetype)
+            NOAHMP36_struc(n)%noahmp36(t)%nroot = & 
+                 NROTBL(NOAHMP36_struc(n)%noahmp36(t)%vegetype)
+
             IF (NROTBL(NOAHMP36_struc(n)%noahmp36(t)%vegetype) .gt. &
                 NOAHMP36_struc(n)%nsoil) THEN
                WRITE (LIS_logunit,*) 'Warning: too many root layers'

--- a/lis/surfacemodels/land/noahmp.3.6/noahmp_driver_36.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/noahmp_driver_36.F90
@@ -26,7 +26,7 @@ subroutine noahmp_driver_36(iloc, jloc, &
                             p_csoil , p_bexp  , p_dksat , p_dwsat , p_psisat,           & ! SY: in : calibratable parameters for enabling OPTUE
                             p_quartz, p_smcmax, p_smcref, p_smcwlt,                     & ! SY: in : calibratable parameters for enabling OPTUE
                             p_czil  , p_frzk  , p_refdk , p_refkdt, p_slope ,          & ! SY: in : calibratable parameters for enabling OPTUE
-                            p_topt  , p_rgl   , p_rsmax , p_rsmin , p_hs    ,          & ! SY: in : calibratable parameters for enabling OPTUE
+                            p_topt  , p_rgl   , p_rsmax , p_rsmin , p_hs, p_nroot,     & ! SY: in : calibratable parameters for enabling OPTUE
                             p_CH2OP , p_DLEAF , p_Z0MVT , p_HVT   , p_HVB   ,          & ! SY: in : calibratable parameters for enabling OPTUE
                             p_RC    , p_RHOL1 , p_RHOL2 , p_RHOS1 , p_RHOS2 ,          & ! SY: in : calibratable parameters for enabling OPTUE
                             p_TAUL1 , p_TAUL2 , p_TAUS1 , p_TAUS2 , p_XL    ,          & ! SY: in : calibratable parameters for enabling OPTUE
@@ -150,6 +150,7 @@ subroutine noahmp_driver_36(iloc, jloc, &
   real,    intent(in) :: p_rsmax                ! maximum stomatal resistance
   real,    intent(in) :: p_rsmin                ! minimum Canopy Resistance [s/m]
   real,    intent(in) :: p_hs                   ! parameter used in vapor pressure deficit function
+  real,    intent(in) :: p_nroot
   real,    intent(in) :: p_CH2OP                ! maximum intercepted h2o per unit lai+sai [mm]
   real,    intent(in) :: p_DLEAF                ! characteristic leaf dimension [m]
   real,    intent(in) :: p_Z0MVT                ! momentum roughness length [m]
@@ -467,6 +468,7 @@ subroutine noahmp_driver_36(iloc, jloc, &
   RSMAX_DATA = p_rsmax
   RSTBL(vegetype) = p_rsmin   
   HSTBL(vegetype) = p_hs  
+  NROTBL(vegetype) = p_nroot  
   ! SY: End VEGETATION PARAMETERS  
   ! SY: End lines following those in REDPRM and NoahMP36_setup
   ! SY: Begin lines following those in read_mp_veg_parameters and NoahMP36_setup

--- a/lis/surfacemodels/land/noahmp.3.6/pe/NoahMP36_peMod.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/pe/NoahMP36_peMod.F90
@@ -107,7 +107,7 @@ contains
 
     allocate(NoahMP36_pe_struc(LIS_rc%nnest))
     n = 1
-    NoahMP36_pe_struc(n)%nparams = 61
+    NoahMP36_pe_struc(n)%nparams = 62
 
     allocate(NoahMP36_pe_struc(n)%param_name(NoahMP36_pe_struc(n)%nparams))
     allocate(NoahMP36_pe_struc(n)%param_select(NoahMP36_pe_struc(n)%nparams))
@@ -165,6 +165,7 @@ contains
           if(vname.eq."RSMAX")      then ; do t=1,NT; vardata(t) = NoahMP36_struc(n)%noahmp36(t)%rsmax          ;enddo ;endif
           if(vname.eq."RSMIN")      then ; do t=1,NT; vardata(t) = NoahMP36_struc(n)%noahmp36(t)%rsmin          ;enddo ;endif
           if(vname.eq."HS")         then ; do t=1,NT; vardata(t) = NoahMP36_struc(n)%noahmp36(t)%hs             ;enddo ;endif
+          if(vname.eq."NROOT")      then ; do t=1,NT; vardata(t) = NoahMP36_struc(n)%noahmp36(t)%nroot          ;enddo ;endif
           if(vname.eq."CSOIL")      then ; do t=1,NT; vardata(t) = NoahMP36_struc(n)%noahmp36(t)%csoil          ;enddo ;endif
           if(vname.eq."BEXP")       then ; do t=1,NT; vardata(t) = NoahMP36_struc(n)%noahmp36(t)%bexp           ;enddo ;endif
           if(vname.eq."DKSAT")      then ; do t=1,NT; vardata(t) = NoahMP36_struc(n)%noahmp36(t)%dksat          ;enddo ;endif
@@ -283,6 +284,16 @@ contains
                    endif
                 enddo
              enddo
+             if(vname.eq."NROOT") then !integer value
+
+                do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)/LIS_rc%nensem(n)
+                   do m=1,LIS_rc%nensem(n)
+                      vardata((t-1)*LIS_rc%nensem(n)+m) = &
+                           nint(vardata((t-1)*LIS_rc%nensem(n)+m))
+                   enddo
+                enddo
+                
+             endif
           endif
        enddo
     endif

--- a/lis/surfacemodels/land/noahmp.3.6/pe/NoahMP36_set_pedecvars.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/pe/NoahMP36_set_pedecvars.F90
@@ -290,6 +290,8 @@ subroutine NoahMP36_setVars(n,DEC_State,mod_flag_NoahMP36)
                    NoahMP36_struc(n)%noahmp36(t)%rsmin = vardata(t) 
               if(vname.eq."HS") & 
                    NoahMP36_struc(n)%noahmp36(t)%hs = vardata(t) 
+              if(vname.eq."NROOT") &
+                   NoahMP36_struc(n)%noahmp36(t)%nroot = vardata(t) 
               if(vname.eq."CSOIL") &
                    NoahMP36_struc(n)%noahmp36(t)%csoil = vardata(t) 
               if(vname.eq."BEXP") & 


### PR DESCRIPTION
This commit exposes the NROOT variable in Noah-MP so that OPT/UE routines can access it.
The variable is also defined as a spatially distributed parameter

Enables feature/#4