### PR TITLE
Allow LDT to compile as a serial executable

### DIFF
--- a/ldt/core/LDT_LMLCMod.F90
+++ b/ldt/core/LDT_LMLCMod.F90
@@ -23,7 +23,6 @@ module LDT_LMLCMod
 #if(defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
 #endif
-  use mpi
   use LDT_historyMod
   use LDT_paramDataMod
   use LDT_logMod

--- a/ldt/core/LDT_paramProcMod.F90
+++ b/ldt/core/LDT_paramProcMod.F90
@@ -1127,7 +1127,6 @@ contains
   subroutine writeParamData(n, ftn)
 
 ! !USES:
-    use mpi
     use LDT_coreMod
 
     integer  :: n 

--- a/ldt/params/CLM45/CLM45_parmsMod.F90
+++ b/ldt/params/CLM45/CLM45_parmsMod.F90
@@ -22,7 +22,6 @@ module CLM45_parmsMod
   use netcdf
 #endif
 
-  use mpi
   use ESMF
   use LDT_coreMod
   use LDT_historyMod


### PR DESCRIPTION
When selecting 'serial' at the Parallelism prompt

  Parallelism (0-serial, 1-dmpar, default=0): 0

LDT failed to compile with the message:
"Can't open module file 'mpi.mod' ...".

Remove unneeded 'use mpi' statements.

Resolves: #9