### PR TITLE
Fix compiling LVT with GCC

### DIFF
--- a/lvt/core/LVT_histDataMod.F90
+++ b/lvt/core/LVT_histDataMod.F90
@@ -1604,7 +1604,7 @@ contains
          allocate(dataEntry%unittypes(dataEntry%nunits))
          allocate(dataEntry%valid_min(dataEntry%nunits))
          allocate(dataEntry%valid_max(dataEntry%nunits))
-         dataEntry%unittypes = (/"W/m2","m/s","kg/m/s2"/)
+         dataEntry%unittypes = (/"W/m2   ","m/s    ","kg/m/s2"/)
          dataEntry%valid_min = (/-100.0,-100.0,-100.0/)
          dataEntry%valid_max = (/100.0,100.0,100.0/)
          dataEntry%ndirs = 2

--- a/lvt/datastreams/JULES2Ddata/readJULES2Dobs.F90
+++ b/lvt/datastreams/JULES2Ddata/readJULES2Dobs.F90
@@ -581,7 +581,7 @@ subroutine readJULES2DObs(source)
            end where	
 	else if(c.gt.1)then
 	   ilo=ilo+1
-	   if((ANY(lonJ.gt.MAXVAL(msklo(1:ilo-1))).eq..true.))then
+	   if((ANY(lonJ.gt.MAXVAL(msklo(1:ilo-1))).eqv..true.))then
 	      JULES2Dobs(source)%lonc(ilo) = MINVAL(lonJ,mask=lonJ.gt.MAXVAL(msklo(1:ilo-1)))
 	      msklo(ilo) = JULES2Dobs(source)%lonc(ilo)
 	      where(lonJ .eq. JULES2Dobs(source)%lonc(ilo))
@@ -607,7 +607,7 @@ subroutine readJULES2DObs(source)
            end where	 
 	else if(r.gt.1)then
 	   ila=ila+1
-	   if(ANY(latJ.gt.MAXVAL(mskla(1:ila-1))).eq..true.)then
+	   if(ANY(latJ.gt.MAXVAL(mskla(1:ila-1))).eqv..true.)then
 	      JULES2Dobs(source)%latc(ila) = MINVAL(latJ,mask=latJ.gt.MAXVAL(mskla(1:ila-1)))
 	      mskla(ila) = JULES2Dobs(source)%latc(ila)
 	      where(latJ .eq. JULES2Dobs(source)%latc(ila))


### PR DESCRIPTION
Compiling LVT with GCC raised these errors:

../core/LVT_histDataMod.F90:1607:40:

          dataEntry%unittypes = (/"W/m2","m/s","kg/m/s2"/)
                                        1
Error: Different CHARACTER lengths (4/3) in array constructor at (1)

../datastreams/JULES2Ddata/readJULES2Dobs.F90:584:8:

     if((ANY(lonJ.gt.MAXVAL(msklo(1:ilo-1))).eq..true.))then
        1
Error: Logicals at (1) must be compared with .eqv. instead of .eq.

../datastreams/JULES2Ddata/readJULES2Dobs.F90:610:7:

     if(ANY(latJ.gt.MAXVAL(mskla(1:ila-1))).eq..true.)then
       1
Error: Logicals at (1) must be compared with .eqv. instead of .eq.

Resolves: #11