### PR TITLE
IMERG reader bug fix - precompile commands

### DIFF
--- a/lis/metforcing/imerg/read_imerg.F90
+++ b/lis/metforcing/imerg/read_imerg.F90
@@ -5,6 +5,7 @@
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
 !BOP
 ! !ROUTINE: read_imerg
 ! \label{read_imerg}
@@ -90,7 +91,7 @@ subroutine read_imerg (n, kk, name_imerg, findex, order, ferror_imerg )
         "[INFO] Reading HDF5 IMERG precipitation data from ", fname
    call read_imerghdf(fname, xd, yd, realprecip, ireaderr)
    if (ireaderr .ne. 0) then
-     if(LIS_masterproc) write(*,*) &
+     if(LIS_masterproc) write(LIS_logunit,*) &
         "[WARN] Error reading IMERG file ",fname
      ferror_imerg = 0
    endif


### PR DESCRIPTION
The read_imerghdf subroutine has precompiler instructions that require
USE_HDF5 to be defined in order for the subroutine to read the IMERG data.
These definitions are now in the LIS_misc.h file and were not included before
this fix. The user would see the prompt that the file was being read, but the subroutine
would not execute. LIS_misc.h is now added as an included file.

One of the error messages was also set to be printed to the screen. It is now
printing to the LIS log, which is similar to what occurs with the other
error statements.