### PR TITLE
Fix compiling LVT with GCC

### DIFF
--- a/lvt/core/LVT_LISoutputHandlerMod.F90
+++ b/lvt/core/LVT_LISoutputHandlerMod.F90
@@ -5784,7 +5784,7 @@ subroutine get_moc_attributes(modelSpecConfig, head_dataEntry, &
                      LVT_LIS_MOC_CANOPINT(source))%dataEntryPtr
              else
                 write(LVT_logunit,*) &
-                     '[ERR] Please enable TWS, SWE, SoilMoist, and '&
+                     '[ERR] Please enable TWS, SWE, SoilMoist, and ' // &
                      '  CanopInt in the LIS output to compute GWS'
                 call LVT_endrun()
              endif


### PR DESCRIPTION
Compiling LVT with GCC raised this error:

  ../core/LVT_LISoutputHandlerMod.F90:5787.68:

                 '[ERR] Please enable TWS, SWE, SoilMoist, and '&
                                                                1
I corrected the line continuation.

Resolves: #16