### PR TITLE
IMERG LIS reader filename update

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5812,9 +5812,15 @@ anchor:sssec_supp_imerg[IMERG precipitation]
 `IMERG forcing directory:` specifies the location of the
 GPM IMERG precipitation forcing files.
 
+'IMERG version:' specifies the version of the GPM IMERG 
+precipitation forcing files. The valid options are: early,
+late, and final. If no version is specified, the reader will
+default to the 'final' version of GPM IMERG. 
+
 .Example _lis.config_ entry
 ....
-MERG forcing directory:     ./FORCING/IMERG
+IMERG forcing directory:     ./FORCING/IMERG
+IMERG version: 'final'
 ....
 
 

--- a/lis/metforcing/imerg/0Intro_imerg.txt
+++ b/lis/metforcing/imerg/0Intro_imerg.txt
@@ -2,4 +2,10 @@
 !\section{IMERG}
 !This section describes the implementation of the L3 precipitation
 !product from GPM known as IMERG. 
+!
+!IMERG reader updated on 11/26/2018
+!The IMERG reader is updated to read in three versions of IMERG data:
+!early, late, and final
+!The reader currently is compatible with IMERG algorithm version V05B.
+!
 !EOP

--- a/lis/metforcing/imerg/get_imerg.F90
+++ b/lis/metforcing/imerg/get_imerg.F90
@@ -21,7 +21,7 @@ subroutine get_imerg(n, findex)
   use LIS_coreMod, only : LIS_rc, LIS_masterproc
   use LIS_timeMgrMod, only : LIS_tick, LIS_get_nstep
   use imerg_forcingMod, only :imerg_struc
-  use LIS_logMod, only : LIS_logunit
+  use LIS_logMod, only : LIS_logunit, LIS_endrun
 
   implicit none
 ! !ARGUMENTS: 
@@ -124,7 +124,8 @@ subroutine imergfile(n, kk, findex, imergdir, &
 
   use LIS_coreMod
   use LIS_forecastMod
-
+  use LIS_logMod, only : LIS_logunit, LIS_endrun
+  use imerg_forcingMod, only : imerg_struc
   implicit none
 
 ! !ARGUMENTS: 
@@ -192,9 +193,20 @@ subroutine imergfile(n, kk, findex, imergdir, &
     write(cmnadd, '(I2.2)') umnadd 
     write(cmnday, '(I4.4)') umnday
 
-    fstem = '/3B-HHR.MS.MRG.3IMERG.'
+    if(imerg_struc(n)%imergver == 'early') then
+       fstem = '/3B-HHR-E.MS.MRG.3IMERG.'
+    elseif(imerg_struc(n)%imergver == 'late') then
+       fstem = '/3B-HHR-L.MS.MRG.3IMERG.'
+    elseif(imerg_struc(n)%imergver == 'final') then
+       fstem = '/3B-HHR.MS.MRG.3IMERG.'
+    else
+       write(LIS_logunit,*) "[ERR] Invalid IMERG version option was chosen."
+       write(LIS_logunit,*) "[ERR] Please choose either 'early', 'late', or 'final'."
+       call LIS_endrun()
+    endif
+
     filename = trim(imergdir)//"/"//cyr//cmo//trim(fstem)// &
-          cyr//cmo//cda//"-S"//chr//cmn//"00-E"//chr//cmnadd//"59."//cmnday//".V03D.HDF5" 
+          cyr//cmo//cda//"-S"//chr//cmn//"00-E"//chr//cmnadd//"59."//cmnday//".V05B.HDF5" 
 
 ! Forecast mode (e.g., ESP):
   else
@@ -220,9 +232,20 @@ subroutine imergfile(n, kk, findex, imergdir, &
     write(cmnadd, '(I2.2)') umnadd
     write(cmnday, '(I4.4)') umnday
 
-    fstem = '/3B-HHR.MS.MRG.3IMERG.'
+    if(imerg_struc(n)%imergver == 'early') then
+       fstem = '/3B-HHR-E.MS.MRG.3IMERG.'
+    elseif(imerg_struc(n)%imergver == 'late') then
+       fstem = '/3B-HHR-L.MS.MRG.3IMERG.'
+    elseif(imerg_struc(n)%imergver == 'final') then
+       fstem = '/3B-HHR.MS.MRG.3IMERG.'
+    else
+       write(LIS_logunit,*) "[ERR] Invalid IMERG version option was chosen."
+       write(LIS_logunit,*) "[ERR] Please choose either 'early', 'late', or 'final'."
+       call LIS_endrun()
+    endif
+
     filename = trim(imergdir)//"/"//cyr//cmo//trim(fstem)// &
-          cyr//cmo//cda//"-S"//chr//cmn//"00-E"//chr//cmnadd//"59."//cmnday//".V03D.HDF5"
+          cyr//cmo//cda//"-S"//chr//cmn//"00-E"//chr//cmnadd//"59."//cmnday//".V05B.HDF5"
   endif
 
 end subroutine imergfile

--- a/lis/metforcing/imerg/imerg_forcingMod.F90
+++ b/lis/metforcing/imerg/imerg_forcingMod.F90
@@ -65,6 +65,7 @@ module imerg_forcingMod
      real    :: ts
      integer :: ncold, nrold     ! IMERG dimensions
      character*100 :: imergdir   ! IMERG Forcing Directory
+     character*5 :: imergver     ! IMERG version (early, late, final)
      real*8  :: imergtime
      real*8  :: griduptime1
      logical :: gridchange1

--- a/lis/metforcing/imerg/read_imerg.F90
+++ b/lis/metforcing/imerg/read_imerg.F90
@@ -5,6 +5,7 @@
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
 !BOP
 ! !ROUTINE: read_imerg
 ! \label{read_imerg}
@@ -90,7 +91,7 @@ subroutine read_imerg (n, kk, name_imerg, findex, order, ferror_imerg )
         "[INFO] Reading HDF5 IMERG precipitation data from ", fname
    call read_imerghdf(fname, xd, yd, realprecip, ireaderr)
    if (ireaderr .ne. 0) then
-     if(LIS_masterproc) write(*,*) &
+     if(LIS_masterproc) write(LIS_logunit,*) &
         "[WARN] Error reading IMERG file ",fname
      ferror_imerg = 0
    endif

--- a/lis/metforcing/imerg/readcrd_imerg.F90
+++ b/lis/metforcing/imerg/readcrd_imerg.F90
@@ -36,6 +36,20 @@ subroutine readcrd_imerg()
      call ESMF_ConfigGetAttribute(LIS_config,imerg_struc(n)%imergdir,rc=rc)
   enddo
 
+  call ESMF_ConfigFindLabel(LIS_config,"IMERG version:",rc=rc)
+  if(rc /= 0) then
+     write(LIS_logunit,*) "[WARN] IMERG version not specified. Defauling to 'final' version."
+     write(LIS_logunit,*) "[WARN] Valid options for IMERG are 'early', 'late', and 'final'."
+
+     do n=1, LIS_rc%nnest
+        imerg_struc(n)%imergver = 'final'
+     enddo
+  else
+     do n=1, LIS_rc%nnest
+        call ESMF_ConfigGetAttribute(LIS_config,imerg_struc(n)%imergver,rc=rc)
+     enddo
+  endif
+
 !  call ESMF_ConfigFindLabel(LIS_config,"IMERG domain x-dimension size:",rc=rc)
 !  do n=1, LIS_rc%nnest
 !     call ESMF_ConfigGetAttribute(LIS_config,imerg_struc(n)%ncold,rc=rc)
@@ -48,6 +62,7 @@ subroutine readcrd_imerg()
   do n=1, LIS_rc%nnest
      write(LIS_logunit,*)'Using IMERG forcing'
      write(LIS_logunit,*)'IMERG forcing directory : ',trim(imerg_struc(n)%IMERGDIR)
+     write(LIS_logunit,*)'IMERG version : ',trim(imerg_struc(n)%imergver)
 !------------------------------------------------------------------------
 ! Setting global observed precip times to zero to ensure 
 ! data is read in during first time step


### PR DESCRIPTION
This code modification updates the LIS reader to read in version
V05B (latest IMERG algorithm version available) instead of V03D.
This code has also added a config option to allow the user to switch
between the three release versions of IMERG (early, late, and final),
all of which have different filename conventions.
 If no version is declared in the configuration file, the reader defaults to the final
version.