### PR TITLE
Princeton testcase bug fix

### DIFF
--- a/lis/testcases/metforcing/princeton/lis.config
+++ b/lis/testcases/metforcing/princeton/lis.config
@@ -160,6 +160,7 @@ Albedo climatology interval type: "monthly"
 
 #--------------------------------FORCINGS----------------------------------
 PRINCETON forcing directory:      ./input/MET_FORCING/PRINCETON
+PRINCETON forcing version: "2"
 
 #-----------------------LAND SURFACE MODELS--------------------------
 TEMPLATE model timestep:              30mn


### PR DESCRIPTION
When the Princeton reader was updated to read in Princeton version 3 data, the reader
required an old config option to be defined in 'lis.config'. This config option was
optional and was not present in the old Princeton testcase config file.
This bug was first reported by Bob Rosenberg when he tried to use the test case after the
Princeton reader was updated. The option is now added to the config file in the test case
and the test case should now run without any issues.