### PR TITLE
Fix binary output of undefined tiles

### DIFF
--- a/lis/core/LIS_historyMod.F90
+++ b/lis/core/LIS_historyMod.F90
@@ -646,15 +646,14 @@ contains
              if(dataEntry%count(t,k).gt.0) then 
                 if(dataEntry%timeAvgOpt.eq.3) then  !do nothing
                    continue       
-                elseif(dataEntry%timeAvgOpt.eq.2) then 
-                   dataEntry%modelOutput(1,t,k) = dataEntry%modelOutput(1,t,k)/&
-                        dataEntry%count(t,k)
-                elseif(dataEntry%timeAvgOpt.eq.1) then 
+                elseif(dataEntry%timeAvgOpt.eq.2.or.dataEntry%timeAvgOpt.eq.1) then
                    dataEntry%modelOutput(1,t,k) = dataEntry%modelOutput(1,t,k)/&
                         dataEntry%count(t,k)
                 else !do nothing
-
+                   continue
                 endif
+             else
+                dataEntry%modelOutput(1,t,k) = LIS_rc%udef
              endif
           enddo
        enddo


### PR DESCRIPTION
When a tile is undefined in binary HIST history output,
the value written out is zero, and not the undefined
value as set in the lis.config file.  netCDF and GRIB
output formats did not have this issue.  Essentally,
the code to set the undefined output values was copied
from these other formats and applied to binary format.

Resolves: #55