### PR TITLE
Fixes issue #57

### DIFF
--- a/lvt/core/LVT_TSMod.F90
+++ b/lvt/core/LVT_TSMod.F90
@@ -768,7 +768,8 @@ contains
              if(maxv1.eq.max_param) maxv1 = LVT_rc%udef
              if(minv1.eq.min_param) minv1 = LVT_rc%udef
 
-             if(nsum_v1.ge.(LVT_TSobj(i)%ts_min_pts*LVT_TSobj(i)%npts)) then 
+             if(nsum_v1.ge.(LVT_TSobj(i)%ts_min_pts*LVT_TSobj(i)%npts).and.&
+                  nsum_v1.gt.0) then 
                 mean_v1 = sum_v1/nsum_v1
              else
                 mean_v1 = LVT_rc%udef

--- a/lvt/core/LVT_domainMod.F90
+++ b/lvt/core/LVT_domainMod.F90
@@ -3258,7 +3258,7 @@ contains
 !BOP
 ! !ROUTINE: LVT_readDataMask
 ! \label{LVT_readDataMask}
-! 
+! r
 ! !INTERFACE: 
   subroutine LVT_readDataMask
 ! !USES:     


### PR DESCRIPTION
The format of the TS_LOCATIONS.TXT file was changed to use
percentage of the total number of locations (instead of a minimum
number data points) as the threshold when time series data is
written out. When time series data at point locations are output,
then this percentage needs to be set to 0.0 to ensure data output.
If there are gaps in the data, then this could lead to divide by
zero errors. This has been fixed by adding additional checks
in the calculations.

Resolves #57