### PR TITLE
Fixes the processing of RTM output in LVT

### DIFF
--- a/lvt/core/LVT_histDataMod.F90
+++ b/lvt/core/LVT_histDataMod.F90
@@ -5539,7 +5539,7 @@ contains
          allocate(dataEntry%dirtypes(dataEntry%ndirs))
          dataEntry%dirtypes = (/"-"/)
       endif
-   elseif(name.eq."RTMemissivity") then 
+   elseif(name.eq."RTM_emissivity") then 
       if(LVT_MOC_RTM_EMISSIVITY(source).eq.LVT_rc%udef) then 
          LVT_MOC_RTM_EMISSIVITY(source) = var_count
          dataEntry%standard_name = "rtm_emissivity"
@@ -5555,7 +5555,7 @@ contains
          allocate(dataEntry%dirtypes(dataEntry%ndirs))
          dataEntry%dirtypes = (/"-"/)
       endif
-   elseif(name.eq."RTMTb") then 
+   elseif(name.eq."RTM_Tb") then 
       if(LVT_MOC_RTM_TB(source).eq.LVT_rc%udef) then 
          LVT_MOC_RTM_TB(source) = var_count
          dataEntry%standard_name = "rtm_brightness_temperature"
@@ -5571,7 +5571,7 @@ contains
          allocate(dataEntry%dirtypes(dataEntry%ndirs))
          dataEntry%dirtypes = (/"-"/)
       endif
-   elseif(name.eq."RTMSoilMoist") then 
+   elseif(name.eq."RTM_SoilMoist") then 
       if(LVT_MOC_RTM_SM(source).eq.LVT_rc%udef) then 
          LVT_MOC_RTM_SM(source) = var_count
          dataEntry%standard_name = "rtm_soil_moisture"


### PR DESCRIPTION
The variable names for RTM outputs were inconsistent with the
convention used in LIS. They have been renamed to the following
RTM_Tb
RTM_emissivity
RTM_SoilMoist
The datastream attributes table in lvt.config must be updated
to reflect these changes. For e.g.
LVT datastream attributes table::
RTM_Tb  1 2 K      -  1 2     RTM_Tb  1 2 K      -  1 2
::

Resolves #59