### PR TITLE
Bug fix for LDT downscaling bug when using GDAS

### DIFF
--- a/ldt/metforcing/gdas/create_gdasfilename.F90
+++ b/ldt/metforcing/gdas/create_gdasfilename.F90
@@ -182,9 +182,9 @@ subroutine create_gdasfilename(option, name00, name03, name06, &
   F06flag = .false. 
 
   if ( option == 2 ) then !bookend 2
-     if ( .not. is_analysis_hr ) F06flag = .true. ! need to read two files     
+     if ( .not. is_analysis_hr ) F06flag = .true. ! need to read two files
   else
-     if ( is_analysis_hr ) F06flag = .true. ! need to read two files     
+     if ( is_analysis_hr ) F06flag = .false. ! need to read only one file
   endif
 
   if ( option == 2 ) then !bookend 2 

--- a/ldt/metforcing/gdas/create_gdasfilename.F90
+++ b/ldt/metforcing/gdas/create_gdasfilename.F90
@@ -184,7 +184,7 @@ subroutine create_gdasfilename(option, name00, name03, name06, &
   if ( option == 2 ) then !bookend 2
      if ( .not. is_analysis_hr ) F06flag = .true. ! need to read two files
   else
-     if ( is_analysis_hr ) F06flag = .false. ! need to read only one file
+     if ( is_analysis_hr ) F06flag = .true. ! need to read two files
   endif
 
   if ( option == 2 ) then !bookend 2 

--- a/ldt/metforcing/gdas/gdas_forcingMod.F90
+++ b/ldt/metforcing/gdas/gdas_forcingMod.F90
@@ -121,6 +121,7 @@ module gdas_forcingMod
      real, allocatable      :: w112(:,:),w122(:,:)
      real, allocatable      :: w212(:,:),w222(:,:)
 
+     logical       :: reset_flag
   end type gdas_type_dec
   
   type(gdas_type_dec), allocatable :: gdas_struc(:)
@@ -190,6 +191,7 @@ contains
        call LDT_update_timestep(LDT_rc, n, gdas_struc(n)%ts)
     enddo
 
+    gdas_struc%reset_flag = .false.
     gdas_struc(:)%nmif    = 9 
 
   ! Metforcing and parameter grid info:

--- a/ldt/metforcing/gdas/get_gdas.F90
+++ b/ldt/metforcing/gdas/get_gdas.F90
@@ -107,11 +107,12 @@ subroutine get_gdas(n, findex)
   nstep = LDT_get_nstep(LDT_rc,n)
   nforce = gdas_struc(n)%nmif
   
-  if ( LDT_rc%tscount(n).eq.1 .or. LDT_rc%rstflag(n)== 1) then
+  if ( LDT_rc%tscount(n).eq.1 .or. LDT_rc%rstflag(n)== 1 .or. gdas_struc(n)%reset_flag ) then
      gdas_struc(n)%findtime1=1
      gdas_struc(n)%findtime2=1
      movetime=0        ! movetime is not properly set at time-step = 1
      LDT_rc%rstflag(n) = 0
+     gdas_struc(n)%reset_flag = .false.
   endif
   
   !-----------------------------------------------------------------

--- a/ldt/metforcing/gdas/reset_gdas.F90
+++ b/ldt/metforcing/gdas/reset_gdas.F90
@@ -44,6 +44,7 @@ subroutine reset_gdas
      gridDesci(10) = 47
      gridDesci(20) = 0
      gdas_struc(n)%mi = gdas_struc(n)%nc*gdas_struc(n)%nr
+     gdas_struc(n)%reset_flag = .true.
        
        ! This grid is good for some time in the 1990's.
        ! Look up the exact dates.


### PR DESCRIPTION
This fix is for the bug that occurred in LDT when using the 'Metforce temporal downscaling'
option along with the GDAS forcing dataset. The GDAS reader was not properly reseting and ingesting
new GDAS data at the downscaled time interval. A secondary flag was added to the reader that corrects this issue. This fix is similar to the fix in the MERRA2 and CHIRPS readers in LDT.

This fix resolves issue #66