### PR TITLE
Enables parallel support in HyMAP2

### DIFF
--- a/lis/core/LIS_historyMod.F90
+++ b/lis/core/LIS_historyMod.F90
@@ -96,6 +96,7 @@ module LIS_historyMod
   public :: LIS_readvar_gridded  ! read a variable from a gridded file
   public :: LIS_writevar_gridded ! write a variable in grid space to a file
   public :: LIS_tile2grid        ! convert a tilespace variable to gridspace
+  public :: LIS_grid2tile        ! convert gridspace to tilespace
   public :: LIS_patch2tile       ! convert a patchspace variable to tilespace
   public :: LIS_grid2patch       ! convert a gridspace variable to patchspace
   public :: LIS_writevar_spread  ! writes ensemble spared to a gridded file
@@ -307,6 +308,7 @@ module LIS_historyMod
   interface LIS_grid2patch
 ! !PRIVATE MEMBER FUNCTIONS: 
 !     module procedure grid2patch
+     module procedure grid2patch_local
      module procedure grid2patch_global
      module procedure grid2patch_global_ens
 !
@@ -6421,6 +6423,44 @@ subroutine writevar_grib2_withstats_real(ftn, ftn_stats, n,   &
           
 end subroutine writevar_grib2_withstats_real
 
+!BOP
+! !ROUTINE: LIS_grid2tile
+! \label{LIS_grid2tile}
+!
+! !INTERFACE:
+  subroutine LIS_grid2tile(n,gvar,tvar)
+! !USES:
+
+    implicit none
+! !ARGUMENTS:     
+    integer, intent(in) :: n
+    real                :: tvar(LIS_rc%ntiles(n))
+    real                :: gvar(LIS_rc%lnc(n),LIS_rc%lnr(n))
+! !DESCRIPTION:
+!  This routine converts a tile space variable to the corresponding
+!  grid space. The aggregation involves weighted average of each tile
+!  in a grid cell based on the vegetation distribution. 
+!
+!  The arguments are: 
+!  \begin{description}
+!   \item [n]
+!     index of the domain or nest.
+!   \item [tvar]
+!     variable dimensioned in the tile space. 
+!   \item [gvar]
+!     variable after converstion to the grid space
+!  \end{description}
+!
+!EOP
+    integer           :: t,c,r
+
+    do t=1,LIS_rc%ntiles(n)
+       r = LIS_domain(n)%tile(t)%row
+       c = LIS_domain(n)%tile(t)%col
+       tvar(t) = gvar(c,r)
+    enddo
+  end subroutine LIS_grid2tile
+
 
 !BOP
 ! !ROUTINE: tile2grid_local
@@ -6569,7 +6609,25 @@ end subroutine writevar_grib2_withstats_real
     
   end subroutine LIS_patch2tile
 
-  subroutine grid2patch_global(n,m,gvar,tvar)
+  subroutine grid2patch_local(n,m,gvar,tvar)
+
+    implicit none
+    
+    integer, intent(in) :: n 
+    integer, intent(in) :: m
+    real                :: gvar(LIS_rc%lnc(n), LIS_rc%lnr(n))
+    real                :: tvar(LIS_rc%npatch(n,m))
+    integer             :: t,r,c
+
+    do t=1,LIS_rc%npatch(n,m)
+       r = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%row
+       c = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%col
+       tvar(t) = gvar(c,r)
+    enddo
+
+  end subroutine grid2patch_local
+
+  subroutine grid2patch_global(n,m,gvar,tvar,dummy)
 
     implicit none
     
@@ -6581,6 +6639,7 @@ end subroutine writevar_grib2_withstats_real
     
     integer             :: count1
     integer             :: l,r,c,gid,stid,t,npatch, tid
+    logical             :: dummy
     integer             :: ierr
 
 !    if(LIS_masterproc) then        

--- a/lis/plugins/LIS_lsmrouting_pluginMod.F90
+++ b/lis/plugins/LIS_lsmrouting_pluginMod.F90
@@ -80,6 +80,7 @@ subroutine LIS_lsmrouting_plugin
 #if ( defined SM_CLSM_F2_5 )
    external clsmf25_getrunoffs
    external clsmf25_getrunoffs_mm
+   external clsmf25_getrunoffs_hymap2
 #endif
 
 #if ( defined SM_VIC_4_1_2 )
@@ -194,8 +195,8 @@ subroutine LIS_lsmrouting_plugin
 
 #if ( defined SM_CLSM_F2_5 )
    call registerlsmroutinggetrunoff(trim(LIS_clsmf25Id)//"+"//&
-                                    trim(LIS_HYMAP2routerId)//char(0), &
-                                    clsmf25_getrunoffs_mm)
+        trim(LIS_HYMAP2routerId)//char(0), &
+        clsmf25_getrunoffs_hymap2)
 #endif
 
 #if ( defined SM_VIC_4_1_2 )

--- a/lis/routing/HYMAP2_router/HYMAP2_model.F90
+++ b/lis/routing/HYMAP2_router/HYMAP2_model.F90
@@ -11,6 +11,7 @@
 ! 13 Apr 2016: Augusto Getirana, Inclusion of option for hybrid runs with a 
 !                                river flow map. 
 !
+#include "LIS_misc.h"
 subroutine HYMAP2_model(n,mis,nx,ny,yr,mo,da,hr,mn,ss,&
      nseqall,nz,dt,flowmap,linres,evapflag,  &
      rivout_pre,rivdph_pre,                  &
@@ -31,6 +32,8 @@ subroutine HYMAP2_model(n,mis,nx,ny,yr,mo,da,hr,mn,ss,&
                    
   use HYMAP2_modelMod
   use HYMAP2_routingMod
+  use LIS_mpiMod
+  use LIS_coreMod
   
   implicit none
 
@@ -141,11 +144,15 @@ subroutine HYMAP2_model(n,mis,nx,ny,yr,mo,da,hr,mn,ss,&
 
   !ag (29Jan2016)
   integer                :: counti, countf, count_rate
-
+  integer                :: maxi
+  real                   :: mindt
   real                   :: tmp
   real*8                 :: dt1
+  integer                :: status
 
+#if 0 
   call system_clock(counti,count_rate)
+#endif
 
 ! ================================================
   !ag 3 Apr 2014 
@@ -163,7 +170,7 @@ subroutine HYMAP2_model(n,mis,nx,ny,yr,mo,da,hr,mn,ss,&
 ! ================================================
 
   if(steptype==1)then
-    dta(:)=dt
+    dta=dt
     nt(:)=1
   elseif(steptype==2)then
     do ic=1,nseqall
@@ -178,7 +185,17 @@ subroutine HYMAP2_model(n,mis,nx,ny,yr,mo,da,hr,mn,ss,&
   dtaout=dta
   iloc(:)=minloc(dta)
   i=iloc(1)
+!find the maximum of i and minimum dt across all processors
+#if (defined SPMD)
+  call MPI_ALLREDUCE(nt(i),maxi, 1, MPI_INTEGER, MPI_MAX, &
+       LIS_mpi_comm,status)
 
+  call MPI_ALLREDUCE(dta(i),mindt, 1, MPI_REAL, MPI_MIN, &
+       LIS_mpi_comm,status)
+#else 
+  maxi = nt(i)
+  mindt = dta(i)
+#endif
   rivout0=rivout
   rivvel0=rivvel
   fldout0=fldout
@@ -190,14 +207,16 @@ subroutine HYMAP2_model(n,mis,nx,ny,yr,mo,da,hr,mn,ss,&
   fldvel=0. 
   evpout=0. 
 
-!    dta(:)=dt
-!    nt(:)=1
-  do it=1,nt(i)
+  do it=1,maxi
     !call HYMAP2_date2frac(yr,mo,da,hr,mn,ss,real(dta(i)*(it-1)-dt),time)
 
-    dt1=real(dta(i)*it-dt)
-    time=dble(yr*10000+mo*100+da) + (dble(hr)+(dble(mn)+(dble(ss)+dt1)/60.)/60.)/24.
-    call HYMAP2_model_core(n,mis,nseqall,nz,time,dta(i),flowmap,linres,evapflag, &
+    dt1=real(mindt*it-dt)
+
+    time=dble(yr*10000+mo*100+da) +&
+         (dble(hr)+(dble(mn)+(dble(ss)+dt1)/60.)/60.)/24.
+
+    call HYMAP2_model_core(n,mis,nseqall,nz,time,&
+         dta(i),flowmap,linres,evapflag, &
          resopflag,floodflag,dwiflag,                               &
          rivout_pre,rivdph_pre,grv,                 &
          fldout_pre,flddph_pre,fldelv1,                &
@@ -230,9 +249,10 @@ subroutine HYMAP2_model(n,mis,nx,ny,yr,mo,da,hr,mn,ss,&
   !  evpout(ic)=evpout0(ic)
   !enddo
 
+#if 0 
   call system_clock(countf)
   HYMAP2_routing_struc(n)%dt_proc=HYMAP2_routing_struc(n)%dt_proc+real(countf-counti)/real(count_rate)
-  
+#endif
   tmp=minval(dtaout)
   !write(unit=HYMAP2_logunit,fmt='(8i5,10f15.4)')n,yr,mo,da,hr,mn,ss,nt(i),dta(i),sum(HYMAP2_routing_struc(:)%dt_proc),minval(dtaout,dtaout>tmp),maxval(dtaout),real(count(dtaout==minval(dtaout)))
 !  write(unit=LIS_logunit,fmt='(a,i5,f10.2,f10.4,3f10.2)')'[INFO] HYMAP2_log: ',nt(i),dta(i),sum(HYMAP2_routing_struc(:)%dt_proc),minval(dtaout,dtaout>tmp),maxval(dtaout),real(count(dtaout==minval(dtaout)))

--- a/lis/routing/HYMAP2_router/HYMAP2_model_core.F90
+++ b/lis/routing/HYMAP2_router/HYMAP2_model_core.F90
@@ -11,6 +11,7 @@
 ! 13 Apr 2016: Augusto Getirana, Inclusion of option for hybrid runs with a 
 !                                river flow map. 
 !
+#include "LIS_misc.h"
 subroutine HYMAP2_model_core(n,mis,nseqall,nz,time,dt,  &
      flowmap,linres,evapflag,resopflag,floodflag,dwiflag, &
      rivout_pre,rivdph_pre,grv,                         &
@@ -34,8 +35,13 @@ subroutine HYMAP2_model_core(n,mis,nseqall,nz,time,dt,  &
   
   use HYMAP2_modelMod
   use HYMAP2_resopMod
-  use LIS_logMod,     only : LIS_logunit
-  
+  use LIS_logMod
+  use LIS_coreMod
+  use HYMAP2_routingMod
+
+  use LIS_coreMod
+  use LIS_mpiMod
+
   implicit none
 
   real*8,  intent(in)  :: time         !current time [year]
@@ -111,7 +117,7 @@ subroutine HYMAP2_model_core(n,mis,nseqall,nz,time,dt,  &
   real                 :: basflw1(nseqall)    !input baseflow [mm.dt-1]
   
   real                 :: sfcelv0(nseqall)    !averaged floodplain surface elevation [m]
-  integer              :: ic,ic_down
+  integer              :: ic,ic_down,icg
   
   real                 :: rivelv_down
   real                 :: rivsto_down
@@ -121,175 +127,406 @@ subroutine HYMAP2_model_core(n,mis,nseqall,nz,time,dt,  &
   real                 :: fldsto_down
   real                 :: flddph1_down
   real                 :: flddph_pre_down
+  
+  real, allocatable    :: rivelv_glb(:)
+  real, allocatable    :: rivsto_glb(:)
+  real, allocatable    :: rivdph_glb(:)
+  real, allocatable    :: rivdph_pre_glb(:)
+  real, allocatable    :: fldelv1_glb(:)
+  real, allocatable    :: fldsto_glb(:)
+  real, allocatable    :: flddph1_glb(:)
+  real, allocatable    :: flddph_pre_glb(:)
+  real, allocatable    :: rivout_glb(:)
+  real, allocatable    :: fldout_glb(:)
+
+
+  integer              :: ic1,ic2
+  integer              :: status
+  real                 :: tmp_value
+
+  integer              :: ix,iy,ix1,iy1
 ! ================================================
   !23 Nov 2016
   !Deep water infiltration
   do ic=1,nseqall 
     if(outlet(ic)==mis)cycle
     if(dwiflag==1)then
-      call HYMAP2_dwi(runoff0(ic),basflw0(ic),rnfdwi_ratio(ic),&
-                      bsfdwi_ratio(ic),runoff1(ic),basflw1(ic),rnfdwi(ic),bsfdwi(ic))
+       call HYMAP2_dwi(runoff0(ic),basflw0(ic),rnfdwi_ratio(ic),&
+            bsfdwi_ratio(ic),runoff1(ic),basflw1(ic),rnfdwi(ic),bsfdwi(ic))
     else
-      runoff1(ic)=runoff0(ic)
-      basflw1(ic)=basflw0(ic)
+       runoff1(ic)=runoff0(ic)
+       basflw1(ic)=basflw0(ic)
     endif
-  enddo
-! ================================================
-  !convert units [kg m-2 sec-1] to [m3 sec-1]
-  where(runoff0/=mis.and.grarea/=mis)
-     runoff1=runoff1*grarea/1e3
-     basflw1=basflw1*grarea/1e3
-  else where
-     runoff1=0.
-     basflw1=0.
-  end where
-! ================================================
-  !Store runoff and baseflow in linear reservoirs
-  do ic=1,nseqall 
+ enddo
+ ! ================================================
+ !convert units [kg m-2 sec-1] to [m3 sec-1]
+ where(runoff0/=mis.and.grarea/=mis)
+    runoff1=runoff1*grarea/1e3
+    basflw1=basflw1*grarea/1e3
+ else where
+    runoff1=0.
+    basflw1=0.
+ end where
+ ! ================================================
+ !Store runoff and baseflow in linear reservoirs
+ 
+ do ic=1,nseqall 
     if(outlet(ic)==mis)cycle
-    !ic_down=next(ic)
     if(linres==1)then
-       !print*,ic,basfsto(ic),basflw1(ic),tbsflw(ic)
-       call HYMAP2_linear_reservoir_lis(dt,mis,runoff1(ic),basflw1(ic),trnoff(ic),tbsflw(ic),&
-                                 cntime(ic),roffsto(ic),basfsto(ic),runoff(ic))
+       call HYMAP2_linear_reservoir_lis(dt,mis,runoff1(ic),basflw1(ic),&
+            trnoff(ic),tbsflw(ic),cntime(ic),roffsto(ic),&
+            basfsto(ic),runoff(ic))
     elseif(linres==0)then
        call HYMAP2_no_reservoir_lis(dt,mis,runoff1(ic),basflw1(ic),&
-                             roffsto(ic),basfsto(ic),runoff(ic))      
+            roffsto(ic),basfsto(ic),runoff(ic))      
     else
        write(LIS_logunit,*)"HYMAP routing model linear reservoir flag: unknown value"
-       stop
+       call LIS_endrun()
     endif
-  enddo
+ enddo
 ! ================================================
-  do ic=1,nseqall 
+ do ic=1,nseqall 
     if(outlet(ic)==mis)cycle
-    !ic_down=next(ic)
     if(evapflag.ne.0)then
-      !calculate evaporation from floodplains
-      call HYMAP2_calc_evap_fld(dt,grarea(ic),fldare(ic),rivare(ic),fldsto(ic),rivsto(ic),evpdif(ic),evpout(ic))
+       !calculate evaporation from floodplains
+       call HYMAP2_calc_evap_fld(dt,grarea(ic),fldare(ic),rivare(ic),&
+            fldsto(ic),rivsto(ic),evpdif(ic),evpout(ic))
     else
-      !does not calculate evaporation from floodplains
-      evpout(ic)=0.
+       !does not calculate evaporation from floodplains
+       evpout(ic)=0.
     endif
-  enddo
-! ================================================
-  do ic=1,nseqall 
+ enddo
+ ! ================================================
+ do ic=1,nseqall 
     if(outlet(ic)==mis)cycle
-    !ic_down=next(ic)
-    !Calculate flood and river storage
+    !Calculate floodplain and river storage
     call HYMAP2_calc_fldstg(nz,grarea(ic),rivlen(ic),rivwth(ic),       &
          rivstomax(ic),fldstomax(ic,:),fldgrd(ic,:),            &
          rivsto(ic),fldsto(ic),rivdph(ic),flddph(ic),flddph1(ic),   &
          fldelv1(ic),fldwth(ic),fldfrc(ic),fldare(ic),          &
          rivelv(ic),nxtdst(ic),rivare(ic))
-  enddo
-! ================================================
-  do ic=1,nseqall 
+ enddo
+ 
+
+ allocate(rivelv_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+ allocate(rivsto_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+ allocate(rivdph_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+ allocate(rivdph_pre_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+ allocate(fldelv1_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+ allocate(fldsto_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+ allocate(flddph1_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+ allocate(flddph_pre_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+ 
+ call HYMAP2_gather_tiles(n,rivelv,rivelv_glb)
+ call HYMAP2_gather_tiles(n,rivsto,rivsto_glb)
+ call HYMAP2_gather_tiles(n,rivdph,rivdph_glb)
+ call HYMAP2_gather_tiles(n,rivdph_pre,rivdph_pre_glb)
+ call HYMAP2_gather_tiles(n,fldelv1,fldelv1_glb)
+ call HYMAP2_gather_tiles(n,fldsto,fldsto_glb)
+ call HYMAP2_gather_tiles(n,flddph1,flddph1_glb)
+ call HYMAP2_gather_tiles(n,flddph_pre,flddph_pre_glb)
+ 
+ ! ================================================
+  
+
+ do ic=1,nseqall 
     if(outlet(ic)==mis)cycle
-        
-    if(outlet(ic)==0)then
-      ic_down=next(ic)
-      rivelv_down=rivelv(ic_down)
-      rivsto_down=rivsto(ic_down)
-      rivdph_down=rivdph(ic_down)
-      rivdph_pre_down=rivdph_pre(ic_down)
-      fldelv1_down=fldelv1(ic_down)
-      fldsto_down=fldsto(ic_down)
-      flddph1_down=flddph1(ic_down)
-      flddph_pre_down=flddph_pre(ic_down)
-    elseif(outlet(ic)==1)then
-      !temporarily defining outlet's downstream pixel dynamics as:
-      rivelv_down=rivelv(ic)
-      rivsto_down=rivsto(ic)
-      rivdph_down=-rivelv(ic)
-      rivdph_pre_down=-rivelv(ic)
-      fldelv1_down=fldelv1(ic)
-      fldsto_down=fldsto(ic)
-      flddph1_down=-fldelv1(ic)
-      flddph_pre_down=-fldelv1(ic)
-    else
-      write(LIS_logunit,*)"Wrong outlet id"
-      stop
-    endif
     
+    if(outlet(ic)==0)then
+       ic_down=next(ic)
+       rivelv_down=rivelv_glb(ic_down)
+       rivsto_down=rivsto_glb(ic_down)
+       rivdph_down=rivdph_glb(ic_down)
+       rivdph_pre_down=rivdph_pre_glb(ic_down)
+       fldelv1_down=fldelv1_glb(ic_down)
+       fldsto_down=fldsto_glb(ic_down)
+       flddph1_down=flddph1_glb(ic_down)
+       flddph_pre_down=flddph_pre_glb(ic_down)
+    elseif(outlet(ic)==1)then
+       !temporarily defining outlet's downstream pixel dynamics as:
+       rivelv_down=rivelv(ic)
+       rivsto_down=rivsto(ic)
+       rivdph_down=-rivelv(ic)
+       rivdph_pre_down=-rivelv(ic)
+       fldelv1_down=fldelv1(ic)
+       fldsto_down=fldsto(ic)
+       flddph1_down=-fldelv1(ic)
+       flddph_pre_down=-fldelv1(ic)
+    else
+       write(LIS_logunit,*)"Wrong outlet id"
+       stop
+    endif
     if(flowmap(ic)==1)then
-      !Calculate river flow based on the kinematic wave equation
-      call HYMAP2_calc_rivout_kine(outlet(ic),dt,rivelv(ic),rivelv_down,nxtdst(ic),&
-                            rivwth(ic),sfcelv(ic),rivlen(ic),rivman(ic),slpmin, &
-                            rivsto(ic),rivdph(ic),rivout(ic),rivvel(ic))
-      !Calculate floodplain
-      if(floodflag==1)then
-        !Calculate floodplain flow based on the kinematic wave equation
-        call HYMAP2_calc_rivout_kine(outlet(ic),dt,fldelv1(ic),fldelv1_down,nxtdst(ic),&
-                              fldwth(ic),sfcelv(ic),rivlen(ic),fldman(ic),slpmin,&
-                              fldsto(ic),flddph1(ic),fldout(ic),fldvel(ic))
-      elseif(floodflag==0)then
-        !No floodplain dynamics
-        call HYMAP2_no_floodplain_flow(fldelv1(ic),flddph1(ic),fldout(ic),fldvel(ic),sfcelv0(ic),fldout_pre(ic),flddph_pre(ic))
-      else
-        write(LIS_logunit,*)"HYMAP floodplain dynamics: unknown value"
-      endif
+       !Calculate river flow based on the kinematic wave equation
+       call HYMAP2_calc_rivout_kine(outlet(ic),dt,rivelv(ic),rivelv_down,nxtdst(ic),&
+            rivwth(ic),sfcelv(ic),rivlen(ic),rivman(ic),slpmin, &
+            rivsto(ic),rivdph(ic),rivout(ic),rivvel(ic))
+       !Calculate floodplain
+       if(floodflag==1)then
+          !Calculate floodplain flow based on the kinematic wave equation
+          call HYMAP2_calc_rivout_kine(outlet(ic),dt,fldelv1(ic),fldelv1_down,&
+               nxtdst(ic),fldwth(ic),sfcelv(ic),rivlen(ic),fldman(ic),slpmin,&
+               fldsto(ic),flddph1(ic),fldout(ic),fldvel(ic))
+       elseif(floodflag==0)then
+          !No floodplain dynamics
+          call HYMAP2_no_floodplain_flow(fldelv1(ic),flddph1(ic),fldout(ic),&
+               fldvel(ic),sfcelv0(ic),fldout_pre(ic),flddph_pre(ic))
+       else
+          write(LIS_logunit,*)"HYMAP floodplain dynamics: unknown value"
+       endif
     elseif(flowmap(ic)==2.or.flowmap(ic)==3.or.flowmap(ic)==4.or.flowmap(ic)==5)then
-      !Calculate river flow based on the local inertia wave equation
-      call HYMAP2_calc_rivout_iner(outlet(ic),dt,rivelv(ic),rivelv_down,elevtn(ic),nxtdst(ic),    &
-                            rivwth(ic),rivsto(ic),rivsto_down,rivdph(ic),rivdph_down,rivlen(ic),rivman(ic),&
-                            grv,rivout(ic),rivvel(ic),sfcelv(ic), &
-                            rivout_pre(ic),rivdph_pre(ic),rivdph_pre_down)
-      !Calculate floodplain
-      if(floodflag==1)then
-        !Calculate floodplain flow based on the local inertia wave equation
-        call HYMAP2_calc_rivout_iner(outlet(ic),dt,fldelv1(ic),fldelv1_down,elevtn(ic),nxtdst(ic),    &
-                              fldwth(ic),fldsto(ic),fldsto_down,flddph1(ic),flddph1_down,rivlen(ic),fldman(ic),&
-                              grv,fldout(ic),fldvel(ic),sfcelv0(ic),  &
-                              fldout_pre(ic),flddph_pre(ic),flddph_pre_down)
-      elseif(floodflag==0)then
-        !No floodplain dynamics
-        call HYMAP2_no_floodplain_flow(fldelv1(ic),flddph1(ic),fldout(ic),fldvel(ic),sfcelv0(ic),fldout_pre(ic),flddph_pre(ic))
-      else
-        write(LIS_logunit,*)"HYMAP floodplain dynamics: unknown value"
-      endif
+       !Calculate river flow based on the local inertia wave equation
+
+       call HYMAP2_calc_rivout_iner(outlet(ic),dt,rivelv(ic),rivelv_down,&
+            elevtn(ic),nxtdst(ic), rivwth(ic),rivsto(ic),rivsto_down,&
+            rivdph(ic),rivdph_down,rivlen(ic),rivman(ic),&
+            grv,rivout(ic),rivvel(ic),sfcelv(ic), &
+            rivout_pre(ic),rivdph_pre(ic),rivdph_pre_down)
+
+        !Calculate floodplain
+       if(floodflag==1)then
+
+          !Calculate floodplain flow based on the local inertia wave equation
+          call HYMAP2_calc_rivout_iner(outlet(ic),dt,fldelv1(ic),fldelv1_down,&
+               elevtn(ic),nxtdst(ic),fldwth(ic),fldsto(ic),fldsto_down,&
+               flddph1(ic),flddph1_down,rivlen(ic),fldman(ic),&
+               grv,fldout(ic),fldvel(ic),sfcelv0(ic),  &
+               fldout_pre(ic),flddph_pre(ic),flddph_pre_down)
+       elseif(floodflag==0)then
+          !No floodplain dynamics
+          call HYMAP2_no_floodplain_flow(fldelv1(ic),flddph1(ic),&
+               fldout(ic),fldvel(ic),sfcelv0(ic),fldout_pre(ic),flddph_pre(ic))
+       else
+          write(LIS_logunit,*)"HYMAP floodplain dynamics: unknown value"
+       endif
     else
        write(LIS_logunit,*)"HYMAP routing method: unknown value",ic,flowmap(ic)
        stop
     endif
+    
+    !set the updated variable back into the global one
+    call HYMAP2_map_l2g_index(n, ic,icg)
+    rivdph_pre_glb(icg) = rivdph_pre(ic)
+    
+    rivelv_glb(icg) = rivelv(ic)
+    rivsto_glb(icg) = rivsto(ic)
+    rivdph_glb(icg) = rivdph(ic)
+    rivdph_pre_glb(icg) = rivdph_pre(ic)
+    fldelv1_glb(icg) = fldelv1(ic)
+    fldsto_glb(icg) = fldsto(ic)
+    flddph1_glb(icg) = flddph1(ic)
+    flddph_pre_glb(icg) = flddph_pre(ic)
+
   enddo
+
+  deallocate(rivelv_glb)
+  deallocate(rivdph_glb)
+  deallocate(rivdph_pre_glb)
+  deallocate(fldelv1_glb)
+  deallocate(flddph1_glb)
+  deallocate(flddph_pre_glb)
+
 ! ================================================
-    !reservoir simulation
-    if(resopflag==1)call HYMAP2_resop_run(n,mis,nseqall,nz,time,dt,next,rivsto,fldsto,rivout,fldout,rivvel,fldvel,&
-                     elevtn,fldhgt,fldstomax,grarea,rivstomax,rivelv,rivlen,rivwth)
-! ================================================
-  do ic=1,nseqall 
-    if(outlet(ic)==mis)cycle
-    if(outlet(ic)==0)then
-      ic_down=next(ic)
-      rivsto_down=rivsto(ic_down)
-      fldsto_down=fldsto(ic_down)
-    elseif(outlet(ic)==1)then
-      rivsto_down=1e20 !rivsto(ic)
-      fldsto_down=1e20 !fldsto(ic)
-    else
-      write(LIS_logunit,*)"Wrong outlet id"
-      stop
-    endif
-    !Update water storage in river and floodplain reservoirs
-    call HYMAP2_calc_stonxt(outlet(ic),dt,rivout(ic),fldout(ic),rivsto(ic),fldsto(ic),rivsto_down,fldsto_down)
-    if(outlet(ic)==0)then
-      rivsto(ic_down)=rivsto_down
-      fldsto(ic_down)=fldsto_down
-    endif
-  enddo
+  !reservoir simulation
+  if(resopflag==1)call HYMAP2_resop_run(n,mis,nseqall,nz,time,dt,next,&
+       rivsto,fldsto,rivout,fldout,rivvel,fldvel,&
+       elevtn,fldhgt,fldstomax,grarea,rivstomax,rivelv,rivlen,rivwth)
+  ! ================================================
+
+  allocate(rivout_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+  allocate(fldout_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+  
+  call HYMAP2_gather_tiles(n,rivout,rivout_glb)
+  call HYMAP2_gather_tiles(n,fldout,fldout_glb)
+  call HYMAP2_gather_tiles(n,rivsto,rivsto_glb)
+  call HYMAP2_gather_tiles(n,fldsto,fldsto_glb)
+
+  if(LIS_masterproc) then 
+     do ic=1,HYMAP2_routing_struc(n)%nseqall_glb 
+        if(HYMAP2_routing_struc(n)%outlet_glb(ic)==mis)cycle
+        if(HYMAP2_routing_struc(n)%outlet_glb(ic)==0)then
+           ic_down=HYMAP2_routing_struc(n)%next_glb(ic)
+           rivsto_down=rivsto_glb(ic_down)
+           fldsto_down=fldsto_glb(ic_down)          
+           
+        elseif(HYMAP2_routing_struc(n)%outlet_glb(ic)==1)then
+           rivsto_down=1e20 !rivsto(ic)
+           fldsto_down=1e20 !fldsto(ic)
+        else
+           write(LIS_logunit,*)"Wrong outlet id"
+           stop
+        endif
+        !Update water storage in river and floodplain reservoirs
+        call HYMAP2_calc_stonxt(HYMAP2_routing_struc(n)%outlet_glb(ic),&
+             dt,rivout_glb(ic),fldout_glb(ic),&
+             rivsto_glb(ic),fldsto_glb(ic),rivsto_down,fldsto_down)
+        if(HYMAP2_routing_struc(n)%outlet_glb(ic)==0)then
+           rivsto_glb(ic_down)=rivsto_down
+           fldsto_glb(ic_down)=fldsto_down
+        endif
+     enddo
+  endif
+
+#if (defined SPMD)
+  call MPI_BCAST(rivout_glb, &
+       HYMAP2_routing_struc(n)%nseqall_glb, &
+       MPI_REAL,0, &
+       LIS_mpi_comm, status)
+  
+  call MPI_BCAST(fldout_glb, &
+       HYMAP2_routing_struc(n)%nseqall_glb, &
+       MPI_REAL,0, &
+       LIS_mpi_comm, status)
+
+  call MPI_BCAST(rivsto_glb, &
+       HYMAP2_routing_struc(n)%nseqall_glb, &
+       MPI_REAL,0, &
+       LIS_mpi_comm, status)
+
+  call MPI_BCAST(fldsto_glb, &
+       HYMAP2_routing_struc(n)%nseqall_glb, &
+       MPI_REAL,0, &
+       LIS_mpi_comm, status)
+
+#endif
+
+  call HYMAP2_map_g2l(n, rivout_glb,rivout)
+  call HYMAP2_map_g2l(n, fldout_glb,fldout)
+  call HYMAP2_map_g2l(n, rivsto_glb,rivsto)
+  call HYMAP2_map_g2l(n, fldsto_glb,fldsto)
+
 ! ================================================
 ! Calculate runoff in the river network for the current time step
   do ic=1,nseqall 
-    if(outlet(ic)==mis)cycle
-    !ic_down=next(ic)
-    call HYMAP2_calc_runoff(dt,fldfrc(ic),runoff(ic),rivsto(ic),fldsto(ic))
+     if(outlet(ic)==mis)cycle
+     call HYMAP2_calc_runoff(dt,fldfrc(ic),runoff(ic),rivsto(ic),fldsto(ic))
   enddo
-! ================================================
-! Calculate surface water storage [mm]
+
+  ! ================================================
+  ! Calculate surface water storage [mm]
   do ic=1,nseqall 
-    if(outlet(ic)==mis)cycle
-    surfws(ic)=1e3*(rivsto(ic)+fldsto(ic))/grarea(ic)
-  enddo  
-  
+     if(outlet(ic)==mis)cycle
+     surfws(ic)=1e3*(rivsto(ic)+fldsto(ic))/grarea(ic)
+  enddo
+
+  deallocate(rivout_glb)
+  deallocate(rivsto_glb)
+  deallocate(fldsto_glb)
+  deallocate(fldout_glb)
+
 end subroutine HYMAP2_model_core
+
+!BOP
+!
+! !ROUTINE: HYMAP2_gather_tiles
+! \label{HYMAP2_gather_tiles}
+! 
+! !INTERFACE:
+subroutine HYMAP2_gather_tiles(n,var,var_glb)
+! !USES:
+  use LIS_coreMod
+  use LIS_mpiMod
+  use HYMAP2_routingMod
+!
+! !DESCRIPTION: 
+!  This subroutine gathers an individual variable
+!  across different processors into a global array
+!EOP
+
+  implicit none
+
+  integer        :: n 
+  real           :: var(HYMAP2_routing_struc(n)%nseqall)
+  real           :: var_glb(HYMAP2_routing_struc(n)%nseqall_glb)
+
+  real           :: tmpvar(HYMAP2_routing_struc(n)%nseqall_glb)
+  integer        :: i,l,ix,iy,ix1,iy1
+  integer        :: status
+
+#if (defined SPMD)
+  call MPI_ALLGATHERV(var,&
+       HYMAP2_routing_struc(n)%nseqall,&
+       MPI_REAL,tmpvar,&
+       HYMAP2_routing_struc(n)%gdeltas(:),&
+       HYMAP2_routing_struc(n)%goffsets(:),&
+       MPI_REAL,LIS_mpi_comm,status)
+#endif
+  !rearrange them to be in correct order.
+  do l=1,LIS_npes
+     do i=1,HYMAP2_routing_struc(n)%gdeltas(l-1)
+        ix = HYMAP2_routing_struc(n)%seqx_glb(i+&
+             HYMAP2_routing_struc(n)%goffsets(l-1))
+        iy = HYMAP2_routing_struc(n)%seqy_glb(i+&
+             HYMAP2_routing_struc(n)%goffsets(l-1))
+        ix1 = ix + LIS_ews_halo_ind(n,l) - 1
+        iy1 = iy + LIS_nss_halo_ind(n,l)-1
+        var_glb(HYMAP2_routing_struc(n)%sindex(ix1,iy1)) = &
+             tmpvar(i+HYMAP2_routing_struc(n)%goffsets(l-1))
+     enddo
+  enddo
+
+end subroutine HYMAP2_gather_tiles
+
+!BOP
+! !ROUTINE: HYMAP2_map_g2l
+! \label{HYMAP2_map_g2l}
+! 
+! !INTERFACE:
+subroutine HYMAP2_map_g2l(n, var_glb,var_local)
+! !USES:
+  use LIS_coreMod
+  use HYMAP2_routingMod
+! 
+! !DESCRIPTION:
+! This subroutine maps a global array in the HYMAP2
+! tile space to the local processor space. 
+! 
+!EOP
+  implicit none
+
+  integer             :: n 
+  real                :: var_glb(HYMAP2_routing_struc(n)%nseqall_glb)
+  real                :: var_local(HYMAP2_routing_struc(n)%nseqall)
+
+  integer             :: i, ix,iy,ix1,iy1,jx,jy
+
+  do i=1,HYMAP2_routing_struc(n)%nseqall
+     ix = HYMAP2_routing_struc(n)%seqx(i)
+     iy = HYMAP2_routing_struc(n)%seqy(i)
+     ix1 = ix + LIS_ews_halo_ind(n,LIS_localPet+1) -1
+     iy1 = iy + LIS_nss_halo_ind(n,LIS_localPet+1) -1
+     var_local(i)  = var_glb(HYMAP2_routing_struc(n)%sindex(ix1,iy1))
+  enddo
+
+end subroutine HYMAP2_map_g2l
+
+!BOP
+! !ROUTINE: HYMAP2_map_l2g_index
+! \label{HYMAP2_map_l2g_index}
+! 
+! !INTERFACE: 
+subroutine HYMAP2_map_l2g_index(n, local_index,glb_index)
+! !USES:
+  use LIS_coreMod
+  use HYMAP2_routingMod
+!
+! !DESCRIPTION: 
+!  This subroutine converts the local tile index into the 
+!  the global index. 
+! 
+!EOP
+  implicit none
+
+  integer             :: n 
+  integer             :: local_index
+  integer             :: glb_index
+
+  integer             :: i, ix,iy,ix1,iy1,jx,jy
+
+  ix = HYMAP2_routing_struc(n)%seqx(local_index)
+  iy = HYMAP2_routing_struc(n)%seqy(local_index)
+  ix1 = ix + LIS_ews_halo_ind(n,LIS_localPet+1) -1
+  iy1 = iy + LIS_nss_halo_ind(n,LIS_localPet+1) -1
+  glb_index = HYMAP2_routing_struc(n)%sindex(ix1,iy1)
+
+end subroutine HYMAP2_map_l2g_index

--- a/lis/routing/HYMAP2_router/HYMAP2_resopMod.F90
+++ b/lis/routing/HYMAP2_router/HYMAP2_resopMod.F90
@@ -169,7 +169,7 @@ contains
           h1=elevtn;v1=rivstomax
           h2=dph(1);v2=fldstomax(1)
         else
-          stop '[HYMAP2_get_volume_profile] Please check Reservoir elevation'
+          stop'[HYMAP2_get_volume_profile] Please check Reservoir elevation'
         endif
         vol=v1+(v2-v1)*(elv-h1)/(h2-h1)
       endif   
@@ -210,7 +210,7 @@ contains
           h1=elevtn;v1=rivstomax
           h2=dph(1);v2=fldstomax(1)
         else
-          stop '[HYMAP2_get_elevation_profile] Please check Reservoir elevation'
+          stop'[HYMAP2_get_elevation_profile] Please check Reservoir elevation'
         endif
         elv=h1+(h2-h1)*(vol-v1)/(v2-v1)
       endif   

--- a/lis/routing/HYMAP2_router/HYMAP2_routingMod.F90
+++ b/lis/routing/HYMAP2_router/HYMAP2_routingMod.F90
@@ -62,12 +62,21 @@ module HYMAP2_routingMod
 ! === River sequence ====================================
   integer, allocatable :: seqx(:)       !1D sequence horizontal
   integer, allocatable :: seqy(:)       !1D sequence vertical
+  integer, allocatable :: seqx_glb(:)
+  integer, allocatable :: seqy_glb(:)
   !integer              :: nseqriv       !length of 1D sequnece for river
   integer              :: nseqall       !length of 1D sequnece for river and mouth  
+  integer              :: nseqall_glb   !global length of 1D sequnece for river and mouth  
+  integer, allocatable :: gdeltas(:)
+  integer, allocatable :: goffsets(:)
 ! === Map ===============================================
   integer, allocatable :: sindex(:,:)     !2-D sequence index
   integer, allocatable :: outlet(:)       !outlet flag: 0 - river; 1 - ocean
+  integer, allocatable :: outlet_glb(:)       !outlet flag: 0 - river; 1 - ocean
   integer, allocatable :: next(:)        !downstream grid cell
+  integer, allocatable :: next_glb(:)        !downstream grid cell
+  integer, allocatable :: nextx(:,:)        
+  integer, allocatable :: nexty(:,:)        
   real,    allocatable :: elevtn(:)      !river bed elevation [m]
   real,    allocatable :: nxtdst(:)      !distance to the next grid [m]
   real,    allocatable :: grarea(:)      !area of the grid [m^2] 
@@ -186,6 +195,7 @@ contains
     use LIS_logMod
     use LIS_routingMod    
     use HYMAP2_initMod
+    use LIS_mpiMod
     
     integer              :: n 
     integer              :: ftn 
@@ -213,7 +223,7 @@ contains
     
     !ag (19Feb2016)
     real,    allocatable :: tmp_real(:,:),tmp_real_nz(:,:,:)
-    integer, allocatable :: nextx(:,:),nexty(:,:),mask(:,:)
+    integer, allocatable :: nextx(:,:),nexty(:,:),mask(:,:),maskg(:,:)
     real,    allocatable :: elevtn(:,:),uparea(:,:),basin(:,:)
     
     !ag (11Mar2016)
@@ -229,6 +239,8 @@ contains
     !ag (03Apr2017)
     character*20 :: evapflag0
     !character*20 :: pevap_comp_method
+    integer       :: ic, c,r,ic_down
+    integer       :: gdeltas
     
     allocate(HYMAP2_routing_struc(LIS_rc%nnest))
     
@@ -313,7 +325,7 @@ contains
        elseif(flowtype.eq."hybrid") then 
           HYMAP2_routing_struc(n)%flowtype = 0
        else
-         write(LIS_logunit,*)"HYMAP2 routing method: unknown value ",trim(flowtype)
+         write(LIS_logunit,*)"[ERR] HYMAP2 routing method: unknown value ",trim(flowtype)
          stop
        endif
     enddo
@@ -331,7 +343,7 @@ contains
        elseif(steptype.eq."adaptive") then 
           HYMAP2_routing_struc(n)%steptype = 2
        else
-         write(LIS_logunit,*)"HYMAP2 routing model time step method: unknown value"
+         write(LIS_logunit,*)"[ERR] HYMAP2 routing model time step method: unknown value"
          stop          
        endif
     enddo
@@ -380,7 +392,7 @@ contains
        elseif(evapflag0.eq."penman") then 
           HYMAP2_routing_struc(n)%evapflag = 1
        else
-         write(LIS_logunit,*)"HYMAP2 routing model evaporation option: ",trim(evapflag0)
+         write(LIS_logunit,*)"[ERR] HYMAP2 routing model evaporation option: ",trim(evapflag0)
          stop
        endif
     enddo 
@@ -443,407 +455,596 @@ contains
         elseif(resoptype.eq."streamflow") then 
           HYMAP2_routing_struc(n)%resoptype = 2
         else
-          write(LIS_logunit,*)"HYMAP2 routing model time step method: unknown value"
+          write(LIS_logunit,*)"[ERR] HYMAP2 routing model time step method: unknown value"
           stop          
         endif
       endif
     enddo
 
-    if(LIS_masterproc) then 
-       write(LIS_logunit,*) 'Initializing HYMAP....'
-       !allocate matrixes
-       do n=1, LIS_rc%nnest
-          write(LIS_logunit,*)'columns and rows', LIS_rc%gnc(n),LIS_rc%gnr(n)
-
-          !ag (19Feb2016)
-          allocate(nextx(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-          ctitle = 'HYMAP_flow_direction_x'
-          call HYMAP2_read_param_int(ctitle,1,n,nextx)
-
-          allocate(nexty(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-          ctitle = 'HYMAP_flow_direction_y'
-          call HYMAP2_read_param_int(ctitle,1,n,nexty)
+    write(LIS_logunit,*) '[INFO] Initializing HYMAP....'
+    !allocate matrixes
+    do n=1, LIS_rc%nnest
+       write(LIS_logunit,*)'[INFO] columns and rows', &
+            LIS_rc%lnc(n),LIS_rc%lnr(n)
        
-          allocate(elevtn(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-          ctitle = 'HYMAP_grid_elevation'
-          call HYMAP2_read_param_real(ctitle,1,n,elevtn)
+       !ag (19Feb2016)
+       allocate(HYMAP2_routing_struc(n)%nextx(LIS_rc%gnc(n),LIS_rc%gnr(n)))
+       ctitle = 'HYMAP_flow_direction_x'
+       call HYMAP2_read_param_int_2d_global(ctitle,n,HYMAP2_routing_struc(n)%nextx)
+       
+       allocate(HYMAP2_routing_struc(n)%nexty(LIS_rc%gnc(n),LIS_rc%gnr(n)))
+       ctitle = 'HYMAP_flow_direction_y'
+       call HYMAP2_read_param_int_2d_global(ctitle,n,HYMAP2_routing_struc(n)%nexty)
+       
+       allocate(elevtn(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+       ctitle = 'HYMAP_grid_elevation'
+       call HYMAP2_read_param_real_2d(ctitle,n,elevtn)
+       
+       allocate(uparea(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+       ctitle = 'HYMAP_drain_area'
+       call HYMAP2_read_param_real_2d(ctitle,n,uparea)
+       
+       allocate(basin(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+       ctitle = 'HYMAP_basin'
+       call HYMAP2_read_param_real_2d(ctitle,n,basin)	  
+       
+       allocate(mask(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+       ctitle = 'HYMAP_basin_mask'
+       call HYMAP2_read_param_int_2d(ctitle,n,mask)	  
 
-          allocate(uparea(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-          ctitle = 'HYMAP_drain_area'
-          call HYMAP2_read_param_real(ctitle,1,n,uparea)
+       allocate(maskg(LIS_rc%gnc(n),LIS_rc%gnr(n)))
+       ctitle = 'HYMAP_basin_mask'
+       call HYMAP2_read_param_int_2d_global(ctitle,n,maskg)	  
+      
+       
+       write(LIS_logunit,*) '[INFO] Get number of HYMAP2 grid cells'
+       call HYMAP2_get_vector_size(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            LIS_rc%gnc(n),LIS_rc%gnr(n),&
+            LIS_ews_halo_ind(n,LIS_localPet+1), &
+            LIS_nss_halo_ind(n,LIS_localPet+1), &
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%nextx,&
+            mask,HYMAP2_routing_struc(n)%nseqall)
 
-          allocate(basin(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-          ctitle = 'HYMAP_basin'
-          call HYMAP2_read_param_real(ctitle,1,n,basin)	  
+       allocate(HYMAP2_routing_struc(n)%gdeltas(0:LIS_npes-1))
+       allocate(HYMAP2_routing_struc(n)%goffsets(0:LIS_npes-1))
 
-          allocate(mask(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-          ctitle = 'HYMAP_basin_mask'
-          call HYMAP2_read_param_int(ctitle,1,n,mask)	  
+       gdeltas = HYMAP2_routing_struc(n)%nseqall      
+       
+#if (defined SPMD)
+       call MPI_ALLREDUCE(HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%nseqall_glb,1,&
+            MPI_INTEGER,MPI_SUM,&
+            LIS_mpi_comm,status)
 
-          allocate(tmp_real(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-          allocate(tmp_real_nz(LIS_rc%gnc(n),LIS_rc%gnr(n),HYMAP2_routing_struc(n)%nz))
+       call MPI_ALLGATHER(gdeltas,1,MPI_INTEGER,&
+            HYMAP2_routing_struc(n)%gdeltas(:),1,MPI_INTEGER,&
+            LIS_mpi_comm,status)
 
-          write(LIS_logunit,*) 'Get number of HYMAP2 grid cells'
-          call HYMAP2_get_vector_size(LIS_rc%gnc(n),LIS_rc%gnr(n),HYMAP2_routing_struc(n)%imis,nextx,mask,HYMAP2_routing_struc(n)%nseqall)
-          
-          allocate(HYMAP2_routing_struc(n)%seqx(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%seqy(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%sindex(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-          allocate(HYMAP2_routing_struc(n)%outlet(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%next(HYMAP2_routing_struc(n)%nseqall))
-          !allocate(HYMAP2_routing_struc(n)%nextx(HYMAP2_routing_struc(n)%nseqall))
-          !allocate(HYMAP2_routing_struc(n)%nexty(HYMAP2_routing_struc(n)%nseqall)) 
-          !allocate(HYMAP2_routing_struc(n)%mask(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%elevtn(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%nxtdst(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%grarea(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%fldgrd(HYMAP2_routing_struc(n)%nseqall,&
-               HYMAP2_routing_struc(n)%nz))
-          allocate(HYMAP2_routing_struc(n)%fldman(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%fldhgt(HYMAP2_routing_struc(n)%nseqall,&
-               HYMAP2_routing_struc(n)%nz))
-          allocate(HYMAP2_routing_struc(n)%cntime(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%trnoff(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%tbsflw(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%fldstomax(HYMAP2_routing_struc(n)%nseqall,&
-               HYMAP2_routing_struc(n)%nz))
-          allocate(HYMAP2_routing_struc(n)%rivman(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%rivelv(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%rivstomax(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%rivlen(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%rivwth(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%rivhgt(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%rivare(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%runoff0(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%basflw0(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%flowmap(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%rnfdwi_ratio(HYMAP2_routing_struc(n)%nseqall))
-          allocate(HYMAP2_routing_struc(n)%bsfdwi_ratio(HYMAP2_routing_struc(n)%nseqall))
-          !ag (4Feb2016)
-          if(HYMAP2_routing_struc(n)%resopflag==1)then
-            allocate(HYMAP2_routing_struc(n)%resopaltloc(HYMAP2_routing_struc(n)%nresop))
-            allocate(HYMAP2_routing_struc(n)%resopoutmin(HYMAP2_routing_struc(n)%nresop))
-            allocate(HYMAP2_routing_struc(n)%tresopalt(HYMAP2_routing_struc(n)%nresop,HYMAP2_routing_struc(n)%ntresop))
-            allocate(HYMAP2_routing_struc(n)%resopalt(HYMAP2_routing_struc(n)%nresop,HYMAP2_routing_struc(n)%ntresop))
-          endif
+#else
+       HYMAP2_routing_struc(n)%nseqall_glb = HYMAP2_routing_struc(n)%nseqall
+#endif
 
-          if(HYMAP2_routing_struc(n)%useens.eq.0) then 
-             allocate(HYMAP2_routing_struc(n)%rivsto(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%rivdph(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%rivvel(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%rivout(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%evpout(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%fldout(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%fldsto(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%flddph(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%fldvel(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%fldfrc(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%fldare(HYMAP2_routing_struc(n)%nseqall,&
+       if(LIS_masterproc) then 
+          HYMAP2_routing_struc(n)%goffsets = 0 
+          do i=1,LIS_npes-1
+             HYMAP2_routing_struc(n)%goffsets(i) = &
+                  HYMAP2_routing_struc(n)%goffsets(i-1) +& 
+                  HYMAP2_routing_struc(n)%gdeltas(i-1)
+          enddo
+       endif
+#if (defined SPMD)
+       call MPI_BCAST(HYMAP2_routing_struc(n)%goffsets, &
+            LIS_npes, MPI_INTEGER,0, &
+            LIS_mpi_comm, status)
+#endif
+
+       allocate(HYMAP2_routing_struc(n)%seqx(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%seqy(HYMAP2_routing_struc(n)%nseqall))
+
+       allocate(HYMAP2_routing_struc(n)%seqx_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+       allocate(HYMAP2_routing_struc(n)%seqy_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+
+       allocate(HYMAP2_routing_struc(n)%sindex(LIS_rc%gnc(n),LIS_rc%gnr(n)))
+       allocate(HYMAP2_routing_struc(n)%outlet(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%outlet_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+       allocate(HYMAP2_routing_struc(n)%next(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%next_glb(HYMAP2_routing_struc(n)%nseqall_glb))
+       !allocate(HYMAP2_routing_struc(n)%nextx(HYMAP2_routing_struc(n)%nseqall))
+       !allocate(HYMAP2_routing_struc(n)%nexty(HYMAP2_routing_struc(n)%nseqall)) 
+       !allocate(HYMAP2_routing_struc(n)%mask(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%elevtn(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%nxtdst(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%grarea(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%fldgrd(HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%nz))
+       allocate(HYMAP2_routing_struc(n)%fldman(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%fldhgt(HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%nz))
+       allocate(HYMAP2_routing_struc(n)%cntime(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%trnoff(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%tbsflw(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%fldstomax(HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%nz))
+       allocate(HYMAP2_routing_struc(n)%rivman(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%rivelv(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%rivstomax(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%rivlen(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%rivwth(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%rivhgt(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%rivare(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%runoff0(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%basflw0(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%flowmap(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%rnfdwi_ratio(HYMAP2_routing_struc(n)%nseqall))
+       allocate(HYMAP2_routing_struc(n)%bsfdwi_ratio(HYMAP2_routing_struc(n)%nseqall))
+       !ag (4Feb2016)
+       if(HYMAP2_routing_struc(n)%resopflag==1)then
+          allocate(HYMAP2_routing_struc(n)%resopaltloc(HYMAP2_routing_struc(n)%nresop))
+          allocate(HYMAP2_routing_struc(n)%resopoutmin(HYMAP2_routing_struc(n)%nresop))
+          allocate(HYMAP2_routing_struc(n)%tresopalt(HYMAP2_routing_struc(n)%nresop,HYMAP2_routing_struc(n)%ntresop))
+          allocate(HYMAP2_routing_struc(n)%resopalt(HYMAP2_routing_struc(n)%nresop,HYMAP2_routing_struc(n)%ntresop))
+       endif
+       
+       if(HYMAP2_routing_struc(n)%useens.eq.0) then 
+          allocate(HYMAP2_routing_struc(n)%rivsto(HYMAP2_routing_struc(n)%nseqall,&
                1))
-             allocate(HYMAP2_routing_struc(n)%sfcelv(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%rnfsto(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%bsfsto(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%rnfdwi(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%bsfdwi(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%surfws(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-                  
-             allocate(HYMAP2_routing_struc(n)%dtaout(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             !ag (19Jan2016)
-             allocate(HYMAP2_routing_struc(n)%rivout_pre(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%rivdph_pre(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%fldout_pre(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%flddph_pre(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%fldelv1(HYMAP2_routing_struc(n)%nseqall,&
-                  1))         
-             !ag (03May2017)
-             allocate(HYMAP2_routing_struc(n)%ewat(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-             allocate(HYMAP2_routing_struc(n)%edif(HYMAP2_routing_struc(n)%nseqall,&
-                  1))
-          else
-             allocate(HYMAP2_routing_struc(n)%rivsto(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%rivdph(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%rivvel(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%rivout(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%evpout(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%fldout(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%fldsto(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%flddph(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%fldvel(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%fldfrc(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%fldare(HYMAP2_routing_struc(n)%nseqall,&
+          allocate(HYMAP2_routing_struc(n)%rivdph(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%rivvel(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%rivout(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%evpout(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%fldout(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%fldsto(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%flddph(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%fldvel(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%fldfrc(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%fldare(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%sfcelv(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%rnfsto(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%bsfsto(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%rnfdwi(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%bsfdwi(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%surfws(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          
+          allocate(HYMAP2_routing_struc(n)%dtaout(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          !ag (19Jan2016)
+          allocate(HYMAP2_routing_struc(n)%rivout_pre(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%rivdph_pre(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%fldout_pre(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%flddph_pre(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%fldelv1(HYMAP2_routing_struc(n)%nseqall,&
+               1))         
+          !ag (03May2017)
+          allocate(HYMAP2_routing_struc(n)%ewat(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+          allocate(HYMAP2_routing_struc(n)%edif(HYMAP2_routing_struc(n)%nseqall,&
+               1))
+       else
+          allocate(HYMAP2_routing_struc(n)%rivsto(HYMAP2_routing_struc(n)%nseqall,&
                LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%sfcelv(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%rnfsto(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%bsfsto(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%rnfdwi(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%bsfdwi(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%surfws(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%rivdph(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%rivvel(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%rivout(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%evpout(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%fldout(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%fldsto(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%flddph(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%fldvel(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%fldfrc(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%fldare(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%sfcelv(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%rnfsto(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%bsfsto(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%rnfdwi(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%bsfdwi(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%surfws(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
 
-             allocate(HYMAP2_routing_struc(n)%dtaout(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-
-             !ag (19Jan2016)
-             allocate(HYMAP2_routing_struc(n)%rivout_pre(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%rivdph_pre(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%fldout_pre(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%flddph_pre(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%fldelv1(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-
-             !ag (03May2017)
-             allocate(HYMAP2_routing_struc(n)%ewat(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-             allocate(HYMAP2_routing_struc(n)%edif(HYMAP2_routing_struc(n)%nseqall,&
-                  LIS_rc%nensem(n)))
-          endif
-
-          HYMAP2_routing_struc(n)%seqx=0.0
-          HYMAP2_routing_struc(n)%seqy=0.0
-          HYMAP2_routing_struc(n)%sindex=0.0
-          HYMAP2_routing_struc(n)%outlet=0.0
-          HYMAP2_routing_struc(n)%next=0.0
-          !HYMAP2_routing_struc(n)%nextx=0.0
-          !HYMAP2_routing_struc(n)%nexty=0.0 
-          !HYMAP2_routing_struc(n)%mask=0.0
-          HYMAP2_routing_struc(n)%elevtn=0.0
-          HYMAP2_routing_struc(n)%nxtdst=0.0
-          HYMAP2_routing_struc(n)%grarea=0.0
-          HYMAP2_routing_struc(n)%fldgrd=0.0
-          HYMAP2_routing_struc(n)%fldman=0.0
-          HYMAP2_routing_struc(n)%fldhgt=0.0
-          HYMAP2_routing_struc(n)%cntime=0.0
-          HYMAP2_routing_struc(n)%trnoff=0.0
-          HYMAP2_routing_struc(n)%tbsflw=0.0
-          HYMAP2_routing_struc(n)%fldstomax=0.0
-          HYMAP2_routing_struc(n)%rivman=0.0
-          HYMAP2_routing_struc(n)%rivelv=0.0
-          HYMAP2_routing_struc(n)%rivstomax=0.0
-          HYMAP2_routing_struc(n)%rivlen=0.0
-          HYMAP2_routing_struc(n)%rivwth=0.0
-          HYMAP2_routing_struc(n)%rivhgt=0.0
-          HYMAP2_routing_struc(n)%rivare=0.0
-          HYMAP2_routing_struc(n)%runoff0=0.0
-          HYMAP2_routing_struc(n)%basflw0=0.0
-          HYMAP2_routing_struc(n)%rivsto=0.0
-          HYMAP2_routing_struc(n)%rivdph=0.0
-          HYMAP2_routing_struc(n)%rivvel=0.0
-          HYMAP2_routing_struc(n)%rivout=0.0
-          HYMAP2_routing_struc(n)%evpout=0.0
-          HYMAP2_routing_struc(n)%fldout=0.0
-          HYMAP2_routing_struc(n)%fldsto=0.0
-          HYMAP2_routing_struc(n)%flddph=0.0
-          HYMAP2_routing_struc(n)%fldvel=0.0
-          HYMAP2_routing_struc(n)%fldfrc=0.0
-          HYMAP2_routing_struc(n)%fldare=0.0
-          HYMAP2_routing_struc(n)%sfcelv=0.0
-          HYMAP2_routing_struc(n)%rnfsto=0.0
-          HYMAP2_routing_struc(n)%bsfsto=0.0
-          HYMAP2_routing_struc(n)%flowmap=0.0
-          HYMAP2_routing_struc(n)%rnfdwi_ratio=0.0
-          HYMAP2_routing_struc(n)%bsfdwi_ratio=0.0
-          HYMAP2_routing_struc(n)%rnfdwi=0.0
-          HYMAP2_routing_struc(n)%bsfdwi=0.0
-          HYMAP2_routing_struc(n)%surfws=0.0
-
-          HYMAP2_routing_struc(n)%dtaout=1000000.
+          allocate(HYMAP2_routing_struc(n)%dtaout(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
 
           !ag (19Jan2016)
-          HYMAP2_routing_struc(n)%rivout_pre=0.0
-          HYMAP2_routing_struc(n)%rivdph_pre=0.0
-          HYMAP2_routing_struc(n)%fldout_pre=0.0
-          HYMAP2_routing_struc(n)%flddph_pre=0.0
-          HYMAP2_routing_struc(n)%fldelv1=0.0
-
-          !ag (4Feb2016)
-          if(HYMAP2_routing_struc(n)%resopflag==1)then
-            HYMAP2_routing_struc(n)%resopaltloc=real(HYMAP2_routing_struc(n)%imis)
-            HYMAP2_routing_struc(n)%resopoutmin=0.0
-            HYMAP2_routing_struc(n)%tresopalt=dble(HYMAP2_routing_struc(n)%imis)
-            HYMAP2_routing_struc(n)%resopalt=real(HYMAP2_routing_struc(n)%imis)
-          endif
+          allocate(HYMAP2_routing_struc(n)%rivout_pre(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%rivdph_pre(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%fldout_pre(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%flddph_pre(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%fldelv1(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
 
           !ag (03May2017)
-          HYMAP2_routing_struc(n)%ewat=0.0
-          HYMAP2_routing_struc(n)%edif=0.0
+          allocate(HYMAP2_routing_struc(n)%ewat(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+          allocate(HYMAP2_routing_struc(n)%edif(HYMAP2_routing_struc(n)%nseqall,&
+               LIS_rc%nensem(n)))
+       endif
 
-       enddo
+       HYMAP2_routing_struc(n)%seqx=0.0
+       HYMAP2_routing_struc(n)%seqy=0.0
 
-       write(LIS_logunit,*) 'Get HYMAP2 cell vector sequence'
-       do n=1, LIS_rc%nnest
-         call HYMAP2_get_seq(LIS_rc%gnc(n),LIS_rc%gnr(n),HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,nextx,nexty,mask,HYMAP2_routing_struc(n)%sindex,HYMAP2_routing_struc(n)%outlet,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,HYMAP2_routing_struc(n)%next)
-       enddo
+       HYMAP2_routing_struc(n)%sindex=0.0
+       HYMAP2_routing_struc(n)%outlet=0.0
+       HYMAP2_routing_struc(n)%outlet_glb=0.0
+       HYMAP2_routing_struc(n)%next=0.0
+       HYMAP2_routing_struc(n)%next_glb=0.0
+       !HYMAP2_routing_struc(n)%nextx=0.0
+       !HYMAP2_routing_struc(n)%nexty=0.0 
+       !HYMAP2_routing_struc(n)%mask=0.0
+       HYMAP2_routing_struc(n)%elevtn=0.0
+       HYMAP2_routing_struc(n)%nxtdst=0.0
+       HYMAP2_routing_struc(n)%grarea=0.0
+       HYMAP2_routing_struc(n)%fldgrd=0.0
+       HYMAP2_routing_struc(n)%fldman=0.0
+       HYMAP2_routing_struc(n)%fldhgt=0.0
+       HYMAP2_routing_struc(n)%cntime=0.0
+       HYMAP2_routing_struc(n)%trnoff=0.0
+       HYMAP2_routing_struc(n)%tbsflw=0.0
+       HYMAP2_routing_struc(n)%fldstomax=0.0
+       HYMAP2_routing_struc(n)%rivman=0.0
+       HYMAP2_routing_struc(n)%rivelv=0.0
+       HYMAP2_routing_struc(n)%rivstomax=0.0
+       HYMAP2_routing_struc(n)%rivlen=0.0
+       HYMAP2_routing_struc(n)%rivwth=0.0
+       HYMAP2_routing_struc(n)%rivhgt=0.0
+       HYMAP2_routing_struc(n)%rivare=0.0
+       HYMAP2_routing_struc(n)%runoff0=0.0
+       HYMAP2_routing_struc(n)%basflw0=0.0
+       HYMAP2_routing_struc(n)%rivsto=0.0
+       HYMAP2_routing_struc(n)%rivdph=0.0
+       HYMAP2_routing_struc(n)%rivvel=0.0
+       HYMAP2_routing_struc(n)%rivout=0.0
+       HYMAP2_routing_struc(n)%evpout=0.0
+       HYMAP2_routing_struc(n)%fldout=0.0
+       HYMAP2_routing_struc(n)%fldsto=0.0
+       HYMAP2_routing_struc(n)%flddph=0.0
+       HYMAP2_routing_struc(n)%fldvel=0.0
+       HYMAP2_routing_struc(n)%fldfrc=0.0
+       HYMAP2_routing_struc(n)%fldare=0.0
+       HYMAP2_routing_struc(n)%sfcelv=0.0
+       HYMAP2_routing_struc(n)%rnfsto=0.0
+       HYMAP2_routing_struc(n)%bsfsto=0.0
+       HYMAP2_routing_struc(n)%flowmap=0.0
+       HYMAP2_routing_struc(n)%rnfdwi_ratio=0.0
+       HYMAP2_routing_struc(n)%bsfdwi_ratio=0.0
+       HYMAP2_routing_struc(n)%rnfdwi=0.0
+       HYMAP2_routing_struc(n)%bsfdwi=0.0
+       HYMAP2_routing_struc(n)%surfws=0.0
+       
+       HYMAP2_routing_struc(n)%dtaout=1000000.
+       
+       !ag (19Jan2016)
+       HYMAP2_routing_struc(n)%rivout_pre=0.0
+       HYMAP2_routing_struc(n)%rivdph_pre=0.0
+       HYMAP2_routing_struc(n)%fldout_pre=0.0
+       HYMAP2_routing_struc(n)%flddph_pre=0.0
+       HYMAP2_routing_struc(n)%fldelv1=0.0
+       
+       !ag (4Feb2016)
+       if(HYMAP2_routing_struc(n)%resopflag==1)then
+          HYMAP2_routing_struc(n)%resopaltloc=real(HYMAP2_routing_struc(n)%imis)
+          HYMAP2_routing_struc(n)%resopoutmin=real(HYMAP2_routing_struc(n)%imis)
+          HYMAP2_routing_struc(n)%tresopalt=dble(HYMAP2_routing_struc(n)%imis)
+          HYMAP2_routing_struc(n)%resopalt=real(HYMAP2_routing_struc(n)%imis)
+       endif
 
-       ctitle = 'HYMAP_river_width'
-       do n=1, LIS_rc%nnest
-          call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-          call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%rivwth)
-       enddo
+       !ag (03May2017)
+       HYMAP2_routing_struc(n)%ewat=0.0
+       HYMAP2_routing_struc(n)%edif=0.0
        
-       ctitle = 'HYMAP_river_length'
-       do n=1, LIS_rc%nnest
-          call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-          call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%rivlen)
-       enddo
-       
-       ctitle = 'HYMAP_river_height'
-       do n=1, LIS_rc%nnest
-          call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-          call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%rivhgt)  
-       enddo
-       
-       ctitle = 'HYMAP_river_roughness'
-       do n=1, LIS_rc%nnest
-          call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-          call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%rivman)  
-       enddo
-       
-       ctitle = 'HYMAP_floodplain_height'
-       do n=1, LIS_rc%nnest
-          call HYMAP2_read_param_real(ctitle,HYMAP2_routing_struc(n)%nz,n,&
-               tmp_real_nz)
-          call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),HYMAP2_routing_struc(n)%nz,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real_nz,HYMAP2_routing_struc(n)%fldhgt)	  
-       enddo
-       
-       ctitle = 'HYMAP_floodplain_roughness'
-       do n=1, LIS_rc%nnest
-          call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-          call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%fldman)
-       enddo       
+    enddo
+    
+    do n=1,LIS_rc%nnest
+       allocate(tmp_real(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+       allocate(tmp_real_nz(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            HYMAP2_routing_struc(n)%nz))
+    enddo
 
-       ctitle = 'HYMAP_grid_elevation'
-       do n=1, LIS_rc%nnest
-          call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-          where(tmp_real<0)tmp_real=0
-          call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%elevtn)
+    write(LIS_logunit,*) '[INFO] Get HYMAP2 cell vector sequence'
+    do n=1, LIS_rc%nnest
+       call HYMAP2_get_sindex(LIS_rc%gnc(n),&
+            LIS_rc%gnr(n),&
+            HYMAP2_routing_struc(n)%nseqall_glb,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%nextx,&
+            HYMAP2_routing_struc(n)%nexty,maskg,&
+            HYMAP2_routing_struc(n)%sindex,&
+            HYMAP2_routing_struc(n)%outlet_glb,&
+            HYMAP2_routing_struc(n)%next_glb)
+#if 0 
+       ic = 0 
+       do c=1,LIS_rc%gnc(n)
+          do r=1,LIS_rc%gnr(n)
+             if(HYMAP2_routing_struc(n)%nextx(c,r)/=HYMAP2_routing_struc(n)%imis.and.maskg(c,r)>0) then 
+                ic = ic + 1
+                print*, ic, & !c,r,HYMAP2_routing_struc(n)%sindex(c,r)
+                     -56.875 + (r-1)*0.25, -82.875 + (c-1)*0.25
+             endif
+          enddo
        enddo
-       
-       ctitle = 'HYMAP_grid_distance'
-       do n=1, LIS_rc%nnest
-          call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-          call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%nxtdst)
-          where(HYMAP2_routing_struc(n)%outlet==1)HYMAP2_routing_struc(n)%nxtdst=HYMAP2_routing_struc(n)%dstend
-       enddo
+       stop
+#endif
 
-       ctitle = 'HYMAP_grid_area'
-       do n=1, LIS_rc%nnest
-          call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-          call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%grarea)
-       enddo
-       
-       ctitle = 'HYMAP_runoff_time_delay'
-       do n=1, LIS_rc%nnest
-          call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-          call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%cntime)
-          where(HYMAP2_routing_struc(n)%cntime==0)HYMAP2_routing_struc(n)%cntime=minval(HYMAP2_routing_struc(n)%cntime,HYMAP2_routing_struc(n)%cntime>0)
-       enddo
-               
-               
-       ctitle = 'HYMAP_runoff_time_delay_multiplier'
-       do n=1, LIS_rc%nnest
-          call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-          call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%trnoff)	  
-       enddo
-       
-       ctitle = 'HYMAP_baseflow_time_delay'
-       do n=1, LIS_rc%nnest
-          call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-          call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%tbsflw)
-          write(LIS_logunit,*)'Remove zeros from groundwater time delay'
-          where(HYMAP2_routing_struc(n)%tbsflw<HYMAP2_routing_struc(n)%cntime/86400..and.&
-               HYMAP2_routing_struc(n)%cntime>0)&
-               HYMAP2_routing_struc(n)%tbsflw=HYMAP2_routing_struc(n)%cntime/86400.
-       enddo
-       
-       !ag (23Nov2016)
-       ctitle = 'HYMAP_runoff_dwi_ratio'
-       do n=1, LIS_rc%nnest
-         if(HYMAP2_routing_struc(n)%dwiflag==1)then
-           call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-           call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%rnfdwi_ratio)	  
-         else
-           HYMAP2_routing_struc(n)%rnfdwi_ratio=0.
-         endif
-       enddo
-       !ag (23Nov2016)
-       ctitle = 'HYMAP_baseflow_dwi_ratio'
-       do n=1, LIS_rc%nnest
-         if(HYMAP2_routing_struc(n)%dwiflag==1)then
-           call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-           call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%bsfdwi_ratio)	  
-         else
-           HYMAP2_routing_struc(n)%bsfdwi_ratio=0.
-         endif
-       enddo
+       call HYMAP2_get_seq(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            LIS_rc%gnc(n),LIS_rc%gnr(n),&
+            LIS_ews_halo_ind(n,LIS_localPet+1), &
+            LIS_nss_halo_ind(n,LIS_localPet+1), &
+            HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%nextx,&
+            HYMAP2_routing_struc(n)%nexty,maskg,&
+            HYMAP2_routing_struc(n)%sindex,&
+            HYMAP2_routing_struc(n)%outlet,&
+            HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%seqy,HYMAP2_routing_struc(n)%next)
 
-       !ag (13Apr2016)
-       ctitle = 'HYMAP_river_flow_type'
-       do n=1, LIS_rc%nnest
-         if(HYMAP2_routing_struc(n)%flowtype==0)then
-           call HYMAP2_read_param_real(ctitle,1,n,tmp_real)
-           call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_real,HYMAP2_routing_struc(n)%flowmap)	  
-         else
-           HYMAP2_routing_struc(n)%flowmap=HYMAP2_routing_struc(n)%flowtype
-         endif
-       enddo
+    enddo
+    
+#if (defined SPMD)
+    do n=1,LIS_rc%nnest    
+       call MPI_ALLGATHERV(HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%nseqall,MPI_INTEGER,&
+            HYMAP2_routing_struc(n)%seqx_glb,&
+            HYMAP2_routing_struc(n)%gdeltas(:),&
+            HYMAP2_routing_struc(n)%goffsets(:),&
+            MPI_INTEGER,&
+            LIS_mpi_comm,status)
 
-       !ag (20Sep2016) Correction for cases where parameter maps don't match
-       do n=1, LIS_rc%nnest
-         do i=1,HYMAP2_routing_struc(n)%nseqall
-           if(HYMAP2_routing_struc(n)%rivwth(i)==HYMAP2_routing_struc(n)%imis.or.&
-             HYMAP2_routing_struc(n)%rivlen(i)==HYMAP2_routing_struc(n)%imis.or.&
-             HYMAP2_routing_struc(n)%rivhgt(i)==HYMAP2_routing_struc(n)%imis.or.&
-             HYMAP2_routing_struc(n)%rivman(i)==HYMAP2_routing_struc(n)%imis.or.&
-             HYMAP2_routing_struc(n)%fldhgt(i,1)==HYMAP2_routing_struc(n)%imis.or.&
-             HYMAP2_routing_struc(n)%elevtn(i)==HYMAP2_routing_struc(n)%imis.or.&
-             HYMAP2_routing_struc(n)%nxtdst(i)==HYMAP2_routing_struc(n)%imis.or.&
-             HYMAP2_routing_struc(n)%grarea(i)==HYMAP2_routing_struc(n)%imis.or.&
-             HYMAP2_routing_struc(n)%cntime(i)==HYMAP2_routing_struc(n)%imis.or.&
-             HYMAP2_routing_struc(n)%trnoff(i)==HYMAP2_routing_struc(n)%imis.or.&
-             HYMAP2_routing_struc(n)%tbsflw(i)==HYMAP2_routing_struc(n)%imis.or.&
-             HYMAP2_routing_struc(n)%flowmap(i)==HYMAP2_routing_struc(n)%imis)then
-         
+       call MPI_ALLGATHERV(HYMAP2_routing_struc(n)%seqy,&
+            HYMAP2_routing_struc(n)%nseqall,MPI_INTEGER,&
+            HYMAP2_routing_struc(n)%seqy_glb,&
+            HYMAP2_routing_struc(n)%gdeltas(:),&
+            HYMAP2_routing_struc(n)%goffsets(:),&
+            MPI_INTEGER,&
+            LIS_mpi_comm,status)
+    enddo
+#endif
+
+    ctitle = 'HYMAP_river_width'
+    do n=1, LIS_rc%nnest
+       call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+       call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            1,HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%seqy,&
+            tmp_real,HYMAP2_routing_struc(n)%rivwth)
+    enddo
+    
+
+    ctitle = 'HYMAP_river_length'
+    do n=1, LIS_rc%nnest
+       call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+       call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            1,HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%seqy,&
+            tmp_real,HYMAP2_routing_struc(n)%rivlen)
+    enddo
+    
+    ctitle = 'HYMAP_river_height'
+    do n=1, LIS_rc%nnest
+       call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+       call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            1,HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%seqy,&
+            tmp_real,HYMAP2_routing_struc(n)%rivhgt)  
+    enddo
+    
+    ctitle = 'HYMAP_river_roughness'
+    do n=1, LIS_rc%nnest
+       call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+       call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            1,HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%seqy,&
+            tmp_real,HYMAP2_routing_struc(n)%rivman)  
+    enddo
+    
+    ctitle = 'HYMAP_floodplain_height'
+    do n=1, LIS_rc%nnest
+       call HYMAP2_read_param_real(ctitle,HYMAP2_routing_struc(n)%nz,n,&
+            tmp_real_nz)
+       call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            HYMAP2_routing_struc(n)%nz,&
+            HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%seqy,&
+            tmp_real_nz,HYMAP2_routing_struc(n)%fldhgt)
+    enddo
+
+    ctitle = 'HYMAP_floodplain_roughness'
+    do n=1, LIS_rc%nnest
+       call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+       call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            1,HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%seqy,&
+            tmp_real,HYMAP2_routing_struc(n)%fldman)
+    enddo
+
+    ctitle = 'HYMAP_grid_elevation'
+    do n=1, LIS_rc%nnest
+       call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+       where(tmp_real<0)tmp_real=0
+       call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            1,HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%seqy,&
+            tmp_real,HYMAP2_routing_struc(n)%elevtn)
+    enddo
+
+    ctitle = 'HYMAP_grid_distance'
+    do n=1, LIS_rc%nnest
+       call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+       call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            1,HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%seqy,&
+            tmp_real,HYMAP2_routing_struc(n)%nxtdst)
+       where(HYMAP2_routing_struc(n)%outlet==1)HYMAP2_routing_struc(n)%nxtdst=HYMAP2_routing_struc(n)%dstend
+    enddo
+
+    ctitle = 'HYMAP_grid_area'
+    do n=1, LIS_rc%nnest
+       call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+       call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            1,HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%seqy,&
+            tmp_real,HYMAP2_routing_struc(n)%grarea)
+    enddo
+
+    ctitle = 'HYMAP_runoff_time_delay'
+    do n=1, LIS_rc%nnest
+       call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+       call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            1,HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%seqy,&
+            tmp_real,HYMAP2_routing_struc(n)%cntime)
+       where(HYMAP2_routing_struc(n)%cntime==0)HYMAP2_routing_struc(n)%cntime=minval(HYMAP2_routing_struc(n)%cntime,HYMAP2_routing_struc(n)%cntime>0)
+    enddo
+
+
+    ctitle = 'HYMAP_runoff_time_delay_multiplier'
+    do n=1, LIS_rc%nnest
+       call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+       call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            1,HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%seqy,&
+            tmp_real,HYMAP2_routing_struc(n)%trnoff)	  
+    enddo
+
+    ctitle = 'HYMAP_baseflow_time_delay'
+    do n=1, LIS_rc%nnest
+       call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+       call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+            1,HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%imis,&
+            HYMAP2_routing_struc(n)%seqx,&
+            HYMAP2_routing_struc(n)%seqy,&
+            tmp_real,HYMAP2_routing_struc(n)%tbsflw)
+       write(LIS_logunit,*)'[INFO] Remove zeros from groundwater time delay'
+       where(HYMAP2_routing_struc(n)%tbsflw<HYMAP2_routing_struc(n)%cntime/86400..and.&
+            HYMAP2_routing_struc(n)%cntime>0)&
+            HYMAP2_routing_struc(n)%tbsflw=HYMAP2_routing_struc(n)%cntime/86400.
+    enddo
+
+    !ag (23Nov2016)
+    ctitle = 'HYMAP_runoff_dwi_ratio'
+    do n=1, LIS_rc%nnest
+       if(HYMAP2_routing_struc(n)%dwiflag==1)then
+          call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+          call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+               1,HYMAP2_routing_struc(n)%nseqall,&
+               HYMAP2_routing_struc(n)%imis,&
+               HYMAP2_routing_struc(n)%seqx,&
+               HYMAP2_routing_struc(n)%seqy,&
+               tmp_real,HYMAP2_routing_struc(n)%rnfdwi_ratio)	  
+       else
+          HYMAP2_routing_struc(n)%rnfdwi_ratio=0.
+       endif
+    enddo
+    !ag (23Nov2016)
+    ctitle = 'HYMAP_baseflow_dwi_ratio'
+    do n=1, LIS_rc%nnest
+       if(HYMAP2_routing_struc(n)%dwiflag==1)then
+          call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+          call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+               1,HYMAP2_routing_struc(n)%nseqall,&
+               HYMAP2_routing_struc(n)%imis,&
+               HYMAP2_routing_struc(n)%seqx,&
+               HYMAP2_routing_struc(n)%seqy,&
+               tmp_real,HYMAP2_routing_struc(n)%bsfdwi_ratio)	  
+       else
+          HYMAP2_routing_struc(n)%bsfdwi_ratio=0.
+       endif
+    enddo
+
+    !ag (13Apr2016)
+    ctitle = 'HYMAP_river_flow_type'
+    do n=1, LIS_rc%nnest
+       if(HYMAP2_routing_struc(n)%flowtype==0)then
+          call HYMAP2_read_param_real_2d(ctitle,n,tmp_real)
+          call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),&
+               1,HYMAP2_routing_struc(n)%nseqall,&
+               HYMAP2_routing_struc(n)%imis,&
+               HYMAP2_routing_struc(n)%seqx,&
+               HYMAP2_routing_struc(n)%seqy,&
+               tmp_real,HYMAP2_routing_struc(n)%flowmap)	  
+       else
+          HYMAP2_routing_struc(n)%flowmap=HYMAP2_routing_struc(n)%flowtype
+       endif
+
+    enddo
+
+    !ag (20Sep2016) Correction for cases where parameter maps don't match
+    do n=1, LIS_rc%nnest
+       do i=1,HYMAP2_routing_struc(n)%nseqall
+          if(HYMAP2_routing_struc(n)%rivwth(i)==HYMAP2_routing_struc(n)%imis.or.&
+               HYMAP2_routing_struc(n)%rivlen(i)==HYMAP2_routing_struc(n)%imis.or.&
+               HYMAP2_routing_struc(n)%rivhgt(i)==HYMAP2_routing_struc(n)%imis.or.&
+               HYMAP2_routing_struc(n)%rivman(i)==HYMAP2_routing_struc(n)%imis.or.&
+               HYMAP2_routing_struc(n)%fldhgt(i,1)==HYMAP2_routing_struc(n)%imis.or.&
+               HYMAP2_routing_struc(n)%elevtn(i)==HYMAP2_routing_struc(n)%imis.or.&
+               HYMAP2_routing_struc(n)%nxtdst(i)==HYMAP2_routing_struc(n)%imis.or.&
+               HYMAP2_routing_struc(n)%grarea(i)==HYMAP2_routing_struc(n)%imis.or.&
+               HYMAP2_routing_struc(n)%cntime(i)==HYMAP2_routing_struc(n)%imis.or.&
+               HYMAP2_routing_struc(n)%trnoff(i)==HYMAP2_routing_struc(n)%imis.or.&
+               HYMAP2_routing_struc(n)%tbsflw(i)==HYMAP2_routing_struc(n)%imis.or.&
+               HYMAP2_routing_struc(n)%flowmap(i)==HYMAP2_routing_struc(n)%imis)then
+
              HYMAP2_routing_struc(n)%rivwth(i)=HYMAP2_routing_struc(n)%imis
              HYMAP2_routing_struc(n)%rivlen(i)=HYMAP2_routing_struc(n)%imis
              HYMAP2_routing_struc(n)%rivhgt(i)=HYMAP2_routing_struc(n)%imis
@@ -857,217 +1058,167 @@ contains
              HYMAP2_routing_struc(n)%tbsflw(i)=HYMAP2_routing_struc(n)%imis
              HYMAP2_routing_struc(n)%flowmap(i)=HYMAP2_routing_struc(n)%imis
              HYMAP2_routing_struc(n)%outlet(i)=HYMAP2_routing_struc(n)%imis
-           endif
-         enddo
-       enddo
-
-
-       write(LIS_logunit,*) 'Processing data before running HYMAP'
-       do n=1, LIS_rc%nnest
-          write(LIS_logunit,*)'Calculate maximum river storage'
-          HYMAP2_routing_struc(n)%rivstomax = HYMAP2_routing_struc(n)%rivlen* &
-               HYMAP2_routing_struc(n)%rivwth * HYMAP2_routing_struc(n)%rivhgt
-          write(LIS_logunit,*)'Calculate river bed elevation'
-          HYMAP2_routing_struc(n)%rivelv = HYMAP2_routing_struc(n)%elevtn -&
-               HYMAP2_routing_struc(n)%rivhgt
-          write(LIS_logunit,*)'Calculate river surface area'
-          where(HYMAP2_routing_struc(n)%rivwth>0)HYMAP2_routing_struc(n)%rivare =&
-               min(HYMAP2_routing_struc(n)%grarea, HYMAP2_routing_struc(n)%rivlen *&
-               HYMAP2_routing_struc(n)%rivwth)
-          write(LIS_logunit,*)'Setting floodplain staging'
-          call HYMAP2_set_fldstg(HYMAP2_routing_struc(n)%nz,&
-                          HYMAP2_routing_struc(n)%nseqall,&
-                          HYMAP2_routing_struc(n)%fldhgt,&
-                          HYMAP2_routing_struc(n)%grarea,&
-                          HYMAP2_routing_struc(n)%rivlen,&
-                          HYMAP2_routing_struc(n)%rivwth,&
-                          HYMAP2_routing_struc(n)%rivstomax,&
-                          HYMAP2_routing_struc(n)%fldstomax,&
-                          HYMAP2_routing_struc(n)%fldgrd,&
-                          HYMAP2_routing_struc(n)%rivare)		   
-          !Start storages
-          HYMAP2_routing_struc(n)%rivsto=0.0
-          HYMAP2_routing_struc(n)%fldsto=0.0
-          HYMAP2_routing_struc(n)%rnfsto=0.0
-          HYMAP2_routing_struc(n)%bsfsto=0.0
-       enddo
-
-       !ag (4Feb2016) - read reservoir operation data
-       do n=1, LIS_rc%nnest
-         if(HYMAP2_routing_struc(n)%resopflag==1)then
-           call HYMAP2_get_data_resop_alt(HYMAP2_routing_struc(n)%resopdir,HYMAP2_routing_struc(n)%resopheader,&
-                                   LIS_rc%gnc(n),LIS_rc%gnr(n),HYMAP2_routing_struc(n)%sindex,&
-                                   HYMAP2_routing_struc(n)%nresop,HYMAP2_routing_struc(n)%ntresop,&
-                                   HYMAP2_routing_struc(n)%resopaltloc,&
-                                   HYMAP2_routing_struc(n)%tresopalt,HYMAP2_routing_struc(n)%resopalt)
-         endif
-       enddo
-
-       call ESMF_ConfigFindLabel(LIS_config,&
-            "HYMAP2 routing model start mode:",rc=status)
-       do n=1, LIS_rc%nnest
-          call ESMF_ConfigGetAttribute(LIS_config,&
-               HYMAP2_routing_struc(n)%startmode,rc=status)
-          call LIS_verify(status,&
-               "HYMAP2 routing model start mode: not defined")
-       enddo
-       
-       call ESMF_ConfigFindLabel(LIS_config,&
-            "HYMAP2 routing model restart interval:",rc=status)
-       do n=1, LIS_rc%nnest
-          call ESMF_ConfigGetAttribute(LIS_config,time,rc=status)
-          call LIS_verify(status,&
-               "HYMAP2 routing model restart interval: not defined")
-          call LIS_parseTimeString(time,HYMAP2_routing_struc(n)%rstInterval)
-       enddo
-       
-       call ESMF_ConfigFindLabel(LIS_config,&
-            "HYMAP2 routing model restart file:",rc=status)
-       do n=1, LIS_rc%nnest
-          call ESMF_ConfigGetAttribute(LIS_config,&
-               HYMAP2_routing_struc(n)%rstfile,rc=status)
-          call LIS_verify(status,&
-               "HYMAP2 routing model restart file: not defined")
-       enddo
-       
-       if(LIS_rc%lsm.eq."none") then 
-          call initrunoffdata(trim(LIS_rc%runoffdatasource)//char(0))
-       endif
-
-       do n=1, LIS_rc%nnest
-          call ESMF_ArraySpecSet(realarrspec,rank=1,typekind=ESMF_TYPEKIND_R4,&
-               rc=status)
-          call LIS_verify(status)
-          
-          global_grid_dg = ESMF_DistGridCreate(minIndex=(/1/),&
-               maxIndex=(/LIS_rc%glbntiles(n)/),&
-               regDecomp=(/1/),rc=status)
-          call LIS_verify(status,&
-               'ESMF_DistGridCreate failed in HYMAP2_routingInit')
-          
-          global_grid = ESMF_GridCreate(name="Global Grid",&
-               coordTypeKind=ESMF_TYPEKIND_R4,&
-               distgrid = global_grid_dg, &
-               gridEdgeLWidth=(/0/), gridEdgeUWidth=(/0/),rc=status)
-          call LIS_verify(status,&
-               'ESMF_GridCreate failed in HYMAP2_routingInit')
-          
-          !create LSM interface objects to store runoff and baseflow
-          sf_runoff_field =ESMF_FieldCreate(arrayspec=realarrspec,&
-               grid=global_grid, name="Surface Runoff",rc=status)
-          call LIS_verify(status, 'ESMF_FieldCreate failed')
-          
-          baseflow_field =ESMF_FieldCreate(arrayspec=realarrspec,&
-               grid=global_grid, name="Subsurface Runoff",rc=status)
-          call LIS_verify(status, 'ESMF_FieldCreate failed')
-          
-          call ESMF_FieldGet(sf_runoff_field,localDE=0,farrayPtr=sfrunoff,&
-               rc=status)
-          call LIS_verify(status)
-          sfrunoff = 0.0 
-
-          call ESMF_FieldGet(baseflow_field,localDE=0,farrayPtr=baseflow,&
-               rc=status)
-          call LIS_verify(status)
-          baseflow = 0.0
-
-          call ESMF_stateAdd(LIS_runoff_state(n),(/sf_runoff_field/),rc=status)
-          call LIS_verify(status, 'ESMF_StateAdd failed for surface runoff')
-
-          call ESMF_stateAdd(LIS_runoff_state(n),(/baseflow_field/),rc=status)
-          call LIS_verify(status, 'ESMF_StateAdd failed for base flow')
-          
-          !hkb (4Mar2016)
-          !create LSM interface objects to store evapotranspiration and 
-          !potential evaporation only if source is readin
-          if ( HYMAP2_routing_struc(n)%evapflag .ne. 0 ) then
-           !if ( HYMAP2_routing_struc(n)%evapsrc .eq. "readin" ) then
-            evapotranspiration_field =ESMF_FieldCreate(arrayspec=realarrspec,&
-                   grid=global_grid, name="Total Evapotranspiration",rc=status)
-            call LIS_verify(status, 'ESMF_FieldCreate failed')
-          
-            !potential_evaporation_field =ESMF_FieldCreate(arrayspec=realarrspec,&
-            !       grid=global_grid, name="Potential Evaporation",rc=status)
-            !call LIS_verify(status, 'ESMF_FieldCreate failed')
-          
-            call ESMF_FieldGet(evapotranspiration_field,localDE=0,farrayPtr=evapotranspiration,&
-               rc=status)
-            call LIS_verify(status)
-            evapotranspiration = 0.0 
-
-            !call ESMF_FieldGet(potential_evaporation_field,localDE=0, &
-            !     farrayPtr=potevap,rc=status)
-            !call LIS_verify(status)
-            !potevap = 0.0 
-
-            call ESMF_stateAdd(LIS_runoff_state(n),(/evapotranspiration_field/),rc=status)
-            call LIS_verify(status, 'ESMF_StateAdd failed for Total Evapotranspiration')
-
-            !call ESMF_stateAdd(LIS_runoff_state(n),(/potential_evaporation_field/),rc=status)
-            !call LIS_verify(status, 'ESMF_StateAdd failed for potential evaporation')
-           !endif
           endif
-
-          HYMAP2_routing_struc(n)%mo = -1
        enddo
+    enddo
 
-    else
-       do n=1, LIS_rc%nnest
-          allocate(HYMAP2_routing_struc(n)%seqx(1))
-          allocate(HYMAP2_routing_struc(n)%seqy(1))
-          allocate(HYMAP2_routing_struc(n)%sindex(1,1))
-          allocate(HYMAP2_routing_struc(n)%outlet(1))
-          allocate(HYMAP2_routing_struc(n)%next(1))
-          allocate(HYMAP2_routing_struc(n)%elevtn(1))
-          allocate(HYMAP2_routing_struc(n)%nxtdst(1))
-          allocate(HYMAP2_routing_struc(n)%grarea(1))
-          allocate(HYMAP2_routing_struc(n)%fldgrd(1,&
-		           HYMAP2_routing_struc(n)%nz))
-          allocate(HYMAP2_routing_struc(n)%fldman(1))
-          allocate(HYMAP2_routing_struc(n)%fldhgt(1,&
-		           HYMAP2_routing_struc(n)%nz))
-          allocate(HYMAP2_routing_struc(n)%cntime(1))
-          allocate(HYMAP2_routing_struc(n)%trnoff(1))
-          allocate(HYMAP2_routing_struc(n)%tbsflw(1))
-          allocate(HYMAP2_routing_struc(n)%rnfsto(1,1))
-          allocate(HYMAP2_routing_struc(n)%bsfsto(1,1))
-          allocate(HYMAP2_routing_struc(n)%fldstomax(1,&
-		           HYMAP2_routing_struc(n)%nz))
-          allocate(HYMAP2_routing_struc(n)%rivman(1))
-          allocate(HYMAP2_routing_struc(n)%rivelv(1))
-          allocate(HYMAP2_routing_struc(n)%rivstomax(1))
-          allocate(HYMAP2_routing_struc(n)%rivlen(1))
-          allocate(HYMAP2_routing_struc(n)%rivwth(1))
-          allocate(HYMAP2_routing_struc(n)%rivhgt(1))
-          allocate(HYMAP2_routing_struc(n)%rivare(1))
-          allocate(HYMAP2_routing_struc(n)%runoff0(1))
-          allocate(HYMAP2_routing_struc(n)%basflw0(1))
-          allocate(HYMAP2_routing_struc(n)%rivsto(1,1))
-          allocate(HYMAP2_routing_struc(n)%rivdph(1,1))
-          allocate(HYMAP2_routing_struc(n)%rivvel(1,1))
-          allocate(HYMAP2_routing_struc(n)%rivout(1,1))
-          allocate(HYMAP2_routing_struc(n)%evpout(1,1))
-          allocate(HYMAP2_routing_struc(n)%fldout(1,1))
-          allocate(HYMAP2_routing_struc(n)%fldsto(1,1))
-          allocate(HYMAP2_routing_struc(n)%flddph(1,1))
-          allocate(HYMAP2_routing_struc(n)%fldvel(1,1))
-          allocate(HYMAP2_routing_struc(n)%fldfrc(1,1))
-          allocate(HYMAP2_routing_struc(n)%fldare(1,1))
-          allocate(HYMAP2_routing_struc(n)%sfcelv(1,1))
-          !ag (19Jan2016)
-          allocate(HYMAP2_routing_struc(n)%rivout_pre(1,1))
-          allocate(HYMAP2_routing_struc(n)%rivdph_pre(1,1))
-          allocate(HYMAP2_routing_struc(n)%fldout_pre(1,1))
-          allocate(HYMAP2_routing_struc(n)%flddph_pre(1,1))
-          allocate(HYMAP2_routing_struc(n)%fldelv1(1,1))
 
-          !ag (03May2017)
-          allocate(HYMAP2_routing_struc(n)%ewat(1,1))
-          allocate(HYMAP2_routing_struc(n)%edif(1,1))
+    write(LIS_logunit,*) '[INFO] Processing data before running HYMAP'
+    do n=1, LIS_rc%nnest
+       write(LIS_logunit,*)'[INFO] Calculate maximum river storage'
+       HYMAP2_routing_struc(n)%rivstomax = HYMAP2_routing_struc(n)%rivlen* &
+            HYMAP2_routing_struc(n)%rivwth * HYMAP2_routing_struc(n)%rivhgt
+       write(LIS_logunit,*)'[INFO] Calculate river bed elevation'
+       HYMAP2_routing_struc(n)%rivelv = HYMAP2_routing_struc(n)%elevtn -&
+            HYMAP2_routing_struc(n)%rivhgt
+       write(LIS_logunit,*)'[INFO] Calculate river surface area'
+       where(HYMAP2_routing_struc(n)%rivwth>0)HYMAP2_routing_struc(n)%rivare =&
+            min(HYMAP2_routing_struc(n)%grarea, HYMAP2_routing_struc(n)%rivlen *&
+            HYMAP2_routing_struc(n)%rivwth)
+       write(LIS_logunit,*)'[INFO] Setting floodplain staging'
+       call HYMAP2_set_fldstg(HYMAP2_routing_struc(n)%nz,&
+            HYMAP2_routing_struc(n)%nseqall,&
+            HYMAP2_routing_struc(n)%fldhgt,&
+            HYMAP2_routing_struc(n)%grarea,&
+            HYMAP2_routing_struc(n)%rivlen,&
+            HYMAP2_routing_struc(n)%rivwth,&
+            HYMAP2_routing_struc(n)%rivstomax,&
+            HYMAP2_routing_struc(n)%fldstomax,&
+            HYMAP2_routing_struc(n)%fldgrd,&
+            HYMAP2_routing_struc(n)%rivare)		   
+       !Start storages
+       HYMAP2_routing_struc(n)%rivsto=0.0
+       HYMAP2_routing_struc(n)%fldsto=0.0
+       HYMAP2_routing_struc(n)%rnfsto=0.0
+       HYMAP2_routing_struc(n)%bsfsto=0.0
+    enddo
 
-       enddo
+    !ag (4Feb2016) - read reservoir operation data
+    do n=1, LIS_rc%nnest
+!TBD: SVK - block below needs update for parallelism
+       if(HYMAP2_routing_struc(n)%resopflag==1)then
+          call HYMAP2_get_data_resop_alt(HYMAP2_routing_struc(n)%resopdir,&
+               HYMAP2_routing_struc(n)%resopheader,&
+               LIS_rc%gnc(n),LIS_rc%gnr(n),HYMAP2_routing_struc(n)%sindex,&
+               HYMAP2_routing_struc(n)%nresop,HYMAP2_routing_struc(n)%ntresop,&
+               HYMAP2_routing_struc(n)%resopaltloc,&
+               HYMAP2_routing_struc(n)%resopoutmin,&
+               HYMAP2_routing_struc(n)%tresopalt,&
+               HYMAP2_routing_struc(n)%resopalt)
+          where(HYMAP2_routing_struc(n)%resopoutmin==real(HYMAP2_routing_struc(n)%imis).or.HYMAP2_routing_struc(n)%resopoutmin<0.)&
+               HYMAP2_routing_struc(n)%resopoutmin=0.
+       endif
+    enddo
+
+    call ESMF_ConfigFindLabel(LIS_config,&
+         "HYMAP2 routing model start mode:",rc=status)
+    do n=1, LIS_rc%nnest
+       call ESMF_ConfigGetAttribute(LIS_config,&
+            HYMAP2_routing_struc(n)%startmode,rc=status)
+       call LIS_verify(status,&
+            "HYMAP2 routing model start mode: not defined")
+    enddo
+
+    call ESMF_ConfigFindLabel(LIS_config,&
+         "HYMAP2 routing model restart interval:",rc=status)
+    do n=1, LIS_rc%nnest
+       call ESMF_ConfigGetAttribute(LIS_config,time,rc=status)
+       call LIS_verify(status,&
+            "HYMAP2 routing model restart interval: not defined")
+       call LIS_parseTimeString(time,HYMAP2_routing_struc(n)%rstInterval)
+    enddo
+
+    call ESMF_ConfigFindLabel(LIS_config,&
+         "HYMAP2 routing model restart file:",rc=status)
+    do n=1, LIS_rc%nnest
+       call ESMF_ConfigGetAttribute(LIS_config,&
+            HYMAP2_routing_struc(n)%rstfile,rc=status)
+       call LIS_verify(status,&
+            "HYMAP2 routing model restart file: not defined")
+    enddo
+
+    if(LIS_rc%lsm.eq."none") then 
+       call initrunoffdata(trim(LIS_rc%runoffdatasource)//char(0))
     endif
 
+    do n=1, LIS_rc%nnest
+       call ESMF_ArraySpecSet(realarrspec,rank=1,typekind=ESMF_TYPEKIND_R4,&
+            rc=status)
+       call LIS_verify(status)
+
+!       global_grid_dg = ESMF_DistGridCreate(minIndex=(/1/),&
+!            maxIndex=(/LIS_rc%glbntiles(n)/),&
+!            regDecomp=(/1/),rc=status)
+!       call LIS_verify(status,&
+!            'ESMF_DistGridCreate failed in HYMAP2_routingInit')
+
+!       global_grid = ESMF_GridCreate(name="Global Grid",&
+!            coordTypeKind=ESMF_TYPEKIND_R4,&
+!            distgrid = global_grid_dg, &
+!            gridEdgeLWidth=(/0/), gridEdgeUWidth=(/0/),rc=status)
+!       call LIS_verify(status,&
+!            'ESMF_GridCreate failed in HYMAP2_routingInit')
+
+       !create LSM interface objects to store runoff and baseflow
+       sf_runoff_field =ESMF_FieldCreate(arrayspec=realarrspec,&
+            grid=LIS_vecTile(n), name="Surface Runoff",rc=status)
+       call LIS_verify(status, 'ESMF_FieldCreate failed')
+
+       baseflow_field =ESMF_FieldCreate(arrayspec=realarrspec,&
+            grid=LIS_vecTile(n), name="Subsurface Runoff",rc=status)
+       call LIS_verify(status, 'ESMF_FieldCreate failed')
+
+       call ESMF_FieldGet(sf_runoff_field,localDE=0,farrayPtr=sfrunoff,&
+            rc=status)
+       call LIS_verify(status)
+       sfrunoff = 0.0 
+
+       call ESMF_FieldGet(baseflow_field,localDE=0,farrayPtr=baseflow,&
+            rc=status)
+       call LIS_verify(status)
+       baseflow = 0.0
+
+       call ESMF_stateAdd(LIS_runoff_state(n),(/sf_runoff_field/),rc=status)
+       call LIS_verify(status, 'ESMF_StateAdd failed for surface runoff')
+
+       call ESMF_stateAdd(LIS_runoff_state(n),(/baseflow_field/),rc=status)
+       call LIS_verify(status, 'ESMF_StateAdd failed for base flow')
+
+       !hkb (4Mar2016)
+       !create LSM interface objects to store evapotranspiration and 
+       !potential evaporation only if source is readin
+       if ( HYMAP2_routing_struc(n)%evapflag .ne. 0 ) then
+          !if ( HYMAP2_routing_struc(n)%evapsrc .eq. "readin" ) then
+          evapotranspiration_field =ESMF_FieldCreate(arrayspec=realarrspec,&
+               grid=LIS_vecTile(n), name="Total Evapotranspiration",rc=status)
+          call LIS_verify(status, 'ESMF_FieldCreate failed')
+
+          !potential_evaporation_field =ESMF_FieldCreate(arrayspec=realarrspec,&
+          !       grid=global_grid, name="Potential Evaporation",rc=status)
+          !call LIS_verify(status, 'ESMF_FieldCreate failed')
+
+          call ESMF_FieldGet(evapotranspiration_field,localDE=0,&
+               farrayPtr=evapotranspiration,&
+               rc=status)
+          call LIS_verify(status)
+          evapotranspiration = 0.0 
+
+          !call ESMF_FieldGet(potential_evaporation_field,localDE=0, &
+          !     farrayPtr=potevap,rc=status)
+          !call LIS_verify(status)
+          !potevap = 0.0 
+
+          call ESMF_stateAdd(LIS_runoff_state(n),(/evapotranspiration_field/),rc=status)
+          call LIS_verify(status, 'ESMF_StateAdd failed for Total Evapotranspiration')
+
+          !call ESMF_stateAdd(LIS_runoff_state(n),(/potential_evaporation_field/),rc=status)
+          !call LIS_verify(status, 'ESMF_StateAdd failed for potential evaporation')
+          !endif
+       endif
+
+       HYMAP2_routing_struc(n)%mo = -1
+
+    enddo 
     do n=1,LIS_rc%nnest
        call ESMF_AttributeSet(LIS_runoff_state(n),"Routing model evaporation option",&
             HYMAP2_routing_struc(n)%evapflag, rc=status)
@@ -1082,6 +1233,21 @@ contains
        call LIS_registerAlarm("HYMAP2 router restart alarm",&
             HYMAP2_routing_struc(n)%dt,HYMAP2_routing_struc(n)%rstInterval)          
     enddo
+
+#if 0 
+!test
+    do n=1,LIS_rc%nnest
+       do ic=1,HYMAP2_routing_struc(n)%nseqall 
+          if(HYMAP2_routing_struc(n)%outlet(ic)==HYMAP2_routing_struc(n)%imis)cycle
+          
+          if(HYMAP2_routing_struc(n)%outlet(ic)==0)then
+             ic_down=HYMAP2_routing_struc(n)%next(ic)
+!             print*, LIS_localPet, ic, ic_down
+          endif
+       enddo
+    enddo
+#endif
+
   end subroutine HYMAP2_routingInit
   !=============================================
   !=============================================
@@ -1098,12 +1264,14 @@ contains
     character(*), intent(in)    :: ctitle
     integer,      intent(in)    :: z
     integer,      intent(in)    :: n 
-    real*4,       intent(inout) :: array(LIS_rc%gnc(n),LIS_rc%gnr(n),z)
+    real*4,       intent(inout) :: array(LIS_rc%lnc(n),LIS_rc%lnr(n),z)
     integer                     :: ftn 
     logical                     :: file_exists
     integer                     :: status
+    integer                     :: l
     integer                     :: varid
     character*100               :: cfile
+    real*4                      :: array1(LIS_rc%gnc(n),LIS_rc%gnr(n),z)
 
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
 
@@ -1118,18 +1286,83 @@ contains
             'nf90_inq_varid failed for '//trim(ctitle)//&
             ' in read_param_real@HYMAP2_routingMod')
        
-       call LIS_verify(nf90_get_var(ftn,varid, array), &
+       call LIS_verify(nf90_get_var(ftn,varid, array1), &
             'nf90_get_var failed for '//trim(ctitle)//&
             ' in read_param_real@HYMAP2_routingMod')
        
+       call LIS_verify(nf90_close(ftn),&
+            'nf90_close failed in HYMAP2_routindMod')
+       
+       do l=1,z
+          array(:,:,l) = nint(array1(&
+               LIS_ews_halo_ind(n,LIS_localPet+1):&         
+               LIS_ewe_halo_ind(n,LIS_localPet+1), &
+               LIS_nss_halo_ind(n,LIS_localPet+1): &
+               LIS_nse_halo_ind(n,LIS_localPet+1),l))
+       enddo
     else
-       write(LIS_logunit,*) 'parameter input file '//trim(LIS_rc%paramfile(n))
-       write(LIS_logunit,*) 'failed in read_param_real@HYMAP2_routingMod'
+       write(LIS_logunit,*) '[ERR] parameter input file '//trim(LIS_rc%paramfile(n))
+       write(LIS_logunit,*) '[ERR] failed in read_param_real@HYMAP2_routingMod'
        call LIS_endrun()
     endif
     
 #endif
   end subroutine HYMAP2_read_param_real
+
+  !=============================================
+  subroutine HYMAP2_read_param_real_2d(ctitle,n,array)
+    
+    !USES: 
+    use LIS_coreMod
+    use LIS_logMod
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+    use netcdf
+#endif
+    
+    implicit none	  
+    character(*), intent(in)    :: ctitle
+    integer,      intent(in)    :: n 
+    real*4,       intent(inout) :: array(LIS_rc%lnc(n),LIS_rc%lnr(n))
+    integer                     :: ftn 
+    logical                     :: file_exists
+    integer                     :: status
+    integer                     :: varid
+    character*100               :: cfile
+    real*4                      :: array1(LIS_rc%gnc(n),LIS_rc%gnr(n))
+
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+
+    inquire(file=LIS_rc%paramfile(n),exist=file_exists)
+    
+    if(file_exists) then 
+
+       call LIS_verify(nf90_open(path=LIS_rc%paramfile(n),&
+            mode=NF90_NOWRITE, ncid = ftn), &
+            'nf90_open failed in read_param_real@HYMAP2_routingMod')
+       call LIS_verify(nf90_inq_varid(ftn,trim(ctitle),varid), &
+            'nf90_inq_varid failed for '//trim(ctitle)//&
+            ' in read_param_real@HYMAP2_routingMod')
+       
+       call LIS_verify(nf90_get_var(ftn,varid, array1), &
+            'nf90_get_var failed for '//trim(ctitle)//&
+            ' in read_param_real@HYMAP2_routingMod')
+       
+       call LIS_verify(nf90_close(ftn),&
+            'nf90_close failed in HYMAP2_routindMod')
+       
+       array(:,:) = array1(&
+            LIS_ews_halo_ind(n,LIS_localPet+1):&         
+            LIS_ewe_halo_ind(n,LIS_localPet+1), &
+            LIS_nss_halo_ind(n,LIS_localPet+1): &
+            LIS_nse_halo_ind(n,LIS_localPet+1))
+    else
+       write(LIS_logunit,*) '[ERR] parameter input file '//trim(LIS_rc%paramfile(n))
+       write(LIS_logunit,*) '[ERR] failed in read_param_real@HYMAP2_routingMod'
+       call LIS_endrun()
+    endif
+    
+#endif
+  end subroutine HYMAP2_read_param_real_2d
 
   subroutine HYMAP2_read_param_int(ctitle,z,n,array)
     
@@ -1144,7 +1377,7 @@ contains
     character(*), intent(in)    :: ctitle
     integer,      intent(in)    :: z
     integer,      intent(in)    :: n 
-    integer,      intent(inout) :: array(LIS_rc%gnc(n),LIS_rc%gnr(n),z)
+    integer,      intent(inout) :: array(LIS_rc%lnc(n),LIS_rc%lnr(n),z)
     integer                     :: ftn 
     logical                     :: file_exists
     integer                     :: status
@@ -1169,25 +1402,133 @@ contains
        call LIS_verify(nf90_get_var(ftn,varid, array1), &
             'nf90_get_var failed for '//trim(ctitle)//&
             ' in read_param_int@HYMAP2_routingMod')
+
+       call LIS_verify(nf90_close(ftn),&
+            'nf90_close failed in HYMAP2_routindMod')
+
        do l=1,z
-          do r=1,LIS_rc%gnr(n)
-             do c=1,LIS_rc%gnc(n)
-                array(c,r,l) = nint(array1(c,r,l))
-             enddo
-          enddo
+          array(:,:,l) = nint(array1(&
+               LIS_ews_halo_ind(n,LIS_localPet+1):&         
+               LIS_ewe_halo_ind(n,LIS_localPet+1), &
+               LIS_nss_halo_ind(n,LIS_localPet+1): &
+               LIS_nse_halo_ind(n,LIS_localPet+1),l))
        enddo
     else
-       write(LIS_logunit,*) 'parameter input file '//trim(LIS_rc%paramfile(n))
-       write(LIS_logunit,*) 'failed in read_param_int@HYMAP2_routingMod'
+       write(LIS_logunit,*) '[ERR] parameter input file '//trim(LIS_rc%paramfile(n))
+       write(LIS_logunit,*) '[ERR] failed in read_param_int@HYMAP2_routingMod'
        call LIS_endrun()
     endif
     
 #endif
   end subroutine HYMAP2_read_param_int
+
+  subroutine HYMAP2_read_param_int_2d(ctitle,n,array)
+    
+    !USES: 
+    use LIS_coreMod
+    use LIS_logMod
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+    use netcdf
+#endif
+    
+    implicit none	  
+    character(*), intent(in)    :: ctitle
+    integer,      intent(in)    :: n 
+    integer,      intent(inout) :: array(LIS_rc%lnc(n),LIS_rc%lnr(n))
+    integer                     :: ftn 
+    logical                     :: file_exists
+    integer                     :: status
+    integer                     :: c,r
+    character*100               :: cfile
+    integer                     :: varid
+    real                        :: array1(LIS_rc%gnc(n),LIS_rc%gnr(n))
+
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+
+    inquire(file=LIS_rc%paramfile(n),exist=file_exists)
+    
+    if(file_exists) then 
+
+       call LIS_verify(nf90_open(path=LIS_rc%paramfile(n),&
+            mode=NF90_NOWRITE, ncid = ftn), &
+            'nf90_open failed in read_param_int@HYMAP2_routingMod')
+       call LIS_verify(nf90_inq_varid(ftn,trim(ctitle),varid), &
+            'nf90_inq_varid failed for '//trim(ctitle)//&
+            ' in read_param_int@HYMAP2_routingMod')
+       
+       call LIS_verify(nf90_get_var(ftn,varid, array1), &
+            'nf90_get_var failed for '//trim(ctitle)//&
+            ' in read_param_int@HYMAP2_routingMod')
+
+       call LIS_verify(nf90_close(ftn),&
+            'nf90_close failed in HYMAP2_routindMod')
+
+       array(:,:) = nint(array1(&
+            LIS_ews_halo_ind(n,LIS_localPet+1):&         
+            LIS_ewe_halo_ind(n,LIS_localPet+1), &
+            LIS_nss_halo_ind(n,LIS_localPet+1): &
+            LIS_nse_halo_ind(n,LIS_localPet+1)))
+    else
+       write(LIS_logunit,*) '[ERR] parameter input file '//trim(LIS_rc%paramfile(n))
+       write(LIS_logunit,*) '[ERR] failed in read_param_int@HYMAP2_routingMod'
+       call LIS_endrun()
+    endif
+    
+#endif
+  end subroutine HYMAP2_read_param_int_2d
+
+  subroutine HYMAP2_read_param_int_2d_global(ctitle,n,array)
+    
+    !USES: 
+    use LIS_coreMod
+    use LIS_logMod
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+    use netcdf
+#endif
+    
+    implicit none	  
+    character(*), intent(in)    :: ctitle
+    integer,      intent(in)    :: n 
+    integer,      intent(inout) :: array(LIS_rc%gnc(n),LIS_rc%gnr(n))
+    integer                     :: ftn 
+    logical                     :: file_exists
+    integer                     :: status
+    integer                     :: c,r
+    character*100               :: cfile
+    integer                     :: varid
+
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+
+    inquire(file=LIS_rc%paramfile(n),exist=file_exists)
+    
+    if(file_exists) then 
+
+       call LIS_verify(nf90_open(path=LIS_rc%paramfile(n),&
+            mode=NF90_NOWRITE, ncid = ftn), &
+            'nf90_open failed in read_param_int@HYMAP2_routingMod')
+       call LIS_verify(nf90_inq_varid(ftn,trim(ctitle),varid), &
+            'nf90_inq_varid failed for '//trim(ctitle)//&
+            ' in read_param_int@HYMAP2_routingMod')
+       
+       call LIS_verify(nf90_get_var(ftn,varid, array), &
+            'nf90_get_var failed for '//trim(ctitle)//&
+            ' in read_param_int@HYMAP2_routingMod')
+
+       call LIS_verify(nf90_close(ftn),&
+            'nf90_close failed in HYMAP2_routindMod')
+
+    else
+       write(LIS_logunit,*) '[ERR] parameter input file '//trim(LIS_rc%paramfile(n))
+       write(LIS_logunit,*) '[ERR] failed in read_param_int@HYMAP2_routingMod'
+       call LIS_endrun()
+    endif
+    
+#endif
+  end subroutine HYMAP2_read_param_int_2d_global
   
   !=============================================
   !=============================================
-  subroutine HYMAP2_get_data_resop_alt(resopdir,resopheader,nx,ny,sindex,nresop,ntresop,resoploc,tresop,resop)
+  subroutine HYMAP2_get_data_resop_alt(resopdir,resopheader,nx,ny,sindex,nresop,ntresop,resoploc,resopoutmin,tresop,resop)
   
     implicit none
     character(*), intent(in)  :: resopdir,resopheader
@@ -1196,13 +1537,13 @@ contains
     integer,      intent(in)  :: nresop,ntresop
     integer,      intent(out) :: resoploc(nresop)
     real*8,       intent(out) :: tresop(nresop,ntresop)
-    real,         intent(out) :: resop(nresop,ntresop)
+    real,         intent(out) :: resop(nresop,ntresop),resopoutmin(nresop)
     integer                   :: res
     integer                   :: xresop(nresop),yresop(nresop)
     character(50)            :: resopname(nresop)
     character(500)            :: yfile
     
-    call HYMAP2_read_header(trim(resopheader),nresop,resopname,xresop,yresop)
+    call HYMAP2_read_header_resop(trim(resopheader),nresop,resopname,xresop,yresop,resopoutmin)
     do res=1,nresop
       resoploc(res)=sindex(xresop(res),yresop(res))
     enddo
@@ -1211,6 +1552,46 @@ contains
       call HYMAP2_read_resop_alt(ntresop,trim(yfile),tresop(res,:),resop(res,:))
     enddo
   end subroutine HYMAP2_get_data_resop_alt
+  !=============================================
+  !=============================================  
+  subroutine HYMAP2_read_header_resop(yheader,inst,yqname,ix,iy,outmin)
+
+    use LIS_logMod
+    implicit none
+
+    character(*), intent(in)    :: yheader
+    integer,      intent(in)    :: inst
+    character(*), intent(inout) :: yqname(inst)
+    integer,      intent(inout) :: ix(inst),iy(inst)
+    real,         intent(inout) :: outmin(inst)   
+    logical                     :: file_exists
+    integer                     :: ist
+
+    inquire(file=yheader,exist=file_exists)
+    
+    if(file_exists) then 
+      !get name of station files
+      write(LIS_logunit,*)'[read_header] get stations info: name and coordinates'
+      write(LIS_logunit,*)'[read_header] ',yheader,inst
+      open(2,file=trim(yheader), status='old')
+      !print*,inst
+      do ist=1,inst
+        read(2,*,end=10)yqname(ist),ix(ist),iy(ist),outmin(ist)
+        write(LIS_logunit,'(a,i5,a,2i5,f10.2)')'[read_header] ',ist,trim(yqname(ist)),ix(ist),iy(ist),outmin(ist)
+      enddo
+      close(2)
+    else
+      write(LIS_logunit,*) 'header file '//trim(yheader)
+      write(LIS_logunit,*) 'failed in read_header@HYMAP2_routingMod'
+      call LIS_endrun()
+    endif
+    return
+10  continue
+    write(LIS_logunit,*) 'header file '//trim(yheader)
+    write(LIS_logunit,*) 'failed in read_header@HYMAP2_routingMod'
+    call LIS_endrun()
+
+  end subroutine HYMAP2_read_header_resop
   !=============================================
   !=============================================  
   subroutine HYMAP2_read_header(yheader,inst,yqname,ix,iy)

--- a/lis/routing/HYMAP2_router/HYMAP2_routing_output.F90
+++ b/lis/routing/HYMAP2_router/HYMAP2_routing_output.F90
@@ -18,6 +18,7 @@ subroutine HYMAP2_routing_output(n)
   use LIS_fileIOMod
   use HYMAP2_routingMod
 
+  use LIS_mpiMod
   implicit none
   
   integer, intent(in)   :: n 
@@ -30,6 +31,7 @@ subroutine HYMAP2_routing_output(n)
   integer               :: mo, da
   logical               :: open_stats
   logical               :: alarmCheck
+  integer               :: status
 
   alarmCheck = .false. 
   if ( LIS_rc%time >= LIS_histData(n)%time ) then
@@ -89,12 +91,10 @@ subroutine HYMAP2_routing_output(n)
 !-----------------------------------------------------------------------
            ! Grib expects soil layers to be in cm.
            ! lyrthk = (/100.0,300.0,600.0,1000.0/) mm.
-
            call LIS_writeModelOutput(n,filename, name, open_stats,  &
                 outInterval=HYMAP2_routing_struc(n)%outInterval,     &
                 nsoillayers = 1,lyrthk = (/1.0/), nsoillayers2 = 1, &
                 group=2)
-                         
         endif
      endif
   endif

--- a/lis/routing/HYMAP2_router/HYMAP2_routing_readrst.F90
+++ b/lis/routing/HYMAP2_router/HYMAP2_routing_readrst.F90
@@ -5,16 +5,36 @@
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
 
+!BOP
+! !ROUTINE: HYMAP2_routing_readrst
+! \label{HYMAP2_routing_readrst} 
+!
+! !REVISION HISTORY:
+! 15 Nov 2011: Augusto Getirana;  Initial implementation
+! 19 Jan 2016: Augusto Getirana;  Inclusion of four Local Inertia variables
+! 10 Mar 2019: Sujay Kumar;       Added support for NetCDF and parallel 
+!                                 processing. 
+!  
+! !INTERFACE: 
 subroutine HYMAP2_routing_readrst
-
-  ! Augusto Getirana - 11/15/2011
+! !USES: 
   use ESMF
   use LIS_fileIOMod
   use LIS_coreMod
   use LIS_logMod
   use LIS_timeMgrMod
   use HYMAP2_routingMod, only : HYMAP2_routing_struc
+
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+  use netcdf
+#endif
+! 
+! !DESCRIPTION: 
+!  This routine reads NetCDF formatted HYMAP2 restart files. 
+! 
+!EOP
 
   implicit none
 
@@ -28,70 +48,144 @@ subroutine HYMAP2_routing_readrst
   real*8            :: time
   real              :: gmt
 
-  if(LIS_masterproc) then   
-     do n=1, LIS_rc%nnest
-
-        read_restart = .false. 
-
-        if(HYMAP2_routing_struc(n)%startmode.eq."restart") then !cold start
+  do n=1, LIS_rc%nnest
+     
+     read_restart = .false. 
+     
+     if(HYMAP2_routing_struc(n)%startmode.eq."restart") then !cold start
+        read_restart = .true. 
+     endif
+     
+     if(LIS_rc%runmode.eq."ensemble smoother") then 
+        if(LIS_rc%iterationId(n).gt.1) then 
            read_restart = .true. 
-        endif
-
-        if(LIS_rc%runmode.eq."ensemble smoother") then 
-           if(LIS_rc%iterationId(n).gt.1) then 
-              read_restart = .true. 
-              
-              if(HYMAP2_routing_struc(n)%rstInterval.eq.2592000) then 
-                 !create the restart filename based on the timewindow start time
-                 call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
-                      dd=da,calendar=LIS_calendar,rc=status)
-                 hr = 0 
-                 mn = 0 
-                 ss = 0 
-                 call LIS_tick(time,doy,gmt,yr,mo,da,hr,mn,ss,&
-                      (-1)*(HYMAP2_routing_struc(n)%dt))
-              else
-                 call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
-                      dd=da,calendar=LIS_calendar,rc=status)
-                 hr = 0 
-                 mn = 0 
-                 ss = 0 
-              endif
-              
-              call LIS_create_restart_filename(n,filename,&
-                   'ROUTING','HYMAP2_router',&
-                   yr, mo, da, hr, mn, ss, & 
-                   wformat="binary")
-              
-              HYMAP2_routing_struc(n)%rstfile = filename
+           
+           if(HYMAP2_routing_struc(n)%rstInterval.eq.2592000) then 
+              !create the restart filename based on the timewindow start time
+              call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
+                   dd=da,calendar=LIS_calendar,rc=status)
+              hr = 0 
+              mn = 0 
+              ss = 0 
+              call LIS_tick(time,doy,gmt,yr,mo,da,hr,mn,ss,&
+                   (-1)*(HYMAP2_routing_struc(n)%dt))
+           else
+              call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
+                   dd=da,calendar=LIS_calendar,rc=status)
+              hr = 0 
+              mn = 0 
+              ss = 0 
            endif
+           
+           call LIS_create_restart_filename(n,filename,&
+                'ROUTING','HYMAP2_router',&
+                yr, mo, da, hr, mn, ss, & 
+                wformat="netcdf")
+           
+           HYMAP2_routing_struc(n)%rstfile = filename
         endif
+     endif
+     
+     if(read_restart) then 
+        write(LIS_logunit,*) 'HYMAP2 restart file used: ', &
+             trim(HYMAP2_routing_struc(n)%rstfile)
 
-        if(read_restart) then 
-           write(LIS_logunit,*) 'HYMAP2 restart file used: ', &
-                                 trim(HYMAP2_routing_struc(n)%rstfile)
-           ftn = LIS_getNextUnitNumber()
-           open(ftn,file=trim(HYMAP2_routing_struc(n)%rstfile),&
-                status='old',form='unformatted',&
-                iostat = ios)
-           if(ios.ne.0) then 
-              write(LIS_logunit,*) 'File '//trim(HYMAP2_routing_struc(n)%rstfile)//& 
-                   'does not exist '
-              call LIS_endrun()
-           endif
-           read(ftn) HYMAP2_routing_struc(n)%rivsto
-           read(ftn) HYMAP2_routing_struc(n)%fldsto
-           read(ftn) HYMAP2_routing_struc(n)%rnfsto
-           read(ftn) HYMAP2_routing_struc(n)%bsfsto
-           if(HYMAP2_routing_struc(n)%flowtype==3)then
-             read(ftn) HYMAP2_routing_struc(n)%rivout_pre
-             read(ftn) HYMAP2_routing_struc(n)%rivdph_pre
-             read(ftn) HYMAP2_routing_struc(n)%fldout_pre
-             read(ftn) HYMAP2_routing_struc(n)%flddph_pre
-           endif
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+        status = nf90_open(path=HYMAP2_routing_struc(n)%rstfile, &
+             mode=NF90_NOWRITE, ncid=ftn)
+        call LIS_verify(status, "Error opening file "//&
+             trim(HYMAP2_routing_struc(n)%rstfile))
+#endif
+        call HYMAP2_readvar_restart(ftn,n,&
+             HYMAP2_routing_struc(n)%rivsto,&
+             "RIVSTO")
+        call HYMAP2_readvar_restart(ftn,n,&
+             HYMAP2_routing_struc(n)%fldsto,&
+             "FLDSTO")
+        call HYMAP2_readvar_restart(ftn,n,&
+             HYMAP2_routing_struc(n)%rnfsto,&
+             "RNFSTO")
+        call HYMAP2_readvar_restart(ftn,n,&
+             HYMAP2_routing_struc(n)%bsfsto,&
+             "BSFSTO")
 
-           call LIS_releaseUnitNumber(ftn)     
+        if(HYMAP2_routing_struc(n)%flowtype==3)then
+           call HYMAP2_readvar_restart(ftn,n,&
+                HYMAP2_routing_struc(n)%rivout_pre,&
+                "RIVOUT_PRE")
+           call HYMAP2_readvar_restart(ftn,n,&
+                HYMAP2_routing_struc(n)%rivdph_pre,&
+                "RIVDPH_PRE")
+           call HYMAP2_readvar_restart(ftn,n,&
+                HYMAP2_routing_struc(n)%fldout_pre,&
+                "FLDOUT_PRE")
+           call HYMAP2_readvar_restart(ftn,n,&
+                HYMAP2_routing_struc(n)%flddph_pre,&
+                "FLDDPH_PRE")
         endif
-     enddo
-  end if
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+        status = nf90_close(ftn)
+        call LIS_verify(status, "Error in nf90_close in HYMAP2_routing_readrst")
+#endif
+     endif
+  enddo
+
 end subroutine HYMAP2_routing_readrst
+
+!BOP
+! !ROUTINE: HYMAP2_readvar_restart
+! \label{HYMAP2_readvar_restart}
+! 
+! !INTERFACE:
+  subroutine HYMAP2_readvar_restart(ftn, n, var, varname)
+! !USES:
+    use LIS_coreMod
+    use LIS_logMod
+    use HYMAP2_routingMod
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+  use netcdf
+#endif
+
+    implicit none
+! !ARGUMENTS: 
+    integer, intent(in)   :: ftn
+    integer, intent(in)   :: n
+    real, intent(inout)   :: var(HYMAP2_routing_struc(n)%nseqall)
+    character(len=*)      :: varname
+    
+! !DESCRIPTION:
+!  Reads a real variable from a NetCDF restart file. 
+!
+!  The arguments are: 
+!  \begin{description}
+!   \item [n]
+!     index of the domain or nest.
+!   \item [ftn]
+!     unit number of the binary output file
+!   \item [var]
+!     variables being written, dimensioned in the tile space
+!  \end{description}
+!EOP
+    real, allocatable :: gtmp(:)
+    integer           :: varid
+    integer           :: i,ix,iy,ix1,iy1
+    integer           :: status
+
+    allocate(gtmp(HYMAP2_routing_struc(n)%nseqall_glb))
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+    status = nf90_inq_varid(ftn,trim(varname),varid)
+    call LIS_verify(status,'Error in nf90_inq_varid in HYMAP2_readvar_restart')
+    status = nf90_get_var(ftn,varid,gtmp)
+    call LIS_verify(status,'Error in nf90_get_var in HYMAP2_readvar_restart')
+#endif       
+
+    do i=1,HYMAP2_routing_struc(n)%nseqall
+       ix = HYMAP2_routing_struc(n)%seqx(i)
+       iy = HYMAP2_routing_struc(n)%seqy(i)
+       ix1 = ix + LIS_ews_halo_ind(n,LIS_localPet+1) -1
+       iy1 = iy + LIS_nss_halo_ind(n,LIS_localPet+1) -1
+       var(i)  = gtmp(HYMAP2_routing_struc(n)%sindex(ix1,iy1))
+    enddo
+     
+    deallocate(gtmp)   
+  end subroutine HYMAP2_readvar_restart

--- a/lis/routing/HYMAP2_router/HYMAP2_routing_run.F90
+++ b/lis/routing/HYMAP2_router/HYMAP2_routing_run.F90
@@ -43,10 +43,10 @@ subroutine HYMAP2_routing_run(n)
   use HYMAP2_evapMod
   use HYMAP2_initMod, only : HYMAP2_grid2vector,HYMAP2_vector2grid
   
-  
-  !use clsmf25_lsmMod, only : clsmf25_struc
   use LIS_metforcingMod, only : LIS_FORC_State
   use LIS_FORC_AttributesMod 
+
+  use LIS_mpiMod
 
 #if(defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
@@ -82,8 +82,6 @@ subroutine HYMAP2_routing_run(n)
   type(ESMF_Field)      :: potential_evaporation_field
   real,   pointer       :: evapotranspiration_t(:)
   real,   pointer       :: potential_evaporation_t(:)
-  !real,   allocatable   :: dif_evap(:)
-  !real,   allocatable   :: tmppe(:,:),tmpet(:,:),tmpde(:,:)
   real,   allocatable   ::  tmpet(:,:)
  
   real,   allocatable   :: rivsto_lvec(:)
@@ -117,29 +115,32 @@ subroutine HYMAP2_routing_run(n)
   type(ESMF_Field)   :: psurfField
   real,pointer       :: tmp(:),q2(:),uwind(:),vwind(:),swd(:),lwd(:)
   real,pointer       :: psurf(:)
-  
+
+  integer            :: ix, iy, ix1, iy1
+!TBD:SVK - need to redo the code to work with ntiles rather than npatches. 
+!
   alarmCheck = LIS_isAlarmRinging(LIS_rc, "HYMAP2 router model alarm")
   if(alarmCheck) then
-     allocate(rivsto_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(rivdph_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(rivvel_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(rivout_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(evpout_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(fldout_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(fldsto_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(flddph_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(fldvel_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(fldfrc_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(fldare_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(sfcelv_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(rnfsto_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(bsfsto_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(rnfdwi_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(bsfdwi_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(surfws_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
+     allocate(rivsto_lvec(LIS_rc%ntiles(n)))
+     allocate(rivdph_lvec(LIS_rc%ntiles(n)))
+     allocate(rivvel_lvec(LIS_rc%ntiles(n)))
+     allocate(rivout_lvec(LIS_rc%ntiles(n)))
+     allocate(evpout_lvec(LIS_rc%ntiles(n)))
+     allocate(fldout_lvec(LIS_rc%ntiles(n)))
+     allocate(fldsto_lvec(LIS_rc%ntiles(n)))
+     allocate(flddph_lvec(LIS_rc%ntiles(n)))
+     allocate(fldvel_lvec(LIS_rc%ntiles(n)))
+     allocate(fldfrc_lvec(LIS_rc%ntiles(n)))
+     allocate(fldare_lvec(LIS_rc%ntiles(n)))
+     allocate(sfcelv_lvec(LIS_rc%ntiles(n)))
+     allocate(rnfsto_lvec(LIS_rc%ntiles(n)))
+     allocate(bsfsto_lvec(LIS_rc%ntiles(n)))
+     allocate(rnfdwi_lvec(LIS_rc%ntiles(n)))
+     allocate(bsfdwi_lvec(LIS_rc%ntiles(n)))
+     allocate(surfws_lvec(LIS_rc%ntiles(n)))
 
-     allocate(ewat_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-     allocate(edif_lvec(LIS_rc%npatch(n,LIS_rc%lsm_index)))
+     allocate(ewat_lvec(LIS_rc%ntiles(n)))
+     allocate(edif_lvec(LIS_rc%ntiles(n)))
 
      rivsto_lvec = LIS_rc%udef
      rivdph_lvec = LIS_rc%udef
@@ -161,904 +162,571 @@ subroutine HYMAP2_routing_run(n)
 
      ewat_lvec = LIS_rc%udef
      edif_lvec = LIS_rc%udef
+
+     allocate(surface_runoff(HYMAP2_routing_struc(n)%nseqall))     
+     allocate(baseflow(HYMAP2_routing_struc(n)%nseqall))
+     allocate(tmpr(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+     allocate(tmpb(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+
+     if(HYMAP2_routing_struc(n)%evapflag.ne.0)then
+        allocate(tmp_tmp(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+        allocate(tmp_q2(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+        allocate(tmp_psurf(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+        allocate(tmp_wind(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+        allocate(tmp_qnet(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+        
+        allocate(evap(HYMAP2_routing_struc(n)%nseqall))     
+        allocate(tair(HYMAP2_routing_struc(n)%nseqall))     
+        allocate(qair(HYMAP2_routing_struc(n)%nseqall))
+        allocate(pres(HYMAP2_routing_struc(n)%nseqall))     
+        allocate(wind(HYMAP2_routing_struc(n)%nseqall))     
+        allocate(qnet(HYMAP2_routing_struc(n)%nseqall))
+        allocate(tmpet(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+        
+     endif
      
-     if(LIS_masterproc)then
-        allocate(surface_runoff(HYMAP2_routing_struc(n)%nseqall))     
-        allocate(baseflow(HYMAP2_routing_struc(n)%nseqall))
-        allocate(tmpr(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-        allocate(tmpb(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-        if(HYMAP2_routing_struc(n)%evapflag.ne.0)then
-           allocate(tmp_tmp(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-           allocate(tmp_q2(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-           allocate(tmp_psurf(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-           allocate(tmp_wind(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-           allocate(tmp_qnet(LIS_rc%gnc(n),LIS_rc%gnr(n)))
+     if(HYMAP2_routing_struc(n)%useens.eq.0) then 
+        allocate(rnfsto_mm(HYMAP2_routing_struc(n)%nseqall,1))
+        allocate(bsfsto_mm(HYMAP2_routing_struc(n)%nseqall,1))
+     elseif(HYMAP2_routing_struc(n)%useens.eq.1) then
+        allocate(rnfsto_mm(HYMAP2_routing_struc(n)%nseqall,LIS_rc%nensem(n)))
+        allocate(bsfsto_mm(HYMAP2_routing_struc(n)%nseqall,LIS_rc%nensem(n)))
+     endif
+  
+     !ag (03May2017)
+     !import evaporation from open water     
+     !TBD: SVK - block that needs update for parallelism  
+     if(HYMAP2_routing_struc(n)%evapflag.ne.0)then !"compute" 
+        call ESMF_StateGet(LIS_runoff_state(n),"Total Evapotranspiration",&
+             evapotranspiration_field, rc=status)
+        call LIS_verify(status, "HYMAP2_routing_run: ESMF_StateGet failed for Total Evapotranspiration")
+        
+        call ESMF_FieldGet(evapotranspiration_field,localDE=0,&
+             farrayPtr=evapotranspiration_t,rc=status)
+        call LIS_verify(status, "HYMAP2_routing_run: ESMF_FieldGet failed for Total Evapotranspiration")
+        
+        call LIS_tile2grid(n,tmpet,evapotranspiration_t)
 
-           allocate(evap(HYMAP2_routing_struc(n)%nseqall))     
-           allocate(tair(HYMAP2_routing_struc(n)%nseqall))     
-           allocate(qair(HYMAP2_routing_struc(n)%nseqall))
-           allocate(pres(HYMAP2_routing_struc(n)%nseqall))     
-           allocate(wind(HYMAP2_routing_struc(n)%nseqall))     
-           allocate(qnet(HYMAP2_routing_struc(n)%nseqall))
-           allocate(tmpet(LIS_rc%gnc(n),LIS_rc%gnr(n)))
-           
-        endif
+        call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+             HYMAP2_routing_struc(n)%nseqall,&
+             HYMAP2_routing_struc(n)%imis,&
+             HYMAP2_routing_struc(n)%seqx,&
+             HYMAP2_routing_struc(n)%seqy,tmpet,evap)
 
-        if(HYMAP2_routing_struc(n)%useens.eq.0) then 
-           allocate(rnfsto_mm(HYMAP2_routing_struc(n)%nseqall,1))
-           allocate(bsfsto_mm(HYMAP2_routing_struc(n)%nseqall,1))
-        elseif(HYMAP2_routing_struc(n)%useens.eq.1) then
-           allocate(rnfsto_mm(HYMAP2_routing_struc(n)%nseqall,LIS_rc%nensem(n)))
-           allocate(bsfsto_mm(HYMAP2_routing_struc(n)%nseqall,LIS_rc%nensem(n)))
-        endif
+        call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_Tair%varname(1)),tmpField,rc=status)
+        call LIS_verify(status,'HYMAP2_routing_run: ESMF_FieldGet failed for Tair')
+        
+        call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_Qair%varname(1)),q2Field,rc=status)
+        call LIS_verify(status,'HYMAP2_routing_run: ESMF_FieldGet failed for Qair')
+        
+        call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_SWdown%varname(1)),swdField,rc=status)
+        call LIS_verify(status,'HYMAP2_routing_run: ESMF_FieldGet failed for SWdown')
+        
+        call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_LWdown%varname(1)),lwdField,rc=status)
+        call LIS_verify(status,'HYMAP2_routing_run: ESMF_FieldGet failed for LWdown')
+        
+        call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_Wind_E%varname(1)),uField,rc=status)
+        call LIS_verify(status,'HYMAP2_routing_run: ESMF_FieldGet failed for Wind_E')
+        
+        call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_Wind_N%varname(1)),vField,rc=status)
+        call LIS_verify(status,'HYMAP2_routing_run: ESMF_FieldGet failed for Wind_N')
+        
+        call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_Psurf%varname(1)),psurfField,rc=status)
+        call LIS_verify(status, 'HYMAP2_routing_run: ESMF_FieldGet failed for PSurf')
+        
+        call ESMF_FieldGet(tmpField, localDE=0, farrayPtr=tmp,rc=status)
+        call LIS_verify(status)
+        
+        call ESMF_FieldGet(q2Field, localDE=0, farrayPtr=q2,rc=status)
+        call LIS_verify(status)
+        
+        call ESMF_FieldGet(uField, localDE=0, farrayPtr=uwind,rc=status)
+        call LIS_verify(status)
+        
+        call ESMF_FieldGet(vField, localDE=0, farrayPtr=vwind,rc=status)
+        call LIS_verify(status)
+        
+        call ESMF_FieldGet(psurfField, localDE=0, farrayPtr=psurf,rc=status)
+        call LIS_verify(status)
+        
+        call ESMF_FieldGet(lwdField, localDE=0, farrayPtr=lwd,rc=status)
+        call LIS_verify(status)
+        
+        call ESMF_FieldGet(swdField, localDE=0, farrayPtr=swd,rc=status)
+        call LIS_verify(status)
+        
+        
+        call LIS_tile2grid(n,tmp_tmp,tmp-273.15)
+        call LIS_tile2grid(n,tmp_q2,q2)
+        call LIS_tile2grid(n,tmp_psurf,psurf/1e3)
+        call LIS_tile2grid(n,tmp_wind,sqrt(uwind**2+vwind**2))
+        call LIS_tile2grid(n,tmp_qnet,(lwd+swd)/1e6)
+        
+        
+        call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+             HYMAP2_routing_struc(n)%nseqall,&
+             HYMAP2_routing_struc(n)%imis,&
+             HYMAP2_routing_struc(n)%seqx,&
+             HYMAP2_routing_struc(n)%seqy,tmp_tmp,tair)
+
+        call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+             HYMAP2_routing_struc(n)%nseqall,&
+             HYMAP2_routing_struc(n)%imis,&
+             HYMAP2_routing_struc(n)%seqx,&
+             HYMAP2_routing_struc(n)%seqy,tmp_q2,qair)
+
+        call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+             HYMAP2_routing_struc(n)%nseqall,&
+             HYMAP2_routing_struc(n)%imis,&
+             HYMAP2_routing_struc(n)%seqx,&
+             HYMAP2_routing_struc(n)%seqy,tmp_psurf,pres)
+
+        call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+             HYMAP2_routing_struc(n)%nseqall,&
+             HYMAP2_routing_struc(n)%imis,&
+             HYMAP2_routing_struc(n)%seqx,&
+             HYMAP2_routing_struc(n)%seqy,tmp_qnet,qnet)
+
+        call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+             HYMAP2_routing_struc(n)%nseqall,&
+             HYMAP2_routing_struc(n)%imis,&
+             HYMAP2_routing_struc(n)%seqx,&
+             HYMAP2_routing_struc(n)%seqy,tmp_wind,wind)
+        
+        call HYMAP2_evap_main(HYMAP2_routing_struc(n)%evapflag,n,&
+             HYMAP2_routing_struc(n)%nseqall,&
+             real(HYMAP2_routing_struc(n)%imis),&
+             HYMAP2_routing_struc(n)%outlet,&
+             pres,tair,qair,wind,qnet,evap,&
+             HYMAP2_routing_struc(n)%ewat,&
+             HYMAP2_routing_struc(n)%edif)
+
      endif
 
-     if(HYMAP2_routing_struc(n)%useens.eq.1) then 
-        if(LIS_masterproc) then     
-           allocate(tmp_nensem(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n)))
-           !run the routing model at 1 hour output interval   
-           call ESMF_StateGet(LIS_runoff_state(n),"Surface Runoff",&
-                sf_runoff_field,rc=status)
-           call LIS_verify(status, "ESMF_StateGet failed for Surface Runoff")
-
-           call ESMF_StateGet(LIS_runoff_state(n),"Subsurface Runoff",&
-                baseflow_field, rc=status)
-           call LIS_verify(status, "ESMF_StateGet failed for Subsurface Runoff")
-
-           call ESMF_FieldGet(sf_runoff_field,localDE=0,&
-                farrayPtr=surface_runoff_t,rc=status)
-           call LIS_verify(status, "ESMF_FieldGet failed for Surface Runoff")
-
-           call ESMF_FieldGet(baseflow_field,localDE=0,farrayPtr=baseflow_t,&
-                rc=status)
-           call LIS_verify(status, "ESMF_FieldGet failed for Subsurface Runoff")
-
-
-           do m=1,LIS_rc%nensem(n)
-
-              surface_runoff = 0.0
-              baseflow = 0.0
-
-              !temporary solution  
-              tmpr=0.
-              call LIS_tile2grid(n,m,tmpr,surface_runoff_t)
-              call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmpr,surface_runoff)
-
-              !temporary solution  
-              tmpb=0.
-              call LIS_tile2grid(n,m,tmpb,baseflow_t)
-              call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmpb,baseflow)
-
-              call HYMAP2_model(n,real(HYMAP2_routing_struc(n)%imis),&
-                   LIS_rc%gnc(n),&
-                   LIS_rc%gnr(n),&
-                   LIS_rc%yr,&
-                   LIS_rc%mo,&
-                   LIS_rc%da,&
-                   LIS_rc%hr,&
-                   LIS_rc%mn,&
-                   LIS_rc%ss,&				   
-                   HYMAP2_routing_struc(n)%nseqall,&
-                   HYMAP2_routing_struc(n)%nz,&
-                   HYMAP2_routing_struc(n)%dt,&
-                   HYMAP2_routing_struc(n)%flowmap,&
-                   HYMAP2_routing_struc(n)%linresflag,&
-                   HYMAP2_routing_struc(n)%evapflag,&
-                                !ag (19Jan2016)
-                   HYMAP2_routing_struc(n)%rivout_pre(:,m),&
-                   HYMAP2_routing_struc(n)%rivdph_pre(:,m),&
-                   HYMAP2_routing_struc(n)%fldout_pre(:,m),&
-                   HYMAP2_routing_struc(n)%flddph_pre(:,m),&
-                   HYMAP2_routing_struc(n)%fldelv1(:,m),&
-                   HYMAP2_routing_struc(n)%grv,&
-                   HYMAP2_routing_struc(n)%cadp,&
-                   HYMAP2_routing_struc(n)%steptype,&
-                   HYMAP2_routing_struc(n)%resopflag,&                   
-                   HYMAP2_routing_struc(n)%floodflag,&                   
-                   HYMAP2_routing_struc(n)%outlet,&
-                   HYMAP2_routing_struc(n)%next,&
-                   HYMAP2_routing_struc(n)%elevtn,&
-                   HYMAP2_routing_struc(n)%nxtdst,&
-                   HYMAP2_routing_struc(n)%grarea,&	   
-                   HYMAP2_routing_struc(n)%fldgrd,&
-                   HYMAP2_routing_struc(n)%fldman,&
-                   HYMAP2_routing_struc(n)%fldhgt,&
-                   HYMAP2_routing_struc(n)%fldstomax,&
-                   HYMAP2_routing_struc(n)%rivman,&
-                   HYMAP2_routing_struc(n)%rivelv,&
-                   HYMAP2_routing_struc(n)%rivstomax,&
-                   HYMAP2_routing_struc(n)%rivlen,&
-                   HYMAP2_routing_struc(n)%rivwth,&
-                   HYMAP2_routing_struc(n)%rivhgt,&
-                   HYMAP2_routing_struc(n)%rivare,&
-                   HYMAP2_routing_struc(n)%rslpmin,&
-                   HYMAP2_routing_struc(n)%trnoff,&
-                   HYMAP2_routing_struc(n)%tbsflw,&
-                   HYMAP2_routing_struc(n)%cntime,&
-                   HYMAP2_routing_struc(n)%dwiflag,&
-                   HYMAP2_routing_struc(n)%rnfdwi_ratio,&
-                   HYMAP2_routing_struc(n)%bsfdwi_ratio,&
-                   surface_runoff,&
-                   baseflow,&
-                   HYMAP2_routing_struc(n)%edif(:,m),&
-                   HYMAP2_routing_struc(n)%rivsto(:,m),&
-                   HYMAP2_routing_struc(n)%rivdph(:,m),&
-                   HYMAP2_routing_struc(n)%rivvel(:,m),&
-                   HYMAP2_routing_struc(n)%rivout(:,m),&
-                   HYMAP2_routing_struc(n)%evpout(:,m),&
-                   HYMAP2_routing_struc(n)%fldout(:,m),&
-                   HYMAP2_routing_struc(n)%fldsto(:,m),&
-                   HYMAP2_routing_struc(n)%flddph(:,m),&
-                   HYMAP2_routing_struc(n)%fldvel(:,m),&
-                   HYMAP2_routing_struc(n)%fldfrc(:,m),&
-                   HYMAP2_routing_struc(n)%fldare(:,m),&
-                   HYMAP2_routing_struc(n)%sfcelv(:,m),&
-                   HYMAP2_routing_struc(n)%rnfsto(:,m),&
-                   HYMAP2_routing_struc(n)%bsfsto(:,m),&
-                   HYMAP2_routing_struc(n)%rnfdwi(:,m),&
-                   HYMAP2_routing_struc(n)%bsfdwi(:,m),&
-                   HYMAP2_routing_struc(n)%surfws(:,m),&
-                   HYMAP2_routing_struc(n)%dtaout(:,m) )
-              !========================================================================			
-              ! the following is done to distribute the global arrays to the individual 
-              ! processors, so that they can use the generic LIS interfaces for writing
-              ! output -- which works based on the assumption of multiprocessors. 
-              ! When the HYMAP routine itself is parallelized, this can (should) be taken
-              ! out. 
-              rnfsto_mm(:,m)=1000*HYMAP2_routing_struc(n)%rnfsto(:,m)/HYMAP2_routing_struc(n)%grarea
-              bsfsto_mm(:,m)=1000*HYMAP2_routing_struc(n)%bsfsto(:,m)/HYMAP2_routing_struc(n)%grarea
-           enddo
-
-        endif
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),&
-                LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,&
-                HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,&
-                tmp_nensem,HYMAP2_routing_struc(n)%rivsto)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             rivsto_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%rivdph)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             rivdph_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%rivvel)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             rivvel_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%rivout)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             rivout_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%evpout)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             evpout_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%fldout)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             fldout_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%fldsto)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             fldsto_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%flddph)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             flddph_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%fldvel)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             fldvel_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%fldfrc)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             fldfrc_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%fldare)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             fldare_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%sfcelv)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             sfcelv_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,rnfsto_mm)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             rnfsto_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,bsfsto_mm)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             bsfsto_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%rnfdwi)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             rnfdwi_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%bsfdwi)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             bsfdwi_lvec,1)
-
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n),HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_nensem,HYMAP2_routing_struc(n)%surfws)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem,&
-             surfws_lvec,1)
-
-        !do t=1, LIS_rc%npatch(n,LIS_rc%lsm_index)
-        do t=1, LIS_rc%ntiles(n)        
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RIVSTO,&
-                value=rivsto_lvec(t),vlevel=1,unit="m3",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RIVDPH,&
-                value=rivdph_lvec(t),vlevel=1,unit="m",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RIVVEL,&
-                value=rivvel_lvec(t),vlevel=1,unit="m s-1",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_STREAMFLOW,&
-                value=rivout_lvec(t),vlevel=1,unit="m3 s-1",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDEVAP,&
-                value=evpout_lvec(t),vlevel=1,unit="kg m-2 s-1",&   
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDOUT,&
-                value=fldout_lvec(t),vlevel=1,unit="m3 s-1",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDSTO,&
-                value=fldsto_lvec(t),vlevel=1,unit="m3",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDDPH,&
-                value=flddph_lvec(t),vlevel=1,unit="m",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDVEL,&
-                value=fldvel_lvec(t),vlevel=1,unit="m s-1",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDFRC,&
-                value=fldfrc_lvec(t),vlevel=1,unit="-",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDARE,&
-                value=fldare_lvec(t),vlevel=1,unit="m2",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_SFCELV,&
-                value=sfcelv_lvec(t),vlevel=1,unit="m",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RNFSTO,&
-                value=rnfsto_lvec(t),vlevel=1,unit="mm",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_BSFSTO,&
-                value=bsfsto_lvec(t),vlevel=1,unit="mm",&
-                direction="-")        
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RNFDWI,&
-                value=rnfdwi_lvec(t),vlevel=1,unit="mm",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_BSFDWI,&
-                value=bsfdwi_lvec(t),vlevel=1,unit="mm",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_SURFWS,&
-                value=surfws_lvec(t),vlevel=1,unit="mm",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_ewat,&
-                value=ewat_lvec(t),vlevel=1,unit="kg m-2 s-1",&   
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_edif,&
-                value=edif_lvec(t),vlevel=1,unit="kg m-2 s-1",&   
-                direction="-")
-        enddo
-     else    
-        !ag (03May2017)
-        !import evaporation from open water       
-        if(HYMAP2_routing_struc(n)%evapflag.ne.0)then !"compute" 
-           if(LIS_rc%lsm.ne."none") then !from current lsm run
-
-              if(LIS_masterproc)then     
-                 call ESMF_StateGet(LIS_runoff_state(n),"Total Evapotranspiration",&
-                      evapotranspiration_field, rc=status)
-                 call LIS_verify(status, "HYMAP2_routing_run: ESMF_StateGet failed for Total Evapotranspiration")
-
-                 call ESMF_FieldGet(evapotranspiration_field,localDE=0,&
-                      farrayPtr=evapotranspiration_t,rc=status)
-                 call LIS_verify(status, "HYMAP2_routing_run: ESMF_FieldGet failed for Total Evapotranspiration")
-          
-!print*,minval(gvar6),maxval(gvar6),minval(lwd),maxval(lwd)
-!print*,minval(gvar7),maxval(gvar7),minval(swd),maxval(swd)
-
-                 call LIS_tile2grid(n,tmpet,evapotranspiration_t,1)
-                 call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                      HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,&
-                      HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmpet,evap)
-              endif
-
-              call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_Tair%varname(1)),tmpField,rc=status)
-              call LIS_verify(status,'HYMAP2_routing_run: ESMF_FieldGet failed for Tair')
-
-              call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_Qair%varname(1)),q2Field,rc=status)
-              call LIS_verify(status,'HYMAP2_routing_run: ESMF_FieldGet failed for Qair')
-
-              call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_SWdown%varname(1)),swdField,rc=status)
-              call LIS_verify(status,'HYMAP2_routing_run: ESMF_FieldGet failed for SWdown')
-
-              call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_LWdown%varname(1)),lwdField,rc=status)
-              call LIS_verify(status,'HYMAP2_routing_run: ESMF_FieldGet failed for LWdown')
-
-              call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_Wind_E%varname(1)),uField,rc=status)
-              call LIS_verify(status,'HYMAP2_routing_run: ESMF_FieldGet failed for Wind_E')
-
-              call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_Wind_N%varname(1)),vField,rc=status)
-              call LIS_verify(status,'HYMAP2_routing_run: ESMF_FieldGet failed for Wind_N')
-
-              call ESMF_StateGet(LIS_FORC_State(n),trim(LIS_FORC_Psurf%varname(1)),psurfField,rc=status)
-              call LIS_verify(status, 'HYMAP2_routing_run: ESMF_FieldGet failed for PSurf')
-
-
-              call ESMF_FieldGet(tmpField, localDE=0, farrayPtr=tmp,rc=status)
-              call LIS_verify(status)
-
-              call ESMF_FieldGet(q2Field, localDE=0, farrayPtr=q2,rc=status)
-              call LIS_verify(status)
-
-              call ESMF_FieldGet(uField, localDE=0, farrayPtr=uwind,rc=status)
-              call LIS_verify(status)
-
-              call ESMF_FieldGet(vField, localDE=0, farrayPtr=vwind,rc=status)
-              call LIS_verify(status)
-
-              call ESMF_FieldGet(psurfField, localDE=0, farrayPtr=psurf,rc=status)
-              call LIS_verify(status)
-
-              call ESMF_FieldGet(lwdField, localDE=0, farrayPtr=lwd,rc=status)
-              call LIS_verify(status)
-
-              call ESMF_FieldGet(swdField, localDE=0, farrayPtr=swd,rc=status)
-              call LIS_verify(status)
-
-
-              call LIS_gather_tiled_vector_output(n, gvar1, tmp)
-              call LIS_gather_tiled_vector_output(n, gvar2, q2)
-              call LIS_gather_tiled_vector_output(n, gvar3, psurf)
-              call LIS_gather_tiled_vector_output(n, gvar4, uwind)
-              call LIS_gather_tiled_vector_output(n, gvar5, vwind)
-              call LIS_gather_tiled_vector_output(n, gvar6, lwd)
-              call LIS_gather_tiled_vector_output(n, gvar7, swd)
-
-
-              if(LIS_masterproc)then     
-                 call LIS_tile2grid(n,tmp_tmp,gvar1-273.15,1)
-                 call LIS_tile2grid(n,tmp_q2,gvar2,1)
-                 call LIS_tile2grid(n,tmp_psurf,gvar3/1e3,1)
-                 call LIS_tile2grid(n,tmp_wind,sqrt(gvar4**2+gvar5**2),1)
-                 call LIS_tile2grid(n,tmp_qnet,(gvar6+gvar7)/1e6,1)
-
-                 deallocate(gvar1)
-                 deallocate(gvar2)
-                 deallocate(gvar3)
-                 deallocate(gvar4)
-                 deallocate(gvar5)
-                 deallocate(gvar6)
-                 deallocate(gvar7)
-
-                 call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                      HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,&
-                      HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_tmp,tair)
-                 call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                      HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,&
-                      HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_q2,qair)
-                 call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                      HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,&
-                      HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_psurf,pres)
-                 call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                      HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,&
-                      HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_qnet,qnet)
-                 call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                      HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,&
-                      HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmp_wind,wind)
-              endif
-
-           else
-              print*,'wrong value for evapflag or LSM id'
-              stop
-           endif
-
-           if(LIS_masterproc)then     
-              call HYMAP2_evap_main(HYMAP2_routing_struc(n)%evapflag,n,&
-                   HYMAP2_routing_struc(n)%nseqall,real(HYMAP2_routing_struc(n)%imis),&
-                   HYMAP2_routing_struc(n)%outlet,pres,tair,qair,&
-                   wind,qnet,evap,HYMAP2_routing_struc(n)%ewat,HYMAP2_routing_struc(n)%edif)
-           endif
-        endif
-
-        if(LIS_masterproc)then     
-           allocate(tmp_nensem(LIS_rc%gnc(n),LIS_rc%gnr(n),1))
-           tmpr=0.
-           tmpb=0.
-
-           !import surface runoff and baseflow
-           if(LIS_rc%lsm.ne."none") then !from current lsm run
-              call ESMF_StateGet(LIS_runoff_state(n),"Surface Runoff",sf_runoff_field,&
-                   rc=status)
-              call LIS_verify(status, "ESMF_StateGet failed for Surface Runoff")
-
-              call ESMF_StateGet(LIS_runoff_state(n),"Subsurface Runoff",&
-                   baseflow_field, rc=status)
-              call LIS_verify(status, "ESMF_StateGet failed for Subsurface Runoff")
-
-              call ESMF_FieldGet(sf_runoff_field,localDE=0,farrayPtr=surface_runoff_t,&
-                   rc=status)
-              call LIS_verify(status, "ESMF_FieldGet failed for Surface Runoff")
-
-              call ESMF_FieldGet(baseflow_field,localDE=0,farrayPtr=baseflow_t,&
-                   rc=status)
-              call LIS_verify(status, "ESMF_FieldGet failed for Subsurface Runoff")
-              !call LIS_tile2grid(n,surface_runoff,surface_runoff_t,1)
-              !call LIS_tile2grid(n,baseflow,baseflow_t,1)
-
-              !temporary solution  
-              call LIS_tile2grid(n,tmpr,surface_runoff_t,1)
-              call LIS_tile2grid(n,tmpb,baseflow_t,1)
-           else !read from previous output. 
-              call readrunoffdata(trim(LIS_rc%runoffdatasource)//char(0),&
-                   n,tmpr, tmpb)
-           endif
-           call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,&
-                HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmpr,surface_runoff)
-           call HYMAP2_grid2vector(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,HYMAP2_routing_struc(n)%imis,&
-                HYMAP2_routing_struc(n)%seqx,HYMAP2_routing_struc(n)%seqy,tmpb,baseflow)
-
-
-           call HYMAP2_model(n,real(HYMAP2_routing_struc(n)%imis),&
-                LIS_rc%gnc(n),&
-                LIS_rc%gnr(n),&
-                LIS_rc%yr,&
-                LIS_rc%mo,&
-                LIS_rc%da,&
-                LIS_rc%hr,&
-                LIS_rc%mn,&
-                LIS_rc%ss,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%nz,&
-                HYMAP2_routing_struc(n)%dt,&
-                HYMAP2_routing_struc(n)%flowmap,&
-                HYMAP2_routing_struc(n)%linresflag,&
-                HYMAP2_routing_struc(n)%evapflag,&
-                                !ag (19Jan2016)
-                HYMAP2_routing_struc(n)%rivout_pre,&
-                HYMAP2_routing_struc(n)%rivdph_pre,&
-                HYMAP2_routing_struc(n)%fldout_pre,&
-                HYMAP2_routing_struc(n)%flddph_pre,&
-                HYMAP2_routing_struc(n)%fldelv1,&
-                HYMAP2_routing_struc(n)%grv,&
-                HYMAP2_routing_struc(n)%cadp,&
-                HYMAP2_routing_struc(n)%steptype,&
-                HYMAP2_routing_struc(n)%resopflag,&                
-                HYMAP2_routing_struc(n)%floodflag,&                   
-                HYMAP2_routing_struc(n)%outlet,&
-                HYMAP2_routing_struc(n)%next,&
-                HYMAP2_routing_struc(n)%elevtn,&
-                HYMAP2_routing_struc(n)%nxtdst,&
-                HYMAP2_routing_struc(n)%grarea,&	   
-                HYMAP2_routing_struc(n)%fldgrd,&
-                HYMAP2_routing_struc(n)%fldman,&
-                HYMAP2_routing_struc(n)%fldhgt,&
-                HYMAP2_routing_struc(n)%fldstomax,&
-                HYMAP2_routing_struc(n)%rivman,&
-                HYMAP2_routing_struc(n)%rivelv,&
-                HYMAP2_routing_struc(n)%rivstomax,&
-                HYMAP2_routing_struc(n)%rivlen,&
-                HYMAP2_routing_struc(n)%rivwth,&
-                HYMAP2_routing_struc(n)%rivhgt,&
-                HYMAP2_routing_struc(n)%rivare,&
-                HYMAP2_routing_struc(n)%rslpmin,&
-                HYMAP2_routing_struc(n)%trnoff,&
-                HYMAP2_routing_struc(n)%tbsflw,&
-                HYMAP2_routing_struc(n)%cntime,&
-                HYMAP2_routing_struc(n)%dwiflag,&
-                HYMAP2_routing_struc(n)%rnfdwi_ratio,&
-                HYMAP2_routing_struc(n)%bsfdwi_ratio,&
-                surface_runoff,&
-                baseflow,&
-                HYMAP2_routing_struc(n)%edif,&
-                HYMAP2_routing_struc(n)%rivsto,&
-                HYMAP2_routing_struc(n)%rivdph,&
-                HYMAP2_routing_struc(n)%rivvel,&
-                HYMAP2_routing_struc(n)%rivout,&
-                HYMAP2_routing_struc(n)%evpout,&
-                HYMAP2_routing_struc(n)%fldout,&
-                HYMAP2_routing_struc(n)%fldsto,&
-                HYMAP2_routing_struc(n)%flddph,&
-                HYMAP2_routing_struc(n)%fldvel,&
-                HYMAP2_routing_struc(n)%fldfrc,&
-                HYMAP2_routing_struc(n)%fldare,&
-                HYMAP2_routing_struc(n)%sfcelv,&
-                HYMAP2_routing_struc(n)%rnfsto,&
-                HYMAP2_routing_struc(n)%bsfsto,&
-                HYMAP2_routing_struc(n)%rnfdwi,&
-                HYMAP2_routing_struc(n)%bsfdwi,&
-                HYMAP2_routing_struc(n)%surfws,&
-                HYMAP2_routing_struc(n)%dtaout)
+     allocate(tmp_nensem(LIS_rc%lnc(n),LIS_rc%lnr(n),1))
+     tmpr=0.
+     tmpb=0.
+     
+     !import surface runoff and baseflow
+!     if(LIS_rc%lsm.ne."none") then !from current lsm run
+     call ESMF_StateGet(LIS_runoff_state(n),"Surface Runoff",sf_runoff_field,&
+          rc=status)
+     call LIS_verify(status, "ESMF_StateGet failed for Surface Runoff")
+     
+     call ESMF_StateGet(LIS_runoff_state(n),"Subsurface Runoff",&
+          baseflow_field, rc=status)
+     call LIS_verify(status, "ESMF_StateGet failed for Subsurface Runoff")
+     
+     call ESMF_FieldGet(sf_runoff_field,localDE=0,farrayPtr=surface_runoff_t,&
+          rc=status)
+     call LIS_verify(status, "ESMF_FieldGet failed for Surface Runoff")
+     
+     call ESMF_FieldGet(baseflow_field,localDE=0,farrayPtr=baseflow_t,&
+          rc=status)
+     call LIS_verify(status, "ESMF_FieldGet failed for Subsurface Runoff")
+     !call LIS_tile2grid(n,surface_runoff,surface_runoff_t,1)
+     !call LIS_tile2grid(n,baseflow,baseflow_t,1)
+     
+     !temporary solution  
+     call LIS_tile2grid(n,tmpr,surface_runoff_t)
+     call LIS_tile2grid(n,tmpb,baseflow_t)
+!  else !read from previous output. 
+!           call readrunoffdata(trim(LIS_rc%runoffdatasource)//char(0),&
+!                n,tmpr, tmpb)
+!        endif
+
+     call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,&
+          HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmpr,surface_runoff)
+     call HYMAP2_grid2vector(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,&
+          HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmpb,baseflow)
+     
+     call HYMAP2_model(n,real(HYMAP2_routing_struc(n)%imis),&
+          LIS_rc%lnc(n),&
+          LIS_rc%lnr(n),&
+          LIS_rc%yr,&
+          LIS_rc%mo,&
+          LIS_rc%da,&
+          LIS_rc%hr,&
+          LIS_rc%mn,&
+          LIS_rc%ss,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%nz,&
+          HYMAP2_routing_struc(n)%dt,&
+          HYMAP2_routing_struc(n)%flowmap,&
+          HYMAP2_routing_struc(n)%linresflag,&
+          HYMAP2_routing_struc(n)%evapflag,&
+          !ag (19Jan2016)
+          HYMAP2_routing_struc(n)%rivout_pre,&
+          HYMAP2_routing_struc(n)%rivdph_pre,&
+          HYMAP2_routing_struc(n)%fldout_pre,&
+          HYMAP2_routing_struc(n)%flddph_pre,&
+          HYMAP2_routing_struc(n)%fldelv1,&
+          HYMAP2_routing_struc(n)%grv,&
+          HYMAP2_routing_struc(n)%cadp,&
+          HYMAP2_routing_struc(n)%steptype,&
+          HYMAP2_routing_struc(n)%resopflag,&                
+          HYMAP2_routing_struc(n)%floodflag,&                   
+          HYMAP2_routing_struc(n)%outlet,&
+          HYMAP2_routing_struc(n)%next,&
+          HYMAP2_routing_struc(n)%elevtn,&
+          HYMAP2_routing_struc(n)%nxtdst,&
+          HYMAP2_routing_struc(n)%grarea,&	   
+          HYMAP2_routing_struc(n)%fldgrd,&
+          HYMAP2_routing_struc(n)%fldman,&
+          HYMAP2_routing_struc(n)%fldhgt,&
+          HYMAP2_routing_struc(n)%fldstomax,&
+          HYMAP2_routing_struc(n)%rivman,&
+          HYMAP2_routing_struc(n)%rivelv,&
+          HYMAP2_routing_struc(n)%rivstomax,&
+          HYMAP2_routing_struc(n)%rivlen,&
+          HYMAP2_routing_struc(n)%rivwth,&
+          HYMAP2_routing_struc(n)%rivhgt,&
+          HYMAP2_routing_struc(n)%rivare,&
+          HYMAP2_routing_struc(n)%rslpmin,&
+          HYMAP2_routing_struc(n)%trnoff,&
+          HYMAP2_routing_struc(n)%tbsflw,&
+          HYMAP2_routing_struc(n)%cntime,&
+          HYMAP2_routing_struc(n)%dwiflag,&
+          HYMAP2_routing_struc(n)%rnfdwi_ratio,&
+          HYMAP2_routing_struc(n)%bsfdwi_ratio,&
+          surface_runoff,&
+          baseflow,&
+          HYMAP2_routing_struc(n)%edif,&
+          HYMAP2_routing_struc(n)%rivsto,&
+          HYMAP2_routing_struc(n)%rivdph,&
+          HYMAP2_routing_struc(n)%rivvel,&
+          HYMAP2_routing_struc(n)%rivout,&
+          HYMAP2_routing_struc(n)%evpout,&
+          HYMAP2_routing_struc(n)%fldout,&
+          HYMAP2_routing_struc(n)%fldsto,&
+          HYMAP2_routing_struc(n)%flddph,&
+          HYMAP2_routing_struc(n)%fldvel,&
+          HYMAP2_routing_struc(n)%fldfrc,&
+          HYMAP2_routing_struc(n)%fldare,&
+          HYMAP2_routing_struc(n)%sfcelv,&
+          HYMAP2_routing_struc(n)%rnfsto,&
+          HYMAP2_routing_struc(n)%bsfsto,&
+          HYMAP2_routing_struc(n)%rnfdwi,&
+          HYMAP2_routing_struc(n)%bsfdwi,&
+          HYMAP2_routing_struc(n)%surfws,&
+          HYMAP2_routing_struc(n)%dtaout)            
+     
+!write(*,'(10f15.3)')HYMAP2_routing_struc(n)%sfcelv(23509,1),HYMAP2_routing_struc(n)%rivdph(23509,1),HYMAP2_routing_struc(n)%rivelv(23509),HYMAP2_routing_struc(n)%rivhgt(23509)
            !========================================================================			
            ! the following is done to distribute the global arrays to the individual 
            ! processors, so that they can use the generic LIS interfaces for writing
            ! output -- which works based on the assumption of multiprocessors. 
            ! When the HYMAP routine itself is parallelized, this can (should) be taken
            ! out. 
+     
+     rnfsto_mm(:,1)=1000*HYMAP2_routing_struc(n)%rnfsto(:,1)/&
+          HYMAP2_routing_struc(n)%grarea
+     bsfsto_mm(:,1)=1000*HYMAP2_routing_struc(n)%bsfsto(:,1)/&
+          HYMAP2_routing_struc(n)%grarea
+           
+! The following calls are done because the vector size in LIS and HYMAP are different 
+! (and because the LIS I/O system is being leveraged for output
 
-           rnfsto_mm(:,1)=1000*HYMAP2_routing_struc(n)%rnfsto(:,1)/HYMAP2_routing_struc(n)%grarea
-           bsfsto_mm(:,1)=1000*HYMAP2_routing_struc(n)%bsfsto(:,1)/HYMAP2_routing_struc(n)%grarea
-        else
-           allocate(tmp_nensem(1,1,1))
-        endif
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%rivsto)    
+     
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          rivsto_lvec)
+     
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%rivdph)             
+     
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          rivdph_lvec)
 
-        if(LIS_masterproc)then
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                HYMAP2_routing_struc(n)%rivsto)    
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             rivsto_lvec)
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%rivvel)             
 
-        if(LIS_masterproc) then 
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                HYMAP2_routing_struc(n)%rivdph)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             rivdph_lvec)
-        if(LIS_masterproc) then 
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                HYMAP2_routing_struc(n)%rivvel)             
-        endif
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          rivvel_lvec)
 
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             rivvel_lvec)
-        if(LIS_masterproc) then 
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                HYMAP2_routing_struc(n)%rivout)  
-        endif
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%rivout)  
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          rivout_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%evpout)             
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          evpout_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%fldout)             
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          fldout_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%fldsto)             
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          fldsto_lvec)           
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%flddph)             
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          flddph_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%fldvel)  
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          fldvel_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%fldfrc)             
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          fldfrc_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%fldare)             
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          fldare_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%sfcelv)    
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          sfcelv_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          rnfsto_mm)             
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          rnfsto_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),bsfsto_mm)             
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          bsfsto_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%rnfdwi) 
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          rnfdwi_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%bsfdwi)   
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          bsfdwi_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%surfws)             
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          surfws_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%ewat)             
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          ewat_lvec)
+
+     call HYMAP2_vector2grid(LIS_rc%lnc(n),LIS_rc%lnr(n),1,&
+          HYMAP2_routing_struc(n)%nseqall,&
+          HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
+          HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
+          HYMAP2_routing_struc(n)%edif)             
+
+     call LIS_grid2tile(n,tmp_nensem(:,:,1),&
+          edif_lvec)
+
+     deallocate(tmp_nensem)
+
+     do t=1, LIS_rc%ntiles(n)
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RIVSTO,&
+             value=rivsto_lvec(t),vlevel=1,unit="m3",&  
+             direction="-")
         
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             rivout_lvec)
-        if(LIS_masterproc) then 
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                HYMAP2_routing_struc(n)%evpout)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             evpout_lvec)
-        if(LIS_masterproc) then 
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                HYMAP2_routing_struc(n)%fldout)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             fldout_lvec)
-        if(LIS_masterproc) then 
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                HYMAP2_routing_struc(n)%fldsto)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             fldsto_lvec)
-
-        if(LIS_masterproc) then 
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                HYMAP2_routing_struc(n)%flddph)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             flddph_lvec)
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RIVDPH,&
+             value=rivdph_lvec(t),vlevel=1,unit="m",&
+             direction="-")
         
-        if(LIS_masterproc) then 
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                HYMAP2_routing_struc(n)%fldvel)  
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             fldvel_lvec)
-        if(LIS_masterproc) then            
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                HYMAP2_routing_struc(n)%fldfrc)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             fldfrc_lvec)
-        if(LIS_masterproc) then            
-
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),HYMAP2_routing_struc(n)%fldare)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             fldare_lvec)
-        if(LIS_masterproc) then            
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                HYMAP2_routing_struc(n)%sfcelv)    
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             sfcelv_lvec)
-
-        if(LIS_masterproc) then            
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                rnfsto_mm)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-                   rnfsto_lvec)
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RIVVEL,&
+             value=rivvel_lvec(t),vlevel=1,unit="m s-1",&
+             direction="-")
         
-        if(LIS_masterproc) then            
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),bsfsto_mm)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             bsfsto_lvec)
-        if(LIS_masterproc) then            
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                HYMAP2_routing_struc(n)%rnfdwi) 
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             rnfdwi_lvec)
-        if(LIS_masterproc) then             
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),HYMAP2_routing_struc(n)%bsfdwi)   
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             bsfdwi_lvec)
-        if(LIS_masterproc) then           
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),&
-                HYMAP2_routing_struc(n)%surfws)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             surfws_lvec)
-        if(LIS_masterproc) then           
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),HYMAP2_routing_struc(n)%ewat)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             ewat_lvec)
-        if(LIS_masterproc) then           
-           call HYMAP2_vector2grid(LIS_rc%gnc(n),LIS_rc%gnr(n),1,&
-                HYMAP2_routing_struc(n)%nseqall,&
-                HYMAP2_routing_struc(n)%imis,HYMAP2_routing_struc(n)%seqx,&
-                HYMAP2_routing_struc(n)%seqy,tmp_nensem(:,:,1),HYMAP2_routing_struc(n)%edif)             
-        endif
-        call LIS_grid2patch(n,LIS_rc%lsm_index,tmp_nensem(:,:,1),&
-             edif_lvec)
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_STREAMFLOW,&
+             value=rivout_lvec(t),vlevel=1,unit="m3 s-1",&
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDEVAP,&
+             value=evpout_lvec(t),vlevel=1,unit="kg m-2 s-1",&   
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDOUT,&
+             value=fldout_lvec(t),vlevel=1,unit="m3 s-1",&
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDSTO,&
+             value=fldsto_lvec(t),vlevel=1,unit="m3",&
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDDPH,&
+             value=flddph_lvec(t),vlevel=1,unit="m",&
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDVEL,&
+             value=fldvel_lvec(t),vlevel=1,unit="m s-1",&
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDFRC,&
+             value=fldfrc_lvec(t),vlevel=1,unit="-",&
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDARE,&
+             value=fldare_lvec(t),vlevel=1,unit="m2",&
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_SFCELV,&
+             value=sfcelv_lvec(t),vlevel=1,unit="m",&
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RNFSTO,&
+             value=rnfsto_lvec(t),vlevel=1,unit="mm",&
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_BSFSTO,&
+             value=bsfsto_lvec(t),vlevel=1,unit="mm",&
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RNFDWI,&
+             value=rnfdwi_lvec(t),vlevel=1,unit="mm",&
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_BSFDWI,&
+             value=bsfdwi_lvec(t),vlevel=1,unit="mm",&
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_SURFWS,&
+             value=surfws_lvec(t),vlevel=1,unit="mm",&
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_ewat,&
+             value=ewat_lvec(t),vlevel=1,unit="kg m-2 s-1",&   
+             direction="-")
+        
+        call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_edif,&
+             value=edif_lvec(t),vlevel=1,unit="kg m-2 s-1",&   
+             direction="-")
+     enddo
+     
+  endif
 
-        deallocate(tmp_nensem)
-
-        !do t=1, LIS_rc%npatch(n,LIS_rc%lsm_index)
-        do t=1, LIS_rc%ntiles(n)  
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RIVSTO,&
-                value=rivsto_lvec(t),vlevel=1,unit="m3",&  
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RIVDPH,&
-                value=rivdph_lvec(t),vlevel=1,unit="m",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RIVVEL,&
-                value=rivvel_lvec(t),vlevel=1,unit="m s-1",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_STREAMFLOW,&
-                value=rivout_lvec(t),vlevel=1,unit="m3 s-1",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDEVAP,&
-                value=evpout_lvec(t),vlevel=1,unit="kg m-2 s-1",&   
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDOUT,&
-                value=fldout_lvec(t),vlevel=1,unit="m3 s-1",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDSTO,&
-                value=fldsto_lvec(t),vlevel=1,unit="m3",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDDPH,&
-                value=flddph_lvec(t),vlevel=1,unit="m",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDVEL,&
-                value=fldvel_lvec(t),vlevel=1,unit="m s-1",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDFRC,&
-                value=fldfrc_lvec(t),vlevel=1,unit="-",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_FLDARE,&
-                value=fldare_lvec(t),vlevel=1,unit="m2",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_SFCELV,&
-                value=sfcelv_lvec(t),vlevel=1,unit="m",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RNFSTO,&
-                value=rnfsto_lvec(t),vlevel=1,unit="mm",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_BSFSTO,&
-                value=bsfsto_lvec(t),vlevel=1,unit="mm",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_RNFDWI,&
-                value=rnfdwi_lvec(t),vlevel=1,unit="mm",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_BSFDWI,&
-                value=bsfdwi_lvec(t),vlevel=1,unit="mm",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_SURFWS,&
-                value=surfws_lvec(t),vlevel=1,unit="mm",&
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_ewat,&
-                value=ewat_lvec(t),vlevel=1,unit="kg m-2 s-1",&   
-                direction="-")
-
-           call LIS_diagnoseRoutingOutputVar(n, t,LIS_MOC_edif,&
-                value=edif_lvec(t),vlevel=1,unit="kg m-2 s-1",&   
-                direction="-")
-        enddo
-
-     endif
-     deallocate(rivsto_lvec)
-     deallocate(rivdph_lvec)
-     deallocate(rivvel_lvec)
-     deallocate(rivout_lvec)
-     deallocate(evpout_lvec)
-     deallocate(fldout_lvec)
-     deallocate(fldsto_lvec)
-     deallocate(flddph_lvec)
-     deallocate(fldvel_lvec)
-     deallocate(fldfrc_lvec)
-     deallocate(fldare_lvec)
-     deallocate(sfcelv_lvec)
-     deallocate(rnfsto_lvec)
-     deallocate(bsfsto_lvec)
-     deallocate(rnfdwi_lvec)
-     deallocate(bsfdwi_lvec)
-     deallocate(surfws_lvec)
-     deallocate(ewat_lvec)
-     deallocate(edif_lvec)
-
-     if(LIS_masterproc)then
-        deallocate(surface_runoff)     
-        deallocate(baseflow)
-        deallocate(tmpr)
-        deallocate(tmpb)
-        !deallocate(tmp_nensem)
-
-        deallocate(rnfsto_mm)
-        deallocate(bsfsto_mm)
-
-        !ag (22Sep2016)
-        if(HYMAP2_routing_struc(n)%evapflag.ne.0)then
-           deallocate(tmp_tmp)
-           deallocate(tmp_q2)
-           deallocate(tmp_qnet)
-           deallocate(tmp_wind)
-           deallocate(tmp_psurf)
-           deallocate(tair)     
-           deallocate(qair)
-           deallocate(pres)     
-           deallocate(wind)     
-           deallocate(qnet)
-           deallocate(tmpet)
-        endif
-     endif
-
+  deallocate(rivsto_lvec)
+  deallocate(rivdph_lvec)
+  deallocate(rivvel_lvec)
+  deallocate(rivout_lvec)
+  deallocate(evpout_lvec)
+  deallocate(fldout_lvec)
+  deallocate(fldsto_lvec)
+  deallocate(flddph_lvec)
+  deallocate(fldvel_lvec)
+  deallocate(fldfrc_lvec)
+  deallocate(fldare_lvec)
+  deallocate(sfcelv_lvec)
+  deallocate(rnfsto_lvec)
+  deallocate(bsfsto_lvec)
+  deallocate(rnfdwi_lvec)
+  deallocate(bsfdwi_lvec)
+  deallocate(surfws_lvec)
+  deallocate(ewat_lvec)
+  deallocate(edif_lvec)
+  
+  deallocate(surface_runoff)     
+  deallocate(baseflow)
+  deallocate(tmpr)
+  deallocate(tmpb)
+  !deallocate(tmp_nensem)
+  
+  deallocate(rnfsto_mm)
+  deallocate(bsfsto_mm)
+  
+  !ag (22Sep2016)
+  if(HYMAP2_routing_struc(n)%evapflag.ne.0)then
+     deallocate(tmp_tmp)
+     deallocate(tmp_q2)
+     deallocate(tmp_qnet)
+     deallocate(tmp_wind)
+     deallocate(tmp_psurf)
+     deallocate(tair)     
+     deallocate(qair)
+     deallocate(pres)     
+     deallocate(wind)     
+     deallocate(qnet)
+     deallocate(tmpet)
   endif
 
 end subroutine HYMAP2_routing_run

--- a/lis/routing/HYMAP2_router/HYMAP2_routing_writerst.F90
+++ b/lis/routing/HYMAP2_router/HYMAP2_routing_writerst.F90
@@ -5,11 +5,28 @@
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
+#include "LIS_NetCDF_inc.h"
+
+!BOP
+! !ROUTINE: HYMAP2_routing_writerst
+! \label{HYMAP2_routing_writerst} 
+!
+! !REVISION HISTORY:
+! 15 Nov 2011: Augusto Getirana;  Initial implementation
+! 19 Jan 2016: Augusto Getirana;  Inclusion of four Local Inertia variables
+! 10 Mar 2019: Sujay Kumar;       Added support for NetCDF and parallel 
+!                                 processing. 
+!  
+! !INTERFACE: 
 subroutine HYMAP2_routing_writerst(n)
 
-
-  ! Augusto Getirana - 11/15/2011
-  ! 19 Jan 2016: Augusto Getirana, Inclusion of four Local Inertia variables
+!
+! !DESCRIPTION: 
+!  This routine writes restart files for HYMAP2. The restart files
+!  are in NetCDF format. 
+!
+!EOP
 
   use ESMF
   use LIS_coreMod
@@ -17,6 +34,9 @@ subroutine HYMAP2_routing_writerst(n)
   use LIS_fileIOMod
   use LIS_timeMgrMod
   use HYMAP2_routingMod
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)           
+  use netcdf
+#endif
 
   implicit none
   
@@ -26,31 +46,557 @@ subroutine HYMAP2_routing_writerst(n)
   integer               :: ftn
   integer               :: status
   logical               :: alarmCheck
-
-  if(LIS_masterproc) then
-     alarmCheck = LIS_isAlarmRinging(LIS_rc,&
+  
+  alarmCheck = LIS_isAlarmRinging(LIS_rc,&
           "HYMAP2 router restart alarm")
-     if(alarmCheck.or.(LIS_rc%endtime ==1)) then 
-        ftn = LIS_getNextUnitNumber()
+  if(alarmCheck.or.(LIS_rc%endtime ==1)) then 
+     if(LIS_masterproc) then 
         call LIS_create_output_directory('ROUTING')
         call LIS_create_restart_filename(n,filename,&
              'ROUTING','HYMAP2_router',&
-             wformat="binary")
+             wformat="netcdf")
         write(LIS_logunit,*) 'Writing routing restart ',trim(filename)
-
-        open(ftn,file=trim(filename), form='unformatted')
-		
-        write(ftn) HYMAP2_routing_struc(n)%rivsto
-        write(ftn) HYMAP2_routing_struc(n)%fldsto
-        write(ftn) HYMAP2_routing_struc(n)%rnfsto
-        write(ftn) HYMAP2_routing_struc(n)%bsfsto
-        write(ftn) HYMAP2_routing_struc(n)%rivout_pre
-        write(ftn) HYMAP2_routing_struc(n)%rivdph_pre
-        write(ftn) HYMAP2_routing_struc(n)%fldout_pre
-        write(ftn) HYMAP2_routing_struc(n)%flddph_pre
-
-        call LIS_releaseUnitNumber(ftn)
-        
+       
+#if (defined USE_NETCDF4)
+        status = nf90_create(path=filename, cmode=nf90_hdf5, ncid = ftn)
+        call LIS_verify(status,"Error in nf90_open in HYMAP2_routing_writerst")
+#endif
+#if (defined USE_NETCDF3)
+        status = nf90_create(Path = filename, cmode = nf90_clobber, ncid = ftn)
+        call LIS_verify(status, "Error in nf90_open in HYMAP2_routing_writerst")
+#endif
      endif
+     call HYMAP2_dump_restart(n, ftn)
+          
+     if (LIS_masterproc) then
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+        status = nf90_close(ftn)
+        call LIS_verify(status, "Error in nf90_close in NoahMP36_writerst")
+#endif
+     endif
+     
   endif
+
 end subroutine HYMAP2_routing_writerst
+
+
+!BOP
+!
+! !ROUTINE: HYMAP2_dump_restart
+! \label{HYMAP2_dump_restart}
+!
+! !REVISION HISTORY:
+!
+! !INTERFACE:
+subroutine HYMAP2_dump_restart(n, ftn)
+
+! !USES:
+    use LIS_coreMod, only : LIS_rc, LIS_masterproc
+    use LIS_logMod, only  : LIS_logunit
+    use LIS_historyMod
+    use HYMAP2_routingMod
+
+    implicit none
+
+    integer, intent(in) :: ftn
+    integer, intent(in) :: n
+
+!
+! !DESCRIPTION:
+!  This routine gathers the necessary restart variables and performs
+!  the actual write statements to create the restart files.
+!
+!  The arguments are:
+!  \begin{description}
+!   \item[n]
+!    index of the nest
+!   \item[ftn]
+!    unit number for the restart file
+!  \end{description}
+!
+! 
+!EOP 
+        
+    integer :: dimID(1)
+    integer :: rivsto_ID
+    integer :: fldsto_ID
+    integer :: rnfsto_ID
+    integer :: bsfsto_ID
+    integer :: rivout_pre_ID
+    integer :: rivdph_pre_ID
+    integer :: fldout_pre_ID
+    integer :: flddph_pre_ID
+    ! write the header of the restart file
+    call HYMAP2_writeGlobalHeader_restart(ftn, n, &
+         "HYMAP2", &
+         dimID)
+
+    call HYMAP2_writeHeader_restart(ftn, n, dimID, rivsto_ID, "RIVSTO", &
+         "river storage", &
+         "-", 1, -99999.0, 99999.0)
+    call HYMAP2_writeHeader_restart(ftn, n, dimID, fldsto_ID, "FLDSTO", &
+         "flood storage", &
+         "-", 1, -99999.0, 99999.0)
+    call HYMAP2_writeHeader_restart(ftn, n, dimID, rnfsto_ID, "RNFSTO", &
+         "runoff storage", &
+         "-", 1, -99999.0, 99999.0)
+    call HYMAP2_writeHeader_restart(ftn, n, dimID, bsfsto_ID, "BSFSTO", &
+         "baseflow storage", &
+         "-", 1, -99999.0, 99999.0)
+    call HYMAP2_writeHeader_restart(ftn, n, dimID, rivout_pre_ID, "RIVOUT_PRE", &
+         "rivoutpre", &
+         "-", 1, -99999.0, 99999.0)
+    call HYMAP2_writeHeader_restart(ftn, n, dimID, rivdph_pre_ID, "RIVDPH_PRE", &
+         "river depth_pre", &
+         "-", 1, -99999.0, 99999.0)
+    call HYMAP2_writeHeader_restart(ftn, n, dimID, fldout_pre_ID, "FLDOUT_PRE", &
+         "flood discharge pre", &
+         "-", 1, -99999.0, 99999.0)
+    call HYMAP2_writeHeader_restart(ftn, n, dimID, flddph_pre_ID, "FLDDPH_PRE", &
+         "flood depth pre", &
+         "-", 1, -99999.0, 99999.0)
+
+    call HYMAP2_closeHeader_restart(ftn)
+    
+    ! write state variables into restart file
+    ! snow albedo at last time step
+    call HYMAP2_writevar_restart(ftn, n, &
+         HYMAP2_routing_struc(n)%rivsto, &
+         rivsto_ID)    
+    call HYMAP2_writevar_restart(ftn, n, &
+         HYMAP2_routing_struc(n)%fldsto, &
+         fldsto_ID)    
+    call HYMAP2_writevar_restart(ftn, n, &
+         HYMAP2_routing_struc(n)%rnfsto, &
+         rnfsto_ID)    
+    call HYMAP2_writevar_restart(ftn, n, &
+         HYMAP2_routing_struc(n)%bsfsto, &
+         bsfsto_ID)    
+    call HYMAP2_writevar_restart(ftn, n, &
+         HYMAP2_routing_struc(n)%rivout_pre, &
+         rivout_pre_ID)    
+    call HYMAP2_writevar_restart(ftn, n, &
+         HYMAP2_routing_struc(n)%rivdph_pre, &
+         rivdph_pre_ID)    
+    call HYMAP2_writevar_restart(ftn, n, &
+         HYMAP2_routing_struc(n)%fldout_pre, &
+         fldout_pre_ID)    
+    call HYMAP2_writevar_restart(ftn, n, &
+         HYMAP2_routing_struc(n)%flddph_pre, &
+         flddph_pre_ID)    
+
+  end subroutine HYMAP2_dump_restart
+
+!BOP
+! !ROUTINE: HYMAP2_writeGlobalHeader_restart
+! \label{HYMAP2_writeGlobalHeader_restart}
+! 
+! !INTERFACE: HYMAP2_writeGlobalHeader_restart
+  subroutine HYMAP2_writeGlobalHeader_restart(ftn,n,&
+       model_name, dimID)
+! !USES: 
+    use LIS_coreMod
+    use LIS_logMod
+    use HYMAP2_routingMod
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)           
+    use netcdf
+#endif
+    implicit none
+
+! !ARGUMENTS: 
+    integer,   intent(in)     :: n 
+    integer,   intent(in)     :: ftn
+    character(len=*), intent(in) :: model_name
+    integer                   :: dimID(1)
+
+! 
+! !DESCRIPTION: 
+!  This routine writes an output file in the NETCDF format based on the 
+!  list of selected output variables. 
+!  The arguments are: 
+!  \begin{description}
+!    \item[n] index of the nest
+!    \item[ftn] file unit for the output file
+!    \item[model\_name] Name of the model that generates the output
+!  \end{description}
+!
+!EOP
+
+    integer, dimension(8) :: values
+    character(len=8)  :: date
+    character(len=10) :: time
+    character(len=5)  :: zone
+    character*20      :: wout
+
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)           
+    call date_and_time(date,time,zone,values)       
+    if(LIS_masterproc) then 
+       call LIS_verify(nf90_def_dim(ftn,'ntiles',&
+            HYMAP2_routing_struc(n)%nseqall_glb,&
+            dimID(1)),&
+            'nf90_def_dim failed for ntiles in HYMAP2_writeGlobalHeader_restart')
+       call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"missing_value", &
+            LIS_rc%udef),'nf90_put_att failed for missing_value')
+       
+       
+       call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"title", &
+            "LIS land surface model restart"),&
+            'nf90_put_att failed for title')
+       call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"institution", &
+            trim(LIS_rc%institution)),&
+            'nf90_put_att failed for institution')
+       call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"source",&
+            trim(model_name)),&
+            'nf90_put_att failed for source')
+       call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"history", &
+            "created on date: "//date(1:4)//"-"//date(5:6)//"-"//&
+            date(7:8)//"T"//time(1:2)//":"//time(3:4)//":"//time(5:10)),&
+            'nf90_put_att failed for history')
+       call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"references", &
+            "Kumar_etal_EMS_2006, Peters-Lidard_etal_ISSE_2007"),&
+            'nf90_put_att failed for references')
+       call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"conventions", &
+            "CF-1.6"),'nf90_put_att failed for conventions') !CF version 1.6
+       call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"comment", &
+            "website: http://lis.gsfc.nasa.gov/"),&
+            'nf90_put_att failed for comment')
+       
+       if(LIS_rc%lis_map_proj.eq."latlon") then !latlon
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"MAP_PROJECTION", &
+               "EQUIDISTANT CYLINDRICAL"),&
+               'nf90_put_att failed for MAP_PROJECTION')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,&
+               "SOUTH_WEST_CORNER_LAT", &
+               LIS_rc%gridDesc(n,4)),&
+               'nf90_put_att failed for SOUTH_WEST_CORNER_LAT')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,&
+               "SOUTH_WEST_CORNER_LON", &
+               LIS_rc%gridDesc(n,5)),&
+               'nf90_put_att failed for SOUTH_WEST_CORNER_LON')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"DX", &
+               LIS_rc%gridDesc(n,9)),&
+               'nf90_put_att failed for DX')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"DY", &
+               LIS_rc%gridDesc(n,10)),&
+               'nf90_put_att failed for DY')
+       elseif(LIS_rc%lis_map_proj.eq."mercator") then 
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"MAP_PROJECTION", &
+               "MERCATOR"),&
+               'nf90_put_att failed for MAP_PROJECTION')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,&
+               "SOUTH_WEST_CORNER_LAT", &
+               LIS_rc%gridDesc(n,4)),&
+               'nf90_put_att failed for SOUTH_WEST_CORNER_LAT')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,&
+               "SOUTH_WEST_CORNER_LON", &
+               LIS_rc%gridDesc(n,5)),&
+               'nf90_put_att failed for SOUTH_WEST_CORNER_LON') 
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"TRUELAT1", &
+               LIS_rc%gridDesc(n,10)),&
+               'nf90_put_att failed for TRUELAT1')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"STANDARD_LON", &
+               LIS_rc%gridDesc(n,11)),&
+               'nf90_put_att failed for STANDARD_LON')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"DX", &
+               LIS_rc%gridDesc(n,8)),&
+               'nf90_put_att failed for DX')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"DY", &
+               LIS_rc%gridDesc(n,9)),&
+               'nf90_put_att failed for DY')
+       elseif(LIS_rc%lis_map_proj.eq."lambert") then !lambert conformal
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"MAP_PROJECTION", &
+               "LAMBERT CONFORMAL"),&
+               'nf90_put_att failed for MAP_PROJECTION')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,&
+               "SOUTH_WEST_CORNER_LAT", &
+               LIS_rc%gridDesc(n,4)),&
+               'nf90_put_att failed for SOUTH_WEST_CORNER_LAT')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,&
+               "SOUTH_WEST_CORNER_LON", &
+               LIS_rc%gridDesc(n,5)),&
+               'nf90_put_att failed for SOUTH_WEST_CORNER_LON')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"TRUELAT1", &
+               LIS_rc%gridDesc(n,10)),&
+               'nf90_put_att failed for TRUELAT1')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"TRUELAT2", &
+               LIS_rc%gridDesc(n,7)),&
+               'nf90_put_att failed for TRUELAT2')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"STANDARD_LON", &
+               LIS_rc%gridDesc(n,11)),&
+               'nf90_put_att failed for STANDARD_LON')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"DX", &
+               LIS_rc%gridDesc(n,8)),&
+               'nf90_put_att failed for DX')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"DY", &
+               LIS_rc%gridDesc(n,9)),&
+               'nf90_put_att failed for DY')
+          
+       elseif(LIS_rc%lis_map_proj.eq."polar") then ! polar stereographic
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"MAP_PROJECTION", &
+               "POLAR STEREOGRAPHIC"),&
+               'nf90_put_att failed for MAP_PROJECTION')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,&
+               "SOUTH_WEST_CORNER_LAT", &
+               LIS_rc%gridDesc(n,4)),&
+               'nf90_put_att failed for SOUTH_WEST_CORNER_LAT')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,&
+               "SOUTH_WEST_CORNER_LON", &
+               LIS_rc%gridDesc(n,5)),&
+               'nf90_put_att failed for SOUTH_WEST_CORNER_LON')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"TRUELAT1", &
+               LIS_rc%gridDesc(n,10)),&
+               'nf90_put_att failed for TRUELAT1')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"ORIENT", &
+               LIS_rc%gridDesc(n,7)),&
+               'nf90_put_att failed for ORIENT')
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"STANDARD_LON", &
+               LIS_rc%gridDesc(n,11)),&
+               'nf90_put_att failed for STANDARD_LON')                  
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"DX", &
+               LIS_rc%gridDesc(n,8)),&
+               'nf90_put_att failed for DX')                  
+          call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"DY", &
+               LIS_rc%gridDesc(n,9)),&
+               'nf90_put_att failed for DY')                  
+       endif
+    endif
+#endif    
+  end subroutine HYMAP2_writeGlobalHeader_restart
+
+!BOP
+! !ROUTINE: HYMAP2_writeHeader_restart
+! \label{HYMAP2_writeHeader_restart}
+! 
+! !INTERFACE: 
+  subroutine HYMAP2_writeHeader_restart(ftn,n,dimID, vid, standard_name, &
+       long_name, units, vlevels, valid_min, valid_max)
+! !USES: 
+    use LIS_coreMod
+    use LIS_logMod
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)
+    use netcdf
+#endif
+    implicit none
+
+! !ARGUMENTS:     
+    integer                    :: ftn
+    integer                    :: n
+    integer                    :: dimID(1)
+    integer                    :: vid
+    character(len=*)           :: standard_name
+    character(len=*)           :: long_name
+    character(len=*)           :: units
+    integer                    :: vlevels
+    real                       :: valid_min
+    real                       :: valid_max
+
+! 
+! !DESCRIPTION: 
+!    This routine writes the required NETCDF header for a single HYMAP2 variable
+! 
+!   The arguments are: 
+!   \begin{description}
+!   \item[n]
+!    index of the nest
+!   \item[ftn]
+!    NETCDF file unit handle
+!   \item[dimID]
+!    NETCDF dimension ID corresponding to the variable
+!   \item[dataEntry]
+!    object containing the values and attributes of the variable to be 
+!    written
+!   \end{description}
+!
+!   The routines invoked are: 
+!   \begin{description}
+!   \item[LIS\_endrun](\ref{LIS_endrun})
+!     call to abort program when a fatal error is detected. 
+!   \item[LIS\_verify](\ref{LIS_verify})
+!     call to check if the return value is valid or not.
+!   \end{description}
+!EOP
+
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)
+    integer :: data_index
+    integer :: shuffle, deflate, deflate_level
+    integer :: dimID_t(2)
+    integer :: fill_value
+
+    shuffle = NETCDF_shuffle
+    deflate = NETCDF_deflate
+    deflate_level =NETCDF_deflate_level
+
+    dimID_t(1) = dimID(1)
+    fill_value = LIS_rc%udef
+
+    if(LIS_masterproc) then 
+       call LIS_verify(nf90_def_var(ftn,trim(standard_name),&
+            nf90_float,dimids = dimID_t(1:1), varID=vid),&
+            'nf90_def_var(1d) failed in HYMAP2_writeHeader_restart')
+       
+#if(defined USE_NETCDF4)
+       call LIS_verify(nf90_def_var_fill(ftn,&
+            vid, 1,fill_value), 'nf90_def_var_fill failed for '//&
+            standard_name)
+       
+       call LIS_verify(nf90_def_var_deflate(ftn,&
+            vid, shuffle, deflate, deflate_level),&
+            'nf90_def_var_deflate(1d) failed in HYMAP2_writeHeader_restart')
+#endif
+
+       call LIS_verify(nf90_put_att(ftn,vid,&
+            "units",trim(units)),&
+            'nf90_put_att failed for units')
+       call LIS_verify(nf90_put_att(ftn,vid,&
+            "standard_name",trim(standard_name)))
+       call LIS_verify(nf90_put_att(ftn,vid,&
+            "long_name",trim(long_name)),&
+            'nf90_put_att failed for long_name')
+       call LIS_verify(nf90_put_att(ftn,vid,&
+            "scale_factor",1.0),&
+            'nf90_put_att failed for scale_factor')
+       call LIS_verify(nf90_put_att(ftn,vid,&
+            "add_offset",0.0),&
+            'nf90_put_att failed for add_offset')
+       call LIS_verify(nf90_put_att(ftn,vid,&
+            "missing_value",LIS_rc%udef),&
+            'nf90_put_att failed for missing_value')
+       call LIS_verify(nf90_put_att(ftn,vid,&
+            "_FillValue",LIS_rc%udef),&
+            'nf90_put_att failed for _FillValue')
+       call LIS_verify(nf90_put_att(ftn,vid,&
+            "vmin",valid_min),&
+            'nf90_put_att failed for vmin')
+       call LIS_verify(nf90_put_att(ftn,vid,&
+            "vmax",valid_max),&
+            'nf90_put_att failed for vmax')
+#endif
+    endif
+  end subroutine HYMAP2_writeHeader_restart
+  
+
+!BOP
+! !ROUTINE: HYMAP2_closeHeader_restart
+! \label{HYMAP2_closeHeader_restart}
+! 
+! !INTERFACE: 
+  subroutine HYMAP2_closeHeader_restart(ftn)
+
+    use LIS_coreMod
+    use LIS_logMod
+#if ( defined USE_NETCDF3 || defined USE_NETCDF4 )
+    use netcdf
+#endif
+
+    implicit none
+
+! !ARGUMENTS:     
+    integer            :: ftn
+! 
+! !DESCRIPTION: 
+!    This routine closes the required NETCDF header.
+! 
+!   The arguments are: 
+!   \begin{description}
+!   \item[ftn]
+!    NETCDF file unit handle
+!   \item[n]
+!    index of the nest
+!   \item[m]
+!    index of the surface type
+!   \item[dimID]
+!    NETCDF dimension ID corresponding to the variable
+!   \item[rstInterval]
+!    the restart interval
+!   \end{description}
+
+!EOP
+
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)
+       
+    if(LIS_masterproc) then 
+       call LIS_verify(nf90_enddef(ftn),&
+            'nf90_enddef failed')       
+    endif
+#endif
+  end subroutine HYMAP2_closeHeader_restart
+
+!BOP
+! !ROUTINE: HYMAP2_writevar_restart
+! \label{HYMAP2_writevar_restart}
+! 
+! !INTERFACE:
+! Private name: call using LIS_writevar_restart
+  subroutine HYMAP2_writevar_restart(ftn, n, var, varid)
+! !USES:
+    use LIS_coreMod
+    use LIS_mpiMod
+    use LIS_logMod
+    use HYMAP2_routingMod
+#if ( defined USE_NETCDF3 || defined USE_NETCDF4 )
+    use netcdf
+#endif
+
+    implicit none
+! !ARGUMENTS: 
+    integer, intent(in) :: ftn
+    integer, intent(in) :: n
+    real                :: var(HYMAP2_routing_struc(n)%nseqall)
+    integer             :: varid
+
+! !DESCRIPTION:
+!  Writes a real variable to a NetCDF restart file. 
+!
+!  The arguments are: 
+!  \begin{description}
+!   \item [n]
+!     index of the domain or nest.
+!   \item [ftn]
+!     unit number of the binary output file
+!   \item [var]
+!     variables being written, dimensioned in the tile space
+!  \end{description}
+!EOP
+    real, allocatable :: gtmp(:)
+    real, allocatable :: gtmp1(:)
+    integer           :: l,i,ix,iy,ix1,iy1
+    integer :: ierr
+
+    if(LIS_masterproc) then 
+       allocate(gtmp(HYMAP2_routing_struc(n)%nseqall_glb))
+       allocate(gtmp1(HYMAP2_routing_struc(n)%nseqall_glb))
+    else
+       allocate(gtmp1(1))
+    endif
+#if (defined SPMD)      
+    call MPI_GATHERV(var,HYMAP2_routing_struc(n)%nseqall,&
+         MPI_REAL,gtmp1,&
+         HYMAP2_routing_struc(n)%gdeltas(:),&
+         HYMAP2_routing_struc(n)%goffsets(:),&
+         MPI_REAL,0,LIS_mpi_comm,ierr)
+#else 
+    gtmp1 = var
+#endif
+    if(LIS_masterproc) then
+       do l=1,LIS_npes
+          do i=1,HYMAP2_routing_struc(n)%gdeltas(l-1)
+             ix = HYMAP2_routing_struc(n)%seqx_glb(i+&
+                  HYMAP2_routing_struc(n)%goffsets(l-1))
+             iy = HYMAP2_routing_struc(n)%seqy_glb(i+&
+                  HYMAP2_routing_struc(n)%goffsets(l-1))
+             ix1 = ix + LIS_ews_halo_ind(n,l) - 1
+             iy1 = iy + LIS_nss_halo_ind(n,l)-1
+             gtmp(HYMAP2_routing_struc(n)%sindex(ix1,iy1)) = &
+                  gtmp1(i+HYMAP2_routing_struc(n)%goffsets(l-1))
+          enddo
+       enddo
+#if ( defined USE_NETCDF3 || defined USE_NETCDF4 )
+       ierr = nf90_put_var(ftn,varid,gtmp,(/1/),&
+            (/HYMAP2_routing_struc(n)%nseqall_glb/))
+       call LIS_verify(ierr,'nf90_put_var failed in LIS_historyMod')
+#endif   
+       deallocate(gtmp)       
+    endif
+    deallocate(gtmp1)
+
+  end subroutine HYMAP2_writevar_restart


### PR DESCRIPTION
This commit enables HyMAP2 to be run in parallel. No
additional changes in the lis.config file are required.
The commit also enables the HyMAP2 restart files to be in
NetCDF.
Note that the parallel support does not
extend to the previous version of the HyMAP router or the
NLDAS router.
The following features in HyMAP2 are
currently not supported
1. Support for running with ensembles (The land model
can still be run in an ensemble mode. The ensemble average
is then used to perform the routing
2. Support for running with existing land model outputs
(The routing model only runs in online mode).
3. Support for binary restart files (only NetCDF output is
supported).

Resolves #7