### PR TITLE
Updates the support for HyMAP2 routing with NoahMP

### DIFF
--- a/lis/plugins/LIS_lsmrouting_pluginMod.F90
+++ b/lis/plugins/LIS_lsmrouting_pluginMod.F90
@@ -70,6 +70,7 @@ subroutine LIS_lsmrouting_plugin
 #if ( defined SM_NOAHMP_3_6 )
    external noahmp36_getrunoffs
    external noahmp36_getrunoffs_mm
+   external noahmp36_getrunoffs_hymap2
 #endif
 
 #if ( defined SM_RUC_3_7 )
@@ -182,8 +183,8 @@ subroutine LIS_lsmrouting_plugin
 
 #if ( defined SM_NOAHMP_3_6 )
    call registerlsmroutinggetrunoff(trim(LIS_noahmp36Id)//"+"//&
-                                    trim(LIS_HYMAP2routerId)//char(0), &
-                                    noahmp36_getrunoffs_mm)
+        trim(LIS_HYMAP2routerId)//char(0), &
+        noahmp36_getrunoffs_hymap2)
 #endif
 
 #if ( defined SM_RUC_3_7 )

--- a/lis/surfacemodels/land/noahmp.3.6/routing/noahmp36_getrunoffs_hymap2.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/routing/noahmp36_getrunoffs_hymap2.F90
@@ -1,29 +1,27 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
-! NASA Goddard Space Flight Center Land Information System (LIS) v7.1
+! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
 !
 ! Copyright (c) 2015 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
 !BOP
-! !ROUTINE: clsmf25_getrunoffs_hymap2
-!  \label{clsmf25_getrunoffs_hymap2}
+! !ROUTINE: noahmp36_getrunoffs_hymap2
+!  \label{noahmp36_getrunoffs_hymap2}
 !
 ! !REVISION HISTORY:
 !  6 May 2011: Sujay Kumar; Initial Specification
-!  2 May 2017: Augusto Getirana; Include total evapotranspiration
+! 31 Jul 2015: David Mocko, added Noah-MP-3.6 routing into LIS-7
 !
 ! !INTERFACE:
-subroutine clsmf25_getrunoffs_hymap2(n)
+subroutine noahmp36_getrunoffs_hymap2(n)
 ! !USES:
   use ESMF
-  use LIS_coreMod
+  use LIS_coreMod, only : LIS_rc, LIS_masterproc
   use LIS_routingMod, only : LIS_runoff_state
-  use LIS_logMod,     only : LIS_verify
-  
+  use LIS_logMod
   use LIS_historyMod
-  use clsmf25_lsmMod, only : clsmf25_struc
-  use LIS_mpiMod
+  use noahmp36_lsmMod, only : noahmp36_struc
 
   implicit none
 ! !ARGUMENTS: 
@@ -53,43 +51,42 @@ subroutine clsmf25_getrunoffs_hymap2(n)
   real, allocatable      :: evapotranspiration1_t(:)
   integer                :: evapflag
 
-
   allocate(runoff1(LIS_rc%npatch(n,LIS_rc%lsm_index)))
   allocate(runoff2(LIS_rc%npatch(n,LIS_rc%lsm_index)))
   allocate(runoff1_t(LIS_rc%ntiles(n)))
   allocate(runoff2_t(LIS_rc%ntiles(n)))
 
-  call ESMF_AttributeGet(LIS_runoff_state(n),&
-       "Routing model evaporation option",&
+  runoff1_t = -9999.0
+  runoff2_t = -9999.0
+
+  call ESMF_AttributeGet(LIS_runoff_state(n),"Routing model evaporation option",&
        evapflag, rc=status)
 !if option is not defined, then assume that no evap calculations will be done
   if(status.ne.0)then 
      evapflag = 0
   endif
 
+  if(LIS_masterproc) then 
+     call ESMF_StateGet(LIS_runoff_state(n),"Surface Runoff",&
+          sfrunoff_field,rc=status)
+     call LIS_verify(status,'ESMF_StateGet failed for Surface Runoff')
+     
+     call ESMF_StateGet(LIS_runoff_state(n),"Subsurface Runoff",&
+          baseflow_field,rc=status)
+     call LIS_verify(status,'ESMF_StateGet failed for Subsurface Runoff')
 
-  call ESMF_StateGet(LIS_runoff_state(n),"Surface Runoff",&
-       sfrunoff_field,rc=status)
-  call LIS_verify(status,'ESMF_StateGet failed for Surface Runoff')
-  
-  call ESMF_StateGet(LIS_runoff_state(n),"Subsurface Runoff",&
-       baseflow_field,rc=status)
-  call LIS_verify(status,'ESMF_StateGet failed for Subsurface Runoff')
-  
-  call ESMF_FieldGet(sfrunoff_field,localDE=0,farrayPtr=sfrunoff,rc=status)
-  call LIS_verify(status,'ESMF_FieldGet failed for Surface Runoff')
-  
-  call ESMF_FieldGet(baseflow_field,localDE=0,farrayPtr=baseflow,rc=status)
-  call LIS_verify(status,'ESMF_FieldGet failed for Subsurface Runoff')
-  
+     call ESMF_FieldGet(sfrunoff_field,localDE=0,farrayPtr=sfrunoff,rc=status)
+     call LIS_verify(status,'ESMF_FieldGet failed for Surface Runoff')
+     
+     call ESMF_FieldGet(baseflow_field,localDE=0,farrayPtr=baseflow,rc=status)
+     call LIS_verify(status,'ESMF_FieldGet failed for Subsurface Runoff')
 
-  do t=1, LIS_rc%npatch(n,LIS_rc%lsm_index)  
-     runoff1(t) = clsmf25_struc(n)%cat_diagn(t)%runsrf
-     runoff2(t) = clsmf25_struc(n)%cat_diagn(t)%bflow
+  endif
+
+  do t=1, LIS_rc%npatch(n,LIS_rc%lsm_index)  !units?
+     runoff1(t) = NOAHMP36_struc(n)%noahmp36(t)%runsrf
+     runoff2(t) = NOAHMP36_struc(n)%noahmp36(t)%runsub
   enddo
-
-  runoff1_t = LIS_rc%udef
-  runoff2_t = LIS_rc%udef
 
   call LIS_patch2tile(n,1,runoff1_t, runoff1)
   call LIS_patch2tile(n,1,runoff2_t, runoff2)
@@ -102,7 +99,7 @@ subroutine clsmf25_getrunoffs_hymap2(n)
   deallocate(runoff1_t)
   deallocate(runoff2_t)
  
-  !ag (25Apr2017)
+  !ag (05Jun2017)
   !Including meteorological forcings + evapotranspiration for computing evaporation from open waters in HyMAP2)
   if(evapflag.ne.0)then
     allocate(evapotranspiration1(LIS_rc%npatch(n,LIS_rc%lsm_index)))
@@ -110,23 +107,25 @@ subroutine clsmf25_getrunoffs_hymap2(n)
     
     call ESMF_StateGet(LIS_runoff_state(n),"Total Evapotranspiration",&
          evapotranspiration_Field, rc=status)
-    call LIS_verify(status, &
-         "clsmf25_getrunoffs: ESMF_StateGet failed for Total Evapotranspiration")
-    
+    call LIS_verify(status, "noahmp36_getrunoffs_hymap2: ESMF_StateGet failed for Total Evapotranspiration")
+        
     call ESMF_FieldGet(evapotranspiration_Field,localDE=0,&
          farrayPtr=evapotranspiration,rc=status)
-    call LIS_verify(status, "clsmf25_getrunoffs: ESMF_FieldGet failed for Total Evapotranspiration")
-
+    call LIS_verify(status, "noahmp36_getrunoffs_hymap2: ESMF_FieldGet failed for Total Evapotranspiration")
+    
     do t=1, LIS_rc%npatch(n,LIS_rc%lsm_index)  
-       evapotranspiration1(t)  = clsmf25_struc(n)%cat_diagn(t)%evap
+       evapotranspiration1(t)  =  &
+            NOAHMP36_struc(n)%noahmp36(t)%ecan + &
+            NOAHMP36_struc(n)%noahmp36(t)%etran + &
+            NOAHMP36_struc(n)%noahmp36(t)%edir 
     enddo
 
     call LIS_patch2tile(n,1,evapotranspiration1_t, evapotranspiration1)
-
-    evapotranspiration = evapotranspiration1_t
   
+    evapotranspiration = evapotranspiration1_t
+
     deallocate(evapotranspiration1)
     deallocate(evapotranspiration1_t)
   endif  
 
-end subroutine clsmf25_getrunoffs_hymap2
+end subroutine noahmp36_getrunoffs_hymap2


### PR DESCRIPTION
The interface routine in NoahMP that maps the surface runoff
and baseflow (and evaporation) fields from NoahMP for HyMAP2.
The routine has been updated to reflect the changes in HyMAP2
related to parallelism support

Resolves #70