### PR TITLE
Fixes the crash when using HyMAP in a parallel LIS run

### DIFF
--- a/lis/routing/HYMAP_router/HYMAP_routing_run.F90
+++ b/lis/routing/HYMAP_router/HYMAP_routing_run.F90
@@ -65,6 +65,7 @@ subroutine HYMAP_routing_run(n)
   integer               :: status
   logical               :: alarmCheck
   integer               :: c,r,t
+  logical               :: dummy
   integer               :: ios, nid,qsid,qsbid
 
   real,   allocatable   :: rnfsto_mm(:,:,:),bsfsto_mm(:,:,:)
@@ -470,51 +471,51 @@ subroutine HYMAP_routing_run(n)
         endif
         
         call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%rivsto(:,:,1),&
-             rivsto_lvec)
+             rivsto_lvec,dummy)
         
         call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%rivdph(:,:,1),&
-             rivdph_lvec)
+             rivdph_lvec,dummy)
         
         call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%rivvel(:,:,1),&
-             rivvel_lvec)
+             rivvel_lvec,dummy)
         
         call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%rivout(:,:,1),&
-             rivout_lvec)
+             rivout_lvec,dummy)
         
         call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%evpout(:,:,1),&
-             evpout_lvec)
+             evpout_lvec,dummy)
         
         call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%fldout(:,:,1),&
-             fldout_lvec)
+             fldout_lvec,dummy)
         
         call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%fldsto(:,:,1),&
-             fldsto_lvec)
+             fldsto_lvec,dummy)
         
         call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%flddph(:,:,1),&
-             flddph_lvec)
+             flddph_lvec,dummy)
         
         call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%fldvel(:,:,1),&
-             fldvel_lvec)
+             fldvel_lvec,dummy)
         
         call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%fldfrc(:,:,1),&
-             fldfrc_lvec)
+             fldfrc_lvec,dummy)
         
         call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%fldare(:,:,1),&
-             fldare_lvec)
+             fldare_lvec,dummy)
         
         call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%sfcelv(:,:,1),&
-             sfcelv_lvec)
+             sfcelv_lvec,dummy)
         
         !ag (26Oct2017) - converting surface runoff and baseflow storage units from m3 to mm
         !call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%rnfsto(:,:,1),&
-        !     rnfsto_lvec)
+        !     rnfsto_lvec,dummy)
         !
         !call LIS_grid2patch(n,LIS_rc%lsm_index,HYMAP_routing_struc(n)%bsfsto(:,:,1),&
-        !     bsfsto_lvec)
+        !     bsfsto_lvec,dummy)
 
-        call LIS_grid2patch(n,LIS_rc%lsm_index,rnfsto_mm(:,:,1),rnfsto_lvec)
+        call LIS_grid2patch(n,LIS_rc%lsm_index,rnfsto_mm(:,:,1),rnfsto_lvec,dummy)
       
-        call LIS_grid2patch(n,LIS_rc%lsm_index,bsfsto_mm(:,:,1),bsfsto_lvec)
+        call LIS_grid2patch(n,LIS_rc%lsm_index,bsfsto_mm(:,:,1),bsfsto_lvec,dummy)
 
         do t=1, LIS_rc%npatch(n,LIS_rc%lsm_index)
            


### PR DESCRIPTION
This is a bug fix to enable HyMAP router to be used in a parallel LIS run.
The crash was related to the changes made for mapping between the
grid and tile spaces for HyMAP2

Resolves #73