### PR TITLE
Fixes the HyMAP2 crash with large number of processors

### DIFF
--- a/lis/routing/HYMAP2_router/HYMAP2_model.F90
+++ b/lis/routing/HYMAP2_router/HYMAP2_model.F90
@@ -143,6 +143,8 @@ subroutine HYMAP2_model(n,mis,nx,ny,yr,mo,da,hr,mn,ss,&
   integer                :: ic,ic_down,i,iloc(1)
 
   !ag (29Jan2016)
+  integer                :: nt_local
+  real                   :: dta_local
   integer                :: counti, countf, count_rate
   integer                :: maxi
   real                   :: mindt
@@ -185,16 +187,25 @@ subroutine HYMAP2_model(n,mis,nx,ny,yr,mo,da,hr,mn,ss,&
   dtaout=dta
   iloc(:)=minloc(dta)
   i=iloc(1)
+
+  if(nseqall.gt.0) then 
+     nt_local = nt(i)
+     dta_local = dta(i)
+  else
+     nt_local = 1
+     dta_local = dt
+  endif
+
 !find the maximum of i and minimum dt across all processors
 #if (defined SPMD)
-  call MPI_ALLREDUCE(nt(i),maxi, 1, MPI_INTEGER, MPI_MAX, &
+  call MPI_ALLREDUCE(nt_local,maxi, 1, MPI_INTEGER, MPI_MAX, &
        LIS_mpi_comm,status)
 
-  call MPI_ALLREDUCE(dta(i),mindt, 1, MPI_REAL, MPI_MIN, &
+  call MPI_ALLREDUCE(dta_local,mindt, 1, MPI_REAL, MPI_MIN, &
        LIS_mpi_comm,status)
 #else 
-  maxi = nt(i)
-  mindt = dta(i)
+  maxi = nt_local
+  mindt = dta_local
 #endif
   rivout0=rivout
   rivvel0=rivvel

--- a/lis/surfacemodels/land/noahmp.3.6/da_albedo/noahmp36_updatealbedovars.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/da_albedo/noahmp36_updatealbedovars.F90
@@ -181,7 +181,6 @@ subroutine noahmp36_updatealbedovars(n, LSM_State, LSM_Incr_State)
      gid = LIS_domain(n)%gindex(&
           LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col,&
           LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row)
-
      albitmp =  albi(t) + albiincr(t)
 
 


### PR DESCRIPTION
The crash with large number of processors was occurring because some processors
had zero tiles. The code was updated to handle such cases
The two NoahMP files that are being committed only includes code indentation updates

Resolves #77