### PR TITLE
Adds the support for SMAP soil moisture in OPTUE

### DIFF
--- a/lis/core/LIS_PE_HandlerMod.F90
+++ b/lis/core/LIS_PE_HandlerMod.F90
@@ -202,7 +202,7 @@ contains
          smin,            &
          ssec)
     
-    write(unit=LIS_logunit,FMT=*) 'Calibration period start time:',  &
+    write(unit=LIS_logunit,FMT=*) '[INFO] Calibration period start time:',  &
          stime,  &
          syear,  &
          smonth, &

--- a/lis/interp/compute_vinterp_weights.F90
+++ b/lis/interp/compute_vinterp_weights.F90
@@ -93,12 +93,13 @@ subroutine compute_vinterp_weights(obs_nlayers,lis_sf_d, &
   nlayers = 1
 
   do i=1, obs_nlayers
-     if(obs_d(i).ge.lis_sf_d) then 
+     if(obs_d(i).gt.lis_sf_d) then 
         nlayers = i 
         exit
      endif
   enddo
   
+  nlayers = max(1,nlayers-1)
   ! compute all depths upto the last observation depth
   
   ! first check if the top layer is too thick (difference > 2cm) then 
@@ -122,12 +123,12 @@ subroutine compute_vinterp_weights(obs_nlayers,lis_sf_d, &
   
   nlayers = 1
   do i=1, obs_nlayers
-     if(obs_d(i).ge.lis_rz_d) then 
+     if(obs_d(i).gt.lis_rz_d) then 
         nlayers = i 
         exit
      endif
   enddo
-  
+  nlayers = max(1,nlayers-1)
   ! if the deepest observation depth is shallower than the 
   ! LIS model depths
   

--- a/lis/make/default.cfg
+++ b/lis/make/default.cfg
@@ -964,6 +964,11 @@ enabled: True
 macro: PE_OBS_ISMNSM
 path: optUE/type/paramestim/obs/ISMNsm
 
+[PE OBS SMAPsm]
+enabled: True
+macro: PE_OBS_SMAPSM
+path: optUE/type/paramestim/obs/SMAPsm
+
 [PE OBJFUNC LS]
 enabled: True
 macro: PE_OBJFUNC_LS
@@ -1078,6 +1083,7 @@ virtual_da path: surfacemodels/land/noahmp.3.6/da_soilm,
 virtual_routing path: surfacemodels/land/noahmp.3.6/routing
 virtual_optue path: surfacemodels/land/noahmp.3.6/pe,
             surfacemodels/land/noahmp.3.6/pe/obspred/ARSsm,
+            surfacemodels/land/noahmp.3.6/pe/obspred/SMAPsm,
             surfacemodels/land/noahmp.3.6/pe/obspred/ISMNsm
 
 

--- a/lis/optUE/type/paramestim/obs/ISMNsm/read_ISMNsmobs.F90
+++ b/lis/optUE/type/paramestim/obs/ISMNsm/read_ISMNsmobs.F90
@@ -225,8 +225,12 @@ subroutine read_ISMNsmobs(Obj_Space)
                     rzsm = rzsm + rz_wt(v)*ISMNsm_obs_struc(n)%stn(k)%sm(tind,v)
                  endif
               enddo
-              ISMNsm_obs_struc(n)%stn(k)%sfsm(tind) = sfsm
-              ISMNsm_obs_struc(n)%stn(k)%rzsm(tind) = rzsm
+              if(sfsm.gt.0.001) then 
+                 ISMNsm_obs_struc(n)%stn(k)%sfsm(tind) = sfsm
+              endif
+              if(rzsm.gt.0.001) then 
+                 ISMNsm_obs_struc(n)%stn(k)%rzsm(tind) = rzsm
+              endif
            endif
         enddo
         deallocate(depth)

--- a/lis/optUE/type/paramestim/obs/SMAPsm/SMAPsm_obsMod.F90
+++ b/lis/optUE/type/paramestim/obs/SMAPsm/SMAPsm_obsMod.F90
@@ -1,0 +1,182 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
+!
+! Copyright (c) 2015 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+!
+! !MODULE: SMAPsm_obsMod
+! 
+! !DESCRIPTION: 
+!
+!   
+! !REVISION HISTORY: 
+!  21 Sep 2018 Sujay Kumar;   Initial Specification 
+! 
+module SMAPsm_obsMod
+! !USES: 
+  use ESMF
+!EOP
+  implicit none
+  PRIVATE
+
+!-----------------------------------------------------------------------------
+! !PUBLIC MEMBER FUNCTIONS:
+!-----------------------------------------------------------------------------
+  public :: SMAPsm_obs_setup
+!-----------------------------------------------------------------------------
+! !PUBLIC TYPES:
+!-----------------------------------------------------------------------------
+  PUBLIC :: SMAPsm_obs_struc
+
+  type, public ::  SMAPsm_obs_data_dec
+
+     integer                    :: nc
+     integer                    :: nr
+     real,     allocatable      :: smobs(:,:)
+     real,     allocatable      :: smtime(:,:)
+
+     integer, allocatable       :: n11(:)
+
+     character*20               :: data_designation
+     logical                    :: startMode
+
+  end type SMAPsm_obs_data_dec
+
+  type(SMAPsm_obs_data_dec), allocatable :: SMAPsm_obs_struc(:)
+
+contains
+!BOP
+! 
+! !ROUTINE: SMAPsm_obs_setup
+! \label{SMAPsm_obs_setup}
+! 
+! !INTERFACE: 
+  subroutine SMAPsm_obs_setup(Obs_State)
+! !USES: 
+    use LIS_coreMod
+    use LIS_logMod
+    use map_utils
+    use LIS_timeMgrMod
+
+    implicit none 
+
+! !ARGUMENTS: 
+    type(ESMF_State)       ::  Obs_State(LIS_rc%nnest)
+! 
+! !DESCRIPTION: 
+!   
+!   The arguments are: 
+!   \begin{description}
+!    \item[Obs\_State]   observation state object 
+!   \end{description}
+!EOP
+    integer                   ::  n 
+    type(ESMF_ArraySpec)      ::  realarrspec
+    type(ESMF_Field)          ::  obsField
+    character*100             ::  obsdir
+    character*100             ::  vname
+    character*100             ::  obsAttribFile(LIS_rc%nnest)
+    integer                 :: k
+    integer                 :: ftn
+    integer                 :: status
+    real                   :: gridDesci(50)
+
+
+    allocate(SMAPsm_obs_struc(LIS_rc%nnest))
+
+    write(LIS_logunit,*) '[INFO] Setting up SMAP sm data reader....'
+
+    call ESMF_ArraySpecSet(realarrspec,rank=1,typekind=ESMF_TYPEKIND_R4,&
+         rc=status)
+    call LIS_verify(status)
+    
+    call ESMF_ConfigFindLabel(LIS_config,"SMAP soil moisture data directory:",&
+         rc=status)
+    call ESMF_ConfigGetAttribute(LIS_config,obsdir,&
+         rc=status)
+    call LIS_verify(status, 'SMAP soil moisture data directory: not defined')
+    
+    call ESMF_ConfigFindLabel(LIS_config,&
+         "SMAP soil moisture data designation:",&
+         rc=status)
+    do n=1,LIS_rc%nnest
+       call ESMF_ConfigGetAttribute(LIS_config,&
+            SMAPsm_obs_struc(n)%data_designation,&
+            rc=status)
+       call LIS_verify(status, 'SMAP soil moisture data designation: is missing')
+    enddo
+    do n=1,LIS_rc%nnest
+
+       call ESMF_AttributeSet(Obs_State(n),"Data Directory",&
+            obsdir, rc=status)
+       call LIS_verify(status)
+
+       call ESMF_AttributeSet(Obs_State(n),"Data Update Status",&
+            .false., rc=status)
+       call LIS_verify(status)
+    enddo
+
+    do n=1,LIS_rc%nnest
+       if(SMAPsm_obs_struc(n)%data_designation.eq."SPL3SMP") then 
+          gridDesci = 0
+          gridDesci(1) = 9
+          gridDesci(2) = 964
+          gridDesci(3) = 406
+          gridDesci(9) = 4 !M36 grid
+          gridDesci(20) = 64
+          gridDesci(10) = 0.36 
+          gridDesci(11) = 1 !for the global switch
+
+          SMAPsm_obs_struc(n)%nc = 964
+          SMAPsm_obs_struc(n)%nr = 406
+
+       elseif(SMAPsm_obs_struc(n)%data_designation.eq."SPL3SMP_E") then 
+          gridDesci = 0
+          gridDesci(1) = 9
+          gridDesci(2) = 3856
+          gridDesci(3) = 1624
+          gridDesci(9) = 5 !M09 grid
+          gridDesci(20) = 64
+          gridDesci(10) = 0.09 
+          gridDesci(11) = 1 !for the global switch
+
+          SMAPsm_obs_struc(n)%nc = 3856
+          SMAPsm_obs_struc(n)%nr = 1624
+
+       endif
+
+       allocate(SMAPsm_obs_struc(n)%smobs(LIS_rc%lnc(n), &
+            LIS_rc%lnr(n)))
+       SMAPsm_obs_struc(n)%smobs = LIS_rc%udef
+       allocate(SMAPsm_obs_struc(n)%smtime(LIS_rc%lnc(n), &
+            LIS_rc%lnr(n)))
+
+
+       allocate(SMAPsm_obs_struc(n)%n11(LIS_rc%lnc(n)*&
+            LIS_rc%lnr(n)))
+       
+       call neighbor_interp_input(n, gridDesci,&
+            SMAPsm_obs_struc(n)%n11)
+       
+       call LIS_registerAlarm("SMAP data read alarm",&
+            86400.0, 86400.0)
+
+       SMAPsm_obs_struc(n)%startMode = .true. 
+
+       obsField = ESMF_FieldCreate(arrayspec=realarrspec, grid=LIS_vecGrid(n), &
+            name="SMAP_sm", rc=status)
+       call LIS_verify(status)
+       
+       call ESMF_StateAdd(Obs_State(n),(/obsField/),rc=status)
+       call LIS_verify(status)
+
+    enddo
+
+    write(LIS_logunit,*) '[INFO] created the States to hold the SMAP soil moisture data'
+    
+  end subroutine SMAPsm_obs_setup
+  
+end module SMAPsm_obsMod

--- a/lis/optUE/type/paramestim/obs/SMAPsm/read_SMAPsmobs.F90
+++ b/lis/optUE/type/paramestim/obs/SMAPsm/read_SMAPsmobs.F90
@@ -1,0 +1,469 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
+!
+! Copyright (c) 2015 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
+!BOP
+! !ROUTINE: read_SMAPsmobs
+! \label{read_SMAPsmobs}
+!
+! !REVISION HISTORY:
+!  21 Sep 2018   Sujay Kumar;   Initial Specification
+!
+! !INTERFACE: 
+subroutine read_SMAPsmobs(Obj_Space)
+! !USES: 
+  use ESMF
+  use LIS_coreMod
+  use LIS_timeMgrMod
+  use LIS_logMod
+  use LIS_fileIOMod
+  use SMAPsm_obsMod
+  use map_utils
+
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)  
+  use netcdf
+#endif
+
+  implicit none
+! !ARGUMENTS: 
+  type(ESMF_State)    :: Obj_Space
+!
+! !DESCRIPTION:
+!  
+!  The arguments are: 
+!  \begin{description}
+!  \item[n]    index of the nest
+!  \item[Obj\_Space] Objective Space
+!  \end{description}
+!
+!EOP
+  integer                  :: n
+  real,    pointer         :: smc(:)
+  type(ESMF_Field)         :: smcField
+  character*100            :: obsdir
+  integer                  :: status
+  integer                  :: c,r
+  real                     :: lon
+  real                     :: lhour
+  real                     :: gmt
+  integer                  :: zone
+  logical                  :: data_update
+  logical                  :: alarmCheck
+  logical                  :: file_exists
+  integer                  :: grid_index
+  character*100            :: fname
+  real                     :: dt
+  real, allocatable        :: smobs_D(:)
+  real, allocatable        :: smobs_A(:)
+
+  n = 1
+
+  call ESMF_AttributeGet(Obj_Space,"Data Directory",&
+       obsdir, rc=status)
+  call LIS_verify(status)
+  call ESMF_AttributeGet(Obj_Space,"Data Update Status",&
+       data_update, rc=status)
+  call LIS_verify(status)
+
+  alarmCheck = LIS_isAlarmRinging(LIS_rc, "SMAP data read alarm")
+  if(alarmCheck.or.SMAPsm_obs_struc(n)%startMode) then 
+
+     SMAPsm_obs_struc(n)%startMode = .false. 
+
+     if((SMAPsm_obs_struc(n)%data_designation.eq."SPL3SMP_E").or.&
+          (SMAPsm_obs_struc(n)%data_designation.eq."SPL3SMP")) then 
+
+        allocate(smobs_A(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+        allocate(smobs_D(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+        call create_SMAPsmobs_filename(&
+             obsdir, &
+             SMAPsm_obs_struc(n)%data_designation,&
+             LIS_rc%yr, LIS_rc%mo, LIS_rc%da, fname)
+        inquire(file=fname,exist=file_exists) 
+        if(file_exists) then 
+           write(LIS_logunit,*) '[INFO] Reading ',trim(fname)
+           call read_SMAP_E_data(n,'D',fname,smobs_D)
+        else
+           write(LIS_logunit,*) '[WARN] Missing SMAP file: ',trim(fname)
+        endif
+        if(file_exists) then 
+           write(LIS_logunit,*) '[INFO] Reading ',trim(fname)
+           call read_SMAP_E_data(n,'A',fname,smobs_A)
+        else
+           write(LIS_logunit,*) '[WARN] Missing SMAP file: ',trim(fname)
+        endif
+        SMAPsm_obs_struc(n)%smobs = LIS_rc%udef
+        SMAPsm_obs_struc(n)%smtime = -1
+
+!------------------------------------------------------------------------- 
+!   Ascending pass assumed to be at 6pm localtime and the descending 
+!   pass is assumed to be at 6am local time
+!-------------------------------------------------------------------------
+        do r=1,LIS_rc%lnr(n)
+           do c=1,LIS_rc%lnc(n)
+              grid_index = LIS_domain(n)%gindex(c,r)
+              if(grid_index.ne.-1) then 
+                 
+                 if(smobs_D(c+(r-1)*LIS_rc%lnc(n)).ne.-9999.0) then   
+                    SMAPsm_obs_struc(n)%smobs(c,r) = &
+                         smobs_D(c+(r-1)*LIS_rc%lnc(n))                 
+                    lon = LIS_domain(n)%lon(c+(r-1)*LIS_rc%lnc(n))
+                    lhour = 6.0
+                    call LIS_localtime2gmt (gmt,lon,lhour,zone)
+                    SMAPsm_obs_struc(n)%smtime(c,r) = gmt
+
+                 endif
+              end if
+!-------------------------------------------------------------------------  
+! The ascending data is used only over locations where descending data
+! doesn't exist. 
+!-------------------------------------------------------------------------
+              if(smobs_A(c+(r-1)*LIS_rc%lnc(n)).ne.-9999.0.and.&
+                   SMAPsm_obs_struc(n)%smobs(c,r).eq.-9999.0) then   
+                 SMAPsm_obs_struc(n)%smobs(c,r) = &
+                      smobs_A(c+(r-1)*LIS_rc%lnc(n))                 
+                 lon = LIS_domain(n)%lon(c+(r-1)*LIS_rc%lnc(n))
+                 lhour = 18.0
+                 call LIS_localtime2gmt (gmt,lon,lhour,zone)
+                 SMAPsm_obs_struc(n)%smtime(c,r) = gmt
+              endif
+           enddo
+        enddo
+
+        deallocate(smobs_A)
+        deallocate(smobs_D)
+
+     else
+        
+     endif
+  end if
+ 
+  call ESMF_StateGet(Obj_Space,"SMAP_sm",smcField,&
+       rc=status)
+  call LIS_verify(status)
+  
+  call ESMF_FieldGet(smcField,localDE=0,farrayPtr=smc,rc=status)
+  call LIS_verify(status)
+
+  smc = LIS_rc%udef
+  
+  do r=1,LIS_rc%lnr(n)
+     do c=1,LIS_rc%lnc(n)
+        if(LIS_domain(n)%gindex(c,r).ne.-1) then 
+           grid_index =LIS_domain(n)%gindex(c,r)
+
+           dt = (LIS_rc%gmt - SMAPsm_obs_struc(n)%smtime(c,r))*3600.0
+           if(dt.ge.0.and.dt.lt.LIS_rc%ts) then 
+              smc(grid_index) = & 
+                   SMAPsm_obs_struc(n)%smobs(c,r)
+
+           endif
+        endif
+     enddo
+  enddo
+
+  call ESMF_AttributeSet(Obj_Space,"Data Update Status",&
+       .true., rc=status)
+  call LIS_verify(status)
+
+end subroutine read_SMAPsmobs
+
+!BOP
+! 
+! !ROUTINE: read_SMAP_E_data
+! \label{read_SMAP_E_data}
+!
+! !INTERFACE:
+subroutine read_SMAP_E_data(n, pass, fname, smobs_ip)
+! 
+! !USES:   
+
+  use LIS_coreMod,  only : LIS_rc, LIS_domain
+  use LIS_logMod
+  use LIS_timeMgrMod
+  use SMAPsm_obsMod,  only : SMAPsm_obs_struc
+#if (defined USE_HDF5) 
+  use hdf5
+#endif
+
+  implicit none
+!
+! !INPUT PARAMETERS: 
+! 
+  integer                       :: n 
+  character (len=*)             :: pass
+  character (len=*)             :: fname
+  real                          :: smobs_ip(LIS_rc%lnc(n)*LIS_rc%lnr(n))
+
+
+! !OUTPUT PARAMETERS:
+!
+!
+! !DESCRIPTION: 
+!  This subroutine reads the SMOS NESDIS binary file and applies the data
+!  quality flags to filter the data. !\normalsize
+!
+!  tb_time_seconds
+!  Arithmetic average of the same parameters found in the 
+!  fore- and aft-looking groups in the input SPL1CTB granule. 
+!  The resulting parameter thus describes the average of UTC 
+!  acquisition times of SPL1BTB observations whose boresights 
+!  fall within a 36 km EASE-Grid 2.0 cell. The result is then 
+!  expressed in J2000 seconds (the number of seconds since 
+!  11:58:55.816 on January 1, 2000 UT).
+!
+!  The arguments are: 
+!  \begin{description}
+!  \item[n]            index of the nest
+!  \item[fname]        name of the RTNASASMAP AMSR-E file
+!  \item[smobs\_ip]    soil moisture data processed to the LIS domain
+! \end{description}
+!
+!
+!EOP
+
+#if (defined USE_HDF5)
+
+  character*100,    parameter    :: sm_gr_name_D = "Soil_Moisture_Retrieval_Data_AM"
+  character*100,    parameter    :: sm_field_name_D = "soil_moisture"
+  character*100,    parameter    :: sm_qa_name_D = "retrieval_qual_flag"
+  character*100,    parameter    :: sm_gr_name_A = "Soil_Moisture_Retrieval_Data_PM"
+  character*100,    parameter    :: sm_field_name_A = "soil_moisture_pm"
+  character*100,    parameter    :: sm_qa_name_A = "retrieval_qual_flag_pm"
+
+  integer(hsize_t), allocatable  :: dims(:)
+  integer(hsize_t), dimension(2) :: dimsm
+  integer(hsize_t), dimension(2) :: count_file
+  integer(hsize_t), dimension(2) :: count_mem
+  integer(hid_t)                 :: memspace
+  integer(hid_t)                 :: dataspace
+  integer                        :: memrank = 2
+  integer(hsize_t), dimension(2) :: offset_mem = (/0,0/)
+  integer(hsize_t), dimension(2) :: offset_file
+  integer(hid_t)                 :: file_id
+  integer(hid_t)                 :: sm_gr_id_D,sm_field_id_D,sm_qa_id_D
+  integer(hid_t)                 :: sm_gr_id_A,sm_field_id_A,sm_qa_id_A
+  real,             allocatable  :: sm_field(:,:)
+  integer,          allocatable  :: sm_qa(:,:)
+  integer                        :: c,r,t
+  logical*1                      :: sm_data_b(SMAPsm_obs_struc(n)%nc*SMAPsm_obs_struc(n)%nr)
+  logical*1                      :: smobs_b_ip(LIS_rc%lnc(n)*LIS_rc%lnr(n))
+  real                           :: sm_data(SMAPsm_obs_struc(n)%nc*SMAPsm_obs_struc(n)%nr)
+  integer                        :: status,ios
+
+  dimsm      = (/SMAPsm_obs_struc(n)%nc, SMAPsm_obs_struc(n)%nr/)
+  count_file = (/SMAPsm_obs_struc(n)%nc, SMAPsm_obs_struc(n)%nr/)
+  count_mem  = (/SMAPsm_obs_struc(n)%nc, SMAPsm_obs_struc(n)%nr/)
+  
+  allocate(sm_field(SMAPsm_obs_struc(n)%nc, SMAPsm_obs_struc(n)%nr))
+  allocate(sm_qa(SMAPsm_obs_struc(n)%nc, SMAPsm_obs_struc(n)%nr))
+  allocate(dims(2))
+
+  dims(1) = SMAPsm_obs_struc(n)%nc
+  dims(2) = SMAPsm_obs_struc(n)%nr
+
+  call h5open_f(status)
+  call LIS_verify(status, 'Error opening HDF fortran interface')
+  
+  call h5fopen_f(trim(fname),H5F_ACC_RDONLY_F, file_id, status) 
+  call LIS_verify(status, 'Error opening NASASMAP file ')
+  
+  if(pass.eq.'D') then 
+     call h5gopen_f(file_id,sm_gr_name_D,sm_gr_id_D, status)
+     call LIS_verify(status, 'Error opening SM group in NASASMAP file')
+     
+     call h5dopen_f(sm_gr_id_D,sm_field_name_D,sm_field_id_D, status)
+     call LIS_verify(status, 'Error opening SM field in NASASMAP file')
+     
+     call h5dget_space_f(sm_field_id_D, dataspace, status)
+     call LIS_verify(status, 'Error in h5dget_space_f: readNASASMAPObs')
+     
+     call h5sselect_hyperslab_f(dataspace, H5S_SELECT_SET_F, &
+          start=offset_file, count=count_file, hdferr=status)
+     call LIS_verify(status, 'Error setting hyperslab dataspace in readNASASMAPObs')
+     
+     call h5screate_simple_f(memrank,dimsm, memspace, status)
+     call LIS_verify(status, 'Error in h5create_simple_f; read_NASASMAPsm')
+     
+     call h5sselect_hyperslab_f(memspace, H5S_SELECT_SET_F, &
+          start=offset_mem, count=count_mem, hdferr=status)
+     call LIS_verify(status, 'Error in h5sselect_hyperslab_f: read_NASASMAPsm')
+     
+     call h5dread_f(sm_field_id_D, H5T_NATIVE_REAL,sm_field,dims,status, &
+          memspace, dataspace)
+     call LIS_verify(status, 'Error extracting SM field from NASASMAPfile')
+
+     call h5dclose_f(sm_field_id_D,status)
+     call LIS_verify(status,'Error in H5DCLOSE call')
+
+     call h5dopen_f(sm_gr_id_D,sm_qa_name_D,sm_qa_id_D, status)
+     call LIS_verify(status, 'Error opening SM QA field in NASASMAP file')
+     
+     call h5dread_f(sm_qa_id_D, H5T_NATIVE_INTEGER,sm_qa,dims,status, &
+          memspace, dataspace)
+     call LIS_verify(status, 'Error extracting SM QA field from NASASMAPfile')
+     
+     call h5dclose_f(sm_qa_id_D,status)
+     call LIS_verify(status,'Error in H5DCLOSE call')
+
+     call h5gclose_f(sm_gr_id_D,status)
+     call LIS_verify(status,'Error in H5GCLOSE call')
+
+  else
+     call h5gopen_f(file_id,sm_gr_name_A,sm_gr_id_A, status)
+     call LIS_verify(status, 'Error opening SM group in NASASMAP file')
+     
+     call h5dopen_f(sm_gr_id_A,sm_field_name_A,sm_field_id_A, status)
+     call LIS_verify(status, 'Error opening SM field in NASASMAP file')
+     
+     call h5dget_space_f(sm_field_id_A, dataspace, status)
+     call LIS_verify(status, 'Error in h5dget_space_f: readNASASMAPObs')
+     
+     call h5sselect_hyperslab_f(dataspace, H5S_SELECT_SET_F, &
+          start=offset_file, count=count_file, hdferr=status)
+     call LIS_verify(status, 'Error setting hyperslab dataspace in readNASASMAPObs')
+     
+     call h5screate_simple_f(memrank,dimsm, memspace, status)
+     call LIS_verify(status, 'Error in h5create_simple_f; read_NASASMAPsm')
+     
+     call h5sselect_hyperslab_f(memspace, H5S_SELECT_SET_F, &
+          start=offset_mem, count=count_mem, hdferr=status)
+     call LIS_verify(status, 'Error in h5sselect_hyperslab_f: read_NASASMAPsm')
+     
+     call h5dread_f(sm_field_id_A, H5T_NATIVE_REAL,sm_field,dims,status, &
+          memspace, dataspace)
+     call LIS_verify(status, 'Error extracting SM field from NASASMAPfile')
+
+     call h5dclose_f(sm_field_id_A,status)
+     call LIS_verify(status,'Error in H5DCLOSE call')
+     
+     call h5dopen_f(sm_gr_id_A,sm_qa_name_A,sm_qa_id_A, status)
+     call LIS_verify(status, 'Error opening SM QA field in NASASMAP file')
+     
+     call h5dread_f(sm_qa_id_A, H5T_NATIVE_INTEGER,sm_qa,dims,status, &
+          memspace, dataspace)
+     call LIS_verify(status, 'Error extracting SM QA field from NASASMAPfile')
+
+     call h5dclose_f(sm_qa_id_A,status)
+     call LIS_verify(status,'Error in H5DCLOSE call')
+
+     call h5gclose_f(sm_gr_id_A,status)
+     call LIS_verify(status,'Error in H5GCLOSE call')
+     
+  endif
+  
+  call h5fclose_f(file_id,status)
+  call LIS_verify(status,'Error in H5FCLOSE call')
+  
+  call h5close_f(status)
+  call LIS_verify(status,'Error in H5CLOSE call')
+  
+  sm_data_b = .false. 
+  t = 1
+
+! The retrieval_quality_field variable's binary representation consists of bits
+! that indicate whether retrieval is performed or not at a given grid cell. 
+! When retrieval is performed, it contains additional bits to further 
+! indicate the exit status and quality of the retrieval. The first bit 
+! indicates the recommended quality (0-means retrieval has recommended quality
+!
+
+  do r=1,SMAPsm_obs_struc(n)%nr
+     do c=1,SMAPsm_obs_struc(n)%nc        
+        sm_data(t) = sm_field(c,r)
+        if(sm_data(t).ne.-9999.0) then 
+!           if(SMAPsm_obs_struc(n)%qcFlag.eq.1) then 
+              if(ibits(sm_qa(c,r),0,1).eq.0) then 
+                 sm_data_b(t) = .true.
+              else
+                 sm_data(t) = -9999.0
+              endif
+!           else
+!              sm_data_b(t) = .true.
+!           endif
+           endif
+        t = t+1
+     enddo
+  enddo
+
+  deallocate(sm_qa)
+
+!--------------------------------------------------------------------------
+! Interpolate to the LIS running domain
+!-------------------------------------------------------------------------- 
+  call neighbor_interp(LIS_rc%gridDesc(n,:),&
+       sm_data_b, sm_data, smobs_b_ip, smobs_ip, &
+       SMAPsm_obs_struc(n)%nc*SMAPsm_obs_struc(n)%nr, &
+       LIS_rc%lnc(n)*LIS_rc%lnr(n), &
+       LIS_domain(n)%lat, LIS_domain(n)%lon,&
+       SMAPsm_obs_struc(n)%n11, LIS_rc%udef, ios)
+
+  deallocate(sm_field)
+  deallocate(dims)
+
+#endif
+
+end subroutine read_SMAP_E_data
+
+!BOP
+!
+! !ROUTINE: create_SMAPsmobs_filename
+! \label(create_SMAPsmobs_filename)
+!
+! !INTERFACE:
+subroutine create_SMAPsmobs_filename(&
+     obsdir, &
+     designation,&
+     yr, mo, da, fname)
+!
+! !USES:
+  implicit none
+!
+! !INPUT PARAMETERS:
+  character(len=*), intent(in) :: obsdir
+  character(len=*), intent(in) :: designation
+  integer  ,        intent(in) :: yr
+  integer  ,        intent(in) :: mo
+  integer  ,        intent(in) :: da
+  character(len=*), intent(out) :: fname
+!
+! !OUTPUT PARAMETERS:
+!
+! !DESCRIPTION:
+!
+! !FILES USED:
+!
+! !REVISION HISTORY:
+!
+!EOP
+  character (len=4) :: fyr
+  character (len=2) :: fmo,fda
+  
+  write(unit=fyr, fmt='(i4.4)') yr
+  write(unit=fmo, fmt='(i2.2)') mo
+  write(unit=fda, fmt='(i2.2)') da
+
+  if(designation.eq."SPL3SMAP") then 
+     fname = trim(obsdir)//'/'//trim(fyr)//'.'//trim(fmo)//'.'//&
+          trim(fda)//'/SMAP_L3_SM_AP_'&
+          //trim(fyr)//trim(fmo)//trim(fda)//&
+          '_R12170_001.h5'
+  elseif(designation.eq."SPL3SMP") then 
+     fname = trim(obsdir)//'/'//trim(fyr)//'.'//trim(fmo)//'.'//&
+          trim(fda)//'/SMAP_L3_SM_P_'&
+          //trim(fyr)//trim(fmo)//trim(fda)//&
+         '.h5'
+  elseif(designation.eq."SPL3SMP_E") then 
+     fname = trim(obsdir)//'/'//trim(fyr)//'.'//trim(fmo)//'.'//&
+          trim(fda)//'/SMAP_L3_SM_P_E_'&
+          //trim(fyr)//trim(fmo)//trim(fda)//&
+          '.h5'
+  endif
+end subroutine create_SMAPsmobs_filename
+
+

--- a/lis/optUE/type/paramestim/obs/SMAPsm/reset_SMAPsmobs.F90
+++ b/lis/optUE/type/paramestim/obs/SMAPsm/reset_SMAPsmobs.F90
@@ -1,0 +1,40 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
+!
+! Copyright (c) 2015 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: reset_SMAPsmobs
+! \label{reset_SMAPsmobs}
+!
+! !REVISION HISTORY:
+!  21 Sep 2018: Sujay Kumar; Initial Specification
+!
+! !INTERFACE: 
+subroutine reset_SMAPsmobs(Obj_Space)
+! !USES: 
+  use ESMF
+  use LIS_coreMod,        only : LIS_rc
+  use SMAPsm_obsMod,       only : SMAPsm_obs_struc
+
+  implicit none
+! !ARGUMENTS: 
+  type(ESMF_State)    :: Obj_Space
+!
+! !DESCRIPTION:
+!  
+!  resets the SMAP soil moisture data structures
+!  
+!  The arguments are: 
+!  \begin{description}
+!  \item[n]    index of the nest
+!  \item[Obj\_State] observations state
+!  \end{description}
+!
+!EOP
+
+  integer            :: n 
+  
+end subroutine reset_SMAPsmobs

--- a/lis/optUE/type/paramestim/obs/SMAPsm/write_SMAPsmobs.F90
+++ b/lis/optUE/type/paramestim/obs/SMAPsm/write_SMAPsmobs.F90
@@ -1,0 +1,112 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
+!
+! Copyright (c) 2015 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: write_SMAPsmobs
+! \label{write_SMAPsmobs}
+!
+! !REVISION HISTORY:
+!  21 Sep 2018: Sujay Kumar; Initial Specification
+!
+! !INTERFACE: 
+subroutine write_SMAPsmobs(Obj_Space)
+! !USES: 
+  use ESMF
+  use LIS_coreMod,  only : LIS_rc, LIS_masterproc
+  use LIS_logMod,     only : LIS_logunit, LIS_verify, &
+       LIS_getNextUnitNumber, LIS_releaseUnitNumber
+  use LIS_fileIOMod,      only : LIS_create_output_directory
+  use LIS_historyMod,     only : LIS_writevar_gridded
+
+  implicit none
+! !ARGUMENTS: 
+  type(ESMF_State)    :: Obj_Space
+!
+! !DESCRIPTION:
+!  
+!  write the SMAP soil moisture data to disk
+!  
+!  The arguments are: 
+!  \begin{description}
+!  \item[n]    index of the nest
+!  \item[Obj\_State] observations state
+!  \end{description}
+!
+!EOP
+  real,    pointer    :: obsl(:)
+  type(ESMF_Field)    :: smcField
+  logical             :: data_update
+  character*100       :: obsname
+  integer             :: status
+  integer             :: ftn
+  integer             :: n 
+
+  n = 1
+
+  call ESMF_AttributeGet(Obj_Space,"Data Update Status",&
+       data_update, rc=status)
+  call LIS_verify(status)
+
+  if(data_update) then 
+     
+     call ESMF_StateGet(Obj_Space,"SMAP_sm",smcField,&
+          rc=status)
+     call LIS_verify(status)
+
+     call ESMF_FieldGet(smcField, localDE=0,farrayPtr=obsl,rc=status)
+     call LIS_verify(status)
+
+     if(LIS_masterproc) then 
+        ftn = LIS_getNextUnitNumber()
+        call SMAPsm_obsname('smc',obsname)
+
+        call LIS_create_output_directory('PEOBS') 
+        open(ftn,file=trim(obsname), form='unformatted')
+     endif
+     
+     call LIS_writevar_gridded(ftn, n, obsl)
+     
+     if(LIS_masterproc) then 
+        call LIS_releaseUnitNumber(ftn)
+     endif
+
+  endif
+
+end subroutine write_SMAPsmobs
+
+!BOP
+! 
+! !ROUTINE: SMAPsm_obsname
+! \label{SMAPsm_obsname}
+! 
+! !INTERFACE: 
+subroutine SMAPsm_obsname(variabname, obsname)
+! !USES: 
+  use LIS_coreMod, only : LIS_rc
+
+! !ARGUMENTS: 
+  character(len=*)      :: obsname
+  character(len=*)       :: variabname
+! 
+! !DESCRIPTION: 
+!  This method generates a timestamped filename for the processed
+!  SMAPsm observations. 
+! 
+!EOP
+
+  character(len=12)    :: cdate1
+
+  write(unit=cdate1, fmt='(i4.4, i2.2, i2.2, i2.2, i2.2)') &
+       LIS_rc%yr, LIS_rc%mo, &
+       LIS_rc%da, LIS_rc%hr,LIS_rc%mn
+
+  obsname = trim(LIS_rc%odir)//'/PEOBS/'//trim(variabname)//'_'//cdate1//'.1gs4r'
+  
+end subroutine SMAPsm_obsname
+
+
+

--- a/lis/plugins/LIS_PEobs_pluginMod.F90
+++ b/lis/plugins/LIS_PEobs_pluginMod.F90
@@ -93,8 +93,12 @@ subroutine LIS_PEobs_plugin
    use ARSsm_obsMod,     only : ARSsm_obs_setup
 #endif
 
-#if ( defined PE_OBS_ARSSM )
+#if ( defined PE_OBS_ISMNSM )
    use ISMNsm_obsMod,     only : ISMNsm_obs_setup
+#endif
+
+#if ( defined PE_OBS_SMAPSM )
+   use SMAPsm_obsMod,     only : SMAPsm_obs_setup
 #endif
 
 #if ( defined PE_OBS_AMSRE_SR )
@@ -160,6 +164,10 @@ subroutine LIS_PEobs_plugin
 
 #if ( defined PE_OBS_ISMNSM )
    external read_ISMNsmobs, write_ISMNsmobs, reset_ISMNsmobs
+#endif
+
+#if ( defined PE_OBS_SMAPSM )
+   external read_SMAPsmobs, write_SMAPsmobs, reset_SMAPsmobs
 #endif
 
 #if ( defined PE_OBS_AMSRE_SR )
@@ -327,6 +335,28 @@ subroutine LIS_PEobs_plugin
                            write_ISMNsmobs)
    call registerpeobsreset(trim(LIS_ISMNsmobsId)//char(0), &
                            reset_ISMNsmobs)
+#endif
+
+#if ( defined PE_OBS_ISMNSM )
+   call registerpeobssetup(trim(LIS_ISMNsmobsId)//char(0), &
+                           ISMNsm_obs_setup)
+   call registergetpeobs(trim(LIS_ISMNsmobsId)//char(0), &
+                         read_ISMNsmobs)
+   call registerwritepeobs(trim(LIS_ISMNsmobsId)//char(0), &
+                           write_ISMNsmobs)
+   call registerpeobsreset(trim(LIS_ISMNsmobsId)//char(0), &
+                           reset_ISMNsmobs)
+#endif
+
+#if ( defined PE_OBS_SMAPSM )
+   call registerpeobssetup(trim(LIS_SMAPsmobsId)//char(0), &
+                           SMAPsm_obs_setup)
+   call registergetpeobs(trim(LIS_SMAPsmobsId)//char(0), &
+                         read_SMAPsmobs)
+   call registerwritepeobs(trim(LIS_SMAPsmobsId)//char(0), &
+                           write_SMAPsmobs)
+   call registerpeobsreset(trim(LIS_SMAPsmobsId)//char(0), &
+                           reset_SMAPsmobs)
 #endif
 
 #endif

--- a/lis/plugins/LIS_lsmoptue_pluginMod.F90
+++ b/lis/plugins/LIS_lsmoptue_pluginMod.F90
@@ -120,6 +120,9 @@ subroutine LIS_lsmoptue_plugin
    external NoahMP36_getpeobspred_ISMNsmobs
    external NoahMP36_setupobspred_ISMNsmobs
 
+   external NoahMP36_getpeobspred_SMAPsmobs
+   external NoahMP36_setupobspred_SMAPsmobs
+
 #endif
 
 !    call registerlsmf2t(trim(LIS_noah271Id)//char(0), &
@@ -269,6 +272,13 @@ subroutine LIS_lsmoptue_plugin
    call registerlsmpegetobspred(trim(LIS_noahmp36Id)//"+"//      &
                                 trim(LIS_ISMNsmobsId)//char(0), &
                                 NoahMP36_getpeobspred_ISMNsmobs)
+
+   call registerlsmpesetupobspred(trim(LIS_noahmp36Id)//"+"//      &
+                                  trim(LIS_SMAPsmobsId)//char(0), &
+                                  NoahMP36_setupobspred_SMAPsmobs)
+   call registerlsmpegetobspred(trim(LIS_noahmp36Id)//"+"//      &
+                                trim(LIS_SMAPsmobsId)//char(0), &
+                                NoahMP36_getpeobspred_SMAPsmobs)
 #endif
 
 #endif

--- a/lis/plugins/LIS_pluginIndices.F90
+++ b/lis/plugins/LIS_pluginIndices.F90
@@ -293,6 +293,7 @@ module LIS_pluginIndices
    character*50, public,  parameter :: LIS_USDA_ARSsmpeObsId = "USDA ARSsm"
    character*50, public,  parameter :: LIS_ARSsmobsId = "ARS sm" ! SY
    character*50, public,  parameter :: LIS_ISMNsmobsId = "ISMN sm" 
+   character*50, public,  parameter :: LIS_SMAPsmobsId = "SMAP sm"
 !-------------------------------------------------------------------------
 ! Objective Function Evaluation Criteria
 !-------------------------------------------------------------------------

--- a/lis/surfacemodels/land/noahmp.3.6/pe/obspred/SMAPsm/NoahMP36_getpeobspred_SMAPsmobs.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/pe/obspred/SMAPsm/NoahMP36_getpeobspred_SMAPsmobs.F90
@@ -1,0 +1,70 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
+!
+! Copyright (c) 2015 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: NoahMP36_getpeobspred_SMAPsmobs
+!  \label{NoahMP36_getpeobspred_SMAPsmobs}
+!
+! !REVISION HISTORY:
+! 02 Feb 2018: Sujay Kumar; Initial Specification
+!
+! !INTERFACE:
+subroutine NoahMP36_getpeobspred_SMAPsmobs(Obj_Func)
+! !USES:
+  use ESMF
+  use LIS_coreMod, only : LIS_rc
+  use LIS_soilsMod,  only : LIS_soils
+  use NoahMP36_lsmMod, only : NoahMP36_struc
+  use LIS_logMod,       only : LIS_verify, LIS_logunit
+
+  implicit none
+! !ARGUMENTS: 
+  type(ESMF_State)       :: Obj_Func
+!
+! !DESCRIPTION:
+!  
+!  This routine assigns the decision space to NoahMP3.6 model variables. 
+! 
+!EOP
+  integer                :: n
+  type(ESMF_Field)       :: smcField
+  real, pointer          :: smc(:)
+!  type(ESMF_Field)       :: smstdField
+!  real, pointer          :: smstd(:)
+  integer                :: t
+  integer                :: i
+  integer                :: status
+
+!  write(LIS_logunit,*) '[INFO] Here 1 in NoahMP36_getpeobspred_SMAPsmobs '
+
+  n = 1
+
+  call ESMF_StateGet(Obj_Func,"SMAP_sm",smcField,rc=status)
+  call LIS_verify(status)
+
+  call ESMF_FieldGet(smcField,localDE=0,farrayPtr=smc,rc=status)
+  call LIS_verify(status)
+
+!  write(LIS_logunit,*) '[INFO] Here 2 in NoahMP36_getpeobspred_SMAPsmobs '
+
+!  call ESMF_StateGet(Obj_Func,"SMAPsm standard deviation of soil moisture",smstdField,rc=status)
+!  call LIS_verify(status)
+!
+!  call ESMF_FieldGet(smstdField,localDE=0,farrayPtr=smstd,rc=status)
+!  call LIS_verify(status)
+
+  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     smc(t) = NoahMP36_struc(n)%noahmp36(t)%smc(1)
+!     smstd(t) = NoahMP36_struc(n)%noahmp36(t)%smc_std
+  enddo
+
+!  write(LIS_logunit,*) '[INFO] Finished NoahMP36_getpeobspred_SMAPsmobs, smc = ', smc
+
+end subroutine NoahMP36_getpeobspred_SMAPsmobs
+
+
+

--- a/lis/surfacemodels/land/noahmp.3.6/pe/obspred/SMAPsm/NoahMP36_setupobspred_SMAPsmobs.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/pe/obspred/SMAPsm/NoahMP36_setupobspred_SMAPsmobs.F90
@@ -1,0 +1,57 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
+!
+! Copyright (c) 2015 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: NoahMP36_setupobspred_SMAPsmobs
+!  \label{NoahMP36_setupobspred_SMAPsmobs}
+!
+! !REVISION HISTORY:
+! 2 Feb 2019: Sujay Kumar; Initial Specification
+!
+! !INTERFACE:
+subroutine NoahMP36_setupobspred_SMAPsmobs(OBSPred)
+! !USES:
+  use ESMF
+  use LIS_coreMod,      only : LIS_rc, LIS_vecPatch
+  use LIS_logMod,       only : LIS_verify
+
+  implicit none
+! !ARGUMENTS: 
+  type(ESMF_State)       :: OBSPred
+!
+! !DESCRIPTION:
+!  
+!  This routine creates an entry in the Obs pred object used for 
+!  parameter estimation
+! 
+!EOP
+  integer                :: n
+  type(ESMF_ArraySpec)   :: realarrspec
+  type(ESMF_Field)       :: smcField
+!  type(ESMF_Field)       :: smstdField
+  integer                :: status
+
+  n = 1
+  call ESMF_ArraySpecSet(realarrspec, rank=1,typekind=ESMF_TYPEKIND_R4,&
+       rc=status)
+  call LIS_verify(status)
+
+  smcField = ESMF_FieldCreate(arrayspec=realarrspec, grid=LIS_vecPatch(n,LIS_rc%lsm_index), &
+       name="SMAP_sm", rc=status)
+  call LIS_verify(status)
+  
+  call ESMF_StateAdd(OBSPred,(/smcField/),rc=status)
+  call LIS_verify(status)
+
+!  smstdField = ESMF_FieldCreate(arrayspec=realarrspec, grid=LIS_vecPatch(n,LIS_rc%lsm_index), &
+!       name="SMAPsm standard deviation of soil moisture", rc=status)
+!  call LIS_verify(status)
+!  
+!  call ESMF_StateAdd(OBSPred,(/smstdField/),rc=status)
+!  call LIS_verify(status)
+end subroutine NoahMP36_setupobspred_SMAPsmobs
+


### PR DESCRIPTION
This update includes the support for SMAP soil moisture data
for optimization and uncertainty estimation. A bug fix to the
ISMN reader and an improved vertical interpolation code has
also been included

Resolves #81