### PR TITLE
Correct the use of both the USE_GRIBAPI and the USE_ECCODES macros in LVT

### DIFF
--- a/lvt/arch/Config.pl
+++ b/lvt/arch/Config.pl
@@ -538,7 +538,11 @@ if($use_gribapi == 1) {
    printf misc_file "%s\n","#define USE_GRIBAPI ";
 }
 elsif($use_gribapi == 2) {
+   printf misc_file "%s\n","#define USE_GRIBAPI ";
    printf misc_file "%s\n","#define USE_ECCODES ";
+}
+else{
+   printf misc_file "%s\n","#undef USE_GRIBAPI ";
 }
 
 if($use_hdf4 == 1) {

--- a/lvt/core/LVT_DataStreamsMod.F90
+++ b/lvt/core/LVT_DataStreamsMod.F90
@@ -2705,12 +2705,12 @@ contains
     ! because bitmap in GRIB-1 file will fill in the rest
     
 
-#if (defined USE_GRIBAPI)
-    call grib_new_from_template(igrib,"GRIB1",iret)
-    call LVT_verify(iret, 'grib_new_from_template failed in LVT_DataStreamsMod')
-#else
+#if (defined USE_ECCODES)
     call grib_new_from_samples(igrib,"GRIB1",iret)
     call LVT_verify(iret, 'grib_new_from_samples failed in LVT_DataStreamsMod')
+#else
+    call grib_new_from_template(igrib,"GRIB1",iret)
+    call LVT_verify(iret, 'grib_new_from_template failed in LVT_DataStreamsMod')
 #endif
     
     call grib_set(igrib,'table2Version',LVT_rc%grib_table,iret)
@@ -2949,13 +2949,12 @@ contains
     ! Note passing string of defined points only to output
     ! because bitmap in GRIB-1 file will fill in the rest
     
-#if (defined USE_GRIBAPI)
-    call grib_new_from_template(igrib,"GRIB2",iret)
-    call LVT_verify(iret, 'grib_new_from_template failed in LVT_DataStreamsMod')
-#else
-    ! ECCodes version
+#if (defined USE_ECCODES)
     call grib_new_from_samples(igrib,"GRIB2",iret)
     call LVT_verify(iret, 'grib_new_from_samples failed in LVT_DataStreamsMod')
+#else
+    call grib_new_from_template(igrib,"GRIB2",iret)
+    call LVT_verify(iret, 'grib_new_from_template failed in LVT_DataStreamsMod')
 #endif
 
     ! Section 0: Indicator     

--- a/lvt/datastreams/SMOPS/readSMOPSsmObs.F90
+++ b/lvt/datastreams/SMOPS/readSMOPSsmObs.F90
@@ -203,7 +203,7 @@ end subroutine readSMOPSsmObs
 subroutine read_SMOPS_data(source, fname, smobs_ip)
 ! 
 ! !USES:   
-#if (defined USE_ECCODES) 
+#if (defined USE_GRIBAPI)
    use grib_api
 #endif
   use LVT_coreMod,  only : LVT_rc
@@ -412,7 +412,7 @@ subroutine read_SMOPS_data(source, fname, smobs_ip)
 
    integer        :: ix, jx,c_s, c_e, r_s, r_e
 
-#if (defined USE_ECCODES)
+#if (defined USE_GRIBAPI)
    smDataNotAvailable = .false.
    ! Set QA values to NESDIS SMOPS undefined value.
    sm_ASCAT_A_qa_t = 9999


### PR DESCRIPTION
Resolves: #101.