### PR TITLE
Fix uninitialized variables in Noah-3.9 LSM over glacier

### DIFF
--- a/lis/surfacemodels/land/noah.3.9/noah39_main.F90
+++ b/lis/surfacemodels/land/noah.3.9/noah39_main.F90
@@ -985,6 +985,10 @@ subroutine noah39_main(n)
                 noah39_struc(n)%noah(t)%Q1,                            &
                 noah39_struc(n)%noah(t)%SNOTIME1,                      &
                 RIBB,noah39_struc(n)%noah(t)%lvcoef,tsoil)
+
+! flx4 is not calculated in the glacial physics,
+! so set it to zero, as it is output on land points. - D. Mocko
+           flx4 = 0.0
         endif
 
 ! Save variables for passing to WRF or for output

--- a/lis/surfacemodels/land/noah.3.9/phys/module_sf_noah39lsm_glacial.F90
+++ b/lis/surfacemodels/land/noah.3.9/phys/module_sf_noah39lsm_glacial.F90
@@ -189,7 +189,7 @@ CONTAINS
          &                PRCP1,RCH,RR,RSNOW,SNDENS,SNCOND,SN_NEW,     &
          &                T1V,T24,T2V,TH2V,TSNOW,Z0,PRCPF,RHO
     real, intent(in)   :: LVCOEF
-    real, intent(in)   :: TSOIL
+    REAL, INTENT(OUT)  :: TSOIL
 ! ----------------------------------------------------------------------
 ! DECLARATIONS - PARAMETERS
 ! ----------------------------------------------------------------------
@@ -364,7 +364,7 @@ CONTAINS
          &       DQSDT2,FLX2,EMISSI,T1)
 
     CALL SNOPAC (ETP,ETA,PRCP,PRCPF,SNOWNG,NSOIL,DT,DF1,        &
-         &       Q2,T1,SFCTMP,T24,TH2,FDOWN,SSOIL,STC,          &
+         &       Q2,T1,SFCTMP,T24,TH2,FDOWN,SSOIL,TSOIL,STC,    & ! TSOIL added - D. Mocko
          &       SFCPRS,RCH,RR,SNEQV,SNDENS,SNOWH,ZSOIL,TBOT,   &
          &       SNOMLT,DEW,FLX1,FLX2,FLX3,ESNOW,EMISSI,RIBB)
 
@@ -854,7 +854,7 @@ CONTAINS
 ! ----------------------------------------------------------------------
 
   SUBROUTINE SNOPAC (ETP,ETA,PRCP,PRCPF,SNOWNG,NSOIL,DT,DF1,           &
-       &             Q2,T1,SFCTMP,T24,TH2,FDOWN,SSOIL,STC,             &
+       &             Q2,T1,SFCTMP,T24,TH2,FDOWN,SSOIL,TSOIL,STC,       & ! TSOIL added - D. Mocko
        &             SFCPRS,RCH,RR,SNEQV,SNDENS,SNOWH,ZSOIL,TBOT,      &
        &             SNOMLT,DEW,FLX1,FLX2,FLX3,ESNOW,EMISSI,RIBB)
 
@@ -871,6 +871,7 @@ CONTAINS
          &                   T24,TBOT,TH2,EMISSI
     REAL, INTENT(INOUT)   :: SNEQV,FLX2,PRCPF,SNOWH,SNDENS,T1,RIBB,ETP
     REAL, INTENT(OUT)     :: DEW,ESNOW,FLX1,FLX3,SSOIL,SNOMLT
+    REAL, INTENT(OUT)     :: TSOIL 
     REAL, DIMENSION(1:NSOIL),INTENT(IN)     :: ZSOIL
     REAL, DIMENSION(1:NSOIL), INTENT(INOUT) :: STC
     REAL, DIMENSION(1:NSOIL) :: ET1
@@ -1051,6 +1052,9 @@ CONTAINS
 ! ----------------------------------------------------------------------
     ZZ1 = 1.0
     YY = STC (1) -0.5* SSOIL * ZSOIL (1)* ZZ1/ DF1
+
+    ! added by David Mocko on 5/2/2019
+    TSOIL = YY
 
 ! ----------------------------------------------------------------------
 ! SHFLX WILL CALC/UPDATE THE SOIL TEMPS.


### PR DESCRIPTION
Two variables (flx4 and tsoil) were not defined over glacier
points, but were sent as LIS output variables.  This bug fix
sends the tsoil variable from the glacier points correctly to
the LIS output.  flx4 is not used as part of the glacier
physics, and is set to zero over glacier points.

Resolves: #110