### PR TITLE
Fix compiling LISF with GCC (gcc and gfortran)

### DIFF
--- a/ldt/SNODEP/SNODEP_ssmisMod.F90
+++ b/ldt/SNODEP/SNODEP_ssmisMod.F90
@@ -475,7 +475,7 @@ contains
          
          !Get SurfaceFlag (0:Land, 1:Reserved, 2:Near coast, 3:Ice, 4:Possilbe ice, 5:Ocean, 6:Coast,
          !                  7-14: Reserved, 15: Missing value)
-         if ((flag .eq. .true.) .and. (surflag(i)==0 .or. surflag(i)==2)) then
+         if ((flag .eqv. .true.) .and. (surflag(i)==0 .or. surflag(i)==2)) then
             if (option==1) then
                snowdepth(i)=4445.0-17.95*tb37v(i) 
             else if (option==2) then
@@ -969,7 +969,7 @@ contains
       character*2                    :: st_hr_str, cnt
       
       ! EMK
-      character*12,                  :: program_name          ! NAME OF CALLING PROGRAM
+      character*12                   :: program_name          ! NAME OF CALLING PROGRAM
       character*12                   :: routine_name          ! NAME OF THIS ROUTINE
       
       ! define data values

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
@@ -24,7 +24,7 @@ subroutine NoahMP401_readrst()
                                LIS_verify                
     use NoahMP401_lsmMod
 
-#if (defined USE_NETCDF3 .OR. defined USE_NETCDF4)
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
     use netcdf
 #endif
 
@@ -148,7 +148,7 @@ subroutine NoahMP401_readrst()
                    call LIS_endrun
                 endif
             elseif(wformat .eq. "netcdf") then
-#if (defined USE_NETCDF3 .OR. defined USE_NETCDF4)
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
                 status = nf90_open(path=NOAHMP401_struc(n)%rfile, &
                                    mode=NF90_NOWRITE, ncid=ftn)
                 call LIS_verify(status, "Error opening file "//NOAHMP401_struc(n)%rfile)
@@ -396,7 +396,7 @@ subroutine NoahMP401_readrst()
             if(wformat .eq. "binary") then
                 call LIS_releaseUnitNumber(ftn)
             elseif(wformat .eq. "netcdf") then
-#if (defined USE_NETCDF3 .OR. defined USE_NETCDF4)
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
                 status = nf90_close(ftn)
                 call LIS_verify(status, &
                      "Error in nf90_close in NoahMP401_readrst")

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
@@ -24,7 +24,7 @@ subroutine NoahMP401_writerst(n)
                                LIS_create_restart_filename
     use NoahMP401_lsmMod
 
-#if (defined USE_NETCDF3 .OR. defined USE_NETCDF4)
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
     use netcdf
 #endif
 
@@ -87,7 +87,7 @@ subroutine NoahMP401_writerst(n)
             if(wformat .eq. "binary") then
                 call LIS_releaseUnitNumber(ftn)
             elseif(wformat .eq. "netcdf") then
-#if (defined USE_NETCDF3 .OR. defined USE_NETCDF4)
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
                 status = nf90_close(ftn)
                 call LIS_verify(status, &
                      "Error in nf90_close in NoahMP401_writerst")


### PR DESCRIPTION
Compiling LISF with GCC raised several errors like:

error: token "." is not valid in preprocessor expressions

and

Error: Logicals at (1) must be compared with .eqv. instead of .eq.

I corrected the code to be more portable.

Resolves: #112