### PR TITLE
Fix error when reading GDAS data after 2019Jun12

### DIFF
--- a/lis/metforcing/gdas/gdas_forcingMod.F90
+++ b/lis/metforcing/gdas/gdas_forcingMod.F90
@@ -24,7 +24,12 @@ module gdas_forcingMod
 !   2005/05/31 - 2010/07/27 :   T382 (1152x576) grid \newline
 !   2010/07/28 - 2015/01/14 :   T574 (1760x880) grid \newline
 !   2015/01/14 - onwards    :  T1534 (3072x1536) grid
-
+!
+!  On 2019/06/12 12Z, GDAS removed precipitation fields from the f00 data
+!  files. The data fields in these files are now all instantaneous values.
+!  When the reader is using data files after this time, a new subroutine will
+!  be used that excludes precipitation as well as reads in instantaneous radiation
+!  data. For data files prior to the switch, the reader will use the old subroutine.
 !
 !  The implementation in LIS has the derived data type {\tt gdas\_struc} that
 !  includes the variables that specify the runtime options, and the
@@ -55,6 +60,9 @@ module gdas_forcingMod
 !    The time to switch GDAS resolution to T574
 !  \item[griduptime6]
 !    The time to switch GDAS resolution to T1534
+!  \item[datastructime1]
+!    The time to switch to new data structure for f00 files
+!    that removed precipitation fields.
 !  \item[findtime1, findtime2]
 !   boolean flags to indicate which time is to be read for
 !   temporal interpolation.
@@ -104,8 +112,10 @@ module gdas_forcingMod
      real*8        :: gdastime1, gdastime2
      real*8        :: griduptime1, griduptime2, griduptime3
      real*8        :: griduptime4, griduptime5, griduptime6
+     real*8        :: datastructime1
      logical       :: gridchange1, gridchange2, gridchange3
      logical       :: gridchange4, gridchange5, gridchange6
+     logical       :: dstrucchange1
      integer       :: mi
      integer       :: findtime1, findtime2
 
@@ -273,12 +283,22 @@ contains
        mn1 = 0; ss1 = 0
        call LIS_date2time(gdas_struc(n)%griduptime6,updoy,upgmt,yr1,mo1,da1,hr1,mn1,ss1 )
 
+       ! Set time for f00 data structure change
+       yr1 = 2019
+       mo1 = 06
+       da1 = 12
+       hr1 = 9 !09Z is when the reader reads in the 12Zf00 file
+       mn1 = 0; ss1 = 0
+       call LIS_date2time(gdas_struc(n)%datastructime1,updoy,upgmt,yr1,mo1,da1,hr1,mn1,ss1)
+ 
        gdas_struc(n)%gridchange1 = .true.
        gdas_struc(n)%gridchange2 = .true.
        gdas_struc(n)%gridchange3 = .true.
        gdas_struc(n)%gridchange4 = .true.
        gdas_struc(n)%gridchange5 = .true.
        gdas_struc(n)%gridchange6 = .true.
+
+       gdas_struc(n)%dstrucchange1 = .true.
 
        ! Setting up weights for Interpolation
        call gdas_reset_interp_input(n, findex, gridDesci)

--- a/lis/metforcing/gdas/read_gdas.F90
+++ b/lis/metforcing/gdas/read_gdas.F90
@@ -138,7 +138,13 @@ subroutine read_gdas( order, n, findex, &
 ! Set up to open file and retrieve specified field 
 !--------------------------------------------------------------------------
   fname = name00
-  call retrieve_gdas_variables(n, findex, fname,glbdata_i, ferror1)
+  
+  if(gdas_struc(n)%dstrucchange1 .AND.  gdas_struc(n)%gdastime1 .ge. gdas_struc(n)%datastructime1) then
+    !HKB Use special routine for f00 files following 2019 Jun 12 12Z GDAS upgrades
+    call retrieve_gdas_noprecip(n, findex, fname,glbdata_i, ferror1)
+  else
+    call retrieve_gdas_variables(n, findex, fname,glbdata_i, ferror1)
+  endif
 
 !--------------------------------------------------------------------------
 ! read 3hr forecast for time averaged fields
@@ -411,6 +417,206 @@ subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
   endif
 #endif     
 end subroutine retrieve_gdas_variables
+!BOP
+! 
+! !ROUTINE: retrieve_gdas_noprecip
+! \label{retrieve_gdas_noprecip}
+! 
+! !INTERFACE: 
+subroutine retrieve_gdas_noprecip(n, findex, fname, glbdata, errorcode)
+! !USES: 
+  use LIS_coreMod,        only : LIS_rc, LIS_domain
+  use LIS_logMod,         only : LIS_logunit,LIS_getNextUnitNumber,&
+       LIS_releaseUnitNumber, LIS_verify, LIS_warning
+  use gdas_forcingMod,    only : gdas_struc
+
+#if (defined USE_GRIBAPI)
+  use grib_api
+#endif
+
+  implicit none
+! !ARGUMENTS: 
+  integer               :: n
+  integer               :: findex
+  character(len=*)      :: fname
+  real                  :: glbdata(10,LIS_rc%ngrid(n))
+  integer               :: errorcode
+! 
+! !DESCRIPTION: 
+!   This subroutine retrieves GDAS forcing variables, and interpolates
+!  them to the LIS grid. 
+!   This has been adapted to read in only 7 fields after the GDAS data 
+!   change that started on 2019 Jun 12 12Z.
+!EOP
+
+  integer               :: ngdas
+  real, allocatable :: f(:)
+  real, dimension(LIS_rc%lnc(n), LIS_rc%lnr(n)) :: varfield
+  integer :: igrib
+  integer :: iv,c,r,t
+  real    :: missingValue
+  integer :: iret
+  integer :: ftn
+  integer, dimension(gdas_struc(n)%nmif) :: pds5, pds7, pds6,pds16
+  integer :: pds5_val, pds7_val, pds16_val
+  logical*1, allocatable :: lb(:)
+  logical :: file_exists
+  integer :: kk
+  integer :: var_index
+  integer :: nvars
+  integer :: rc
+  logical :: var_status(gdas_struc(n)%nmif)
+  logical :: pcp_flag, var_found
+  integer :: grid_size
+
+#if(defined USE_GRIBAPI) 
+! HKB...Drop last two entries (precip)
+  pds5 = (/ 011,051,204,205,033,034,001 /) !parameter
+  pds6 = -1
+  pds7 = (/ 002,002,000,000,010,010,000 /) !htlev2
+! index 10 indicates instantaneous, 003 indicates time average
+! HKB...All instantaneous fields in f00 files
+  pds16 = (/010,010,010,010,010,010,010 /)
+
+  ngdas = (gdas_struc(n)%ncold*gdas_struc(n)%nrold)
+
+  varfield = 0
+  errorcode = 1
+  var_status = .false.
+
+  inquire (file=fname, exist=file_exists)
+  if (file_exists) then
+
+     call grib_open_file(ftn,trim(fname),'r',iret)
+     if(iret.ne.0) then
+        write(LIS_logunit,*) '[ERR] Could not open file: ',trim(fname)
+        errorcode = 0
+        return
+     endif
+
+     call grib_count_in_file(ftn,nvars,iret)
+     call LIS_warning(iret, 'error in grib_count_in_file in read_gdas')
+     if(iret.ne.0) then
+        errorcode = 0
+        return
+     endif
+
+     allocate(lb(gdas_struc(n)%ncold*gdas_struc(n)%nrold))
+     allocate(f(gdas_struc(n)%ncold*gdas_struc(n)%nrold))
+
+     do kk=1,nvars
+        call grib_new_from_file(ftn, igrib, iret)
+        call LIS_warning(iret, 'error in grib_new_from_file in read_gdas')
+        if(iret.ne.0) then
+           write(LIS_logunit,*) &
+                '[ERR] Could not retrieve entries in file f00a: ',trim(fname)
+           errorcode = 0
+           deallocate(lb)
+           deallocate(f)
+           return
+        endif
+        ! Trap the old "Could not find correct forcing parameter in file"
+        ! error from LIS 6.  This error occurred right before a GDAS
+        ! grid change.  LIS would try to read ahead, but the new data
+        ! would be on the new grid, so LIS would misread it resulting in
+        ! the above error message.  The LIS would roll back to the previous
+        ! day for GDAS forcing.
+        ! Trap this by checking the number of values in one of the
+        ! GRIB fields.
+        call grib_get_size(igrib,'values',grid_size)
+        if ( grid_size /= ngdas ) then
+           write(LIS_logunit,*) &
+              '[ERR] Number of values does not match expected', trim(fname)
+           errorcode = 0
+           deallocate(lb)
+           deallocate(f)
+           return
+        endif
+
+        call grib_get(igrib,'indicatorOfParameter',pds5_val,rc)
+        call LIS_verify(rc, 'error in grib_get: indicatorOfParameter in read_gdas')
+
+        call grib_get(igrib,'level',pds7_val,rc)
+        call LIS_verify(rc, 'error in grib_get: level in read_gdas')
+
+        call grib_get(igrib,'timeRangeIndicator',pds16_val,rc)
+        call LIS_verify(rc, 'error in grib_get: timeRangeIndicator in read_gdas')
+
+        var_found = .false.
+        do iv=1,7  !Only seven variables when no precip present
+           if((pds5_val.eq.pds5(iv)).and.&
+                (pds7_val.eq.pds7(iv)).and.&
+                (pds16_val.eq.pds16(iv))) then
+              var_found = .true.
+              var_index = iv
+              var_status(iv) = .true.
+              exit
+           endif
+        enddo
+        f = -9999.0
+        call grib_get(igrib,'values',f,rc)
+        call LIS_warning(rc, 'error in grib_get:values in read_gdas')
+
+        if(rc.ne.0) then
+           write(LIS_logunit,*) &
+                '[ERR] Could not retrieve entries in file f00a: ',trim(fname),kk,rc
+           errorcode = 0
+           deallocate(lb)
+           deallocate(f)
+           return
+        endif
+
+        call grib_get(igrib,'missingValue',missingValue,rc)
+        call LIS_verify(rc, 'error in grib_get:missingValue in read_gdas')
+
+        call grib_release(igrib,rc)
+        call LIS_verify(rc, 'error in grib_release in read_gdas')
+
+        if(var_found) then
+           lb = .false.
+           do t=1,ngdas
+              if(f(t).ne.missingValue) lb(t) = .true.
+           enddo
+
+           pcp_flag = .false.
+           if(var_index.eq.8.or.var_index.eq.9) pcp_flag = .true.
+
+           call interp_gdas(n, findex,pcp_flag,ngdas,f,&
+                lb,LIS_rc%gridDesc(n,:), &
+                LIS_rc%lnc(n),LIS_rc%lnr(n),varfield)
+
+           do r=1,LIS_rc%lnr(n)
+              do c=1,LIS_rc%lnc(n)
+                 if(LIS_domain(n)%gindex(c,r).ne.-1) then
+                    glbdata(var_index,LIS_domain(n)%gindex(c,r)) =&
+                         varfield(c,r)
+                 endif
+              enddo
+           enddo
+        endif
+
+     enddo
+     call grib_close_file(ftn)
+
+     deallocate(lb)
+     deallocate(f)
+
+     do kk=1,7 !Only seven variables when no precip present
+        if(.not.var_status(kk)) then
+           write(LIS_logunit,*) &
+                '[ERR] Could not retrieve entries in file f00b: ',trim(fname),kk
+           errorcode = 0
+
+           return
+        endif
+     enddo
+  else
+     write(LIS_logunit,*) &
+          '[ERR] Could not find file: ',trim(fname)
+     errorcode = 0
+  endif
+#endif     
+end subroutine retrieve_gdas_noprecip
 !BOP
 ! !ROUTINE: interp_gdas
 ! \label{interp_gdas}

--- a/lis/metforcing/gdas/read_gdas.F90
+++ b/lis/metforcing/gdas/read_gdas.F90
@@ -94,12 +94,13 @@ subroutine read_gdas( order, n, findex, &
   real    :: glbdata_a(10,LIS_rc%ngrid(n))
   real    :: glbdata_a_f06(10,LIS_rc%ngrid(n))
   integer :: nstep
-
+  logical :: dataStrucflag
 !=== End Variable Definition =======================
-
+  glbdata_i = LIS_rc%udef
   glbdata_a = LIS_rc%udef
   glbdata_a_f06 = LIS_rc%udef
   ngdas = (gdas_struc(n)%ncold*gdas_struc(n)%nrold)
+  dataStrucflag = .false.
 !--------------------------------------------------------------------------
 ! Set the GRIB parameter specifiers
 !--------------------------------------------------------------------------
@@ -138,19 +139,17 @@ subroutine read_gdas( order, n, findex, &
 ! Set up to open file and retrieve specified field 
 !--------------------------------------------------------------------------
   fname = name00
-  
   if(gdas_struc(n)%dstrucchange1 .AND.  gdas_struc(n)%gdastime1 .ge. gdas_struc(n)%datastructime1) then
-    !HKB Use special routine for f00 files following 2019 Jun 12 12Z GDAS upgrades
-    call retrieve_gdas_noprecip(n, findex, fname,glbdata_i, ferror1)
-  else
-    call retrieve_gdas_variables(n, findex, fname,glbdata_i, ferror1)
+    dataStrucflag = .true.  !HKB Use special routine for f00 files following 2019 Jun 12 12Z GDAS upgrades
   endif
+  call retrieve_gdas_variables(n, findex, fname, dataStrucflag, glbdata_i, ferror1)
+  dataStrucflag = .false. !Reset flag since f03 and f06 files are not affected by 2019 Jun 12 upgrade
 
 !--------------------------------------------------------------------------
 ! read 3hr forecast for time averaged fields
 !--------------------------------------------------------------------------
   fname = name03
-  call retrieve_gdas_variables(n, findex, fname,glbdata_a, ferror2)
+  call retrieve_gdas_variables(n, findex, fname, dataStrucflag, glbdata_a, ferror2)
 
 !--------------------------------------------------------------------------
 ! read 6hr forecast for time averaged fields, if required. 
@@ -158,7 +157,7 @@ subroutine read_gdas( order, n, findex, &
 
   if(F06flag) then 
      fname = name06
-     call retrieve_gdas_variables(n, findex, fname,glbdata_a_f06, ferror3)
+     call retrieve_gdas_variables(n, findex, fname, dataStrucflag, glbdata_a_f06, ferror3)
   end if
   
   ferror = 1
@@ -218,7 +217,7 @@ end subroutine read_gdas
 ! \label{retrieve_gdas_variables}
 ! 
 ! !INTERFACE: 
-subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
+subroutine retrieve_gdas_variables(n, findex, fname, dataStrucflag, glbdata, errorcode)
 ! !USES: 
   use LIS_coreMod,        only : LIS_rc, LIS_domain
   use LIS_logMod,         only : LIS_logunit,LIS_getNextUnitNumber,& 
@@ -234,6 +233,7 @@ subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
   integer               :: n 
   integer               :: findex
   character(len=*)      :: fname
+  logical               :: dataStrucflag
   real                  :: glbdata(10,LIS_rc%ngrid(n))
   integer               :: errorcode
 ! 
@@ -247,7 +247,7 @@ subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
   real, allocatable :: f(:)
   real, dimension(LIS_rc%lnc(n), LIS_rc%lnr(n)) :: varfield
   integer :: igrib
-  integer :: iv,c,r,t
+  integer :: iv,ivmax,c,r,t
   real    :: missingValue 
   integer :: iret
   integer :: ftn 
@@ -274,8 +274,16 @@ subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
   pds5 = (/ 011,051,204,205,033,034,001,059,214 /) !parameter
   pds6 = -1
   pds7 = (/ 002,002,000,000,010,010,000,000,000 /) !htlev2
-! index 10 indicates instantaneous, 003 indicates time average
-  pds16 = (/010,010,003,003,010,010,010,003,003 /) 
+
+  if(dataStrucflag) then
+    ! HKB...All instantaneous fields in f00 files
+    pds16 = (/010,010,010,010,010,010,010,010,010 /)
+    ivmax = 7
+  else
+    ! index 10 indicates instantaneous, 003 indicates time average
+    pds16 = (/010,010,003,003,010,010,010,003,003 /) 
+    ivmax = 9
+  endif
 
   ngdas = (gdas_struc(n)%ncold*gdas_struc(n)%nrold)
 
@@ -343,7 +351,7 @@ subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
         call LIS_verify(rc, 'error in grib_get: timeRangeIndicator in read_gdas')
 
         var_found = .false. 
-        do iv=1,9
+        do iv=1,ivmax
            if((pds5_val.eq.pds5(iv)).and.&
                 (pds7_val.eq.pds7(iv)).and.&
                 (pds16_val.eq.pds16(iv))) then
@@ -401,7 +409,7 @@ subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
      deallocate(lb)
      deallocate(f)     
          
-     do kk=1,9
+     do kk=1,ivmax
         if(.not.var_status(kk)) then 
            write(LIS_logunit,*) &
                 '[ERR] Could not retrieve entries in file: ',trim(fname)
@@ -417,206 +425,6 @@ subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
   endif
 #endif     
 end subroutine retrieve_gdas_variables
-!BOP
-! 
-! !ROUTINE: retrieve_gdas_noprecip
-! \label{retrieve_gdas_noprecip}
-! 
-! !INTERFACE: 
-subroutine retrieve_gdas_noprecip(n, findex, fname, glbdata, errorcode)
-! !USES: 
-  use LIS_coreMod,        only : LIS_rc, LIS_domain
-  use LIS_logMod,         only : LIS_logunit,LIS_getNextUnitNumber,&
-       LIS_releaseUnitNumber, LIS_verify, LIS_warning
-  use gdas_forcingMod,    only : gdas_struc
-
-#if (defined USE_GRIBAPI)
-  use grib_api
-#endif
-
-  implicit none
-! !ARGUMENTS: 
-  integer               :: n
-  integer               :: findex
-  character(len=*)      :: fname
-  real                  :: glbdata(10,LIS_rc%ngrid(n))
-  integer               :: errorcode
-! 
-! !DESCRIPTION: 
-!   This subroutine retrieves GDAS forcing variables, and interpolates
-!  them to the LIS grid. 
-!   This has been adapted to read in only 7 fields after the GDAS data 
-!   change that started on 2019 Jun 12 12Z.
-!EOP
-
-  integer               :: ngdas
-  real, allocatable :: f(:)
-  real, dimension(LIS_rc%lnc(n), LIS_rc%lnr(n)) :: varfield
-  integer :: igrib
-  integer :: iv,c,r,t
-  real    :: missingValue
-  integer :: iret
-  integer :: ftn
-  integer, dimension(gdas_struc(n)%nmif) :: pds5, pds7, pds6,pds16
-  integer :: pds5_val, pds7_val, pds16_val
-  logical*1, allocatable :: lb(:)
-  logical :: file_exists
-  integer :: kk
-  integer :: var_index
-  integer :: nvars
-  integer :: rc
-  logical :: var_status(gdas_struc(n)%nmif)
-  logical :: pcp_flag, var_found
-  integer :: grid_size
-
-#if(defined USE_GRIBAPI) 
-! HKB...Drop last two entries (precip)
-  pds5 = (/ 011,051,204,205,033,034,001 /) !parameter
-  pds6 = -1
-  pds7 = (/ 002,002,000,000,010,010,000 /) !htlev2
-! index 10 indicates instantaneous, 003 indicates time average
-! HKB...All instantaneous fields in f00 files
-  pds16 = (/010,010,010,010,010,010,010 /)
-
-  ngdas = (gdas_struc(n)%ncold*gdas_struc(n)%nrold)
-
-  varfield = 0
-  errorcode = 1
-  var_status = .false.
-
-  inquire (file=fname, exist=file_exists)
-  if (file_exists) then
-
-     call grib_open_file(ftn,trim(fname),'r',iret)
-     if(iret.ne.0) then
-        write(LIS_logunit,*) '[ERR] Could not open file: ',trim(fname)
-        errorcode = 0
-        return
-     endif
-
-     call grib_count_in_file(ftn,nvars,iret)
-     call LIS_warning(iret, 'error in grib_count_in_file in read_gdas')
-     if(iret.ne.0) then
-        errorcode = 0
-        return
-     endif
-
-     allocate(lb(gdas_struc(n)%ncold*gdas_struc(n)%nrold))
-     allocate(f(gdas_struc(n)%ncold*gdas_struc(n)%nrold))
-
-     do kk=1,nvars
-        call grib_new_from_file(ftn, igrib, iret)
-        call LIS_warning(iret, 'error in grib_new_from_file in read_gdas')
-        if(iret.ne.0) then
-           write(LIS_logunit,*) &
-                '[ERR] Could not retrieve entries in file f00a: ',trim(fname)
-           errorcode = 0
-           deallocate(lb)
-           deallocate(f)
-           return
-        endif
-        ! Trap the old "Could not find correct forcing parameter in file"
-        ! error from LIS 6.  This error occurred right before a GDAS
-        ! grid change.  LIS would try to read ahead, but the new data
-        ! would be on the new grid, so LIS would misread it resulting in
-        ! the above error message.  The LIS would roll back to the previous
-        ! day for GDAS forcing.
-        ! Trap this by checking the number of values in one of the
-        ! GRIB fields.
-        call grib_get_size(igrib,'values',grid_size)
-        if ( grid_size /= ngdas ) then
-           write(LIS_logunit,*) &
-              '[ERR] Number of values does not match expected', trim(fname)
-           errorcode = 0
-           deallocate(lb)
-           deallocate(f)
-           return
-        endif
-
-        call grib_get(igrib,'indicatorOfParameter',pds5_val,rc)
-        call LIS_verify(rc, 'error in grib_get: indicatorOfParameter in read_gdas')
-
-        call grib_get(igrib,'level',pds7_val,rc)
-        call LIS_verify(rc, 'error in grib_get: level in read_gdas')
-
-        call grib_get(igrib,'timeRangeIndicator',pds16_val,rc)
-        call LIS_verify(rc, 'error in grib_get: timeRangeIndicator in read_gdas')
-
-        var_found = .false.
-        do iv=1,7  !Only seven variables when no precip present
-           if((pds5_val.eq.pds5(iv)).and.&
-                (pds7_val.eq.pds7(iv)).and.&
-                (pds16_val.eq.pds16(iv))) then
-              var_found = .true.
-              var_index = iv
-              var_status(iv) = .true.
-              exit
-           endif
-        enddo
-        f = -9999.0
-        call grib_get(igrib,'values',f,rc)
-        call LIS_warning(rc, 'error in grib_get:values in read_gdas')
-
-        if(rc.ne.0) then
-           write(LIS_logunit,*) &
-                '[ERR] Could not retrieve entries in file f00a: ',trim(fname),kk,rc
-           errorcode = 0
-           deallocate(lb)
-           deallocate(f)
-           return
-        endif
-
-        call grib_get(igrib,'missingValue',missingValue,rc)
-        call LIS_verify(rc, 'error in grib_get:missingValue in read_gdas')
-
-        call grib_release(igrib,rc)
-        call LIS_verify(rc, 'error in grib_release in read_gdas')
-
-        if(var_found) then
-           lb = .false.
-           do t=1,ngdas
-              if(f(t).ne.missingValue) lb(t) = .true.
-           enddo
-
-           pcp_flag = .false.
-           if(var_index.eq.8.or.var_index.eq.9) pcp_flag = .true.
-
-           call interp_gdas(n, findex,pcp_flag,ngdas,f,&
-                lb,LIS_rc%gridDesc(n,:), &
-                LIS_rc%lnc(n),LIS_rc%lnr(n),varfield)
-
-           do r=1,LIS_rc%lnr(n)
-              do c=1,LIS_rc%lnc(n)
-                 if(LIS_domain(n)%gindex(c,r).ne.-1) then
-                    glbdata(var_index,LIS_domain(n)%gindex(c,r)) =&
-                         varfield(c,r)
-                 endif
-              enddo
-           enddo
-        endif
-
-     enddo
-     call grib_close_file(ftn)
-
-     deallocate(lb)
-     deallocate(f)
-
-     do kk=1,7 !Only seven variables when no precip present
-        if(.not.var_status(kk)) then
-           write(LIS_logunit,*) &
-                '[ERR] Could not retrieve entries in file f00b: ',trim(fname),kk
-           errorcode = 0
-
-           return
-        endif
-     enddo
-  else
-     write(LIS_logunit,*) &
-          '[ERR] Could not find file: ',trim(fname)
-     errorcode = 0
-  endif
-#endif     
-end subroutine retrieve_gdas_noprecip
 !BOP
 ! !ROUTINE: interp_gdas
 ! \label{interp_gdas}


### PR DESCRIPTION
This fix will allow the reader to read in f00 GDAS data files
  after the 2019 June 12 12Z upgrade by NCEP. The reader expected
  precipitation fields and averaged radiation fields in the f00
  GDAS data files. After the upgrade, these fields were removed or
  were changed to report instantaneous values, respectively.

This fix adds a new subroutine in read_gdas.F90 that conforms to
  the new data file structure. In addition, a check was added so
  the new subroutine is only called when the reader is accessing
  files after 2019 Jun 12 12Z.

Resolves: #159 