### PR TITLE
Adds the support for processing SMAP L2 retrievals

### DIFF
--- a/ldt/DAobs/NASA_SMAPsm/NASASMAPsm_obsMod.F90
+++ b/ldt/DAobs/NASA_SMAPsm/NASASMAPsm_obsMod.F90
@@ -13,7 +13,8 @@
 !  21 Aug 2016: Sujay Kumar, Initial Specification
 !  12 Feb 2018: Mahdi Navari, openwater proximity detection was added
 ! 			edited to read New version of the SPL3SMP_R14 (file structure
-! 			 differs from the previous versions) 
+! 			 differs from the previous versions)
+!  04 Jun 2019: Sujay Kumar, Updated to support SMAP L2 retrievals 
 
 module NASASMAPsm_obsMod
 ! !USES: 
@@ -131,10 +132,6 @@ contains
           gridDesci(10) = 0.36 
           gridDesci(11) = 1 !for the global switch
 
-           
-          allocate(NASASMAPsmobs(n)%n11(LDT_rc%lnc(n)*LDT_rc%lnr(n)))       
-          call neighbor_interp_input (n, gridDesci,&
-               NASASMAPsmobs(n)%n11)
        elseif(NASASMAPsmobs(n)%data_designation.eq."SPL3SMP_E") then 
           NASASMAPsmobs(n)%nc = 3856
           NASASMAPsmobs(n)%nr = 1624
@@ -148,11 +145,37 @@ contains
           gridDesci(10) = 0.09 
           gridDesci(11) = 1 !for the global switch
 
-           
-          allocate(NASASMAPsmobs(n)%n11(LDT_rc%lnc(n)*LDT_rc%lnr(n)))       
-          call neighbor_interp_input (n, gridDesci,&
-               NASASMAPsmobs(n)%n11)
+       elseif(NASASMAPsmobs(n)%data_designation.eq."SPL2SMP") then 
+          NASASMAPsmobs(n)%nc = 964
+          NASASMAPsmobs(n)%nr = 406
+
+          gridDesci = 0 
+          gridDesci(1) = 9
+          gridDesci(2) = 964
+          gridDesci(3) = 406
+          gridDesci(9) = 4 !M36 grid
+          gridDesci(20) = 64
+          gridDesci(10) = 0.36 
+          gridDesci(11) = 1 !for the global switch
+
+       elseif(NASASMAPsmobs(n)%data_designation.eq."SPL2SMP_E") then 
+          NASASMAPsmobs(n)%nc = 3856
+          NASASMAPsmobs(n)%nr = 1624
+
+          gridDesci = 0 
+          gridDesci(1) = 9
+          gridDesci(2) = 3856
+          gridDesci(3) = 1624
+          gridDesci(9) = 5 !M09 grid
+          gridDesci(20) = 64
+          gridDesci(10) = 0.09 
+          gridDesci(11) = 1 !for the global switch
        endif
+       allocate(NASASMAPsmobs(n)%n11(LDT_rc%lnc(n)*LDT_rc%lnr(n)))       
+       call neighbor_interp_input (n, gridDesci,&
+            NASASMAPsmobs(n)%n11)
+       
+
     enddo
   end subroutine NASASMAPsm_obsinit
      

--- a/ldt/DAobs/NASA_SMAPsm/readNASASMAPsmObs.F90
+++ b/ldt/DAobs/NASA_SMAPsm/readNASASMAPsmObs.F90
@@ -13,6 +13,7 @@
 ! 			edited to read New version of the SPL3SMP_R14 (file structure
 ! 			 differs from the previous versions) 
 !  31 Aug 2018: Mahdi Navari, Edited to read SPL3SMP.005 & SPL3SMP_E.002
+!  04 Jun 2019: Sujay Kumar, Updated to support SMAP L2 retrievals
 ! 
 ! !INTERFACE: 
 subroutine readNASASMAPsmObs(n)
@@ -20,6 +21,7 @@ subroutine readNASASMAPsmObs(n)
   use ESMF
   use LDT_coreMod
   use LDT_logMod
+  use LDT_timeMgrMod
   use LDT_DAobsDataMod
   use NASASMAPsm_obsMod
   use map_utils
@@ -35,11 +37,22 @@ subroutine readNASASMAPsmObs(n)
 !
 !EOP
 
-  real              :: timenow
+  real*8            :: timenow
   logical           :: alarmCheck
   logical           :: file_exists
   integer           :: c,r,i,j
   character*100     :: fname
+  integer           :: mn_ind
+  integer           :: yr, mo, da, hr, mn, ss
+  integer           :: doy
+  integer           :: ftn
+  integer           :: ierr
+  real              :: gmt
+  character*8       :: yyyymmdd
+  character*4       :: yyyy
+  character*2       :: mm,dd,hh
+  character*200     :: list_files
+  character*100     :: smap_filename(10)
   real              :: smobs(LDT_rc%lnc(n)*LDT_rc%lnr(n))
 
 !-----------------------------------------------------------------------
@@ -48,30 +61,259 @@ subroutine readNASASMAPsmObs(n)
   NASASMAPsmobs(n)%smobs = LDT_rc%udef
   smobs= LDT_rc%udef
 
-  call create_NASASMAPsm_filename(NASASMAPsmobs(n)%odir, &
-       NASASMAPsmobs(n)%data_designation,&
-       LDT_rc%yr, LDT_rc%mo, LDT_rc%da, fname)
-  
-  inquire(file=trim(fname),exist=file_exists)
-  if(file_exists) then
-     
-     write(LDT_logunit,*) '[INFO] Reading ..',trim(fname)
-     call read_NASASMAP_data(n, fname, smobs)
-     write(LDT_logunit,*) '[INFO] Finished reading ',trim(fname)
+  if(NASASMAPsmobs(n)%data_designation.eq."SPL2SMP".or.&
+       NASASMAPsmobs(n)%data_designation.eq."SPL2SMP_E") then 
 
-     do r=1,LDT_rc%lnr(n)
-        do c=1,LDT_rc%lnc(n)
-           if(smobs(c+(r-1)*LDT_rc%lnc(n)).ne.-9999.0) then 
-              NASASMAPsmobs(n)%smobs(c,r) = smobs(c+(r-1)*LDT_rc%lnc(n))
-           endif
-        enddo
+     if(LDT_rc%ts.gt.3600) then 
+        write(LDT_logunit,*)'[ERR] Please set the LDT timestep to 1hr or less'
+        write(LDT_logunit,*)'[ERR] This is required for SMAPL2 data processing'
+        call LDT_endrun()
+     endif
+
+     write(yyyymmdd,'(i4.4,2i2.2)') LDT_rc%yr, LDT_rc%mo, LDT_rc%da
+     write(yyyy,'(i4.4)') LDT_rc%yr
+     write(mm,'(i2.2)') LDT_rc%mo
+     write(dd,'(i2.2)') LDT_rc%da
+     write(hh,'(i2.2)') LDT_rc%hr
+     
+     list_files = 'ls '//trim(NASASMAPsmobs(n)%odir)//&
+          '/'//trim(yyyy)//'.'//trim(mm)//'.'//dd//&
+          '/SMAP_L2_*'//trim(yyyymmdd)//'T'//trim(hh)&
+          //"*.h5 > SMAP_filelist.dat"
+     
+     call system(trim(list_files))
+
+     i = 1
+     ftn = LDT_getNextUnitNumber()
+     open(ftn,file="./SMAP_filelist.dat",&
+          status='old',iostat=ierr)
+     
+     do while(ierr.eq.0) 
+        read(ftn,'(a)',iostat=ierr) fname
+        if(ierr.ne.0) then 
+           exit
+        endif
+        mn_ind = index(fname,trim(yyyymmdd)//'T'//trim(hh))
+        
+        mn_ind = index(fname,trim(yyyymmdd)//'T'//trim(hh))+11        
+        read(fname(mn_ind:mn_ind+1),'(i2.2)') mn
+        ss=0
+        call LDT_tick(timenow,doy,gmt,LDT_rc%yr, LDT_rc%mo, LDT_rc%da, &
+                LDT_rc%hr, mn, ss, 0.0)
+        
+        smap_filename(i) = fname
+        
+        write(LDT_logunit,*) '[INFO] reading ',trim(smap_filename(i))
+        
+        call read_SMAPL2sm_data(n,smap_filename(i),&
+             NASASMAPsmobs(n)%smobs,timenow)
+        
+        i = i+1
      enddo
+     call LDT_releaseUnitNumber(ftn)
+  else
+     call create_NASASMAPsm_filename(NASASMAPsmobs(n)%odir, &
+          NASASMAPsmobs(n)%data_designation,&
+          LDT_rc%yr, LDT_rc%mo, LDT_rc%da, fname)
+     
+     inquire(file=trim(fname),exist=file_exists)
+     if(file_exists) then
+        
+        write(LDT_logunit,*) '[INFO] Reading ..',trim(fname)
+        call read_NASASMAP_data(n, fname, smobs)
+        write(LDT_logunit,*) '[INFO] Finished reading ',trim(fname)
+        
+        do r=1,LDT_rc%lnr(n)
+           do c=1,LDT_rc%lnc(n)
+              if(smobs(c+(r-1)*LDT_rc%lnc(n)).ne.-9999.0) then 
+                 NASASMAPsmobs(n)%smobs(c,r) = smobs(c+(r-1)*LDT_rc%lnc(n))
+              endif
+           enddo
+        enddo
+     endif
   endif
 
   call LDT_logSingleDAobs(n,LDT_DAobsData(n)%soilmoist_obs,&
        NASASMAPsmobs(n)%smobs,vlevel=1)
 
 end subroutine readNASASMAPsmObs
+
+!BOP
+! 
+! !ROUTINE: read_SMAPL2sm_data
+! \label{read_SMAPL2sm_data}
+!
+! !INTERFACE:
+subroutine read_SMAPL2sm_data(n, fname, smobs_inp, time)
+! 
+! !USES:   
+
+  use LDT_coreMod
+  use LDT_logMod
+  use LDT_timeMgrMod
+  use NASASMAPsm_obsMod
+#if (defined USE_HDF5) 
+  use hdf5
+#endif
+
+  implicit none
+!
+! !INPUT PARAMETERS: 
+! 
+  integer                  :: n
+  character (len=*)        :: fname
+  real                     :: smobs_inp(LDT_rc%lnc(n),LDT_rc%lnr(n))
+  real*8                   :: time
+
+! !OUTPUT PARAMETERS:
+!
+!
+! !DESCRIPTION: 
+!
+!
+!EOP
+
+#if (defined USE_HDF5)
+
+  character*100,    parameter    :: sm_gr_name = "Soil_Moisture_Retrieval_Data"
+  character*100,    parameter    :: sm_field_name = "soil_moisture"
+  character*100,    parameter    :: sm_qa_name = "retrieval_qual_flag"
+
+  integer(hsize_t), dimension(1) :: dims
+  integer(hsize_t), dimension(1) :: maxdims
+  integer(hid_t)                 :: file_id
+  integer(hid_t)                 :: dspace_id
+  integer(hid_t)                 :: row_id, col_id
+  integer(hid_t)                 :: sm_gr_id,sm_field_id, sm_qa_id
+  integer(hid_t)                 :: sm_gr_id_A,sm_field_id_A
+  real,             allocatable  :: sm_field(:)
+  integer,          allocatable  :: sm_qa(:)
+  integer,          allocatable  :: ease_row(:)
+  integer,          allocatable  :: ease_col(:)
+  integer                        :: c,r,t
+  logical*1                      :: sm_data_b(NASASMAPsmobs(n)%nc*NASASMAPsmobs(n)%nr)
+  logical*1                      :: smobs_b_ip(LDT_rc%lnc(n)*LDT_rc%lnr(n))
+  real                           :: sm_data(NASASMAPsmobs(n)%nc*NASASMAPsmobs(n)%nr)
+  real                           :: smobs_ip(LDT_rc%lnc(n)*LDT_rc%lnr(n))
+
+  integer                        :: status,ios,iret
+
+  call h5open_f(status)
+  call LDT_verify(status, 'Error opening HDF fortran interface')
+  
+  call h5fopen_f(trim(fname),H5F_ACC_RDONLY_F, file_id, status) 
+  call LDT_verify(status, 'Error opening SMAP L2 file ')
+  
+  call h5gopen_f(file_id,sm_gr_name,sm_gr_id, status)
+  call LDT_verify(status, 'Error opening SM group in SMAP L2 file')
+  
+  call h5dopen_f(sm_gr_id,sm_field_name,sm_field_id, status)
+  call LDT_verify(status, 'Error opening SM field in SMAP L2 file')
+
+  call h5dopen_f(sm_gr_id,"EASE_row_index",row_id, status)
+  call LDT_verify(status, 'Error opening row index field in SMAP L2 file')
+
+  call h5dopen_f(sm_gr_id,"EASE_column_index",col_id, status)
+  call LDT_verify(status, 'Error opening column index field in SMAP L2 file')
+
+!  call h5dopen_f(sm_gr_id, sm_qa_name,sm_qa_id, status)
+!  call LDT_verify(status, 'Error opening QA field in SMAP L2 file')
+  
+  call h5dget_space_f(sm_field_id, dspace_id, status)
+  call LDT_verify(status, 'Error in h5dget_space_f: readSMAP L2Obs')
+  
+! Size of the arrays
+! This routine returns -1 on failure, rank on success. 
+  call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, status) 
+  if(status.eq.-1) then 
+     call LDT_verify(status, 'Error in h5sget_simple_extent_dims_f: readSMAP L2Obs')
+  endif
+  
+  allocate(sm_field(maxdims(1)))
+!  allocate(sm_qa(maxdims(1)))
+  allocate(ease_row(maxdims(1)))
+  allocate(ease_col(maxdims(1)))
+
+  call h5dread_f(row_id, H5T_NATIVE_INTEGER,ease_row,dims,status)
+  call LDT_verify(status, 'Error extracting row index from SMAP L2 file')
+
+  call h5dread_f(col_id, H5T_NATIVE_INTEGER,ease_col,dims,status)
+  call LDT_verify(status, 'Error extracting col index from SMAP L2 file')
+  
+  call h5dread_f(sm_field_id, H5T_NATIVE_REAL,sm_field,dims,status)
+  call LDT_verify(status, 'Error extracting SM field from SMAP L2 file')
+
+!  call h5dread_f(sm_qa_id, H5T_NATIVE_INTEGER,sm_qa,dims,status)
+!  call LDT_verify(status, 'Error extracting SM field from SMAP L2 file')
+  
+!  call h5dclose_f(sm_qa_id,status)
+!  call LDT_verify(status,'Error in H5DCLOSE call')
+
+  call h5dclose_f(row_id,status)
+  call LDT_verify(status,'Error in H5DCLOSE call')
+
+  call h5dclose_f(col_id,status)
+  call LDT_verify(status,'Error in H5DCLOSE call')
+
+  call h5dclose_f(sm_field_id,status)
+  call LDT_verify(status,'Error in H5DCLOSE call')
+  
+  call h5gclose_f(sm_gr_id,status)
+  call LDT_verify(status,'Error in H5GCLOSE call')
+    
+  call h5fclose_f(file_id,status)
+  call LDT_verify(status,'Error in H5FCLOSE call')
+  
+  call h5close_f(status)
+  call LDT_verify(status,'Error in H5CLOSE call')
+
+  sm_data = LDT_rc%udef
+  sm_data_b = .false. 
+
+!grid the data in EASE projection
+  do t=1,maxdims(1)
+     if(ease_col(t).gt.0.and.ease_row(t).gt.0) then 
+        sm_data(ease_col(t) + &
+             (ease_row(t)-1)*NASASMAPsmobs(n)%nc) = sm_field(t) 
+        if(sm_field(t).ne.-9999.0) then 
+           sm_data_b(ease_col(t) + &
+                (ease_row(t)-1)*NASASMAPsmobs(n)%nc) = .true. 
+        endif
+     endif
+  enddo
+  
+  t = 1
+!--------------------------------------------------------------------------
+! Interpolate to the LDT running domain
+!-------------------------------------------------------------------------- 
+  call neighbor_interp(LDT_rc%gridDesc, sm_data_b, sm_data, &
+       smobs_b_ip, smobs_ip, &
+       NASASMAPsmobs(n)%nc*NASASMAPsmobs(n)%nr,&
+       LDT_rc%lnc(n)*LDT_rc%lnr(n),&
+       LDT_domain(n)%lat, LDT_domain(n)%lon,&
+       NASASMAPsmobs(n)%n11,LDT_rc%udef, iret)
+
+  deallocate(sm_field)
+!  deallocate(sm_qa)
+  deallocate(ease_row)
+  deallocate(ease_col)
+
+!overwrite the input data 
+  do r=1,LDT_rc%lnr(n)
+     do c=1,LDT_rc%lnc(n)
+        if(smobs_ip(c+(r-1)*LDT_rc%lnc(n)).ne.-9999.0) then 
+           smobs_inp(c,r) = & 
+                smobs_ip(c+(r-1)*LDT_rc%lnc(n))
+
+!           NASASMAPsmobs(n)%smtime(c,r) = & 
+!                time
+        endif
+     enddo
+  enddo
+
+#endif
+
+end subroutine read_SMAPL2sm_data
 
 
 !BOP


### PR DESCRIPTION
This commit adds the support for processing the SPL2SMP and SPL2SMP_E
versions of the data. Compared to the L3 data, there are multiple timestamped
files within a day. Based on the timestep of LDT, the code appropriately
gathers the relevant files.

Resolves #165