### PR TITLE
Fix post-2019Jun12 GDAS reader bug in LDT

### DIFF
--- a/ldt/metforcing/gdas/gdas_forcingMod.F90
+++ b/ldt/metforcing/gdas/gdas_forcingMod.F90
@@ -20,7 +20,12 @@ module gdas_forcingMod
 !   2005/05/31 - 2010/07/27 :   T382 (1152x576) grid \newline
 !   2010/07/28 - 2015/01/14 :   T574 (1760x880) grid
 !   2015/01/14 - onwards    :  T1534 (1760x880) grid
-
+!
+!  On 2019/06/12 12Z, GDAS removed precipitation fields from the f00 data
+!  files. The data fields in these files are now all instantaneous values.
+!  When the reader is using data files after this time, a new subroutine will
+!  be used that excludes precipitation as well as reads in instantaneous radiation
+!  data. For data files prior to the switch, the reader will use the old subroutine.
 !
 !  The implementation in LDT has the derived data type {\tt gdas\_struc} that
 !  includes the variables that specify the runtime options, and the 
@@ -51,6 +56,9 @@ module gdas_forcingMod
 !    The time to switch GDAS resolution to T574
 !  \item[griduptime6]
 !    The time to switch GDAS resolution to T1534
+!  \item[datastructime1]
+!    The time to switch to new data structure for f00 files
+!    that removed precipitation fields.
 !  \item[findtime1, findtime2]
 !   boolean flags to indicate which time is to be read for 
 !   temporal interpolation.
@@ -100,8 +108,10 @@ module gdas_forcingMod
      real*8        :: gdastime1, gdastime2
      real*8        :: griduptime1, griduptime2, griduptime3
      real*8        :: griduptime4, griduptime5, griduptime6
+     real*8        :: datastructime1
      logical       :: gridchange1, gridchange2, gridchange3
      logical       :: gridchange4, gridchange5, gridchange6
+     logical       :: dstrucchange1
      integer       :: findtime1, findtime2
      integer       :: mi
 
@@ -354,6 +364,14 @@ contains
        mn1 = 0; ss1 = 0
        call LDT_date2time(gdas_struc(n)%griduptime6,updoy,upgmt,yr1,mo1,da1,hr1,mn1,ss1 )
 
+       ! Set time for f00 data structure change
+       yr1 = 2019
+       mo1 = 06
+       da1 = 12
+       hr1 = 9 !09Z is when the reader reads in the 12Zf00 file
+       mn1 = 0; ss1 = 0
+       call LDT_date2time(gdas_struc(n)%datastructime1,updoy,upgmt,yr1,mo1,da1,hr1,mn1,ss1)
+       
        gdas_struc(n)%gridchange1 = .true.
        gdas_struc(n)%gridchange2 = .true.
        gdas_struc(n)%gridchange3 = .true.
@@ -361,6 +379,7 @@ contains
        gdas_struc(n)%gridchange5 = .true.
        gdas_struc(n)%gridchange6 = .true.
 
+       gdas_struc(n)%dstrucchange1 = .true.
      ! Setting up weights for Interpolation
       
        select case( LDT_rc%met_gridtransform(findex) ) 

--- a/ldt/metforcing/gdas/gdas_forcingMod.F90
+++ b/ldt/metforcing/gdas/gdas_forcingMod.F90
@@ -23,9 +23,9 @@ module gdas_forcingMod
 !
 !  On 2019/06/12 12Z, GDAS removed precipitation fields from the f00 data
 !  files. The data fields in these files are now all instantaneous values.
-!  When the reader is using data files after this time, a new subroutine will
-!  be used that excludes precipitation as well as reads in instantaneous radiation
-!  data. For data files prior to the switch, the reader will use the old subroutine.
+!  When the reader is using data files after this time, the subroutine will
+!  skip the precipitation fields and read in instantaneous radiation data 
+!  from the f00 files.
 !
 !  The implementation in LDT has the derived data type {\tt gdas\_struc} that
 !  includes the variables that specify the runtime options, and the 

--- a/ldt/metforcing/gdas/read_gdas.F90
+++ b/ldt/metforcing/gdas/read_gdas.F90
@@ -89,12 +89,14 @@ subroutine read_gdas( order, n, findex, &
   real    :: glbdata_a(10,LDT_rc%ngrid(n))
   real    :: glbdata_a_f06(10,LDT_rc%ngrid(n))
   integer :: nstep
+  logical :: dataStrucflag
 
 !=== End Variable Definition =======================
-
+  glbdata_i = LDT_rc%udef
   glbdata_a = LDT_rc%udef
   glbdata_a_f06 = LDT_rc%udef
   ngdas = (gdas_struc(n)%nc*gdas_struc(n)%nr)
+  dataStrucflag = .false.
 !--------------------------------------------------------------------------
 ! Set the GRIB parameter specifiers
 !--------------------------------------------------------------------------
@@ -112,14 +114,19 @@ subroutine read_gdas( order, n, findex, &
 !--------------------------------------------------------------------------
 ! Set up to open file and retrieve specified field 
 !--------------------------------------------------------------------------
+  
   fname = name00
-  call retrieve_gdas_variables(n, findex, fname,glbdata_i, ferror1)
+  if(gdas_struc(n)%dstrucchange1 .AND.  gdas_struc(n)%gdastime1 .ge. gdas_struc(n)%datastructime1) then
+    dataStrucflag = .true.  !HKB Use special routine for f00 files following 2019 Jun 12 12Z GDAS upgrades
+  endif
+  call retrieve_gdas_variables(n, findex, fname, dataStrucflag, glbdata_i, ferror1)
+  dataStrucflag = .false. !Reset flag since f03 and f06 files are not affected by 2019 Jun 12 upgrade
 
 !--------------------------------------------------------------------------
 ! read 3hr forecast for time averaged fields
 !--------------------------------------------------------------------------
   fname = name03
-  call retrieve_gdas_variables(n, findex, fname,glbdata_a, ferror2)
+  call retrieve_gdas_variables(n, findex, fname, dataStrucflag, glbdata_a, ferror2)
 
 !--------------------------------------------------------------------------
 ! read 6hr forecast for time averaged fields, if required. 
@@ -127,7 +134,7 @@ subroutine read_gdas( order, n, findex, &
 
   if(F06flag) then 
      fname = name06
-     call retrieve_gdas_variables(n, findex, fname,glbdata_a_f06, ferror3)
+     call retrieve_gdas_variables(n, findex, fname, dataStrucflag, glbdata_a_f06, ferror3)
   end if
   
   ferror = 1
@@ -187,7 +194,7 @@ end subroutine read_gdas
 ! \label{retrieve_gdas_variables}
 ! 
 ! !INTERFACE: 
-subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
+subroutine retrieve_gdas_variables(n, findex, fname, dataStrucflag, glbdata, errorcode)
 ! !USES: 
   use LDT_coreMod,        only : LDT_rc, LDT_domain
   use LDT_logMod,         only : LDT_logunit,LDT_getNextUnitNumber,& 
@@ -203,6 +210,7 @@ subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
   integer               :: n 
   integer               :: findex
   character(len=*)      :: fname
+  logical               :: dataStrucflag
   real                  :: glbdata(10,LDT_rc%ngrid(n))
   integer               :: errorcode
 ! 
@@ -216,7 +224,7 @@ subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
   real, allocatable :: f(:)
   real, dimension(LDT_rc%lnc(n), LDT_rc%lnr(n)) :: varfield
   integer :: igrib
-  integer :: iv,c,r,t
+  integer :: iv,ivmax,c,r,t
   real    :: missingValue 
   integer :: iret
   integer :: ftn 
@@ -241,7 +249,16 @@ subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
   pds7 = (/ 002,002,000,000,010,010,000,000,000 /) !htlev2
 ! index 10 indicates instantaneous, 003 indicates time average
 !  pds16 = (/010,010,003,003,010,010,010,003,003,003 /) 
-  pds16 = (/010,010,003,003,010,010,010,003,003 /) 
+
+  if(dataStrucflag) then
+    ! HKB...All instantaneous fields in f00 files
+    pds16 = (/010,010,010,010,010,010,010,010,010 /)
+    ivmax = 7
+  else
+    ! index 10 indicates instantaneous, 003 indicates time average
+    pds16 = (/010,010,003,003,010,010,010,003,003 /)
+    ivmax = 9
+  endif
 
   ngdas = (gdas_struc(n)%nc*gdas_struc(n)%nr)
 
@@ -309,7 +326,7 @@ subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
         call LDT_verify(rc, 'error in grib_get: timeRangeIndicator in read_gdas')
 
         var_found = .false. 
-        do iv=1,9
+        do iv=1,ivmax
            if((pds5_val.eq.pds5(iv)).and.&
                 (pds7_val.eq.pds7(iv)).and.&
                 (pds16_val.eq.pds16(iv))) then
@@ -367,7 +384,7 @@ subroutine retrieve_gdas_variables(n, findex, fname, glbdata, errorcode)
      deallocate(lb)
      deallocate(f)     
          
-     do kk=1,9
+     do kk=1,ivmax
         if(.not.var_status(kk)) then 
            write(LDT_logunit,*) &
               '[ERR] Could not retrieve entries in file: ',trim(fname)


### PR DESCRIPTION
This fix will allow the reader in LDT to read in f00 GDAS
data files after the 2019 June 12 12Z upgrade by NCEP.
The reader expected precipitation fields and averaged
radiation fields in the f00 GDAS data files. After the
upgrade, these fields were removed or were changed to
report instantaneous values, respectively. This fix is
similar to the LIS fix in pull request #160 

This also fixes a bug where 'glbdata_i' was not properly populated
with LDT_rc%udef.

The test files and configs can be found in:
/discover/nobackup/dpsarmie/work/gitLIS/LDT_GDASUpdateBugFix/ldt

Resolves: #167