### PR TITLE
Added SAVE attribute for dimID in LVT_writevar_data_header.

### DIFF
--- a/lvt/core/LVT_historyMod.F90
+++ b/lvt/core/LVT_historyMod.F90
@@ -258,7 +258,9 @@ contains
 ! 
 !EOP
 
-    integer               :: dimID(5),dimID_t(4)
+    !integer               :: dimID(5),dimID_t(4)
+    integer,save          :: dimID(5) ! EMK preserve between calls
+    integer               :: dimID_t(4)
     integer               :: tdimID
     character*8             :: xtime_begin_date
     character*6             :: xtime_begin_time


### PR DESCRIPTION
This will preserve the netCDF dimension IDs for multiple calls to the
subroutine.  This is important, because the dimension IDs for latitude and
longitude are only set during the first subroutine call.

When Intel compilers are used, the values of dimID were preserved between
subroutine calls.  But this is not the case with GNU compilers, and the
Fortran standard only guarantees preservation if the local variable has the
SAVE attribute.

Resolves:  186