### PR TITLE
Fix LDT crash by only writing OPTUE parameters when in that run mode

### DIFF
--- a/ldt/core/LDT_paramProcMod.F90
+++ b/ldt/core/LDT_paramProcMod.F90
@@ -1118,8 +1118,12 @@ contains
 
 ! - Forcing-specific parameter headers
     call LDT_forcingParms_writeHeader(n,ftn,dimID,met_dimID)
+
 !OPT/UE parameters
-    call LDT_optue_writeHeader(n,ftn,dimID)
+    if (LDT_rc%runmode.eq."OPTUE parameter processing") then
+       call LDT_optue_writeHeader(n,ftn,dimID)
+    endif
+
   end subroutine writeParamHeaders
 
 
@@ -1150,8 +1154,11 @@ contains
 
 ! - Forcing-specific data
     call LDT_forcingParms_writeData(n,ftn)
+
 ! OPT/UE parameters
-    call LDT_optue_writeData(n,ftn)
+    if (LDT_rc%runmode.eq."OPTUE parameter processing") then
+       call LDT_optue_writeData(n,ftn)
+    endif
 
   end subroutine writeParamData
 

--- a/ldt/plugins/LDT_runmode_pluginMod.F90
+++ b/ldt/plugins/LDT_runmode_pluginMod.F90
@@ -134,7 +134,7 @@ contains
     call registerldtrun(trim(LDT_ldtsiId)//char(0), &
          LDT_run_ldtsi)
 
-    ! LDTSI analysis
+    ! OPTUE processing
     call registerldtinit(trim(LDT_OPTUEparamprocId)//char(0), &
          LDT_init_OPTUEparamproc)
     call registerldtrun(trim(LDT_OPTUEparamprocId)//char(0), &


### PR DESCRIPTION
This update will only write OPTUE parameter header and parameter
data when in "OPTUE parameter processing" LDT run mode.  The code
previously would crash when in "LSM parameter processing" mode.
A simple check for the runmode before calling the routines to
write the OPTUE parameters header and the data to the lis_input
netCDF file was added to the code.

Resolves: #197
See also: #183