### PR TITLE
Fix to LDT little_endian issues for GTOPO, SRTM, and TBOT

### DIFF
--- a/ldt/params/Noah/read_ISLSCP1_tbot.F90
+++ b/ldt/params/Noah/read_ISLSCP1_tbot.F90
@@ -107,7 +107,7 @@ subroutine read_ISLSCP1_tbot(n, array)
 
 !- Open 60-minute deep soil temperature data file: 
   open (ftn, file=trim(Noah_struc(n)%tbotFile), form="unformatted", status='old', &
-        access='direct', recl=length )
+        access='direct', convert='big_endian',recl=length )
 
 ! begin_record and end_record may be calculated as follows:
 ! nrec: from north to south (max 1080)

--- a/ldt/params/Noah/read_NCEP_tbot.F90
+++ b/ldt/params/Noah/read_NCEP_tbot.F90
@@ -55,7 +55,7 @@ subroutine read_NCEP_tbot(n, array)
 
   ftn = LDT_getNextUnitNumber()
   open(ftn, file=Noah_struc(n)%tbotFile, access='direct',status='old', &
-       form="unformatted", recl=4)
+       form="unformatted",convert='big_endian',recl=4)
   
   call readLISdata(n, ftn, Noah_struc(n)%tbot_proj,  &
                    Noah_struc(n)%tbot_gridtransform, &

--- a/ldt/params/topo/read_GTOPO30Native_elev.F90
+++ b/ldt/params/topo/read_GTOPO30Native_elev.F90
@@ -178,13 +178,13 @@ subroutine read_GTOPO30Native_elev( n, num_bins, fgrd, elevave )
   tempfile = trim(LDT_rc%elevfile(n))//"/gt30"//we(2)//ns(2)//".dem"
   inquire(file=tempfile, exist=file_exists)
   if(.not.file_exists) then
-     write(LDT_logunit,*) "[ERR] GTOPO30-Native elevation map directory, ",&
-                           trim(LDT_rc%elevfile(n))," not found."
+     write(LDT_logunit,*) "[ERR] GTOPO30-Native elevation map file, ",&
+                           trim(tempfile),", not found."
      write(LDT_logunit,*) "Program stopping ..."
      call LDT_endrun
   endif
-  write(LDT_logunit,*) "[INFO] Reading Native GTOPO30 elevation files, found in directory: ",&
-                        trim(LDT_rc%elevfile(n))
+  write(LDT_logunit,*) "[INFO] Reading Native GTOPO30 elevation files",&
+                       " found in directory: ",trim(LDT_rc%elevfile(n))
   
 ! --
 !  Open and read in tile files:
@@ -214,7 +214,7 @@ subroutine read_GTOPO30Native_elev( n, num_bins, fgrd, elevave )
          if( l < 4 ) then
            open(ftn, file=trim(LDT_rc%elevfile(n))//"/gt30"//we(k)//ns(l)//".dem", &
               form="unformatted", access="direct", status="old", &
-              recl=tile_nc*tile_nr*2)
+              convert='big_endian',recl=tile_nc*tile_nr*2)
            read(ftn, rec=1) read_elevtile(:, :, k)
 
            ! Mosaic all elevation tiles together:
@@ -227,7 +227,7 @@ subroutine read_GTOPO30Native_elev( n, num_bins, fgrd, elevave )
          elseif( l == 4 ) then
            open(ftn, file=trim(LDT_rc%elevfile(n))//"/gt30"//we_antarc(k)//ns(l)//".dem", &
               form="unformatted", access="direct", status="old", &
-              recl=tile_nc_antarc*tile_nr_antarc*2)
+              convert='big_endian',recl=tile_nc_antarc*tile_nr_antarc*2)
            read(ftn, rec=1) read_elevtile_antarc(:, :, k)
 
            ! Mosaic all elevation tiles together:
@@ -338,7 +338,7 @@ subroutine read_GTOPO30Native_elev( n, num_bins, fgrd, elevave )
    end select
    deallocate( gi1, li1 )
 
-   write(LDT_logunit, *) "[INFO] Done reading Native GTOPO30 elevation file."
+   write(LDT_logunit, *) "[INFO] Done reading Native GTOPO30 elevation files."
 
 end subroutine read_GTOPO30Native_elev
 

--- a/ldt/params/topo/read_GTOPO30_aspect.F90
+++ b/ldt/params/topo/read_GTOPO30_aspect.F90
@@ -79,7 +79,7 @@ subroutine read_GTOPO30_aspect( n, num_bins, fgrd, aspectave )
   
   ftn = LDT_getNextUnitNumber()
   open(ftn,file=LDT_rc%aspfile(n),form='unformatted', &
-       access='direct',recl=4,status='old')
+       access='direct',convert='big_endian',recl=4,status='old')
   
 ! -------------------------------------------------------------------
 !     AGGREGATING FINE-SCALE GRIDS TO COARSER LIS OUTPUT GRID

--- a/ldt/params/topo/read_GTOPO30_curv.F90
+++ b/ldt/params/topo/read_GTOPO30_curv.F90
@@ -51,7 +51,7 @@ subroutine read_GTOPO30_curv(n,curv)
   
   ftn = LDT_getNextUnitNumber()
   open(ftn,file=LDT_rc%curvfile(n),form='unformatted', &
-       access='direct',recl=4,status='old')
+       access='direct',convert='big_endian',recl=4,status='old')
 
   call readLISdata(n, ftn, LDT_rc%topo_proj, LDT_rc%topo_gridtransform(n), &
                    LDT_rc%topo_gridDesc(n,:), 1, curv )

--- a/ldt/params/topo/read_GTOPO30_elev.F90
+++ b/ldt/params/topo/read_GTOPO30_elev.F90
@@ -79,8 +79,7 @@ subroutine read_GTOPO30_elev( n, num_bins, fgrd, elevave )
   
   ftn = LDT_getNextUnitNumber()
   open(ftn,file=LDT_rc%elevfile(n),form='unformatted', &
-       access='direct',recl=4,status='old')
-  
+       access='direct',convert='big_endian',recl=4,status='old')
 
 ! -------------------------------------------------------------------
 !     AGGREGATING FINE-SCALE GRIDS TO COARSER LIS OUTPUT GRID

--- a/ldt/params/topo/read_GTOPO30_slope.F90
+++ b/ldt/params/topo/read_GTOPO30_slope.F90
@@ -79,7 +79,7 @@ subroutine read_GTOPO30_slope( n, num_bins, fgrd, slopeave )
   
   ftn = LDT_getNextUnitNumber()
   open(ftn,file=LDT_rc%slfile(n),form='unformatted', &
-       access='direct',recl=4,status='old')
+       access='direct',convert='big_endian',recl=4,status='old')
   
 ! -------------------------------------------------------------------
 !     AGGREGATING FINE-SCALE GRIDS TO COARSER LIS OUTPUT GRID

--- a/ldt/params/topo/read_SRTM_Native_aspect.F90
+++ b/ldt/params/topo/read_SRTM_Native_aspect.F90
@@ -163,13 +163,13 @@ subroutine read_SRTM_Native_aspect( n, num_bins, fgrd, aspectave )
   tempfile = trim(LDT_rc%elevfile(n))//"/"//we(2)//ns(2)//".DEM"
   inquire(file=tempfile, exist=file_exists)
   if(.not.file_exists) then 
-     write(LDT_logunit,*) "[ERR] SRTM-Native elevation map directory, ",&
-                           trim(LDT_rc%elevfile(n))," not found."
+     write(LDT_logunit,*) "[ERR] SRTM-Native elevation map file, ",&
+                           trim(tempfile),", not found."
      write(LDT_logunit,*) "Program stopping ..."
      call LDT_endrun
   endif
-  write(LDT_logunit,*) "[INFO] Reading Native SRTM elevation files, found in directory: ",&
-                        trim(LDT_rc%elevfile(n))
+  write(LDT_logunit,*) "[INFO] Reading Native SRTM elevation files",&
+                       " found in directory: ",trim(LDT_rc%elevfile(n))
 ! --
 !  Open and read in tile files:
 ! --
@@ -199,7 +199,7 @@ subroutine read_SRTM_Native_aspect( n, num_bins, fgrd, aspectave )
          if( l < 4 ) then
          open(ftn, file=trim(LDT_rc%elevfile(n))//"/"//we(k)//ns(l)//".DEM", &
               form="unformatted", access="direct", status="old", &
-              recl=tile_nc*tile_nr*2)
+              convert='big_endian',recl=tile_nc*tile_nr*2)
          read(ftn, rec=1) read_elevtile(:, :, k)
 
       !- Mosaic all elevation tiles together:
@@ -219,7 +219,7 @@ subroutine read_SRTM_Native_aspect( n, num_bins, fgrd, aspectave )
            else
              open(ftn, file=trim(LDT_rc%elevfile(n))//"/gt30"//we_antarc(k)//ns(l)//".dem", &
                 form="unformatted", access="direct", status="old", &
-                recl=tile_nc_antarc*tile_nr_antarc*2)
+                convert='big_endian',recl=tile_nc_antarc*tile_nr_antarc*2)
              read(ftn, rec=1) read_elevtile_antarc(:, :, k)
            endif
 

--- a/ldt/params/topo/read_SRTM_Native_elev.F90
+++ b/ldt/params/topo/read_SRTM_Native_elev.F90
@@ -161,13 +161,13 @@ subroutine read_SRTM_Native_elev( n, num_bins, fgrd, elevave )
   tempfile = trim(LDT_rc%elevfile(n))//"/"//we(2)//ns(2)//".DEM"
   inquire(file=tempfile, exist=file_exists)
   if(.not.file_exists) then 
-     write(LDT_logunit,*) "[ERR] SRTM-Native elevation map directory, ",&
-                           trim(LDT_rc%elevfile(n))," not found."
+     write(LDT_logunit,*) "[ERR] SRTM-Native elevation map file, ",&
+                           trim(tempfile),", not found."
      write(LDT_logunit,*) "Program stopping ..."
      call LDT_endrun
   endif
-  write(LDT_logunit,*)"[INFO] Reading Native SRTM elevation files, found in directory: ",&
-                        trim(LDT_rc%elevfile(n))
+  write(LDT_logunit,*) "[INFO] Reading Native SRTM elevation files",&
+                       " found in directory: ",trim(LDT_rc%elevfile(n))
 ! --
 !  Open and read in tile files:
 ! --
@@ -198,7 +198,7 @@ subroutine read_SRTM_Native_elev( n, num_bins, fgrd, elevave )
          if( l < 4 ) then
            open(ftn, file=trim(LDT_rc%elevfile(n))//"/"//we(k)//ns(l)//".DEM", &
                 form="unformatted", access="direct", status="old", &
-                recl=tile_nc*tile_nr*2)
+                convert='big_endian',recl=tile_nc*tile_nr*2)
            read(ftn, rec=1) read_elevtile(:, :, k)
 
            ! Mosaic all elevation tiles together:
@@ -219,7 +219,7 @@ subroutine read_SRTM_Native_elev( n, num_bins, fgrd, elevave )
            else
              open(ftn, file=trim(LDT_rc%elevfile(n))//"/gt30"//we_antarc(k)//ns(l)//".dem", &
                 form="unformatted", access="direct", status="old", &
-                recl=tile_nc_antarc*tile_nr_antarc*2)
+                convert='big_endian',recl=tile_nc_antarc*tile_nr_antarc*2)
              read(ftn, rec=1) read_elevtile_antarc(:, :, k)
 
              ! EMK....Make sure GTOPO30 ocean points are set to same

--- a/ldt/params/topo/read_SRTM_Native_slope.F90
+++ b/ldt/params/topo/read_SRTM_Native_slope.F90
@@ -164,13 +164,13 @@ subroutine read_SRTM_Native_slope( n, num_bins, fgrd, slopeave )
   tempfile = trim(LDT_rc%elevfile(n))//"/"//we(2)//ns(2)//".DEM"
   inquire(file=tempfile, exist=file_exists)
   if(.not.file_exists) then 
-     write(LDT_logunit,*) "[ERR] SRTM-Native elevation map directory, ",&
-                           trim(LDT_rc%elevfile(n))," not found."
+     write(LDT_logunit,*) "[ERR] SRTM-Native elevation map file, ",&
+                           trim(tempfile),", not found."
      write(LDT_logunit,*) "Program stopping ..."
      call LDT_endrun
   endif
-  write(LDT_logunit,*) "[INFO] Reading Native SRTM elevation files, found in directory: ",&
-                        trim(LDT_rc%elevfile(n))
+  write(LDT_logunit,*) "[INFO] Reading Native SRTM elevation files",&
+                       " found in directory: ",trim(LDT_rc%elevfile(n))
 ! --
 !  Open and read in tile files:
 ! --
@@ -201,7 +201,7 @@ subroutine read_SRTM_Native_slope( n, num_bins, fgrd, slopeave )
          if( l < 4 ) then
          open(ftn, file=trim(LDT_rc%elevfile(n))//"/"//we(k)//ns(l)//".DEM", &
               form="unformatted", access="direct", status="old", &
-              recl=tile_nc*tile_nr*2)
+              convert='big_endian',recl=tile_nc*tile_nr*2)
          read(ftn, rec=1) read_elevtile(:, :, k)
 
       !- Mosaic all elevation tiles together:
@@ -221,7 +221,7 @@ subroutine read_SRTM_Native_slope( n, num_bins, fgrd, slopeave )
            else
              open(ftn, file=trim(LDT_rc%elevfile(n))//"/gt30"//we_antarc(k)//ns(l)//".dem", &
                 form="unformatted", access="direct", status="old", &
-                recl=tile_nc_antarc*tile_nr_antarc*2)
+                convert='big_endian',recl=tile_nc_antarc*tile_nr_antarc*2)
              read(ftn, rec=1) read_elevtile_antarc(:, :, k)
            endif
            ! Mosaic all elevation tiles together:

--- a/ldt/params/topo/read_SRTM_aspect.F90
+++ b/ldt/params/topo/read_SRTM_aspect.F90
@@ -75,8 +75,7 @@ subroutine read_SRTM_aspect( n, num_bins, fgrd, aspectave )
   
   ftn = LDT_getNextUnitNumber()
   open(ftn,file=LDT_rc%aspfile(n),form='unformatted', &
-       access='direct',recl=4,status='old')
-  
+       access='direct',convert='big_endian',recl=4,status='old')
 
 ! -------------------------------------------------------------------
 !     AGGREGATING FINE-SCALE GRIDS TO COARSER LIS OUTPUT GRID

--- a/ldt/params/topo/read_SRTM_elev.F90
+++ b/ldt/params/topo/read_SRTM_elev.F90
@@ -75,7 +75,7 @@ subroutine read_SRTM_elev( n, num_bins, fgrd, elevave )
   
   ftn = LDT_getNextUnitNumber()
   open(ftn,file=LDT_rc%elevfile(n),form='unformatted', &
-       access='direct',recl=4,status='old')
+       access='direct',convert='big_endian',recl=4,status='old')
   
 ! -------------------------------------------------------------------
 !     AGGREGATING FINE-SCALE GRIDS TO COARSER LIS OUTPUT GRID

--- a/ldt/params/topo/read_SRTM_slope.F90
+++ b/ldt/params/topo/read_SRTM_slope.F90
@@ -74,7 +74,7 @@ subroutine read_SRTM_slope( n, num_bins, fgrd, slopeave )
   
   ftn = LDT_getNextUnitNumber()
   open(ftn,file=LDT_rc%slfile(n),form='unformatted', &
-       access='direct',recl=4,status='old')
+       access='direct',convert='big_endian',recl=4,status='old')
 
 ! -------------------------------------------------------------------
 !     AGGREGATING FINE-SCALE GRIDS TO COARSER LIS OUTPUT GRID


### PR DESCRIPTION
This commit fixes issues relating to configuring LDT with
little_endian, but trying to read the natively big_endian
datasets from GTOPO, SRTM, and TBOT.

The primary fixes are to the "???_Native" options for the
topography and to the "ISLCP1" option for TBOT, as these
native datasets are big_endian.

However, related fixes were also made to the "???_LIS"
options for datasets provided by the LIS team.  These
datasets are legacy data, and have traditionally been
produced in big_endian.  Users should consider moving
to the "???_Native" datasets for these parameters.

Resolves: #199
Resolves: #200