### PR TITLE
Enables the support for SMAP L2 soil moisture retrievals

### DIFF
--- a/lvt/configs/lvt.config.master
+++ b/lvt/configs/lvt.config.master
@@ -218,7 +218,7 @@ LVT output methodology:                 "2d gridspace"
 #latex: ``GLEAM'' & GLEAM data\\
 #latex: ``FLUXNET2015 dataset'' & Measurements from FLUXNET2015 dataset\\
 #latex: ``USCRN soil moisture'' & USCRN soil moisture data\\
-#latex: ``SMAP soil moistu'' & SMAP soil moisture data\\
+#latex: ``SMAP soil moisture'' & SMAP soil moisture data\\
 #latex: ``SMAP vegetation water content'' & SMAP vegetation water content\\
 #latex: ``UA SNOW'' & University of Arizona SWE/Snow depth data\\
 #latex: ``SMAP L3 Tb'' & SMAP L3 brightness temperature\\  
@@ -2833,6 +2833,8 @@ USCRN soil moisture station file:            ./USCRN/USCRN_stations.txt
 #latex: Value & Description   \\
 #latex: SPL3SMP & SMAP L3 Radiometer Global Daily 36 km EASE-Grid Soil Moisture \\
 #latex: SPL3SMP_E & SMAP Enhanced L3 Radiometer Global Daily 9 km EASE-Grid Soil Moisture\\
+#latex: SPL2SMP & SMAP L2 Radiometer Global Daily 36 km EASE-Grid Soil Moisture \\
+#latex: SPL2SMP_E & SMAP Enhanced L2 Radiometer Global Daily 9 km EASE-Grid Soil Moisture\\
 #latex: \end{tabular}
 #latex: 
 #latex: 

--- a/lvt/datastreams/SMAPsm/SMAP_smobsMod.F90
+++ b/lvt/datastreams/SMAPsm/SMAP_smobsMod.F90
@@ -118,7 +118,6 @@ contains
     call LVT_verify(status, &
          'SMAP soil moisture data designation: not defined')
 
-    call LVT_update_timestep(LVT_rc, 86400)
 
     if(SMAP_smobs(i)%data_designation.eq."SPL3SMAP") then 
        !SMAP L3 radar/radiometer daily 9km
@@ -141,7 +140,10 @@ contains
        SMAP_smobs(i)%gridDesci(3) = ease_nr  !ny
 
        SMAP_smobs(i)%nc=ease_nc
-       SMAP_smobs(i)%nr=ease_nr       
+       SMAP_smobs(i)%nr=ease_nr    
+
+       call LVT_update_timestep(LVT_rc, 86400)
+   
     elseif(SMAP_smobs(i)%data_designation.eq."SPL3SMP") then 
        !SMAP L3 radiometer daily 36km 
     !filling the items needed by the interpolation library
@@ -158,6 +160,9 @@ contains
 
        SMAP_smobs(i)%nc=ease_nc
        SMAP_smobs(i)%nr=ease_nr       
+       
+       call LVT_update_timestep(LVT_rc, 86400)
+       
     elseif(SMAP_smobs(i)%data_designation.eq."SPL3SMP_E") then 
        ease_nc=3856       
        ease_nr=1624
@@ -171,7 +176,45 @@ contains
        SMAP_smobs(i)%gridDesci(11) = 1
 
        SMAP_smobs(i)%nc=ease_nc
-       SMAP_smobs(i)%nr=ease_nr       
+       SMAP_smobs(i)%nr=ease_nr   
+
+       call LVT_update_timestep(LVT_rc, 86400)
+
+    elseif(SMAP_smobs(i)%data_designation.eq."SPL2SMP") then 
+       ease_nc=964       
+       ease_nr=406
+       SMAP_smobs(i)%gridDesci = 0
+       SMAP_smobs(i)%gridDesci(1) = 9  !input is EASE grid
+       SMAP_smobs(i)%gridDesci(2) = ease_nc  !nx
+       SMAP_smobs(i)%gridDesci(3) = ease_nr  !ny
+       SMAP_smobs(i)%gridDesci(9) = 4 !M36 grid
+       SMAP_smobs(i)%gridDesci(20) = 64
+       SMAP_smobs(i)%gridDesci(10) = 0.36
+       SMAP_smobs(i)%gridDesci(11) = 1
+
+       SMAP_smobs(i)%nc=ease_nc
+       SMAP_smobs(i)%nr=ease_nr
+       
+       call LVT_update_timestep(LVT_rc, 3600)
+    
+    elseif(SMAP_smobs(i)%data_designation.eq."SPL2SMP_E") then 
+
+       ease_nc=3856       
+       ease_nr=1624
+       SMAP_smobs(i)%gridDesci = 0
+       SMAP_smobs(i)%gridDesci(1) = 9  
+       SMAP_smobs(i)%gridDesci(2) = ease_nc  !nx
+       SMAP_smobs(i)%gridDesci(3) = ease_nr  !ny
+       SMAP_smobs(i)%gridDesci(9) = 5 !M09 grid
+       SMAP_smobs(i)%gridDesci(20) = 64
+       SMAP_smobs(i)%gridDesci(10) = 0.09
+       SMAP_smobs(i)%gridDesci(11) = 1
+
+       SMAP_smobs(i)%nc=ease_nc
+       SMAP_smobs(i)%nr=ease_nr   
+       
+       call LVT_update_timestep(LVT_rc, 3600)
+
     endif
 
     npts= LVT_rc%lnc*LVT_rc%lnr
@@ -193,7 +236,7 @@ contains
     SMAP_smobs(i)%startflag = .true. 
 
     allocate(SMAP_smobs(i)%smobs(LVT_rc%lnc*LVT_rc%lnr,2))
-    allocate(SMAP_smobs(i)%smtime(LVT_rc%lnc*LVT_rc%lnr,2))
+    allocate(SMAP_smobs(i)%smtime(LVT_rc%lnc,LVT_rc%lnr))
     allocate(SMAP_smobs(i)%smqc(LVT_rc%lnc*LVT_rc%lnr,2))
 
 !-------------------------------------------------------------------------

--- a/lvt/datastreams/SMAPsm/readSMAPsmobs.F90
+++ b/lvt/datastreams/SMAPsm/readSMAPsmobs.F90
@@ -14,7 +14,8 @@ subroutine readSMAPsmobs(source)
   use ESMF
   use LVT_coreMod,      only : LVT_rc
   use LVT_histDataMod
-  use LVT_logMod,       only : LVT_logunit
+  use LVT_logMod
+  use LVT_timeMgrMod
   use SMAP_smobsMod, only : SMAP_smobs
 
   implicit none
@@ -34,6 +35,7 @@ subroutine readSMAPsmobs(source)
 ! !REVISION HISTORY: 
 !  21 July 2010: Sujay Kumar, Initial Specification
 !  17 Aug 2018: Mahdi Navari, Edited to read SPL3SMP.005 & SPL3SMP_E.002 
+!  19 Jun 2019: Sujay Kumar; Added support for SMAP L2 data
 !EOP
 
   logical           :: alarmcheck, file_exists, readflag
@@ -41,47 +43,311 @@ subroutine readSMAPsmobs(source)
   character*200     :: name
   real              :: smc(LVT_rc%lnc, LVT_rc%lnr)
   integer           :: fnd 
-  real              :: timenow
+  character*8       :: yyyymmdd
+  character*4       :: yyyy
+  character*2       :: mm,dd,hh
+  character*200     :: list_files
+  integer           :: i,ftn,ierr
+  character*200     :: smap_filename(10)
+  character*200     :: fname
+  integer           :: mn_ind
+  integer           :: yr, mo, da, hr, mn, ss
+  real              :: gmt
+  integer           :: c,r
+  integer           :: doy
+  real*8            :: timenow
+  real              :: smobs(LVT_rc%lnc,LVT_rc%lnr)
 
   smc = LVT_rc%udef
+  smobs = LVT_rc%udef
 
   timenow = float(LVT_rc%dhr(source))*3600 +&
        60*LVT_rc%dmn(source) + LVT_rc%dss(source)
-  alarmcheck = (mod(timenow, 86400.0).eq.0)
+
+  if((SMAP_smobs(source)%data_designation.eq."SPL2SMP_E").or.&
+       (SMAP_smobs(source)%data_designation.eq."SPL2SMP")) then     
+     alarmcheck = (mod(timenow, 3600.0).eq.0)
+  else
+     alarmcheck = (mod(timenow, 86400.0).eq.0)
+  endif
+
   if(SMAP_smobs(source)%startflag.or.alarmCheck.or.&
        LVT_rc%resetFlag(source)) then 
      
      LVT_rc%resetFlag(source) = .false. 
 
      SMAP_smobs(source)%startflag = .false. 
-     call SMAP_sm_filename(source,name,&
-          SMAP_smobs(source)%data_designation, & 
-          SMAP_smobs(source)%odir, & 
-        LVT_rc%dyr(source), LVT_rc%dmo(source), LVT_rc%dda(source))
-                 
-     inquire(file=name, exist=file_exists) 
 
-     if(file_exists) then 
-        readflag = .true. 
-     else
-        readflag = .false. 
-     endif
-     
-     if(readflag) then 
-        write(LVT_logunit,*) '[INFO] Reading SMAP file ',name
-        call read_SMAPsm(source, name, smc)
+     if((SMAP_smobs(source)%data_designation.eq."SPL2SMP_E").or.&
+          (SMAP_smobs(source)%data_designation.eq."SPL2SMP")) then  
+
+        write(yyyymmdd,'(i4.4,2i2.2)') LVT_rc%yr, LVT_rc%mo, LVT_rc%da
+        write(yyyy,'(i4.4)') LVT_rc%yr
+        write(mm,'(i2.2)') LVT_rc%mo
+        write(dd,'(i2.2)') LVT_rc%da
+        write(hh,'(i2.2)') LVT_rc%hr
         
+        list_files = 'ls '//trim(SMAP_smobs(source)%odir)//&
+             '/'//trim(yyyy)//'.'//trim(mm)//'.'//dd//&
+             '/SMAP_L2_*'//trim(yyyymmdd)//'T'//trim(hh)&
+             //"*.h5 > SMAP_filelist.dat"
+        
+        call system(trim(list_files))
+
+        i =1
+        ftn = LVT_getNextUnitNumber()
+        open(ftn,file="./SMAP_filelist.dat",&
+             status='old',iostat=ierr)
+        
+        do while(ierr.eq.0) 
+           read(ftn,'(a)',iostat=ierr) fname
+           if(ierr.ne.0) then 
+              exit
+           endif
+           mn_ind = index(fname,trim(yyyymmdd)//'T'//trim(hh))
+
+           mn_ind = index(fname,trim(yyyymmdd)//'T'//trim(hh))+11        
+           read(fname(mn_ind:mn_ind+1),'(i2.2)') mn
+           ss=0
+           call LVT_tick(timenow,doy,gmt,LVT_rc%yr, LVT_rc%mo, LVT_rc%da, &
+                LVT_rc%hr, mn, ss, 0)
+        
+           smap_filename(i) = fname
+           
+           write(LVT_logunit,*) '[INFO] reading ',trim(smap_filename(i))
+           
+           call read_SMAPL2sm_data(source,smap_filename(i),smobs,timenow)
+
+           i = i+1
+        enddo
+        call LVT_releaseUnitNumber(ftn)
+        
+        do r=1,LVT_rc%lnr
+           do c=1,LVT_rc%lnc
+              smc(c,r) = smobs(c,r)
+           enddo
+        enddo
+
+     else
+        call SMAP_sm_filename(source,name,&
+             SMAP_smobs(source)%data_designation, & 
+             SMAP_smobs(source)%odir, & 
+             LVT_rc%dyr(source), LVT_rc%dmo(source), LVT_rc%dda(source))
+        
+        inquire(file=name, exist=file_exists) 
+        
+        if(file_exists) then 
+           readflag = .true. 
+        else
+           readflag = .false. 
+        endif
+        
+        if(readflag) then 
+           write(LVT_logunit,*) '[INFO] Reading SMAP file ',name
+           call read_SMAPsm(source, name, smc)
+           
+        endif
      endif
   endif
 
   call LVT_logSingleDataStreamVar(LVT_MOC_SOILMOIST, source,&
        smc,vlevel=1,units="m3/m3")
- 
-!  open(100,file='test.bin',form='unformatted')
+
+!  open(100,file='test_out.bin',form='unformatted')
 !  write(100) smc
 !  close(100)
 !  stop
+ 
 end subroutine readSMAPsmobs
+
+!BOP
+! 
+! !ROUTINE: read_SMAPL2sm_data
+! \label{read_SMAPL2sm_data}
+!
+! !INTERFACE:
+subroutine read_SMAPL2sm_data(source, fname, smobs_inp, time)
+! 
+! !USES:   
+
+  use LVT_coreMod
+  use LVT_logMod
+  use LVT_timeMgrMod
+  use SMAP_smobsMod, only : SMAP_smobs
+#if (defined USE_HDF5) 
+  use hdf5
+#endif
+
+  implicit none
+!
+! !INPUT PARAMETERS: 
+! 
+  integer                  :: source
+  character (len=*)        :: fname
+  real                     :: smobs_inp(LVT_rc%lnc,LVT_rc%lnr)
+  real*8                   :: time
+
+! !OUTPUT PARAMETERS:
+!
+!
+! !DESCRIPTION: 
+!
+!
+!EOP
+
+#if (defined USE_HDF5)
+
+  character*100,    parameter    :: sm_gr_name = "Soil_Moisture_Retrieval_Data"
+  character*100,    parameter    :: sm_field_name = "soil_moisture"
+  character*100,    parameter    :: sm_qa_name = "retrieval_qual_flag"
+
+  integer(hsize_t), dimension(1) :: dims
+  integer(hsize_t), dimension(1) :: maxdims
+  integer(hid_t)                 :: file_id
+  integer(hid_t)                 :: dspace_id
+  integer(hid_t)                 :: row_id, col_id
+  integer(hid_t)                 :: sm_gr_id,sm_field_id, sm_qa_id
+  integer(hid_t)                 :: sm_gr_id_A,sm_field_id_A
+  real,             allocatable  :: sm_field(:)
+  integer,          allocatable  :: sm_qa(:)
+  integer,          allocatable  :: ease_row(:)
+  integer,          allocatable  :: ease_col(:)
+  integer                        :: c,r,t
+  logical*1                      :: sm_data_b(SMAP_smobs(source)%nc*SMAP_smobs(source)%nr)
+  logical*1                      :: smobs_b_ip(LVT_rc%lnc*LVT_rc%lnr)
+  real                           :: sm_data(SMAP_smobs(source)%nc*SMAP_smobs(source)%nr)
+  real                           :: smobs_ip(LVT_rc%lnc*LVT_rc%lnr)
+
+  integer                        :: status,ios,iret
+
+  smobs_inp = LVT_rc%udef
+
+  call h5open_f(status)
+  call LVT_verify(status, 'Error opening HDF fortran interface')
+  
+  call h5fopen_f(trim(fname),H5F_ACC_RDONLY_F, file_id, status) 
+  call LVT_verify(status, 'Error opening SMAP L2 file ')
+  
+  call h5gopen_f(file_id,sm_gr_name,sm_gr_id, status)
+  call LVT_verify(status, 'Error opening SM group in SMAP L2 file')
+  
+  call h5dopen_f(sm_gr_id,sm_field_name,sm_field_id, status)
+  call LVT_verify(status, 'Error opening SM field in SMAP L2 file')
+
+  call h5dopen_f(sm_gr_id,"EASE_row_index",row_id, status)
+  call LVT_verify(status, 'Error opening row index field in SMAP L2 file')
+
+  call h5dopen_f(sm_gr_id,"EASE_column_index",col_id, status)
+  call LVT_verify(status, 'Error opening column index field in SMAP L2 file')
+
+  call h5dopen_f(sm_gr_id, sm_qa_name,sm_qa_id, status)
+  call LVT_verify(status, 'Error opening QA field in SMAP L2 file')
+  
+  call h5dget_space_f(sm_field_id, dspace_id, status)
+  call LVT_verify(status, 'Error in h5dget_space_f: readSMAP L2Obs')
+  
+! Size of the arrays
+! This routine returns -1 on failure, rank on success. 
+  call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, status) 
+  if(status.eq.-1) then 
+     call LVT_verify(status, 'Error in h5sget_simple_extent_dims_f: readSMAP L2Obs')
+  endif
+  
+  allocate(sm_field(maxdims(1)))
+  allocate(sm_qa(maxdims(1)))
+  allocate(ease_row(maxdims(1)))
+  allocate(ease_col(maxdims(1)))
+
+  call h5dread_f(row_id, H5T_NATIVE_INTEGER,ease_row,dims,status)
+  call LVT_verify(status, 'Error extracting row index from SMAP L2 file')
+
+  call h5dread_f(col_id, H5T_NATIVE_INTEGER,ease_col,dims,status)
+  call LVT_verify(status, 'Error extracting col index from SMAP L2 file')
+  
+  call h5dread_f(sm_field_id, H5T_NATIVE_REAL,sm_field,dims,status)
+  call LVT_verify(status, 'Error extracting SM field from SMAP L2 file')
+
+  call h5dread_f(sm_qa_id, H5T_NATIVE_INTEGER,sm_qa,dims,status)
+  call LVT_verify(status, 'Error extracting SM field from SMAP L2 file')
+  
+  call h5dclose_f(sm_qa_id,status)
+  call LVT_verify(status,'Error in H5DCLOSE call')
+
+  call h5dclose_f(row_id,status)
+  call LVT_verify(status,'Error in H5DCLOSE call')
+
+  call h5dclose_f(col_id,status)
+  call LVT_verify(status,'Error in H5DCLOSE call')
+
+  call h5dclose_f(sm_field_id,status)
+  call LVT_verify(status,'Error in H5DCLOSE call')
+  
+  call h5gclose_f(sm_gr_id,status)
+  call LVT_verify(status,'Error in H5GCLOSE call')
+    
+  call h5fclose_f(file_id,status)
+  call LVT_verify(status,'Error in H5FCLOSE call')
+  
+  call h5close_f(status)
+  call LVT_verify(status,'Error in H5CLOSE call')
+
+  sm_data = LVT_rc%udef
+  sm_data_b = .false. 
+
+!grid the data in EASE projection
+  do t=1,maxdims(1)
+!     if(ibits(sm_qa(t),0,1).eq.0) then 
+     if(ease_col(t).gt.0.and.ease_row(t).gt.0) then 
+        sm_data(ease_col(t) + &
+             (ease_row(t)-1)*SMAP_smobs(source)%nc) = sm_field(t) 
+        if(sm_field(t).ne.-9999.0) then 
+           sm_data_b(ease_col(t) + &
+                (ease_row(t)-1)*SMAP_smobs(source)%nc) = .true. 
+        endif
+     endif
+  enddo
+  
+  t = 1
+
+!  open(100,file='test_inp.bin',form='unformatted')
+!  write(100) sm_data
+!  close(100)
+!--------------------------------------------------------------------------
+! Interpolate to the LVT running domain
+!-------------------------------------------------------------------------- 
+  call neighbor_interp(LVT_rc%gridDesc, sm_data_b, sm_data, &
+       smobs_b_ip, smobs_ip, &
+       SMAP_smobs(source)%nc*SMAP_smobs(source)%nr,&
+       LVT_rc%lnc*LVT_rc%lnr,&
+       SMAP_smobs(source)%rlat2, SMAP_smobs(source)%rlon2,&
+       SMAP_smobs(source)%n112,LVT_rc%udef, iret)
+
+!  open(100,file='test_out.bin',form='unformatted')
+!  write(100) smobs_ip
+!  close(100)
+!  stop
+
+  deallocate(sm_field)
+  deallocate(sm_qa)
+  deallocate(ease_row)
+  deallocate(ease_col)
+
+!overwrite the input data 
+  do r=1,LVT_rc%lnr
+     do c=1,LVT_rc%lnc
+        if(smobs_ip(c+(r-1)*LVT_rc%lnc).ne.-9999.0) then 
+           smobs_inp(c,r) = & 
+                smobs_ip(c+(r-1)*LVT_rc%lnc)
+
+           SMAP_smobs(source)%smtime(c,r) = & 
+                time
+        endif
+     enddo
+  enddo
+
+#endif
+
+end subroutine read_SMAPL2sm_data
 
 !BOP
 ! 


### PR DESCRIPTION
The SMAP soil moisture plugin in LVT has been extended to support
the L2 flavors of SMAP data. The L2 standard retrievals at 36km
and the enhanced version at 9km are supported.

Resolves #208