### PR TITLE
Improve LDT log messages for HyMAP restart files

### DIFF
--- a/ldt/core/LDT_ensRstMod.F90
+++ b/ldt/core/LDT_ensRstMod.F90
@@ -365,19 +365,27 @@ module LDT_ensRstMod
             ftn = LDT_getNextUnitNumber()
             ftn2 = LDT_getNextUnitNumber()
 
-            open(ftn,file=LDT_rc%inputrst,status='old',&
-                 form='unformatted',access='sequential',iostat=ios)
+            ! Check if input restart file is present:
+            inquire( file=trim(LDT_rc%inputrst), exist=file_exists )
+            if( file_exists ) then
+               write(LDT_logunit,*) "[INFO] Opening HYMAP input restart file, "
+               write(LDT_logunit,*)  trim(LDT_rc%inputrst)
+               open(ftn,file=LDT_rc%inputrst,status='old',&
+                    form='unformatted',access='sequential',iostat=ios)
+            else
+               write(LDT_logunit,*) "[ERR] HYMAP input binary restart file, "
+               write(LDT_logunit,*)  trim(LDT_rc%inputrst)
+               write(LDT_logunit,*) " is missing. Stopping run ..."
+               call LDT_endrun
+            endif
 
- 
-            ! If output ensemble restart file exists, don't overwrite ...
+            ! If output ensemble restart file exists, provide warning ...
             inquire( file=trim(LDT_rc%outputrst), exist=file_exists )
             if(file_exists) then
-               write(LDT_logunit,*) "[WARN] If the HYMAP binary restart file, "
+               write(LDT_logunit,*) "[WARN] HYMAP binary restart file, "
                write(LDT_logunit,*)  trim(LDT_rc%outputrst)
-               write(LDT_logunit,*) "  already exists, then remove or rename it and run LDT again." 
-               write(LDT_logunit,*) "  Otherwise intended ensemble HYMAP restart file will not be"
-               write(LDT_logunit,*) "  generated.  Stopping program ..."
-               call LDT_endrun
+               write(LDT_logunit,*) "  already exists! Overwriting the file ..." 
+!               call LDT_endrun
             endif
 
             open(ftn2,file=LDT_rc%outputrst,status='new',&
@@ -413,21 +421,29 @@ module LDT_ensRstMod
             ftn = LDT_getNextUnitNumber()
             ftn2 = LDT_getNextUnitNumber()
 
-            !open(ftn,file=LDT_rc%inputrst,status='old',&
-            !     form='unformatted',access='sequential',iostat=ios)
-            open(ftn,file=LDT_rc%inputrst,status='old',&
-                 form='unformatted',iostat=ios)
+            ! Check if input restart file is present:
+            inquire( file=trim(LDT_rc%inputrst), exist=file_exists )
+            if( file_exists ) then
+               write(LDT_logunit,*) "[INFO] Opening HYMAP input restart file, "
+               write(LDT_logunit,*)  trim(LDT_rc%inputrst)
+               open(ftn,file=LDT_rc%inputrst,status='old',&
+                    form='unformatted',iostat=ios)
+               !open(ftn,file=LDT_rc%inputrst,status='old',&
+               !     form='unformatted',access='sequential',iostat=ios)
+            else
+               write(LDT_logunit,*) "[ERR] HYMAP input binary restart file, "
+               write(LDT_logunit,*)  trim(LDT_rc%inputrst)
+               write(LDT_logunit,*) " is missing. Stopping run ..."
+               call LDT_endrun
+            endif
 
- 
             ! If output ensemble restart file exists, don't overwrite ...
             inquire( file=trim(LDT_rc%outputrst), exist=file_exists )
             if(file_exists) then
                write(LDT_logunit,*) "[WARN] If the HYMAP2 binary restart file, "
                write(LDT_logunit,*)  trim(LDT_rc%outputrst)
-               write(LDT_logunit,*) "  already exists, then remove or rename it and run LDT again." 
-               write(LDT_logunit,*) "  Otherwise intended ensemble HYMAP restart file will not be"
-               write(LDT_logunit,*) "  generated.  Stopping program ..."
-               call LDT_endrun
+               write(LDT_logunit,*) "  already exists! Overwriting the file ..."
+!               call LDT_endrun
             endif
 
             !open(ftn2,file=LDT_rc%outputrst,status='new',&
@@ -712,8 +728,20 @@ module LDT_ensRstMod
 
             ! Open input binary file:
             ftn = LDT_getNextUnitNumber()
-            open(ftn,file=LDT_rc%inputrst,status='old',&
-                 form='unformatted',access='sequential',iostat=ios)
+
+            ! Check if input restart file is present:
+            inquire( file=trim(LDT_rc%inputrst), exist=file_exists )
+            if( file_exists ) then
+               write(LDT_logunit,*) "[INFO] Opening HYMAP input restart file, "
+               write(LDT_logunit,*)  trim(LDT_rc%inputrst)
+               open(ftn,file=LDT_rc%inputrst,status='old',&
+                    form='unformatted',access='sequential',iostat=ios)
+            else
+               write(LDT_logunit,*) "[ERR] HYMAP input binary restart file, "
+               write(LDT_logunit,*)  trim(LDT_rc%inputrst)
+               write(LDT_logunit,*) " is missing. Stopping run ..."
+               call LDT_endrun
+            endif
 
             ! If output ensemble restart file exists, don't overwrite ...
             inquire( file=trim(LDT_rc%outputrst), exist=file_exists )
@@ -777,10 +805,22 @@ module LDT_ensRstMod
 
             ! Open input binary file:
             ftn = LDT_getNextUnitNumber()
-            !open(ftn,file=LDT_rc%inputrst,status='old',&
-            !     form='unformatted',access='sequential',iostat=ios)
-            open(ftn,file=LDT_rc%inputrst,status='old',&
-                 form='unformatted',iostat=ios)
+
+            ! Check if input restart file is present:
+            inquire( file=trim(LDT_rc%inputrst), exist=file_exists )
+            if( file_exists ) then
+               write(LDT_logunit,*) "[INFO] Opening HYMAP input restart file, "
+               write(LDT_logunit,*)  trim(LDT_rc%inputrst)
+               open(ftn,file=LDT_rc%inputrst,status='old',&
+                    form='unformatted',iostat=ios)
+               !open(ftn,file=LDT_rc%inputrst,status='old',&
+               !     form='unformatted',access='sequential',iostat=ios)
+            else
+               write(LDT_logunit,*) "[ERR] HYMAP input binary restart file, "
+               write(LDT_logunit,*)  trim(LDT_rc%inputrst)
+               write(LDT_logunit,*) " is missing. Stopping run ..."
+               call LDT_endrun
+            endif
 
             ! If output ensemble restart file exists, don't overwrite ...
             inquire( file=trim(LDT_rc%outputrst), exist=file_exists )

--- a/ldt/core/LDT_ensRstMod.F90
+++ b/ldt/core/LDT_ensRstMod.F90
@@ -437,7 +437,7 @@ module LDT_ensRstMod
                call LDT_endrun
             endif
 
-            ! If output ensemble restart file exists, don't overwrite ...
+            ! If output ensemble restart file exists, provide warning...
             inquire( file=trim(LDT_rc%outputrst), exist=file_exists )
             if(file_exists) then
                write(LDT_logunit,*) "[WARN] If the HYMAP2 binary restart file, "

--- a/ldt/core/LDT_ensRstMod.F90
+++ b/ldt/core/LDT_ensRstMod.F90
@@ -743,15 +743,13 @@ module LDT_ensRstMod
                call LDT_endrun
             endif
 
-            ! If output ensemble restart file exists, don't overwrite ...
+            ! If output ensemble restart file exists, provide warning ...
             inquire( file=trim(LDT_rc%outputrst), exist=file_exists )
             if(file_exists) then
-               write(LDT_logunit,*) "[WARN] If the HYMAP binary restart file, "
+               write(LDT_logunit,*) "[WARN] HYMAP binary restart file, "
                write(LDT_logunit,*)  trim(LDT_rc%outputrst)
-               write(LDT_logunit,*) "  already exists, then remove or rename it and run LDT again."
-               write(LDT_logunit,*) "  Otherwise intended ensemble HYMAP restart file will not be"
-               write(LDT_logunit,*) "  generated.  Stopping program ..."
-               call LDT_endrun
+               write(LDT_logunit,*) "  already exists! Overwriting the file ..."
+!               call LDT_endrun
             endif
 
             ! Create output binary file:
@@ -822,15 +820,13 @@ module LDT_ensRstMod
                call LDT_endrun
             endif
 
-            ! If output ensemble restart file exists, don't overwrite ...
+            ! If output ensemble restart file exists, provide warning ...
             inquire( file=trim(LDT_rc%outputrst), exist=file_exists )
             if(file_exists) then
-               write(LDT_logunit,*) "[WARN] If the HYMAP binary restart file, "
+               write(LDT_logunit,*) "[WARN] HYMAP binary restart file, "
                write(LDT_logunit,*)  trim(LDT_rc%outputrst)
-               write(LDT_logunit,*) "  already exists, then remove or rename it and run LDT again."
-               write(LDT_logunit,*) "  Otherwise intended ensemble HYMAP restart file will not be"
-               write(LDT_logunit,*) "  generated.  Stopping program ..."
-               call LDT_endrun
+               write(LDT_logunit,*) "  already exists! Overwriting the file ..."
+!               call LDT_endrun
             endif
 
             ! Create output binary file:


### PR DESCRIPTION
Added better log messages to inform and warn user
that an input HyMAP restart (binary) file is present or
not when performing upscaling/upscaling of restart files.