### PR TITLE
Fix/dateline

### DIFF
--- a/ldt/core/LDT_domainMod.F90
+++ b/ldt/core/LDT_domainMod.F90
@@ -505,6 +505,9 @@ end subroutine LDT_timeInit
     integer   :: n, c,r,gindex
     integer   :: bufsize
 
+
+    print *, "In LDT_setDomainSpecs ... (KRA)"
+
     call LDT_domain_plugin
 
     ! Read in the domain's config file entries:
@@ -860,7 +863,7 @@ end subroutine LDT_timeInit
 ! \label{LDT_quilt_domain}
 ! 
 ! !INTERFACE: 
-  subroutine LDT_quilt_domain(n, nc, nr )
+  subroutine LDT_quilt_domain( n, nc, nr )
 
 ! !USES:     
 
@@ -890,29 +893,37 @@ end subroutine LDT_timeInit
     integer    :: nss_ind
     integer    :: nse_ind
 
-     mytask_x = mod( LDT_localPet, LDT_rc%npesx )
-     mytask_y = LDT_localPet / LDT_rc%npesx
 
-     j = 1
-     ips = -1
-     do i=1, nc+1
-        call LDT_mpDecomp(i,j,1,nc+1,1,nr+1,LDT_rc%npesx, LDT_rc%npesy,Px,Py,P)
-        
-        if(Px.eq. mytask_x) then 
-           ipe = i 
-           if(ips.eq.-1) ips = i 
-        endif
-     enddo
+    mytask_x = mod( LDT_localPet, LDT_rc%npesx )
+    mytask_y = LDT_localPet / LDT_rc%npesx
+
+ 
+    print *, "In core/LDT_domainMod.F90 ... (KRA)"
+    print *, nc, nr, LDT_rc%npesx, LDT_rc%npesy, mytask_x, mytask_y
+
+    j = 1
+    ips = -1
+    do i=1, nc+1
+       call LDT_mpDecomp(i,j,1,nc+1,1,nr+1,LDT_rc%npesx, LDT_rc%npesy,Px,Py,P)
+       if(Px.eq.mytask_x) then 
+          ipe = i 
+          if(ips.eq.-1) then
+            ips = i 
+          endif
+       endif
+    enddo
      
-     i = 1
-     jps = -1
-     do j=1, nr+1
-        call LDT_mpDecomp(i,j,1,nc+1,1,nr+1,LDT_rc%npesx,LDT_rc%npesy, Px, Py, P)
-        if(Py.eq.mytask_y) then 
-           jpe = j
-           if(jps.eq.-1) jps = j 
-        endif
-     enddo
+    i = 1
+    jps = -1
+    do j=1, nr+1
+       call LDT_mpDecomp(i,j,1,nc+1,1,nr+1,LDT_rc%npesx,LDT_rc%npesy, Px, Py, P)
+       if(Py.eq.mytask_y) then 
+          jpe = j
+          if(jps.eq.-1) then 
+            jps = j 
+          endif
+       endif
+    enddo
 
 ! Original LDT code:
 #if 0

--- a/ldt/core/LDT_domainMod.F90
+++ b/ldt/core/LDT_domainMod.F90
@@ -506,8 +506,6 @@ end subroutine LDT_timeInit
     integer   :: bufsize
 
 
-    print *, "In LDT_setDomainSpecs ... (KRA)"
-
     call LDT_domain_plugin
 
     ! Read in the domain's config file entries:
@@ -897,9 +895,8 @@ end subroutine LDT_timeInit
     mytask_x = mod( LDT_localPet, LDT_rc%npesx )
     mytask_y = LDT_localPet / LDT_rc%npesx
 
- 
-    print *, "In core/LDT_domainMod.F90 ... (KRA)"
-    print *, nc, nr, LDT_rc%npesx, LDT_rc%npesy, mytask_x, mytask_y
+!    print *, "In core/LDT_domainMod.F90 ... (KRA)"
+!    print *, nc, nr, LDT_rc%npesx, LDT_rc%npesy, mytask_x, mytask_y
 
     j = 1
     ips = -1

--- a/ldt/core/LDT_domainMod.F90
+++ b/ldt/core/LDT_domainMod.F90
@@ -895,9 +895,6 @@ end subroutine LDT_timeInit
     mytask_x = mod( LDT_localPet, LDT_rc%npesx )
     mytask_y = LDT_localPet / LDT_rc%npesx
 
-!    print *, "In core/LDT_domainMod.F90 ... (KRA)"
-!    print *, nc, nr, LDT_rc%npesx, LDT_rc%npesy, mytask_x, mytask_y
-
     j = 1
     ips = -1
     do i=1, nc+1

--- a/ldt/core/LDT_fileIOMod.F90
+++ b/ldt/core/LDT_fileIOMod.F90
@@ -248,7 +248,7 @@ subroutine LDT_create_output_directory(mname,dir_name)
 subroutine LDT_create_output_filename(n, fname, model_name, odir, writeint)
 ! !USES:
    use LDT_coreMod,  only : LDT_rc
-   use LDT_logMod,   only : LDT_log_msg, LDT_endrun
+   use LDT_logMod,   only : LDT_log_msg, LDT_logunit, LDT_endrun
 
    implicit none 
 ! !ARGUMENTS:

--- a/ldt/core/LDT_fileIOMod.F90
+++ b/ldt/core/LDT_fileIOMod.F90
@@ -907,7 +907,7 @@ subroutine LDT_create_daobs_filename(n, fname)
 
 !- Non-supported projections (at this time):
     case default 
-      print*, "This type of run domain or parameter projection:  ",trim(param_proj)
+      print*, "[ERR] This type of run domain or parameter projection:  ",trim(param_proj)
       print*, " is not supported.  Please change to one of these:"
       print*, " -- latlon, lambert, polar, gaussian, mercator, hrap."
       print*, "Program stopping ...."
@@ -953,7 +953,7 @@ subroutine LDT_create_daobs_filename(n, fname)
    integer :: iret
 
 !- Grid transform arrays:
-   integer, allocatable :: n11(:)     ! Map array for aggregating methods
+   integer, allocatable     :: n11(:)     ! Map array for aggregating methods
 
    integer, allocatable     :: n113(:)    ! Map array for nearest neighbor interp
 

--- a/ldt/core/LDT_fileIOMod.F90
+++ b/ldt/core/LDT_fileIOMod.F90
@@ -453,7 +453,7 @@ subroutine LDT_create_output_filename(n, fname, model_name, odir, writeint)
       
       if(LDT_rc%lis_map_proj.eq."polar") then 
          fproj = 'P'
-         print *,"fres ",LDT_rc%gridDesc(n, 9)
+         write(LDT_logunit,*) "[INFO] fres ",LDT_rc%gridDesc(n, 9)
          if (LDT_rc%gridDesc(n, 9) .ge. 10.) then
             write(unit=fres, fmt='(i2)') nint(LDT_rc%gridDesc(n, 9))
          else
@@ -462,7 +462,7 @@ subroutine LDT_create_output_filename(n, fname, model_name, odir, writeint)
          fres2 = trim(fres)//'KM'
       elseif(LDT_rc%lis_map_proj.eq."lambert") then 
          fproj = 'L'
-         print *,"fres ",LDT_rc%gridDesc(n, 9)
+         write(LDT_logunit,*)"[INFO] fres ",LDT_rc%gridDesc(n, 9)
 !         write(unit=fres, fmt='(f2.0)') LDT_rc%gridDesc(n, 9)
          write(unit=fres, fmt='(f3.0)') LDT_rc%gridDesc(n, 9)
          if (LDT_rc%gridDesc(n, 9) .ge. 10.) then
@@ -764,8 +764,8 @@ subroutine LDT_create_daobs_filename(n, fname)
 
 ! ---
     case ( "polar" )  
-      print*, 'not supported currently'
-      stop
+      write(LDT_logunit,*) '[ERR] Polar stereographic case not supported currently'
+      call LDT_endrun
 #if 0       
       call ESMF_ConfigFindLabel(LDT_config,trim(segment_name)//" lower left lat:",rc=rc)
       do i=1,LDT_rc%nnest
@@ -907,10 +907,11 @@ subroutine LDT_create_daobs_filename(n, fname)
 
 !- Non-supported projections (at this time):
     case default 
-      print*, "[ERR] This type of run domain or parameter projection:  ",trim(param_proj)
-      print*, " is not supported.  Please change to one of these:"
-      print*, " -- latlon, lambert, polar, gaussian, mercator, hrap."
-      print*, "Program stopping ...."
+      write(LDT_logunit,*) "[ERR] This type of run domain or parameter projection: ",&
+          trim(param_proj)
+      write(LDT_logunit,*) " is not supported.  Please change to one of these:"
+      write(LDT_logunit,*) " -- latlon, lambert, polar, gaussian, mercator, hrap."
+      write(LDT_logunit,*) " Program stopping ..."
       call LDT_endrun
   end select
 
@@ -1049,13 +1050,13 @@ subroutine LDT_create_daobs_filename(n, fname)
 
    !- When no transform is performed:
       case ( "none" )
-         write(LDT_logunit,*) " No aggregation applied for parameter file ... "
+         write(LDT_logunit,*) "[INFO] No aggregation applied for parameter file ... "
          array_out(:,1) = array_in(:)
 
       case default
-         write(*,*) "This spatial transformation option ("//trim(gridtransform_opt)//") "
+         write(*,*) "[ERR] This spatial transformation option ("//trim(gridtransform_opt)//") "
          write(*,*) " is not currently supported."
-         write(*,*) "Program stopping ...."
+         write(*,*) " Program stopping ..."
          call LDT_endrun
     end select
 
@@ -1248,11 +1249,10 @@ subroutine LDT_create_daobs_filename(n, fname)
          enddo
       enddo
 #endif
-   case default
-      write(*,*) "This parameter projection is not supported ... (in readparam_real_2d)"
-      write(*,*) "Program stopping ...."
-      stop
-
+    case default
+      write(*,*) "[ERR] This parameter projection is not supported (in readparam_real_2d)"
+      write(*,*) " Program stopping ..."
+      call LDT_endrun
    end select 
 
  end subroutine readparam_real_2d
@@ -1430,11 +1430,10 @@ subroutine LDT_create_daobs_filename(n, fname)
          enddo
       enddo
 #endif
-   case default
-      write(*,*) "This parameter projection is not supported ... (in readparam_int_2d)"
-      write(*,*) "Program stopping ...."
-      stop
-
+    case default
+      write(*,*) "[ERR] This parameter projection is not supported (in readparam_int_2d)"
+      write(*,*) " Program stopping ..."
+      call LDT_endrun
    end select 
 
  end subroutine readparam_int_2d
@@ -1522,12 +1521,11 @@ subroutine LDT_create_daobs_filename(n, fname)
           LDT_nss_halo_ind(n,LDT_localPet+1): &
           LDT_nse_halo_ind(n,LDT_localPet+1))
 
-     write(LDT_logunit,*)'Successfully read '//trim(pname)//' map '
+     write(LDT_logunit,*)'[INFO] Successfully read '//trim(pname)//' map '
   else
-     write(LDT_logunit,*) trim(pname)//' map: ',&
-!          trim(LDT_rc%paramfile(n)), ' does not exist'
+     write(LDT_logunit,*)'[ERR] '//trim(pname)//' map: ',&
           trim(LDT_LSMparam_struc(n)%param_filename), ' does not exist'
-     write(LDT_logunit,*) 'program stopping ...'
+     write(LDT_logunit,*) ' Program stopping ...'
      call LDT_endrun
   endif
 

--- a/ldt/core/LDT_gridmappingMod.F90
+++ b/ldt/core/LDT_gridmappingMod.F90
@@ -112,8 +112,6 @@ contains
       do c = 1, LDT_rc%lnc(n)
          call ij_to_latlon( LDT_domain(n)%ldtproj,float(c),float(r),&
                             rlat(c,r),rlon(c,r) )
-         ! TEMP (KRA)
-!         write(200,*) c, r, rlon(c,r), rlat(c,r)
          if(rlat(c,r).gt.lisdom_max_lat) lisdom_max_lat = rlat(c,r)
          if(rlon(c,r).gt.lisdom_max_lon) lisdom_max_lon = rlon(c,r)
          if(rlat(c,r).lt.lisdom_min_lat) lisdom_min_lat = rlat(c,r)
@@ -121,7 +119,6 @@ contains
       enddo
    enddo
 
-!   print *, "Inside ... core/LDT_gridmappingMod.F90 (KRA) ..."
 !   print *, "Rlon, min/max: ",(rlon(1,1)), (rlon(LDT_rc%lnc(n),LDT_rc%lnr(n)))
 !   print *, "Rlat, min/max: ",(rlat(1,1)), (rlat(LDT_rc%lnc(n),LDT_rc%lnr(n)))
 
@@ -381,8 +378,6 @@ contains
            lat_line(c,r) = nint((rlat(c,r)-param_grid(4))/param_grid(10))+1
            lon_line(c,r) = nint((rlon(c,r)-param_grid(5))/param_grid(9))+1
 !           lon_line(c,r) = nint(diff_lon(rlon(c,r),param_grid(5))/param_grid(9))+1
-           ! TEMP (KRA)
-!           write(300,*) c,r,lat_line(c,r),lon_line(c,r)
         enddo
      enddo
      deallocate(rlat,rlon)

--- a/ldt/core/LDT_gridmappingMod.F90
+++ b/ldt/core/LDT_gridmappingMod.F90
@@ -119,9 +119,6 @@ contains
       enddo
    enddo
 
-!   print *, "Rlon, min/max: ",(rlon(1,1)), (rlon(LDT_rc%lnc(n),LDT_rc%lnr(n)))
-!   print *, "Rlat, min/max: ",(rlat(1,1)), (rlat(LDT_rc%lnc(n),LDT_rc%lnr(n)))
-
    lisdom_min_lat = rlat(1,1)
    lisdom_min_lon = rlon(1,1)
    lisdom_max_lat = rlat(LDT_rc%lnc(n),LDT_rc%lnr(n))
@@ -551,8 +548,8 @@ contains
 ! ------------------------------------------------
 
    case default
-      write(*,*) "This parameter projection (",trim(param_proj),") is not supported ..." 
-      write(*,*) "Program stopping ... "
+      write(LDT_logunit,*) "[ERR] This parameter projection (",trim(param_proj),") is not supported." 
+      write(LDT_logunit,*) "Program stopping ... "
       call LDT_endrun
 
   end select

--- a/ldt/core/LDT_gridmappingMod.F90
+++ b/ldt/core/LDT_gridmappingMod.F90
@@ -13,6 +13,7 @@ module LDT_gridmappingMod
 ! !REVISION HISTORY: 
 !  10 Jul 2012;  Kristi Arsenault;  Initial Specification
 !  10 Feb 2014;  Kristi Arsenault;  Updated routines to include add. options
+!  14 Aug 2019;  Kristi Arsenault;  Updated to account for crossing IDL
 ! 
   implicit none
   PRIVATE
@@ -111,12 +112,23 @@ contains
       do c = 1, LDT_rc%lnc(n)
          call ij_to_latlon( LDT_domain(n)%ldtproj,float(c),float(r),&
                             rlat(c,r),rlon(c,r) )
+         ! TEMP (KRA)
+!         write(200,*) c, r, rlon(c,r), rlat(c,r)
          if(rlat(c,r).gt.lisdom_max_lat) lisdom_max_lat = rlat(c,r)
          if(rlon(c,r).gt.lisdom_max_lon) lisdom_max_lon = rlon(c,r)
          if(rlat(c,r).lt.lisdom_min_lat) lisdom_min_lat = rlat(c,r)
          if(rlon(c,r).lt.lisdom_min_lon) lisdom_min_lon = rlon(c,r)
       enddo
    enddo
+
+!   print *, "Inside ... core/LDT_gridmappingMod.F90 (KRA) ..."
+!   print *, "Rlon, min/max: ",(rlon(1,1)), (rlon(LDT_rc%lnc(n),LDT_rc%lnr(n)))
+!   print *, "Rlat, min/max: ",(rlat(1,1)), (rlat(LDT_rc%lnc(n),LDT_rc%lnr(n)))
+
+   lisdom_min_lat = rlat(1,1)
+   lisdom_min_lon = rlon(1,1)
+   lisdom_max_lat = rlat(LDT_rc%lnc(n),LDT_rc%lnr(n))
+   lisdom_max_lon = rlon(LDT_rc%lnc(n),LDT_rc%lnr(n))
 
 !- Calculate LIS run domain corner point resolutions: 
    lisdom_xres_ll = abs(rlon(2,1)-rlon(1,1))
@@ -139,23 +151,23 @@ contains
 
   !- Calculate total points for global (or "full") parameter file domains:
      glpnr = nint((param_grid(7)-param_grid(4))/param_grid(10)) + 1
-     glpnc = nint((param_grid(8)-param_grid(5))/param_grid(9) ) + 1
-     !glpnc = nint(diff_lon(param_grid(8),param_grid(5))/param_grid(9) ) + 1
+!     glpnc = nint((param_grid(8)-param_grid(5))/param_grid(9) ) + 1
+     glpnc = nint(diff_lon(param_grid(8),param_grid(5))/param_grid(9) ) + 1
 
   !- LIS RUN DOMAIN GRID INFORMATION: 
-  !   Used to determine parameter domain to be read in
+  !  Used to determine parameter domain to be read in
      select case ( LDT_rc%lis_map_proj )
 
        case( "latlon" )
           
-      ! Parameter grid resolution SAME as LIS run grid resolution:
+          ! Parameter grid resolution SAME as LIS run grid resolution:
           if( param_grid(9) == (LDT_rc%gridDesc(n,9)/LDT_rc%lis_map_resfactor)) then
              subparm_lllat_ext = lisdom_min_lat 
              subparm_lllon_ext = lisdom_min_lon 
              subparm_urlat_ext = lisdom_max_lat 
              subparm_urlon_ext = lisdom_max_lon 
 
-      ! Parameter grid resolution < as LIS run grid resolution:
+          ! Parameter grid resolution < as LIS run grid resolution:
           elseif( param_grid(9) < (LDT_rc%gridDesc(n,9)/LDT_rc%lis_map_resfactor)) then
              subparm_lllat_ext = lisdom_min_lat - (lisdom_yres_ll/2.) + &
                   (param_grid(10)/2.0)
@@ -166,7 +178,7 @@ contains
              subparm_urlon_ext = lisdom_max_lon + (lisdom_xres_ur/2.) - &
                   (param_grid(9)/2.0)
 
-      ! Parameter grid resolution > as LIS run grid resolution:
+          ! Parameter grid resolution > as LIS run grid resolution:
           elseif( param_grid(9) > (LDT_rc%gridDesc(n,9)/LDT_rc%lis_map_resfactor)) then
              subparm_lllat_ext = param_grid(4)
              subparm_urlat_ext = param_grid(7)
@@ -177,10 +189,10 @@ contains
    !- Lambert conformal LIS run domain:
       case( "lambert" )
          
-      ! Parameter grid resolution <= as LIS run grid resolution:
+         ! Parameter grid resolution <= as LIS run grid resolution:
          if( param_grid(9) <= (LDT_rc%gridDesc(n,9)/LDT_rc%lis_map_resfactor)) then
 
-       !- Locate parameter longitude extents:
+           ! Locate parameter longitude extents:
             do i = 1, nint(param_grid(2))
                plon_search = param_grid(5) + (i-1)*param_grid(9)
                if( plon_search > (lisdom_min_lon-lisdom_xres_ll) .and. &
@@ -192,7 +204,7 @@ contains
                   subparm_urlon_ext = plon_search
                endif
             end do
-            !- Locate parameter latitude extents:
+            ! Locate parameter latitude extents:
             do i = 1, nint(param_grid(3))
                plat_search = param_grid(4) + (i-1)*param_grid(10)
                if( plat_search > (lisdom_min_lat-lisdom_yres_ll) .and. &
@@ -205,10 +217,10 @@ contains
                endif
             end do
 
-      ! Parameter grid resolution > as LIS run grid resolution:
+         ! Parameter grid resolution > as LIS run grid resolution:
          elseif( param_grid(9) > (LDT_rc%gridDesc(n,9)/LDT_rc%lis_map_resfactor)) then
             
-       !- Locate parameter longitude extents:
+            ! Locate parameter longitude extents:
             do i = 1, nint(param_grid(2))
                plon_search = param_grid(5) + (i-1)*param_grid(9)
                if( lisdom_min_lon > ( plon_search-(param_grid(9)/2) ) .and. &
@@ -221,7 +233,7 @@ contains
                endif
             end do
             
-            !- Locate parameter latitude extents:
+            ! Locate parameter latitude extents:
             do i = 1, nint(param_grid(3))
                plat_search = param_grid(4) + (i-1)*param_grid(10)
                if( lisdom_min_lat > ( plat_search-(param_grid(10)/2)) .and. &
@@ -240,10 +252,10 @@ contains
 
    !- Mercator LIS run domain:
       case( "mercator" )
-! Parameter grid resolution <= as LIS run grid resolution:
+        ! Parameter grid resolution <= as LIS run grid resolution:
          if( param_grid(9) <= (LDT_rc%gridDesc(n,9)/LDT_rc%lis_map_resfactor)) then
             
-       !- Locate parameter longitude extents:
+            ! Locate parameter longitude extents:
             do i = 1, nint(param_grid(2))
                plon_search = param_grid(5) + (i-1)*param_grid(9)
                if( plon_search > (lisdom_min_lon-lisdom_xres_ll) .and. &
@@ -255,7 +267,7 @@ contains
                   subparm_urlon_ext = plon_search
                endif
             end do
-       !- Locate parameter latitude extents:
+            ! Locate parameter latitude extents:
             do i = 1, nint(param_grid(3))
                plat_search = param_grid(4) + (i-1)*param_grid(10)
                if( plat_search > (lisdom_min_lat-lisdom_yres_ll) .and. &
@@ -271,7 +283,7 @@ contains
       ! Parameter grid resolution > as LIS run grid resolution:
          elseif( param_grid(9) > (LDT_rc%gridDesc(n,9)/LDT_rc%lis_map_resfactor)) then
 
-       !- Locate parameter longitude extents:
+            ! Locate parameter longitude extents:
             do i = 1, nint(param_grid(2))
                plon_search = param_grid(5) + (i-1)*param_grid(9)
                if( lisdom_min_lon > ( plon_search-(param_grid(9)/2) ) .and. &
@@ -284,7 +296,7 @@ contains
                endif
             end do
             
-       !- Locate parameter latitude extents:
+            ! Locate parameter latitude extents:
             do i = 1, nint(param_grid(3))
                plat_search = param_grid(4) + (i-1)*param_grid(10)
                if( lisdom_min_lat > ( plat_search-(param_grid(10)/2)) .and. &
@@ -308,12 +320,14 @@ contains
          
       end select
 
-  !- Estimate final number of subsetted parameter points:
-     subparam_nc = nint((subparm_urlon_ext - subparm_lllon_ext)/param_grid(9) ) + 1
-     !subparam_nc = nint(diff_lon(subparm_urlon_ext,subparm_lllon_ext)/param_grid(9) ) + 1
+   !! Assemble the parameter subdomain extents and other info:
+
+     ! Estimate final number of subsetted parameter points:
+!     subparam_nc = nint((subparm_urlon_ext - subparm_lllon_ext)/param_grid(9) ) + 1
+     subparam_nc = nint(diff_lon(subparm_urlon_ext,subparm_lllon_ext)/param_grid(9) ) + 1
      subparam_nr = nint((subparm_urlat_ext - subparm_lllat_ext)/param_grid(10)) + 1
 
-  !- Set subsetted parameter grid array inputs:
+     ! Set subsetted parameter grid array inputs:
      subparam_gridDesc(1)  = 0.    ! Latlon
      subparam_gridDesc(2)  = float(subparam_nc)
      subparam_gridDesc(3)  = float(subparam_nr)
@@ -327,7 +341,7 @@ contains
      subparam_gridDesc(11) = 64.
      subparam_gridDesc(20) = 64.
 
-  !- Double check subsetted and global parameter number of rows and columns:
+     ! Double check subsetted and global parameter number of rows and columns:
      if( subparam_nc > glpnc .or. subparam_nr > glpnr ) then
        write(LDT_logunit,*) "[ERR] The number of *subsetted* row or column points"
        write(LDT_logunit,*) "          EXCEEDS the total *global* row or column points "
@@ -346,7 +360,7 @@ contains
        call LDT_endrun
      endif
 
-  !- Set up map_set parameter array ...
+     ! Set up map_set parameter array ...
      call map_set( PROJ_LATLON, subparam_gridDesc(4), subparam_gridDesc(5), &
                    0.0, subparam_gridDesc(9), subparam_gridDesc(10), 0.0,   &
                    subparam_nc, subparam_nr, subset_paramproj )
@@ -359,14 +373,16 @@ contains
      allocate( rlon(subparam_nc,subparam_nr) )
      rlat = 0.; rlon = 0.
 
-  !- Extract LIS-target domain lat and long 2-d arrays:
+     ! Extract LIS-target domain lat and long 2-d arrays:
      do r = 1, subparam_nr
         do c = 1, subparam_nc
            call ij_to_latlon( subset_paramproj, float(c), float(r),&
                               rlat(c,r), rlon(c,r) )
            lat_line(c,r) = nint((rlat(c,r)-param_grid(4))/param_grid(10))+1
            lon_line(c,r) = nint((rlon(c,r)-param_grid(5))/param_grid(9))+1
-           !lon_line(c,r) = nint(diff_lon(rlon(c,r),param_grid(5))/param_grid(9))+1
+!           lon_line(c,r) = nint(diff_lon(rlon(c,r),param_grid(5))/param_grid(9))+1
+           ! TEMP (KRA)
+!           write(300,*) c,r,lat_line(c,r),lon_line(c,r)
         enddo
      enddo
      deallocate(rlat,rlon)
@@ -415,7 +431,7 @@ contains
      subparam_gridDesc(11) = 64.
      subparam_gridDesc(20) = 64.
   
-  !- Set up map_set parameter array ...
+     ! Set up map_set parameter array ...
 !    subset_paramproj = LDT_domain(n)%ldtproj
      call map_set( PROJ_GAUSS, subparam_gridDesc(4), subparam_gridDesc(5), &
                    subparam_gridDesc(9), subparam_gridDesc(3), subparam_gridDesc(4), &
@@ -425,7 +441,7 @@ contains
      allocate( lon_line(subparam_nc,subparam_nr) )
      lat_line = 0.; lon_line = 0.
 
-  !- Extract LIS-target domain lat and long 2-d arrays:
+     ! Extract LIS-target domain lat and long 2-d arrays:
      rmin = 1
      if (abs(rlat(1,1)-param_grid(4)).gt.0.001) then
        nlats = int(param_grid(3))
@@ -540,7 +556,7 @@ contains
 ! ------------------------------------------------
 
    case default
-      write(*,*) "This parameter projection(",trim(param_proj),") is not supported ..." 
+      write(*,*) "This parameter projection (",trim(param_proj),") is not supported ..." 
       write(*,*) "Program stopping ... "
       call LDT_endrun
 

--- a/ldt/core/LDT_paramProcMod.F90
+++ b/ldt/core/LDT_paramProcMod.F90
@@ -1016,7 +1016,6 @@ contains
     integer               :: dimID(3), monthID, qID
     integer,allocatable   :: met_dimID(:,:)
     integer               :: tdimID, xtimeID
-!    integer :: i,j  ! TEMP -- KRA
 
 !SVK-edit    
     if(LDT_masterproc) then 
@@ -1028,24 +1027,10 @@ contains
             (/1,1/),(/LDT_rc%gnc(n),LDT_rc%gnr(n)/)),&
             'nf90_put_att failed for xlat')
 
-!       do j=1,LDT_rc%gnr(n)
-!        do i=1,LDT_rc%gnc(n)
-!           write(501,*) LDT_LSMparam_struc(n)%param_file_ftn, LDT_LSMparam_struc(n)%xlatid, &
-!                  LDT_LSMparam_struc(n)%xlat%value(i,j,1)
-!        enddo
-!       enddo
-       
        call LDT_verify(nf90_put_var(LDT_LSMparam_struc(n)%param_file_ftn,&
             LDT_LSMparam_struc(n)%xlonid, LDT_LSMparam_struc(n)%xlon%value(:,:,1),&
             (/1,1/),(/LDT_rc%gnc(n),LDT_rc%gnr(n)/)),&
             'nf90_put_att failed for xlon')
-
-!       do j=1,LDT_rc%gnr(n)
-!        do i=1,LDT_rc%gnc(n)
-!           write(501,*) LDT_LSMparam_struc(n)%param_file_ftn, LDT_LSMparam_struc(n)%xlonid, &
-!                  LDT_LSMparam_struc(n)%xlon%value(i,j,1)
-!        enddo
-!       enddo
 
        call LDT_verify(nf90_put_var(LDT_LSMparam_struc(n)%param_file_ftn,&
             LDT_LSMparam_struc(n)%xlatbid, LDT_LSMparam_struc(n)%xlat_b%value(:,:,1),&

--- a/ldt/core/LDT_paramProcMod.F90
+++ b/ldt/core/LDT_paramProcMod.F90
@@ -1017,14 +1017,36 @@ contains
     integer,allocatable   :: met_dimID(:,:)
     integer               :: tdimID, xtimeID
 
+    integer :: i,j  ! TEMP -- KRA
+
 !SVK-edit    
     if(LDT_masterproc) then 
+       print *, " I AM HERE (1)..." 
+
+       do j=1,LDT_rc%gnr(n)
+        do i=1,LDT_rc%gnc(n)
+           write(500,*) LDT_LSMparam_struc(n)%param_file_ftn, LDT_LSMparam_struc(n)%xlatid, &
+                  LDT_LSMparam_struc(n)%xlat%value(i,j,1)
+        enddo
+       enddo
+
        call LDT_verify(nf90_enddef(LDT_LSMparam_struc(n)%param_file_ftn))
+       print *, " I AM HERE (2)..." 
        
        call LDT_verify(nf90_put_var(LDT_LSMparam_struc(n)%param_file_ftn,&
             LDT_LSMparam_struc(n)%xlatid, LDT_LSMparam_struc(n)%xlat%value(:,:,1),&
             (/1,1/),(/LDT_rc%gnc(n),LDT_rc%gnr(n)/)),&
             'nf90_put_att failed for xlat')
+
+       print *, "STopping ... " 
+       stop
+       do j=1,LDT_rc%gnr(n)
+        do i=1,LDT_rc%gnc(n)
+           write(500,*) LDT_LSMparam_struc(n)%param_file_ftn, LDT_LSMparam_struc(n)%xlatid, &
+                  LDT_LSMparam_struc(n)%xlat%value(i,j,1)
+        enddo
+       enddo
+       stop
        
        call LDT_verify(nf90_put_var(LDT_LSMparam_struc(n)%param_file_ftn,&
             LDT_LSMparam_struc(n)%xlonid, LDT_LSMparam_struc(n)%xlon%value(:,:,1),&

--- a/ldt/core/LDT_paramProcMod.F90
+++ b/ldt/core/LDT_paramProcMod.F90
@@ -1016,42 +1016,36 @@ contains
     integer               :: dimID(3), monthID, qID
     integer,allocatable   :: met_dimID(:,:)
     integer               :: tdimID, xtimeID
-
-    integer :: i,j  ! TEMP -- KRA
+!    integer :: i,j  ! TEMP -- KRA
 
 !SVK-edit    
     if(LDT_masterproc) then 
-       print *, " I AM HERE (1)..." 
-
-       do j=1,LDT_rc%gnr(n)
-        do i=1,LDT_rc%gnc(n)
-           write(500,*) LDT_LSMparam_struc(n)%param_file_ftn, LDT_LSMparam_struc(n)%xlatid, &
-                  LDT_LSMparam_struc(n)%xlat%value(i,j,1)
-        enddo
-       enddo
 
        call LDT_verify(nf90_enddef(LDT_LSMparam_struc(n)%param_file_ftn))
-       print *, " I AM HERE (2)..." 
-       
+
        call LDT_verify(nf90_put_var(LDT_LSMparam_struc(n)%param_file_ftn,&
             LDT_LSMparam_struc(n)%xlatid, LDT_LSMparam_struc(n)%xlat%value(:,:,1),&
             (/1,1/),(/LDT_rc%gnc(n),LDT_rc%gnr(n)/)),&
             'nf90_put_att failed for xlat')
 
-       print *, "STopping ... " 
-       stop
-       do j=1,LDT_rc%gnr(n)
-        do i=1,LDT_rc%gnc(n)
-           write(500,*) LDT_LSMparam_struc(n)%param_file_ftn, LDT_LSMparam_struc(n)%xlatid, &
-                  LDT_LSMparam_struc(n)%xlat%value(i,j,1)
-        enddo
-       enddo
-       stop
+!       do j=1,LDT_rc%gnr(n)
+!        do i=1,LDT_rc%gnc(n)
+!           write(501,*) LDT_LSMparam_struc(n)%param_file_ftn, LDT_LSMparam_struc(n)%xlatid, &
+!                  LDT_LSMparam_struc(n)%xlat%value(i,j,1)
+!        enddo
+!       enddo
        
        call LDT_verify(nf90_put_var(LDT_LSMparam_struc(n)%param_file_ftn,&
             LDT_LSMparam_struc(n)%xlonid, LDT_LSMparam_struc(n)%xlon%value(:,:,1),&
             (/1,1/),(/LDT_rc%gnc(n),LDT_rc%gnr(n)/)),&
             'nf90_put_att failed for xlon')
+
+!       do j=1,LDT_rc%gnr(n)
+!        do i=1,LDT_rc%gnc(n)
+!           write(501,*) LDT_LSMparam_struc(n)%param_file_ftn, LDT_LSMparam_struc(n)%xlonid, &
+!                  LDT_LSMparam_struc(n)%xlon%value(i,j,1)
+!        enddo
+!       enddo
 
        call LDT_verify(nf90_put_var(LDT_LSMparam_struc(n)%param_file_ftn,&
             LDT_LSMparam_struc(n)%xlatbid, LDT_LSMparam_struc(n)%xlat_b%value(:,:,1),&

--- a/ldt/domains/gaussian/readinput_gaussian.F90
+++ b/ldt/domains/gaussian/readinput_gaussian.F90
@@ -49,7 +49,7 @@ subroutine readinput_gaussian
 !    funtion to find index of a given latitude within in a given
 !    array of Gaussian latitudes
 !  \item[diff\_lon] (\ref{diff_lon}) \newline
-!    funtion to compute the difference between to given longitude values
+!    funtion to compute the difference between two given longitude values
 !  \item[LDT\_quilt\_domain] (\ref{LDT_quilt_domain}) \newline
 !    routine to quilt the given domain
 !  \item[map\_set] (\ref{map_set}) \newline

--- a/ldt/domains/latlon/readinput_latlon.F90
+++ b/ldt/domains/latlon/readinput_latlon.F90
@@ -97,8 +97,6 @@ subroutine readinput_latlon
      call LDT_verify(rc, 'Run domain resolution (dy): not defined')
   enddo
 
-  print *, " In domains/latlon/readinput_latlon.F90 ... (KRA) "
-
   do n=1,LDT_rc%nnest
      stlat = run_dd(n,1)
      stlon = run_dd(n,2)
@@ -120,25 +118,25 @@ subroutine readinput_latlon
      endif
 #endif
 
-     ! INSTALL A CHECK HERE IF LAT/LON VALUES ARE REVERSE ... CROSSING INTERNATIONAL DATELINE ...
+     ! Check if lon values are reverse (e.g., crosses International Dateline)
      if( run_dd(n,4)-run_dd(n,2) < 0. ) then   ! Check long. extents
-        print *, " Long(1) > Long(2) == ",run_dd(n,2), run_dd(n,4)
-        print *, " CALCULATING NC ... "
         nc = nint(diff_lon(run_dd(n,4),run_dd(n,2))/run_dd(n,5)) + 1
      else
         nc = (nint((run_dd(n,4)-run_dd(n,2))/run_dd(n,5))) + 1
      endif
 
-     if( run_dd(n,3)-run_dd(n,1) < 0. ) then   ! Check lat. extents
-        print *, " Lat(1) > Lat(2) == ",run_dd(n,1), run_dd(n,3)
-        print *, " CALCULATING NR ... "
-        stop
-     else
-        nr = (nint((run_dd(n,3)-run_dd(n,1))/run_dd(n,6))) + 1
-     endif
+!     print *, " Lat(1) > Lat(2) == ",run_dd(n,1), run_dd(n,3)
+!     print *, run_dd(n,3)-run_dd(n,1)
+!     if( run_dd(n,3)-run_dd(n,1) < 0. ) then   ! Check lat. extents
+!        print *, " Lat(1) > Lat(2) == ",run_dd(n,1), run_dd(n,3)
+!        print *, " CALCULATING NR ... "
+!        stop
+!     else
+     nr = (nint((run_dd(n,3)-run_dd(n,1))/run_dd(n,6))) + 1
+!     endif
+     LDT_rc%gnc(n) = nc
+     LDT_rc%gnr(n) = nr
      
-     print *, stlat, stlon, dx, dy, nc, nr
-
      ! Quilt domain - decompose global domain:
      call LDT_quilt_domain(n,nc,nr)
   
@@ -152,11 +150,6 @@ subroutine readinput_latlon
           LDT_rc%gridDesc(n,4),LDT_rc%gridDesc(n,7),&
           LDT_rc%gridDesc(n,5),LDT_rc%gridDesc(n,8)
      
-     ! AGAIN - SAME ISSUE ... -NEGATIVE GNC OR GNR VALUES ... ??
-     ! NEED TO ADD CHECKS HERE TOO ...
-     LDT_rc%gnc(n) = nint((run_dd(n,4)-run_dd(n,2))/run_dd(n,5))+1
-     LDT_rc%gnr(n) = nint((run_dd(n,3)-run_dd(n,1))/run_dd(n,6))+1
-
      LDT_rc%gridDesc(n,1) = 0
      LDT_rc%gridDesc(n,9) = run_dd(n,5)
      

--- a/ldt/domains/latlon/readinput_latlon.F90
+++ b/ldt/domains/latlon/readinput_latlon.F90
@@ -103,21 +103,6 @@ subroutine readinput_latlon
      dx    = run_dd(n,5)
      dy    = run_dd(n,6)
 
-#if 0
-     if(run_dd(n,3).lt.run_dd(n,1)) then
-        write(unit=LDT_logunit,fmt=*) 'lat2 must be greater than lat1'
-        write(LDT_logunit,*) run_dd(n,3),run_dd(n,1)
-        write(unit=LDT_logunit,fmt=*) 'Stopping run...'
-        call LDT_endrun
-     endif
-     if(run_dd(n,4).lt.run_dd(n,2)) then
-        write(unit=LDT_logunit,fmt=*) 'lon2 must be greater than lon1'
-        write(LDT_logunit,*) run_dd(n,4),run_dd(n,2)
-        write(unit=LDT_logunit,fmt=*) 'Stopping run...'
-        call LDT_endrun
-     endif
-#endif
-
      ! Check if lon values are reverse (e.g., crosses International Dateline)
      if( run_dd(n,4)-run_dd(n,2) < 0. ) then   ! Check long. extents
         nc = nint(diff_lon(run_dd(n,4),run_dd(n,2))/run_dd(n,5)) + 1
@@ -155,19 +140,16 @@ subroutine readinput_latlon
         LDT_rc%gridDesc(n,20) = 64
      endif
 
-     ! HERE ARE THE ORIGINAL CHECKS FOR WHEN LAT2<LAT1; LON2<LON1 ...
+     ! Original checks for when LAT2<LAT1; LON2<LON1:
 
      if(LDT_rc%gridDesc(n,7).lt.LDT_rc%gridDesc(n,4)) then
-        write(unit=LDT_logunit,fmt=*) '[WARN] lat2 must be greater than lat1 ...'
+        write(LDT_logunit,*) '[ERR] lat2 must be greater than lat1 ...'
         write(LDT_logunit,*) LDT_rc%gridDesc(n,7),LDT_rc%gridDesc(n,4)
-!        write(unit=LDT_logunit,fmt=*) 'Stopping run...'
         call LDT_endrun
      endif
      if(LDT_rc%gridDesc(n,8).lt.LDT_rc%gridDesc(n,5)) then
-        write(unit=LDT_logunit,fmt=*) '[WARN] lon2 should  be greater than lon1 ...'
+        write(LDT_logunit,*) '[ERR] lon2 should  be greater than lon1 ...'
         write(LDT_logunit,*) LDT_rc%gridDesc(n,8),LDT_rc%gridDesc(n,5)
-!        write(unit=LDT_logunit,fmt=*) 'Stopping run...'
-!        call LDT_endrun
      endif
      
      ! Difference in number of longitudes (dx):

--- a/ldt/domains/latlon/readinput_latlon.F90
+++ b/ldt/domains/latlon/readinput_latlon.F90
@@ -38,7 +38,9 @@ subroutine readinput_latlon
 !
 !  The routines invoked are: 
 !  \begin{description}
-!  \item[listask\_for\_point](\ref{LDT_mpDecomp}) \newline
+!  \item[diff\_lon] (\ref{diff_lon}) \newline
+!    funtion to compute the difference between two given longitude values
+!  \item[ldttask\_for\_point](\ref{LDT_mpDecomp}) \newline
 !   routine to perform domain decomposition
 !  \end{description}
 !EOP
@@ -47,6 +49,7 @@ subroutine readinput_latlon
   real, allocatable    :: run_dd(:,:)  ! LIS Target grid/domain
   integer              :: lnc,lnr
   integer              :: nc, nr
+  real                 :: diff_lon
   integer              :: ierr, rc
   integer              :: ips, ipe, jps, jpe
   integer              :: Px, Py, P
@@ -94,16 +97,52 @@ subroutine readinput_latlon
      call LDT_verify(rc, 'Run domain resolution (dy): not defined')
   enddo
 
+  print *, " In domains/latlon/readinput_latlon.F90 ... (KRA) "
+
   do n=1,LDT_rc%nnest
      stlat = run_dd(n,1)
      stlon = run_dd(n,2)
      dx    = run_dd(n,5)
      dy    = run_dd(n,6)
-     nc    = (nint((run_dd(n,4)-run_dd(n,2))/run_dd(n,5))) + 1
-     nr    = (nint((run_dd(n,3)-run_dd(n,1))/run_dd(n,6))) + 1
-     
-     call LDT_quilt_domain(n,nc,nr)
 
+#if 0
+     if(run_dd(n,3).lt.run_dd(n,1)) then
+        write(unit=LDT_logunit,fmt=*) 'lat2 must be greater than lat1'
+        write(LDT_logunit,*) run_dd(n,3),run_dd(n,1)
+        write(unit=LDT_logunit,fmt=*) 'Stopping run...'
+        call LDT_endrun
+     endif
+     if(run_dd(n,4).lt.run_dd(n,2)) then
+        write(unit=LDT_logunit,fmt=*) 'lon2 must be greater than lon1'
+        write(LDT_logunit,*) run_dd(n,4),run_dd(n,2)
+        write(unit=LDT_logunit,fmt=*) 'Stopping run...'
+        call LDT_endrun
+     endif
+#endif
+
+     ! INSTALL A CHECK HERE IF LAT/LON VALUES ARE REVERSE ... CROSSING INTERNATIONAL DATELINE ...
+     if( run_dd(n,4)-run_dd(n,2) < 0. ) then   ! Check long. extents
+        print *, " Long(1) > Long(2) == ",run_dd(n,2), run_dd(n,4)
+        print *, " CALCULATING NC ... "
+        nc = nint(diff_lon(run_dd(n,4),run_dd(n,2))/run_dd(n,5)) + 1
+     else
+        nc = (nint((run_dd(n,4)-run_dd(n,2))/run_dd(n,5))) + 1
+     endif
+
+     if( run_dd(n,3)-run_dd(n,1) < 0. ) then   ! Check lat. extents
+        print *, " Lat(1) > Lat(2) == ",run_dd(n,1), run_dd(n,3)
+        print *, " CALCULATING NR ... "
+        stop
+     else
+        nr = (nint((run_dd(n,3)-run_dd(n,1))/run_dd(n,6))) + 1
+     endif
+     
+     print *, stlat, stlon, dx, dy, nc, nr
+
+     ! Quilt domain - decompose global domain:
+     call LDT_quilt_domain(n,nc,nr)
+  
+     ! Assign LIS domain gridDesc elements, based on decomposed subdomains:
      LDT_rc%gridDesc(n,4) = stlat + (LDT_nss_halo_ind(n,LDT_localPet+1)-1)*dy
      LDT_rc%gridDesc(n,5) = stlon + (LDT_ews_halo_ind(n,LDT_localPet+1)-1)*dx
      LDT_rc%gridDesc(n,7) = stlat + (LDT_nse_halo_ind(n,LDT_localPet+1)-1)*dy
@@ -113,8 +152,11 @@ subroutine readinput_latlon
           LDT_rc%gridDesc(n,4),LDT_rc%gridDesc(n,7),&
           LDT_rc%gridDesc(n,5),LDT_rc%gridDesc(n,8)
      
+     ! AGAIN - SAME ISSUE ... -NEGATIVE GNC OR GNR VALUES ... ??
+     ! NEED TO ADD CHECKS HERE TOO ...
      LDT_rc%gnc(n) = nint((run_dd(n,4)-run_dd(n,2))/run_dd(n,5))+1
      LDT_rc%gnr(n) = nint((run_dd(n,3)-run_dd(n,1))/run_dd(n,6))+1
+
      LDT_rc%gridDesc(n,1) = 0
      LDT_rc%gridDesc(n,9) = run_dd(n,5)
      
@@ -124,6 +166,9 @@ subroutine readinput_latlon
         LDT_rc%gridDesc(n,11) = 64
         LDT_rc%gridDesc(n,20) = 64
      endif
+
+     ! HERE ARE THE ORIGINAL CHECKS FOR WHEN LAT2<LAT1; LON2<LON1 .... !! (KRA) .
+
      if(LDT_rc%gridDesc(n,7).lt.LDT_rc%gridDesc(n,4)) then
         write(unit=LDT_logunit,fmt=*) 'lat2 must be greater than lat1'
         write(LDT_logunit,*) LDT_rc%gridDesc(n,7),LDT_rc%gridDesc(n,4)

--- a/ldt/interp/upscaleByAveraging_input.F90
+++ b/ldt/interp/upscaleByAveraging_input.F90
@@ -82,6 +82,9 @@ subroutine upscaleByAveraging_input( gridDesci, gridDesco, mi, mo, n11 )
   real, parameter     :: fill = -9999.0
 ! ______________________________________________________________
 
+!  print*, "gridin : ",gridDesci(1:10)
+!  print*, "gridout: ",gridDesco(1:10)
+
   allocate( xpts(mi), ypts(mi), rlat(mi), rlon(mi) )
 
   if(gridDesci(1).ge.0) then 

--- a/ldt/interp/upscaleByAveraging_input.F90
+++ b/ldt/interp/upscaleByAveraging_input.F90
@@ -82,9 +82,6 @@ subroutine upscaleByAveraging_input( gridDesci, gridDesco, mi, mo, n11 )
   real, parameter     :: fill = -9999.0
 ! ______________________________________________________________
 
-!  print*, "gridin : ",gridDesci(1:10)
-!  print*, "gridout: ",gridDesco(1:10)
-
   allocate( xpts(mi), ypts(mi), rlat(mi), rlon(mi) )
 
   if(gridDesci(1).ge.0) then 

--- a/ldt/params/landcover/read_MODISNative_lc.F90
+++ b/ldt/params/landcover/read_MODISNative_lc.F90
@@ -83,6 +83,7 @@ subroutine read_MODISNative_lc(n, num_types, fgrd, maskarray )
 !__________________________________________________________________
 
    num_types = 20 
+
 !- Check if land cover file exists:
    inquire( file=trim(LDT_rc%vfile(n)), exist=file_exists )
    if(.not. file_exists) then
@@ -150,10 +151,10 @@ subroutine read_MODISNative_lc(n, num_types, fgrd, maskarray )
 
 !- Other landcover classifications associated with MODIS landcover:
     case default  ! Non-supported options
-      write(LDT_logunit,*) " The native MODIS map with land classification: ",&
+      write(LDT_logunit,*) "[ERR] The native MODIS map with land classification: ",&
                              trim(LDT_rc%lc_type(n)),", is not yet supported."
       write(LDT_logunit,*) " -- Please select: IGBPNCEP "
-      write(LDT_logunit,*) "Program stopping ..."
+      write(LDT_logunit,*) " Program stopping ..."
       call LDT_endrun
 
    end select
@@ -196,14 +197,24 @@ subroutine read_MODISNative_lc(n, num_types, fgrd, maskarray )
    mo = LDT_rc%lnc(n)*LDT_rc%lnr(n)
    lo1 = .false.;  lo2 = .false.
 
+   ! TEMP (KRA)
+!   open(80, file='temp.gbin', form='unformatted',&
+!       access ='direct', recl=4)
+
 !- Assign 2-D array to 1-D for aggregation routines:
    i = 0
    do r = 1, subpnr
       do c = 1, subpnc;  i = i + 1
+         ! TEMP(KRA)
+!         write(80,rec=i) subset_veg(c,r)
+
          gi(i) = subset_veg(c,r)
          if( gi(i) .ne. LDT_rc%udef ) li(i) = .true.
       enddo
    enddo
+
+   ! TEMP (KRA)
+!   close (80)
 
 !- Aggregation/Spatial Transform Section:
    select case ( LDT_rc%lc_gridtransform(n) )

--- a/ldt/params/landcover/read_MODISNative_lc.F90
+++ b/ldt/params/landcover/read_MODISNative_lc.F90
@@ -197,24 +197,14 @@ subroutine read_MODISNative_lc(n, num_types, fgrd, maskarray )
    mo = LDT_rc%lnc(n)*LDT_rc%lnr(n)
    lo1 = .false.;  lo2 = .false.
 
-   ! TEMP (KRA)
-!   open(80, file='temp.gbin', form='unformatted',&
-!       access ='direct', recl=4)
-
 !- Assign 2-D array to 1-D for aggregation routines:
    i = 0
    do r = 1, subpnr
       do c = 1, subpnc;  i = i + 1
-         ! TEMP(KRA)
-!         write(80,rec=i) subset_veg(c,r)
-
          gi(i) = subset_veg(c,r)
          if( gi(i) .ne. LDT_rc%udef ) li(i) = .true.
       enddo
    enddo
-
-   ! TEMP (KRA)
-!   close (80)
 
 !- Aggregation/Spatial Transform Section:
    select case ( LDT_rc%lc_gridtransform(n) )

--- a/ldt/params/mask/create_maskfile.F90
+++ b/ldt/params/mask/create_maskfile.F90
@@ -116,7 +116,7 @@
 
              ! Check gridcell veg total sum:
              if( totalsum == 0. ) then
-                write(LDT_logunit,*) "[ERR] Total vegetation for gridcell, c=",c,", r=",r
+                write(LDT_logunit,*) "[WARN] Total vegetation for gridcell, c=",c,", r=",r
                 write(LDT_logunit,*) "   has the sum of: ",totalsum
                 write(LDT_logunit,*) "  This check performed in routine: create_maskfile "
                 ! Set then localmask to 0.0 (water point or undefined)

--- a/ldt/params/mask/create_maskfile.F90
+++ b/ldt/params/mask/create_maskfile.F90
@@ -104,10 +104,12 @@
           !  (need to retain water points for mask-parm checks later):
              do t = 1, nt
                 if( t /= LDT_rc%waterclass ) then
-                  if( vegcnt(c,r,t) /= LDT_rc%udef) &
+                  if( vegcnt(c,r,t) /= LDT_rc%udef) then
                      vegsum = vegsum + vegcnt(c,r,t)
+                  endif
                 endif
              end do
+
 
              totalsum = sum( vegcnt(c,r,1:nt), &
                         mask=vegcnt(c,r,1:nt).ne.LDT_rc%udef )

--- a/ldt/params/mask/create_maskfile.F90
+++ b/ldt/params/mask/create_maskfile.F90
@@ -112,6 +112,17 @@
              totalsum = sum( vegcnt(c,r,1:nt), &
                         mask=vegcnt(c,r,1:nt).ne.LDT_rc%udef )
 
+             ! Check gridcell veg total sum:
+             if( totalsum == 0. ) then
+                write(LDT_logunit,*) "[ERR] Total vegetation for gridcell, c=",c,", r=",r
+                write(LDT_logunit,*) "   has the sum of: ",totalsum
+                write(LDT_logunit,*) "  This check performed in routine: create_maskfile "
+                ! Set then localmask to 0.0 (water point or undefined)
+                localmask(c,r) = 0.0
+                cycle
+!                call LDT_endrun 
+             endif
+
              if( (vegsum/totalsum) >= LDT_rc%gridcell_water_frac(n) ) then  
                localmask(c,r) = 1.0   ! Designated land points
              else

--- a/ldt/params/mask/create_maskfile.F90
+++ b/ldt/params/mask/create_maskfile.F90
@@ -48,11 +48,11 @@
 !   \end{description}
 !
 !EOP      
-  integer :: c, r, t, i
-  real    :: vegsum, totalsum
-!_________________________________________________________________________________
+  integer  :: c, r, t, i
+  real     :: vegsum, totalsum
   real     :: maxv
   integer  :: maxt
+!_________________________________________________________________________________
 
    LDT_rc%nmaskpts = 0.
    localmask = 0.

--- a/lis/testcases/domains/latlon_idlcross/MODEL_OUTPUT_LIST.TBL
+++ b/lis/testcases/domains/latlon_idlcross/MODEL_OUTPUT_LIST.TBL
@@ -1,0 +1,105 @@
+#short_name select? units signconv timeavg? min/max? std? vert.levels grib_id grib_scalefactor longname
+
+#Energy balance components
+Swnet:         1  W/m2    DN   1 0 0 1 111 10      # Net Shortwave Radiation (W/m2)
+Lwnet:         1  W/m2    DN   1 0 0 1 112 10      # Net Longwave Radiation (W/m2)
+Qle:           1  W/m2    UP   1 0 0 1 121 10      # Latent Heat Flux (W/m2)
+Qh:            1  W/m2    UP   1 0 0 1 122 10      # Sensible Heat Flux (W/m2)
+Qg:            1  W/m2    DN   1 0 0 1 155 10      # Ground Heat Flux (W/m2)
+Qf:            0  W/m2    S2L  1 0 0 1 229 10      # Energy of fusion (W/m2)
+Qv:            0  W/m2    S2V  1 0 0 1 134 10      # Energy of sublimation (W/m2)
+Qa:            0  W/m2    DN   1 0 0 1 136 10      # Advective Energy (W/m2)
+Qtau:          0  N/m2    DN   1 0 0 1 135 10      # Momentum flux (N/m2)
+DelSurfHeat:   0  J/m2    INC  1 0 0 1 137 10      # Change in surface heat storage (J/m2)
+DelColdCont:   0  J/m2    INC  1 0 0 1 138 10      # Change in snow cold content (J/m2)
+BR:            0  -       -    1 0 1 1 256 10      # Bowen ratio
+EF:            0  -       -    1 0 1 1 256 10      # Evaporative fraction
+
+#Water balance components
+Snowf:         0  kg/m2s  DN   1 0 0 1 161 10000   # Snowfall rate (kg/m2s)
+Rainf:         0  kg/m2s  DN   1 0 0 1 162 10000   # Rainfall rate (kg/m2s)
+RainfConv:     0  kg/m2s  DN   1 0 0 1 163 10000   # Convective Rainfall rate (kg/m2s)
+TotalPrecip:   1  kg/m2s  DN   1 0 0 1 164 10000   # Total Precipitation rate (kg/m2s)
+Evap:          1  kg/m2s  UP   1 0 0 1  57 10000   # Total Evapotranspiration (kg/m2s)
+Qs:            1  kg/m2s  OUT  1 0 0 1 235 10000   # Surface runoff (kg/m2s)
+Qsb:           1  kg/m2s  OUT  1 0 0 1 254 10000   # Subsurface runoff (kg/m2s)
+Qrec:          0  kg/m2s  IN   1 0 0 1 143 10000   # Recharge (kg/m2s)
+Qsm:           0  kg/m2s  S2L  1 0 0 1  99 10000   # Snowmelt (kg/m2s)
+Qfz:           0  kg/m2s  L2S  1 0 0 1 146 10000   # Refreezing of water in the snowpack (kg/m2s)
+Qst:           0  kg/m2s  -    1 0 0 1 147 10000   # Snow throughfall (kg/m2s)
+DelSoilMoist:  0  kg/m2   INC  0 0 0 1 148 10000   # Change in soil moisture (kg/m2)
+DelSWE:        0  kg/m2   INC  0 0 0 1 149 1000    # Change in snow water equivalent (kg/m2)
+DelSurfStor:   0  kg/m2   INC  1 0 0 1 150 1000    # Change in surface water storage (kg/m2)
+DelIntercept:  0  kg/m2   INC  1 0 0 1 151 1000    # Change in interception storage (kg/m2)
+RHMin:         0   -      -    0 0 0 1  51 10      # Minimum 2 meter relative humidity (-)
+
+#Surface state variables
+SnowT:         0  K       -    1 0 0 1 152 10      # Snow surface temperature (K)
+VegT:          0  K       -    1 0 0 1 153 10      # Vegetation canopy temperature (K)
+BareSoilT:     0  K       -    1 0 0 1 154 10      # Temperature of bare soil (K)
+AvgSurfT:      0  K       -    0 0 0 1 148 10      # Average surface temperature (K)
+RadT:          0  K       -    1 0 0 1 156 10      # Surface Radiative Temperature (K)
+Albedo:        0  -       -    0 0 0 1  84 100     # Surface Albedo (-)
+SWE:           1  kg/m2   -    0 0 0 1  65 1000    # Snow Water Equivalent (kg/m2)
+SWEVeg:        0  kg/m2   -    1 0 0 1 159 1000    # SWE intercepted by vegetation (kg/m2)
+SurfStor:      0  kg/m2   -    1 0 0 1 160 1000    # Surface water storage (kg/m2)
+
+#Subsurface state variables
+SoilMoist:     1  m3/m3   -    1 0 0 4  86 1000    # Average layer soil moisture (kg/m2)
+SoilTemp:      1  K       -    0 0 0 4  85 1000    # Average layer soil temperature (K)
+SmLiqFrac:     0  -       -    1 0 0 4  85 100     # Average layer fraction of liquid moisture (-)
+SmFrozFrac:    0  -       -    1 0 0 4  85 100     # Average layer fraction of frozen moisture (-)
+SoilWet:       0  -       -    0 0 0 1  85 100     # Total soil wetness (-)
+RelSMC:        0  m3/m3   -    0 0 0 1  86 1000    # Relative soil moisture
+RootTemp:      0  K       -    0 0 0 1  85 1000    # Rootzone temperature (K)
+
+#Evaporation components
+PotEvap:       0  kg/m2s  UP   3 0 0 1 166 1       # Potential Evapotranspiration (kg/m2s)
+TVeg:          0  kg/m2s  UP   1 0 0 1 210 1       # Vegetation transpiration (kg/m2s)
+ECanop:        0  kg/m2s  UP   1 0 0 1 200 1       # Interception evaporation (kg/m2s)
+ESoil:         0  kg/m2s  UP   1 0 0 1 199 1       # Bare soil evaporation (kg/m2s)
+EWater:        0  kg/m2s  UP   1 0 0 1 170 1       # Open water evaporation (kg/m2s)
+RootMoist:     0  kg/m2   -    0 0 0 1 171 1       # Root zone soil moisture (kg/m2)
+CanopInt:      0  kg/m2   -    0 0 0 1 223 1000    # Total canopy water storage (kg/m2)
+EvapSnow:      0  kg/m2s  -    1 0 0 1 173 1000    # Snow evaporation (kg/m2s)
+SubSnow:       0  kg/m2s  -    1 0 0 1 198 1000    # Snow sublimation (kg/m2s)
+SubSurf:       0  kg/m2s  -    1 0 0 1 175 1000    # Sublimation of the snow free area (kg/m2s)
+ACond:         0  m/s     -    1 0 0 1 179 100000  # Aerodynamic conductance
+CCond:         0  m/s     -    1 0 0 1 179 1000000 # Canopy conductance
+
+#Cold season processes
+Snowcover:     0  -       -    0 0 0 1  66 100     # Snow Cover (-)
+SnowDepth:     0  m       -    0 0 0 1  66 1000    # Snow Depth (m)
+SLiqFrac:      0  -       -    0 0 0 1  65 1000    # Fraction of SWE in the liquid phase
+
+#Forcings
+Wind_f:        1  m/s     -    0 0 0 1 177 10      # Near Surface Wind (m/s)
+Rainf_f:       1  kg/m2s  DN   0 0 0 1 162 1000    # Average rainfall rate
+Snowf_f:       0  kg/m2s  DN   0 0 0 1 161 1000    # Average snowfall rate
+Tair_f:        1  K       -    0 0 0 1  11 10      # Near surface air temperature
+Qair_f:        0  kg/kg   -    0 0 0 1  51 1000    # Near surface specific humidity
+Psurf_f:       0  Pa      -    0 0 0 1   1 10      # Surface pressure
+SWdown_f:      1  W/m2    DN   0 0 0 1 204 10      # Surface incident shortwave radiation
+LWdown_f:      1  W/m2    DN   0 0 0 1 205 10      # Surface incident longwave radiation
+
+#Parameters
+Landmask:      0  -       -    0 0 0 1  81 1       # Land Mask (0 - Water, 1- Land)
+Landcover:     0  -       -    0 0 0 1 186 1       # Land cover
+Soiltype:      0  -       -    0 0 0 1 187 1       # Soil type
+SandFrac:      0  -       -    0 0 0 1 999 1       # Sand fraction
+ClayFrac:      0  -       -    0 0 0 1 999 1       # Clay fraction
+SiltFrac:      0  -       -    0 0 0 1 999 1       # Silt fraction
+Porosity:      0  -       -    3 0 0 1 999 1       # Porosity
+Soilcolor:     0  -       -    0 0 0 1 188 1       # Soil color
+Elevation:     0  m       -    0 0 0 1 189 10      # Elevation
+Slope:         0  -       -    0 0 0 1 999 10      # Slope
+LAI:           0  -       -    0 0 0 1 190 100     # LAI
+SAI:           0  -       -    0 0 0 1 191 100     # SAI
+Snfralbedo:    0  -       -    0 0 0 1 192 100     # Snow fraction albedo
+Mxsnalbedo:    0  -       -    0 0 0 1 192 100     # Maximum snow albedo
+Greenness:     1  -       -    0 0 0 1  87 100     # Greenness
+Tempbot:       0  K       -    0 0 0 1 194 10      # Bottom soil temperature
+
+#Irrigation
+Irrigated water:   0 kg/m2s    -     1 0 0 1 333 10      #Irrigation amount
+

--- a/lis/testcases/domains/latlon_idlcross/README
+++ b/lis/testcases/domains/latlon_idlcross/README
@@ -1,0 +1,37 @@
+International Date Line (IDL) Domain Testcase
+
+This is a testcase that uses:
+  (a) The latlon projection 
+  (b) A domain that crosses the International Date Line
+  (c) The Noah version 3.6 land surface model
+  (d) MERRA2 forcing files
+  (e) Domain that covers eastern Australia and New Zealand,
+       with a 11 km spatial resolution
+  (f) A time period from 01:00Z 1 Jan 2001 to 01:00Z 3 Jan 2001
+
+This directory contains:
+  (a) This README file
+  (b) The "ldt.config" file to generate the parameters using LDT
+  (c) An "input.xdf" file used to open the LDT parameters in GrADS
+  (d) The "lis.config" file used for this testcase
+  (e) The "MODEL_OUTPUT_LIST.TBL" file used by the lis.config file
+      to select the output variables
+  (f) An "output.ctl" file used to display the output in GrADS from
+      the LIS run
+  (g) A "testcase.ctl" file used to display the packaged output in
+      GrADS from the OUTPUT tar file provided by the testcase
+
+To run this testcase:
+  (a) Generate the LDT and the LIS executables and copy to local 
+      working directory
+  (b) Run the LDT executable using the "ldt.config" file and the
+      file with the testcase input data
+  (c) Run the LIS executable using the "lis.config" file with the
+      testcase input data
+  (d) View the netcdf output using the testcase GrADS files
+
+Caveats:
+  (a) Please note that this is a simple functional test and the output
+      from the testcase is not expected to be used for any scientific
+      evaluation.
+

--- a/lis/testcases/domains/latlon_idlcross/input.ctl
+++ b/lis/testcases/domains/latlon_idlcross/input.ctl
@@ -1,0 +1,102 @@
+dset ^lis_input.d01.nc
+dtype netcdf
+options template
+undef -9999
+xdef 429 linear 137.1006 0.11
+ydef 315 linear -53.59763 0.11
+zdef 1 linear 1 1
+* dummy tdef
+tdef 1 linear 00z01jan2012 1hr
+vars 91
+LANDMASK=>LANDMASK 1 y,x description
+DOMAINMASK=>DOMAINMASK 1 y,x description
+SURFACETYPE=>SURFACETYPE1 0 0,y,x description
+SURFACETYPE=>SURFACETYPE2 0 1,y,x description
+SURFACETYPE=>SURFACETYPE3 0 2,y,x description
+SURFACETYPE=>SURFACETYPE4 0 3,y,x description
+SURFACETYPE=>SURFACETYPE5 0 4,y,x description
+SURFACETYPE=>SURFACETYPE6 0 5,y,x description
+SURFACETYPE=>SURFACETYPE7 0 6,y,x description
+SURFACETYPE=>SURFACETYPE8 0 7,y,x description
+SURFACETYPE=>SURFACETYPE9 0 8,y,x description
+SURFACETYPE=>SURFACETYPE10 0 9,y,x description
+SURFACETYPE=>SURFACETYPE11 0 10,y,x description
+SURFACETYPE=>SURFACETYPE12 0 11,y,x description
+SURFACETYPE=>SURFACETYPE13 0 12,y,x description
+SURFACETYPE=>SURFACETYPE14 0 13,y,x description
+SURFACETYPE=>SURFACETYPE15 0 14,y,x description
+SURFACETYPE=>SURFACETYPE16 0 15,y,x description
+SURFACETYPE=>SURFACETYPE17 0 16,y,x description
+SURFACETYPE=>SURFACETYPE18 0 17,y,x description
+SURFACETYPE=>SURFACETYPE19 0 18,y,x description
+SURFACETYPE=>SURFACETYPE20 0 19,y,x description
+LANDCOVER=>LANDCOVER1 0 0,y,x description
+LANDCOVER=>LANDCOVER2 0 1,y,x description
+LANDCOVER=>LANDCOVER3 0 2,y,x description
+LANDCOVER=>LANDCOVER4 0 3,y,x description
+LANDCOVER=>LANDCOVER5 0 4,y,x description
+LANDCOVER=>LANDCOVER6 0 5,y,x description
+LANDCOVER=>LANDCOVER7 0 6,y,x description
+LANDCOVER=>LANDCOVER8 0 7,y,x description
+LANDCOVER=>LANDCOVER9 0 8,y,x description
+LANDCOVER=>LANDCOVER10 0 9,y,x description
+LANDCOVER=>LANDCOVER11 0 10,y,x description
+LANDCOVER=>LANDCOVER12 0 11,y,x description
+LANDCOVER=>LANDCOVER13 0 12,y,x description
+LANDCOVER=>LANDCOVER14 0 13,y,x description
+LANDCOVER=>LANDCOVER15 0 14,y,x description
+LANDCOVER=>LANDCOVER16 0 15,y,x description
+LANDCOVER=>LANDCOVER17 0 16,y,x description
+LANDCOVER=>LANDCOVER18 0 17,y,x description
+LANDCOVER=>LANDCOVER19 0 18,y,x description
+LANDCOVER=>LANDCOVER20 0 19,y,x description
+TEXTURE=>TEXTURE1 0 0,y,x description
+TEXTURE=>TEXTURE2 0 1,y,x description
+TEXTURE=>TEXTURE3 0 2,y,x description
+TEXTURE=>TEXTURE4 0 3,y,x description
+TEXTURE=>TEXTURE5 0 4,y,x description
+TEXTURE=>TEXTURE6 0 5,y,x description
+TEXTURE=>TEXTURE7 0 6,y,x description
+TEXTURE=>TEXTURE8 0 7,y,x description
+TEXTURE=>TEXTURE9 0 8,y,x description
+TEXTURE=>TEXTURE10 0 9,y,x description
+TEXTURE=>TEXTURE11 0 10,y,x description
+TEXTURE=>TEXTURE12 0 11,y,x description
+TEXTURE=>TEXTURE13 0 12,y,x description
+TEXTURE=>TEXTURE14 0 13,y,x description
+TEXTURE=>TEXTURE15 0 14,y,x description
+TEXTURE=>TEXTURE16 0 15,y,x description
+ELEVFGRD=>ELEVFGRD 1 y,x description
+ELEVATION=>ELEVATION 1 y,x description
+GREENNESS=>GREENNESS1 0 0,y,x description
+GREENNESS=>GREENNESS2 0 1,y,x description
+GREENNESS=>GREENNESS3 0 2,y,x description
+GREENNESS=>GREENNESS4 0 3,y,x description
+GREENNESS=>GREENNESS5 0 4,y,x description
+GREENNESS=>GREENNESS6 0 5,y,x description
+GREENNESS=>GREENNESS7 0 6,y,x description
+GREENNESS=>GREENNESS8 0 7,y,x description
+GREENNESS=>GREENNESS9 0 8,y,x description
+GREENNESS=>GREENNESS10 0 9,y,x description
+GREENNESS=>GREENNESS11 0 10,y,x description
+GREENNESS=>GREENNESS12 0 11,y,x description
+SHDMIN=>SHDMIN 1 y,x description
+SHDMAX=>SHDMAX 1 y,x description
+ALBEDO=>ALBEDO1 0 0,y,x description
+ALBEDO=>ALBEDO2 0 1,y,x description
+ALBEDO=>ALBEDO3 0 2,y,x description
+ALBEDO=>ALBEDO4 0 3,y,x description
+ALBEDO=>ALBEDO5 0 4,y,x description
+ALBEDO=>ALBEDO6 0 5,y,x description
+ALBEDO=>ALBEDO7 0 6,y,x description
+ALBEDO=>ALBEDO8 0 7,y,x description
+ALBEDO=>ALBEDO9 0 8,y,x description
+ALBEDO=>ALBEDO10 0 9,y,x description
+ALBEDO=>ALBEDO11 0 10,y,x description
+ALBEDO=>ALBEDO12 0 11,y,x description
+MXSNALBEDO=>MXSNALBEDO 1 y,x description
+TBOT=>TBOT 1 y,x description
+SLOPETYPE=>SLOPETYPE 1 y,x description
+lat=>lat 1 y,x description
+lon=>lon 1 y,x description
+endvars

--- a/lis/testcases/domains/latlon_idlcross/input_testcase.ctl
+++ b/lis/testcases/domains/latlon_idlcross/input_testcase.ctl
@@ -1,0 +1,102 @@
+dset ^lis_input_testcase.d01.nc
+dtype netcdf
+options template
+undef -9999
+xdef 429 linear 137.1006 0.11
+ydef 315 linear -53.59763 0.11
+zdef 1 linear 1 1
+* dummy tdef
+tdef 1 linear 00z01jan2012 1hr
+vars 91
+LANDMASK=>LANDMASK 1 y,x description
+DOMAINMASK=>DOMAINMASK 1 y,x description
+SURFACETYPE=>SURFACETYPE1 0 0,y,x description
+SURFACETYPE=>SURFACETYPE2 0 1,y,x description
+SURFACETYPE=>SURFACETYPE3 0 2,y,x description
+SURFACETYPE=>SURFACETYPE4 0 3,y,x description
+SURFACETYPE=>SURFACETYPE5 0 4,y,x description
+SURFACETYPE=>SURFACETYPE6 0 5,y,x description
+SURFACETYPE=>SURFACETYPE7 0 6,y,x description
+SURFACETYPE=>SURFACETYPE8 0 7,y,x description
+SURFACETYPE=>SURFACETYPE9 0 8,y,x description
+SURFACETYPE=>SURFACETYPE10 0 9,y,x description
+SURFACETYPE=>SURFACETYPE11 0 10,y,x description
+SURFACETYPE=>SURFACETYPE12 0 11,y,x description
+SURFACETYPE=>SURFACETYPE13 0 12,y,x description
+SURFACETYPE=>SURFACETYPE14 0 13,y,x description
+SURFACETYPE=>SURFACETYPE15 0 14,y,x description
+SURFACETYPE=>SURFACETYPE16 0 15,y,x description
+SURFACETYPE=>SURFACETYPE17 0 16,y,x description
+SURFACETYPE=>SURFACETYPE18 0 17,y,x description
+SURFACETYPE=>SURFACETYPE19 0 18,y,x description
+SURFACETYPE=>SURFACETYPE20 0 19,y,x description
+LANDCOVER=>LANDCOVER1 0 0,y,x description
+LANDCOVER=>LANDCOVER2 0 1,y,x description
+LANDCOVER=>LANDCOVER3 0 2,y,x description
+LANDCOVER=>LANDCOVER4 0 3,y,x description
+LANDCOVER=>LANDCOVER5 0 4,y,x description
+LANDCOVER=>LANDCOVER6 0 5,y,x description
+LANDCOVER=>LANDCOVER7 0 6,y,x description
+LANDCOVER=>LANDCOVER8 0 7,y,x description
+LANDCOVER=>LANDCOVER9 0 8,y,x description
+LANDCOVER=>LANDCOVER10 0 9,y,x description
+LANDCOVER=>LANDCOVER11 0 10,y,x description
+LANDCOVER=>LANDCOVER12 0 11,y,x description
+LANDCOVER=>LANDCOVER13 0 12,y,x description
+LANDCOVER=>LANDCOVER14 0 13,y,x description
+LANDCOVER=>LANDCOVER15 0 14,y,x description
+LANDCOVER=>LANDCOVER16 0 15,y,x description
+LANDCOVER=>LANDCOVER17 0 16,y,x description
+LANDCOVER=>LANDCOVER18 0 17,y,x description
+LANDCOVER=>LANDCOVER19 0 18,y,x description
+LANDCOVER=>LANDCOVER20 0 19,y,x description
+TEXTURE=>TEXTURE1 0 0,y,x description
+TEXTURE=>TEXTURE2 0 1,y,x description
+TEXTURE=>TEXTURE3 0 2,y,x description
+TEXTURE=>TEXTURE4 0 3,y,x description
+TEXTURE=>TEXTURE5 0 4,y,x description
+TEXTURE=>TEXTURE6 0 5,y,x description
+TEXTURE=>TEXTURE7 0 6,y,x description
+TEXTURE=>TEXTURE8 0 7,y,x description
+TEXTURE=>TEXTURE9 0 8,y,x description
+TEXTURE=>TEXTURE10 0 9,y,x description
+TEXTURE=>TEXTURE11 0 10,y,x description
+TEXTURE=>TEXTURE12 0 11,y,x description
+TEXTURE=>TEXTURE13 0 12,y,x description
+TEXTURE=>TEXTURE14 0 13,y,x description
+TEXTURE=>TEXTURE15 0 14,y,x description
+TEXTURE=>TEXTURE16 0 15,y,x description
+ELEVFGRD=>ELEVFGRD 1 y,x description
+ELEVATION=>ELEVATION 1 y,x description
+GREENNESS=>GREENNESS1 0 0,y,x description
+GREENNESS=>GREENNESS2 0 1,y,x description
+GREENNESS=>GREENNESS3 0 2,y,x description
+GREENNESS=>GREENNESS4 0 3,y,x description
+GREENNESS=>GREENNESS5 0 4,y,x description
+GREENNESS=>GREENNESS6 0 5,y,x description
+GREENNESS=>GREENNESS7 0 6,y,x description
+GREENNESS=>GREENNESS8 0 7,y,x description
+GREENNESS=>GREENNESS9 0 8,y,x description
+GREENNESS=>GREENNESS10 0 9,y,x description
+GREENNESS=>GREENNESS11 0 10,y,x description
+GREENNESS=>GREENNESS12 0 11,y,x description
+SHDMIN=>SHDMIN 1 y,x description
+SHDMAX=>SHDMAX 1 y,x description
+ALBEDO=>ALBEDO1 0 0,y,x description
+ALBEDO=>ALBEDO2 0 1,y,x description
+ALBEDO=>ALBEDO3 0 2,y,x description
+ALBEDO=>ALBEDO4 0 3,y,x description
+ALBEDO=>ALBEDO5 0 4,y,x description
+ALBEDO=>ALBEDO6 0 5,y,x description
+ALBEDO=>ALBEDO7 0 6,y,x description
+ALBEDO=>ALBEDO8 0 7,y,x description
+ALBEDO=>ALBEDO9 0 8,y,x description
+ALBEDO=>ALBEDO10 0 9,y,x description
+ALBEDO=>ALBEDO11 0 10,y,x description
+ALBEDO=>ALBEDO12 0 11,y,x description
+MXSNALBEDO=>MXSNALBEDO 1 y,x description
+TBOT=>TBOT 1 y,x description
+SLOPETYPE=>SLOPETYPE 1 y,x description
+lat=>lat 1 y,x description
+lon=>lon 1 y,x description
+endvars

--- a/lis/testcases/domains/latlon_idlcross/ldt.config
+++ b/lis/testcases/domains/latlon_idlcross/ldt.config
@@ -1,0 +1,131 @@
+
+# == LDT Main Entry Options == 
+
+LDT running mode:             "LSM parameter processing"  # LDT type of run-mode (top-level option)
+Processed LSM parameter filename:  ./lis_input.d01.nc   # Final output file read by LIS-7
+
+LIS number of nests:                   1                # Total number of nests run by LIS
+Number of surface model types:         1                # Total number of desired surface model types
+Surface model types:                 "LSM"              # Surface models:  LSM | Openwater
+Land surface model:                  "Noah.3.3"             # Enter LSM(s) of choice
+Lake model:                          "none"             # Enter Lake model(s) of choice
+Water fraction cutoff value:          0.5               # Fraction at which gridcell is designated as 'water'
+Incorporate crop information:       .false.             # .true. = incorporate crop/irrig info with LSM parameters
+
+Number of met forcing sources:         0                # Enter number of forcing types
+Met forcing sources:                 "none"             # Enter 'none' if no forcing selected
+Met spatial transform methods:      bilinear            # bilinear | budget-bilinear | neighbor | average
+Topographic correction method (met forcing):  "none"    # none | lapse-rate
+
+LDT diagnostic file:                ldtlog        # Log-based diagnostic output file
+Mask-parameter fill diagnostic file:  MaskParamFill.log
+LDT output directory:               OUTPUT              # If metrics or stats are written out
+Undefined value:                   -9999.0              # Universal undefined value
+Number of ensembles per tile:         1                 # The number of ensemble members per tile
+
+# Processor layout (currently not available)
+Number of processors along x:       1
+Number of processors along y:       1
+
+# LIS domain:  (See LDT User's Guide for other projection information)
+Map projection of the LIS domain:    latlon 
+Run domain lower left lat:         -53.597634
+Run domain upper right lat:        -19.049026
+#
+Run domain lower left lon:         137.100627
+Run domain upper right lon:       -175.857586
+Run domain resolution (dx):          0.11
+Run domain resolution (dy):          0.11
+
+# == Landcover, Landmask and Soil Texture Parameters ==
+
+# Landcover/Mask Parameter Inputs 
+Landcover data source:        "MODIS_Native"
+Landcover classification:       "IGBPNCEP"              # Enter land cover classification type
+Landcover file:            ./input/noah_2dparms/igbp.bin      # Landcover map path
+Landcover spatial transform:      tile                  # none | mode | neighbor | tile
+Landcover fill option:            none                  # none | neighbor (Not needed if creating landmask)
+Landcover map projection:        latlon
+
+# Create landmask field from readin landcover map or read in separate landmask file
+Create or readin landmask:      "create"                # create | readin
+Landmask data source:           "MODIS_Native"          # If 'created', recommended to put Landcover source name here
+Landmask file:                   none                   # Land mask file (if needed to be read-in)
+Landmask spatial transform:      none                   # none | mode | neighbor
+
+#Soil texture map:
+Soil texture data source:    STATSGOFAO_Native
+Soil texture map:         ./input/noah_2dparms/topsoil30snew  # Enter soil texture map
+Soil texture spatial transform:   mode                  # none | mode | neighbor | tile
+Soil texture fill option:       neighbor                # none | neighbor
+Soil texture fill radius:         5                     # Number of pixels to search for neighbor
+Soil texture fill value:          6                     # Static value to fill where missing 
+Soil texture map projection:     latlon
+
+Soils spatial transform:        none            # Note: do not use mode with soil fractions
+Soils map projection:          latlon
+
+Elevation data source:         GTOPO30_Native
+Elevation number of bands:        1
+Elevation map:                 ./input/topo_parms/GTOPO30/raw_updated
+Elevation fill option:          average
+Elevation fill radius:            5
+Elevation fill value:            287.
+Topography spatial transform:   average
+Topography map projection:       latlon
+
+# == Main Noah LSM Parameters ==
+
+# Albedo maps:
+Albedo data source:            NCEP_Native
+Albedo map:                 ./input/noah_2dparms/albedo       # Albedo files
+Albedo climatology interval:     monthly                # monthly | quarterly
+Albedo spatial transform:        bilinear               # average | neighbor | bilinear | budget-bilinear
+Albedo fill option:              neighbor               # none | neighbor | average
+Albedo fill radius:                5                    # Number of pixels to search for neighbor
+Albedo fill value:                0.14                  # Static value to fill where missing
+Albedo map projection:           latlon                  
+
+Max snow albedo data source:    NCEP_Native
+Max snow albedo map:      ./input/noah_2dparms/maxsnoalb.asc  # Max. snow albedo map
+Max snow albedo spatial transform:  budget-bilinear     # average | neighbor | bilinear | budget-bilinear
+Max snow albedo fill option:        neighbor            # none | neighbor | average
+Max snow albedo fill radius:         5                  # Number of pixels to search for neighbor
+Max snow albedo fill value:         0.3                 # Static value to fill where missing
+Max snow albedo map projection:    latlon
+
+# Greenness fraction maps:
+Greenness data source:        NCEP_Native
+Greenness fraction map:   ./input/noah_2dparms/gfrac          # Greenness fraction map        
+Greenness climatology interval:   monthly               # monthly
+Calculate min-max greenness fraction: .false.
+Greenness maximum map:    ./input/noah_2dparms/gfrac_max.asc  # Maximum greenness fraction map
+Greenness minimum map:    ./input/noah_2dparms/gfrac_min.asc  # Minimum greenness fraction map
+Greenness spatial transform:   bilinear                 # average | neighbor | bilinear | budget-bilinear
+Greenness fill option:         neighbor                 # none | neighbor | average
+Greenness fill radius:           5                      # Number of pixels to search for neighbor
+Greenness fill value:           0.30                    # Static value to fill where missing
+Greenness maximum fill value:   0.40                    # Static value to fill where missing
+Greenness minimum fill value:   0.20                    # Static value to fill where missing
+Greenness map projection:      latlon
+
+# Slope type map:
+Slope type data source:       NCEP_Native
+Slope type map:           ./input/noah_2dparms/islope         # Slope type map
+Slope type spatial transform:   neighbor                # none | neighbor | mode
+Slope type fill option:         neighbor                # none | neighbor
+Slope type fill radius:           5                     # Number of pixels to search for neighbor
+Slope type fill value:            3.                    # Static value to fill where missing
+Slope type map projection:      latlon
+
+# Bottom temperature map (lapse-rate correction option):
+Bottom temperature data source:        ISLSCP1
+Bottom temperature map:     ./input/noah_2dparms/SOILTEMP.60     # Bottom soil temperature file
+Bottom temperature topographic downscaling:  "lapse-rate"  # none | lapse-rate
+Bottom temperature spatial transform:  bilinear            # average | neighbor | bilinear | budget-bilinear
+Bottom temperature fill option:        average             # none | average | neighbor
+Bottom temperature fill radius:        5                   # Number of pixels to search for neighbor
+Bottom temperature fill value:         287.                # Static value to fill where missing
+Bottom temperature map projection:     latlon              # Projection type
+
+# =======================================================

--- a/lis/testcases/domains/latlon_idlcross/lis.config
+++ b/lis/testcases/domains/latlon_idlcross/lis.config
@@ -1,0 +1,219 @@
+#Overall driver options
+Running mode: 		         "retrospective"
+Map projection of the LIS domain: "latlon"
+Number of nests:                     1 
+Number of surface model types:       1
+Surface model types:               "LSM"
+Land surface model:              "Noah.3.6"
+Surface model output interval:     "6hr"
+
+Number of met forcing sources:       1
+Blending method for forcings:     "overlay"
+Met forcing sources:               "MERRA2"
+Topographic correction method (met forcing):  "none"
+Spatial interpolation method (met forcing):   "bilinear"
+Spatial upscaling method (met forcing):       "average"
+Temporal interpolation method (met forcing):  "linear"
+Enable spatial downscaling of precipitation:   0
+Enable new zterp correction (met forcing):    .true.
+
+Number of ensembles per tile:        1
+
+#Runtime options
+Forcing variables list file:        ./input/forcing_variables.txt
+Output forcing:                            1   #1-yes
+Output parameters:                         0   #0- no
+Output methodology:                        "2d gridspace"
+Output model restart files:                1
+Output data format:                        binary
+Output naming style:                       "3 level hierarchy"
+Start mode:                                coldstart
+#
+Starting year:                             2001
+Starting month:                            1
+Starting day:                              1
+Starting hour:                             1
+Starting minute:                           0
+Starting second:                           0
+Ending year:                               2001
+Ending month:                              1
+Ending day:                                3
+Ending hour:                               1
+Ending minute:                             0
+Ending second:                             0
+#
+Undefined value:                          -9999
+Output directory:                         'OUTPUT'
+Diagnostic output file:                   'lislog'
+
+#The following options are used for subgrid tiling based on vegetation
+Maximum number of surface type tiles per grid:     1
+Minimum cutoff percentage (surface type tiles):    0.10 
+Maximum number of soil texture tiles per grid:     1
+Minimum cutoff percentage (soil texture tiles):    0.10
+Maximum number of soil fraction tiles per grid:    1
+Minimum cutoff percentage (soil fraction tiles):   0.10
+Maximum number of elevation bands per grid:        1
+Minimum cutoff percentage (elevation bands):       0.10
+Maximum number of slope bands per grid:            1
+Minimum cutoff percentage (slope bands):           0.10
+Maximum number of aspect bands per grid:           1
+Minimum cutoff percentage (aspect bands):          0.10
+
+#Processor Layout	
+#Should match the total number of processors used
+
+Number of processors along x:    2 
+Number of processors along y:    2
+Halo size along x: 0 
+Halo size along y: 0 
+
+#------------------------ IRRIGATION ---------------------------------
+
+Irrigation scheme:            "none"
+
+#------------------------ ROUTING -------------------------------------
+
+Routing model:              "none"
+
+#------------------------RADIATIVE TRANSFER MODELS--------------------------
+
+Radiative transfer model:   "none"
+
+#------------------------APPLICATION MODELS---------------------------------
+
+Number of application models: 0
+
+#---------------------DATA ASSIMILATION ----------------------------------
+#Data Assimilation Options
+
+Number of data assimilation instances:               0
+Data assimilation algorithm:                         "none"
+Data assimilation set:                               "none"
+Number of state variables:                           0
+Data assimilation exclude analysis increments:       1
+Data assimilation output interval for diagnostics:   "1da"  
+Data assimilation number of observation types:       1 
+Data assimilation output ensemble members:           0
+Data assimilation output processed observations:     0
+Data assimilation output innovations:                0
+
+Bias estimation algorithm:                "none"
+Bias estimation attributes file:          "none"
+Bias estimation restart output frequency:
+Bias estimation start mode:
+Bias estimation restart file:
+
+#Perturbation options
+Perturbations start mode:                 "coldstart"
+Perturbations restart output interval:    "1mo"
+Perturbations restart filename:           ./LIS_DAPERT_200902282330.d01.bin
+
+Forcing perturbation algorithm:           "none" 
+Forcing perturbation frequency:           "1hr"
+Forcing attributes file:                  none
+Forcing perturbation attributes file:     none
+
+State perturbation algorithm:             "none"
+State perturbation frequency:             "3hr"
+State attributes file:                    none
+State perturbation attributes file:       none 
+
+Observation perturbation algorithm:       "none"
+Observation perturbation frequency:       "6hr"
+Observation attributes file:               none
+Observation perturbation attributes file:  none
+
+
+#------------------------DOMAIN SPECIFICATION--------------------------
+
+#The following options list the choice of parameter maps to be used:
+
+LIS domain and parameter data file:   ./lis_input.d01.nc
+
+Landmask data source:            "LDT"
+Landcover data source:           "LDT"
+Soil texture data source:        "LDT"
+Soil fraction data source:       "none"
+Soil color data source:          "none"
+Elevation data source:           "LDT"
+Slope data source:               "none"
+Aspect data source:              "none"
+Curvature data source:           "none"
+LAI data source:                 "none"
+SAI data source:                 "none"
+Albedo data source:              "LDT"
+Max snow albedo data source:     "LDT"
+Greenness data source:           "LDT"  
+Roughness data source:           "none"  
+Porosity data source:            "none"
+Ksat data source:                "none"
+B parameter data source:         "none"
+Quartz data source:              "none"
+Emissivity data source:          "none"
+
+
+#--------------------------------FORCINGS----------------------------------
+
+# MERRA-2 base forcing:
+MERRA2 forcing directory:            ./input/MET_FORCING/MERRA2/
+MERRA2 use lowest model level forcing:     0  # 0-ref height; 1-lowest model level
+MERRA2 use corrected total precipitation:  1
+
+#-----------------------LAND SURFACE MODELS--------------------------
+
+Noah.3.6 model timestep:                  "15mn"
+Noah.3.6 restart output interval:         "1da"
+Noah.3.6 restart file:                   ./none
+Noah.3.6 vegetation parameter table:     ./input/noah36_parms/VEGPARM.TBL
+Noah.3.6 soil parameter table:           ./input/noah36_parms/SOILPARM.TBL
+Noah.3.6 general parameter table:        ./input/noah36_parms/GENPARM.TBL
+Noah.3.6 Run UA snow-physics option:     .false.
+
+Noah.3.6 use PTF for mapping soil properties: 0
+Noah.3.6 soils scheme:                    2      # 1-Zobler; 2-STATSGO
+Noah.3.6 number of soil layers:           4
+Noah.3.6 layer thicknesses:               0.1  0.3  0.6  1.0
+Noah.3.6 use distributed soil depth map:  0
+Noah.3.6 use distributed root depth map:  0
+Noah.3.6 initial skin temperature:        290.0000                                 # Kelvin
+Noah.3.6 initial soil temperatures:       290.0000  290.0000  290.0000  290.0000   # Kelvin
+Noah.3.6 initial total soil moistures:    0.2000000 0.2000000 0.2000000 0.2000000  # volumetric (m3 m-3)
+Noah.3.6 initial liquid soil moistures:   0.2000000 0.2000000 0.2000000 0.2000000  # volumetric (m3 m-3)
+Noah.3.6 initial canopy water:            0.0                                      # depth (m)
+Noah.3.6 initial snow depth:              0.0                                      # depth (m)
+Noah.3.6 initial snow equivalent:         0.0                                      # also known swe - depth (m)
+Noah.3.6 fixed max snow albedo:           0.0                                      # fraction; 0.0 - do not fix
+Noah.3.6 fixed deep soil temperature:     0.0                                      # Kelvin; 0.0 - do not fix
+Noah.3.6 fixed vegetation type:           0                                        # 0 - do not fix
+Noah.3.6 fixed soil type:                 0                                        # 0 - do not fix
+Noah.3.6 fixed slope type:                0                                        # 0 - do not fix
+Noah.3.6 sfcdif option:                   1      # 0 - previous SFCDIF; 1 - updated SFCDIF
+Noah.3.6 z0 veg-type dependence option:   0      # 0 - off; 1 - on; dependence of CZIL in SFCDIF
+# Green vegetation fraction - by month
+#  - used only if "Greenness data source" above is zero
+Noah.3.6 greenness fraction:  0.01  0.02  0.07  0.17  0.27  0.58  0.93  0.96  0.65  0.24  0.11  0.02
+# Background (i.e., snow-free) albedo - by month
+#  - used only for first timestep; subsequent timesteps use
+#    the values as computed in the previous call to "SFLX"
+Noah.3.6 background albedo:   0.18  0.17  0.16  0.15  0.15  0.15  0.15  0.16  0.16  0.17  0.17  0.18
+# Background (i.e., snow-free) roughness length (m) - by month
+#  - used only for first timestep; subsequent timesteps use
+#    the values as computed in the previous call to "SFLX"
+Noah.3.6 background roughness length: 0.020 0.020 0.025 0.030 0.035 0.036 0.035 0.030 0.027 0.025 0.020 0.020
+Noah.3.6 reference height for forcing T and q:   2.0      # (m) - negative=use height from forcing data
+Noah.3.6 reference height for forcing u and v:   10.0     # (m) - negative=use height from forcing data
+
+#---------------------------MODEL OUTPUT CONFIGURATION-----------------------
+#Specify the list of ALMA variables that need to be featured in the
+#LSM model output
+Model output attributes file:  ./MODEL_OUTPUT_LIST.TBL
+
+# Which date/time want to start writing output:
+Output start year:     
+Output start month:   
+Output start day:       
+Output start hour:      
+Output start minutes:   
+Output start seconds:   
+

--- a/lis/testcases/domains/latlon_idlcross/output.ctl
+++ b/lis/testcases/domains/latlon_idlcross/output.ctl
@@ -1,0 +1,36 @@
+DSET       ^OUTPUT/SURFACEMODEL/%y4%m2/LIS_HIST_%y4%m2%d2%h2%n2.d01.gs4r
+TITLE       LIS Noah-3.6 output
+OPTIONS     template
+OPTIONS     sequential
+OPTIONS     big_endian
+UNDEF       -9999.
+xdef 429 linear 137.1006 0.11
+ydef 315 linear -53.59763 0.11
+ZDEF          1 LINEAR             1.0     1.0
+TDEF          8 LINEAR 06:00Z01jan2001     6hr
+VARS         24
+SWnet         1  99  ** Net shortwave radiation [W m-2]
+LWnet         1  99  ** Net longwave radiation [W m-2]
+Qle           1  99  ** Latent heat flux [W m-2]
+Qh            1  99  ** Sensible heat flux [W m-2]
+Qg            1  99  ** Ground heat flux [W m-2]
+Evap          1  99  ** Total evapotranspiration [kg m-2 sec-1]
+Qs            1  99  ** Surface runoff [kg m-2 sec-1]
+Qsb           1  99  ** Subsurface runoff [kg m-2 sec-1]
+SWE           1  99  ** Snow water equivalent [kg m-2]
+SoilMoist1    1  99  ** Soil water content layer 1 [kg m-2]
+SoilMoist2    1  99  ** Soil water content layer 2 [kg m-2]
+SoilMoist3    1  99  ** Soil water content layer 3 [kg m-2]
+SoilMoist4    1  99  ** Soil water content layer 4 [kg m-2]
+SoilTemp1     1  99  ** Soil temperature layer 1 [K]
+SoilTemp2     1  99  ** Soil temperature layer 2 [K]
+SoilTemp3     1  99  ** Soil temperature layer 3 [K]
+SoilTemp4     1  99  ** Soil temperature layer 4 [K]
+Wind_f        1  99  ** Near-surface wind magnitude [m sec-1]
+Rainf_f       1  99  ** Rainfall rate [kg m-2 sec-1]
+Tair_f        1  99  ** Near-surface air temperature [K]
+SWdown_f      1  99  ** Surface incident shortwave radiation [W m-2]
+LWdown_f      1  99  ** Surface incident longwave radiation [W m-2]
+Greenness     1  99  ** Green vegetation (shade) fraction [-]
+TotalPrecip   1  99  ** Total precipitation rate [kg m-2 sec-1]
+ENDVARS

--- a/lis/testcases/domains/latlon_idlcross/testcase.ctl
+++ b/lis/testcases/domains/latlon_idlcross/testcase.ctl
@@ -1,0 +1,36 @@
+DSET       ^TARGET_OUTPUT/SURFACEMODEL/%y4%m2/LIS_HIST_%y4%m2%d2%h2%n2.d01.gs4r
+TITLE       LIS Noah-3.6 output
+OPTIONS     template
+OPTIONS     sequential
+OPTIONS     big_endian
+UNDEF       -9999.
+xdef 429 linear 137.1006 0.11
+ydef 315 linear -53.59763 0.11
+ZDEF          1 LINEAR             1.0     1.0
+TDEF          8 LINEAR 06:00Z01jan2001     6hr
+VARS         24
+SWnet         1  99  ** Net shortwave radiation [W m-2]
+LWnet         1  99  ** Net longwave radiation [W m-2]
+Qle           1  99  ** Latent heat flux [W m-2]
+Qh            1  99  ** Sensible heat flux [W m-2]
+Qg            1  99  ** Ground heat flux [W m-2]
+Evap          1  99  ** Total evapotranspiration [kg m-2 sec-1]
+Qs            1  99  ** Surface runoff [kg m-2 sec-1]
+Qsb           1  99  ** Subsurface runoff [kg m-2 sec-1]
+SWE           1  99  ** Snow water equivalent [kg m-2]
+SoilMoist1    1  99  ** Soil water content layer 1 [kg m-2]
+SoilMoist2    1  99  ** Soil water content layer 2 [kg m-2]
+SoilMoist3    1  99  ** Soil water content layer 3 [kg m-2]
+SoilMoist4    1  99  ** Soil water content layer 4 [kg m-2]
+SoilTemp1     1  99  ** Soil temperature layer 1 [K]
+SoilTemp2     1  99  ** Soil temperature layer 2 [K]
+SoilTemp3     1  99  ** Soil temperature layer 3 [K]
+SoilTemp4     1  99  ** Soil temperature layer 4 [K]
+Wind_f        1  99  ** Near-surface wind magnitude [m sec-1]
+Rainf_f       1  99  ** Rainfall rate [kg m-2 sec-1]
+Tair_f        1  99  ** Near-surface air temperature [K]
+SWdown_f      1  99  ** Surface incident shortwave radiation [W m-2]
+LWdown_f      1  99  ** Surface incident longwave radiation [W m-2]
+Greenness     1  99  ** Green vegetation (shade) fraction [-]
+TotalPrecip   1  99  ** Total precipitation rate [kg m-2 sec-1]
+ENDVARS


### PR DESCRIPTION
Committed fixes to the LDT latlon domain code to allow for grid domains to cross the International Date Line (IDL).  Main code implemented in LDT but also tested LDT domain that crosses IDL with LIS test as well. 

Test case files have been added to the LIS source code testcase directory.  Input and output target files are located here:
/discover/nobackup/projects/lis/Projects/LDT/LISF_Testcases/Cross_Dateline/Testcase/

LDT files: idlcrossdomain_ldt_v72.tar.gz
LIS input files:  idlcrossdomaintest_input.v72.tar.gz
LIS output files:  idlcrossdomaintest_output_v72.tar.gz

This addresses the ticket issue (bug) number #117 .
 