### PR TITLE
Update Dateline Fix LIS Testcase files

### DIFF
--- a/lis/testcases/domains/latlon_idlcross/ldt.config
+++ b/lis/testcases/domains/latlon_idlcross/ldt.config
@@ -5,9 +5,9 @@ LDT running mode:             "LSM parameter processing"  # LDT type of run-mode
 Processed LSM parameter filename:  ./lis_input.d01.nc   # Final output file read by LIS-7
 
 LIS number of nests:                   1                # Total number of nests run by LIS
-Number of surface model types:         1                # Total number of desired surface model types
-Surface model types:                 "LSM"              # Surface models:  LSM | Openwater
-Land surface model:                  "Noah.3.3"             # Enter LSM(s) of choice
+Number of surface model types:         2                # Total number of desired surface model types
+Surface model types:                 "LSM" "Openwater"  # Surface models:  LSM | Openwater
+Land surface model:                  "Noah.3.3"         # Enter LSM(s) of choice
 Lake model:                          "none"             # Enter Lake model(s) of choice
 Water fraction cutoff value:          0.5               # Fraction at which gridcell is designated as 'water'
 Incorporate crop information:       .false.             # .true. = incorporate crop/irrig info with LSM parameters

--- a/lis/testcases/domains/latlon_idlcross/lis.config
+++ b/lis/testcases/domains/latlon_idlcross/lis.config
@@ -1,14 +1,14 @@
-#Overall driver options
+# Overall LIS driver options:
 Running mode: 		         "retrospective"
 Map projection of the LIS domain: "latlon"
 Number of nests:                     1 
-Number of surface model types:       1
-Surface model types:               "LSM"
-Land surface model:              "Noah.3.6"
+Number of surface model types:       2
+Surface model types:               "LSM" "Openwater"
+Land surface model:                "Noah.3.6"
 Surface model output interval:     "6hr"
 
 Number of met forcing sources:       1
-Blending method for forcings:     "overlay"
+Blending method for forcings:      "overlay"
 Met forcing sources:               "MERRA2"
 Topographic correction method (met forcing):  "none"
 Spatial interpolation method (met forcing):   "bilinear"
@@ -43,8 +43,8 @@ Ending minute:                             0
 Ending second:                             0
 #
 Undefined value:                          -9999
-Output directory:                         'OUTPUT'
-Diagnostic output file:                   'lislog'
+Output directory:                         './OUTPUT'
+Diagnostic output file:                   './OUTPUT/lislog'
 
 #The following options are used for subgrid tiling based on vegetation
 Maximum number of surface type tiles per grid:     1
@@ -61,8 +61,6 @@ Maximum number of aspect bands per grid:           1
 Minimum cutoff percentage (aspect bands):          0.10
 
 #Processor Layout	
-#Should match the total number of processors used
-
 Number of processors along x:    2 
 Number of processors along y:    2
 Halo size along x: 0 
@@ -70,7 +68,7 @@ Halo size along y: 0
 
 #------------------------ IRRIGATION ---------------------------------
 
-Irrigation scheme:            "none"
+Irrigation scheme:          "none"
 
 #------------------------ ROUTING -------------------------------------
 
@@ -125,7 +123,7 @@ Observation attributes file:               none
 Observation perturbation attributes file:  none
 
 
-#------------------------DOMAIN SPECIFICATION--------------------------
+#-------------------- DOMAIN SPECIFICATION -------------------------
 
 #The following options list the choice of parameter maps to be used:
 
@@ -153,14 +151,17 @@ Quartz data source:              "none"
 Emissivity data source:          "none"
 
 
-#--------------------------------FORCINGS----------------------------------
+#------------------------- FORCINGS ------------------------------
 
 # MERRA-2 base forcing:
 MERRA2 forcing directory:            ./input/MET_FORCING/MERRA2/
 MERRA2 use lowest model level forcing:     0  # 0-ref height; 1-lowest model level
 MERRA2 use corrected total precipitation:  1
 
-#-----------------------LAND SURFACE MODELS--------------------------
+#----------------------- SURFACE MODELS --------------------------
+
+Open water model:                         "template open water"
+Template open water timestep:             "15mn"
 
 Noah.3.6 model timestep:                  "15mn"
 Noah.3.6 restart output interval:         "1da"
@@ -204,7 +205,7 @@ Noah.3.6 background roughness length: 0.020 0.020 0.025 0.030 0.035 0.036 0.035 
 Noah.3.6 reference height for forcing T and q:   2.0      # (m) - negative=use height from forcing data
 Noah.3.6 reference height for forcing u and v:   10.0     # (m) - negative=use height from forcing data
 
-#---------------------------MODEL OUTPUT CONFIGURATION-----------------------
+#---------------------- MODEL OUTPUT CONFIGURATION -----------------------
 #Specify the list of ALMA variables that need to be featured in the
 #LSM model output
 Model output attributes file:  ./MODEL_OUTPUT_LIST.TBL


### PR DESCRIPTION
Updated the Issue #117, Crossing the International Dateline,
 testcase in LIS to account for open water surface in addition
 to Noah LSM land surface type.

Updated the ldt.config and lis.config files in LIS directory:

lis/testcases/domains/latlon_idlcross

New tarball input and output testcase files can be found here:

/discover/nobackup/projects/lis/Projects/LDT/LISF_Testcases/Cross_Dateline/Testcase

Input LDT testcase tarball:  LDT_Test/testcase_ldt_input.tar.gz
Input LIS testcase tarball:  LIS_Test/testcase_lis_input.tar.gz
Output LIS testcase tarball:  LIS_Test/testcase_lis_output.tar.gz