### PR TITLE
Fix ECMWF reanalysis metforcing big_endian data read in LIS

### DIFF
--- a/lis/metforcing/ecmwfreanal/read_ecmwfreanal.F90
+++ b/lis/metforcing/ecmwfreanal/read_ecmwfreanal.F90
@@ -162,7 +162,8 @@ subroutine read_ecmwfreanal(order, n, findex, yr, mon, da, hr, ferror)
         ! File name for data variable(v)/year/yearmo
         infile=trim(ecmwfreanal_struc(n)%ecmwfreanaldir)//trim(ecmwf_fv(v))//'/'//cyr//'/'//cyr//cmo
 
-        open(fnum(v), file=trim(infile), form='unformatted', iostat=istat)
+        open(fnum(v), file=trim(infile), form='unformatted', &
+                      convert='big_endian', iostat=istat)
         inquire(unit=fnum(v), exist=file_exists)
         
         if (.not.file_exists) then
@@ -195,7 +196,8 @@ subroutine read_ecmwfreanal(order, n, findex, yr, mon, da, hr, ferror)
         close(fnum(v))
         ! New file name for data variable(v)/year/yearmo
         infile=trim(ecmwfreanal_struc(n)%ecmwfreanaldir)//trim(ecmwf_fv(v))//'/'//cyr//'/'//cyr//cmo
-        open(fnum(v), file=trim(infile), form='unformatted', iostat=istat)
+        open(fnum(v), file=trim(infile), form='unformatted', &
+                      convert='big_endian', iostat=istat)
         inquire(unit=fnum(v), exist=file_exists)
         if (.not.file_exists) then
            write(*,*) 'READ_ECMWFREANAL(2): unit ', fnum(v), '= ', infile


### PR DESCRIPTION
This pull request fixes the reading of the ECMWF reanalysis
metforcing dataset as big_endian.  This binary dataset is
natively big_endian.  After this pull request, the code will
run without crashing when LIS is compiled/configured using
either little_endian or big_endian.

Resolves: #368