### PR TITLE
Update LIS config documentation for MERRA2 reader

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5551,6 +5551,18 @@ Acceptable values are:
 |1     | Use the lowest model level forcing.
 |====
 
+`MERRA2 use 2m wind fields:` specifies whether to use the 
+2m diagnosed wind fields. This option will only work if the 
+lowest model level forcing option is turned off.
+Acceptable values are:
+
+|====
+|Value | Description
+
+|0     | Do not use the 2m diagnosed wind speed fields.
+|1     | Use the 2m diagnosed wind speed fields.
+|====
+
 `MERRA2 use corrected total precipitation:` specifies whether
 to use the bias corrected total precipitation.
 Acceptable values are:
@@ -5565,7 +5577,8 @@ Acceptable values are:
 .Example _lis.config_ entry
 ....
 MERRA2 forcing directory:              ./MERRA2/
-MERRA2 use lowest model level forcing:     1 
+MERRA2 use lowest model level forcing:     1
+MERRA2 use 2m wind fields:                 0 
 MERRA2 use corrected total precipitation:  1
 ....
 


### PR DESCRIPTION
This commit adds documentation for an option to use 2m wind
fields when using the MERRA2 reader. The documentation was
not originally included when the commit was first made. This
option was meant to compliment a secondary reference
evapotranspiration calculation option that is available in
LVT.

There was no issue opened for this fix.