### PR TITLE
Fix Metric Output Directory config check in LVT

### DIFF
--- a/lvt/core/LVT_readConfig.F90
+++ b/lvt/core/LVT_readConfig.F90
@@ -440,14 +440,7 @@ subroutine LVT_readConfig(configfile)
   call ESMF_ConfigGetAttribute(LVT_config,LVT_rc%statsodir,&
        label="Metrics output directory:",&
        rc=rc)
-
-  call ESMF_ConfigGetAttribute(LVT_config, LVT_rc%nensem,&
-       label="Number of ensembles in the LVT analysis:", default=1, rc=rc)
-  
-  call ESMF_ConfigGetAttribute(LVT_config, LVT_rc%noebal_refet,&
-       label="Calculate reference ET without energy balance:", default=0, rc=rc)
-
-  if(rc.ne.0) then 
+  if(rc.ne.0) then
      write(LVT_logunit,*) "[INFO] Please note that the option 'Stats output directory:' is"
      write(LVT_logunit,*) "[INFO] now deprecated. It should be replaced with the"
      write(LVT_logunit,*) "[INFO] entry - 'Metrics output directory:' in the lvt.config file"
@@ -455,6 +448,11 @@ subroutine LVT_readConfig(configfile)
   endif
   call LVT_verify(rc,'Metrics output directory: not defined')
 
+  call ESMF_ConfigGetAttribute(LVT_config, LVT_rc%nensem,&
+       label="Number of ensembles in the LVT analysis:", default=1, rc=rc)
+  
+  call ESMF_ConfigGetAttribute(LVT_config, LVT_rc%noebal_refet,&
+       label="Calculate reference ET without energy balance:", default=0, rc=rc)
 
   if(LVT_rc%runmode.eq.LVT_DataCompId) then 
 


### PR DESCRIPTION
The check to see if the 'Metrics output directory:' option was
successfully read in occurs after two other configuration options
are read in by the program, which results in a check on the wrong
option.

This fix just reorders the subroutine calls so that the check is
directly after the subroutine call that reads in the 'Metrics
output directory:' option.

Resolves: #374 