### PR TITLE
"divided by zero" issue of Noah3.9 has been fixed.

### DIFF
--- a/lis/surfacemodels/land/noah.3.9/phys/module_sf_noah39lsm.F90
+++ b/lis/surfacemodels/land/noah.3.9/phys/module_sf_noah39lsm.F90
@@ -3848,7 +3848,12 @@ CONTAINS
 ! FROZEN GROUND VERSION:
 ! REDUCTION OF INFILTRATION BASED ON FROZEN GROUND PARAMETERS
 ! ----------------------------------------------------------------------
-         INFMAX = (PX * (DDT / (PX + DDT)))/ DT
+         if ((PX + DDT) == 0) then
+            INFMAX = 0
+         else
+            INFMAX = (PX * (DDT / (PX + DDT)))/ DT
+         endif
+
          FCR = 1.
          IF (DICE >  1.E-2) THEN
             ACRT = CVFRZ * FRZX / DICE


### PR DESCRIPTION
Noah.3.9 has encountered an "divided by zero" issue when ensemble run (with soil moisture data assimilation) was tried. I temporary fixed it, but it needs to be double checked later.  