### PR TITLE
Document changes to original Noah 3.9 physics

### DIFF
--- a/lis/surfacemodels/land/noah.3.9/phys/module_sf_noah39lsm.F90
+++ b/lis/surfacemodels/land/noah.3.9/phys/module_sf_noah39lsm.F90
@@ -3848,6 +3848,7 @@ CONTAINS
 ! FROZEN GROUND VERSION:
 ! REDUCTION OF INFILTRATION BASED ON FROZEN GROUND PARAMETERS
 ! ----------------------------------------------------------------------
+         ! Prevent divide-by-zero [Yonghwan Kwon 10/16/2019]
          if ((PX + DDT) == 0) then
             INFMAX = 0
          else


### PR DESCRIPTION
Yonghwan Kwon prevented a divide-by-zero error in original Noah 3.9 physics.