### PR TITLE
Remove redundant assignment to precip_regrid

### DIFF
--- a/lis/metforcing/mrms/read_mrms_grib.F90
+++ b/lis/metforcing/mrms/read_mrms_grib.F90
@@ -89,9 +89,6 @@ subroutine read_mrms_grib( n, fname, findex, order, yr, mo, da, ferror_mrms_grib
      mrms_grib_struc(n)%metdata2 = LIS_rc%udef
   endif
 
-!-- Set necessary parameters for call to interp_mrms_grib   
-  precip_regrid = LIS_rc%udef
-
 !-- Check initially if file exists:
   inquire (file=fname, exist=file_exists ) ! Check if file exists
   if (.not. file_exists)  then 


### PR DESCRIPTION
precip_regrid was being set to LIS_rc%udef before it was allocated.
This caused LIS, compiled with the GNU compilers (version 7.3), to hang.
Further down in the routine, precip_regrid is allocated and then set
to LIS_rc%udef.

Resolves: #381