### PR TITLE
Add missing output variables/units to LIS Noah-MP-4.0.1 LSM

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
@@ -14,6 +14,8 @@
 !
 !   10/25/18: Shugong Wang, Zhuo Wang; initial implementation for NoahMP401 with LIS-7
 !   05/15/19: Yeosang Yoon; code added for snow DA to work
+!   10/29/19: David Mocko; Added RELSMC to output, and an option
+!                          for different units for Qs/Qsb/Albedo
 !
 ! !INTERFACE:
 subroutine NoahMP401_main(n)
@@ -33,6 +35,7 @@ subroutine NoahMP401_main(n)
     integer              :: i
     real                 :: dt
     real                 :: lat, lon
+    real                 :: tempval
     integer              :: row, col
     integer              :: year, month, day, hour, minute, second
     logical              :: alarmCheck
@@ -220,6 +223,7 @@ subroutine NoahMP401_main(n)
     real                 :: tmp_qsnbot             ! melting water out of snow bottom [kg m-2 s-1]
     real                 :: tmp_subsnow            ! snow sublimation rate [kg m-2 s-1]
     real                 :: tmp_pah                ! precipitation advected heat - total (W/m2)
+    real, allocatable    :: tmp_relsmc(:)          ! relative soil moisture [-]
 
     ! Code added by Zhuo Wang 02/28/2019
     real                 :: AvgSurfT_out           ! average surface temperature [K]
@@ -233,6 +237,7 @@ subroutine NoahMP401_main(n)
     allocate( tmp_smc( NOAHMP401_struc(n)%nsoil ) )
     allocate( tmp_sh2o( NOAHMP401_struc(n)%nsoil ) )
     allocate( tmp_tslb( NOAHMP401_struc(n)%nsoil ) )
+    allocate( tmp_relsmc( NOAHMP401_struc(n)%nsoil ) )
     allocate( tmp_tsno( NOAHMP401_struc(n)%nsnow ) )
     allocate( tmp_zss( NOAHMP401_struc(n)%nsnow+NOAHMP401_struc(n)%nsoil) )
     allocate( tmp_snowice( NOAHMP401_struc(n)%nsnow ) )
@@ -643,7 +648,8 @@ subroutine NoahMP401_main(n)
                                    tmp_chleaf            , & ! out   - leaf exchange coefficient [-]
                                    tmp_chuc              , & ! out   - under canopy exchange coefficient [-]
                                    tmp_chv2              , & ! out   - veg 2m exchange coefficient [-]
-                                   tmp_chb2              )   ! out   - bare 2m exchange coefficient [-]
+                                   tmp_chb2              , & ! out   - bare 2m exchange coefficient [-]
+                                   tmp_relsmc            )   ! out   - relative soil moisture [-]
 
             ! save state variables from local variables to global variables
             NOAHMP401_struc(n)%noahmp401(t)%sfcrunoff       = tmp_sfcrunoff
@@ -779,6 +785,11 @@ subroutine NoahMP401_main(n)
             ![ 5] output variable: albedo (unit=- ). ***  total grid albedo
             call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_ALBEDO, value = NOAHMP401_struc(n)%noahmp401(t)%albedo, &
                                               vlevel=1, unit="-", direction="-", surface_type = LIS_rc%lsm_index)
+
+            if (tmp_albedo.ne.LIS_rc%udef) tmp_albedo = tmp_albedo * 100.0
+
+            call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_ALBEDO, value = tmp_albedo, &
+                                              vlevel=1, unit="%", direction="-", surface_type = LIS_rc%lsm_index)
 
             ![ 6] output variable: snowc (unit=-). ***  snow cover fraction
             call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_SNOWCOVER, value = NOAHMP401_struc(n)%noahmp401(t)%snowc, &
@@ -991,9 +1002,15 @@ subroutine NoahMP401_main(n)
             call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_QS, value = NOAHMP401_struc(n)%noahmp401(t)%runsf, &
                                               vlevel=1, unit="kg m-2 s-1", direction="OUT", surface_type = LIS_rc%lsm_index)
 
+            call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_QS, value = NOAHMP401_struc(n)%noahmp401(t)%runsf*dt, &
+                                              vlevel=1, unit="kg m-2", direction="OUT", surface_type = LIS_rc%lsm_index)
+
             ![ 54] output variable: runsb (unit=mm/s ). ***  baseflow (saturation excess)
             call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_QSB, value = NOAHMP401_struc(n)%noahmp401(t)%runsb, &
                                               vlevel=1, unit="kg m-2 s-1", direction="OUT", surface_type = LIS_rc%lsm_index)
+
+            call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_QSB, value = NOAHMP401_struc(n)%noahmp401(t)%runsb*dt, &
+                                              vlevel=1, unit="kg m-2", direction="OUT", surface_type = LIS_rc%lsm_index)
 
             ![ 55] output variable: ecan (unit=mm/s ). ***  evaporation of intercepted water
             call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_ECANOP, value = NOAHMP401_struc(n)%noahmp401(t)%ecan, &
@@ -1213,6 +1230,31 @@ subroutine NoahMP401_main(n)
                             startgw),                                  &
                      vlevel=1,unit="kg m-2",direction="INC",           &
                      surface_type=LIS_rc%lsm_index)
+
+! David Mocko (10/29/2019) - Copy RELSMC calculation from Noah-3.X
+           do i = 1,tmp_nsoil
+              if (tmp_relsmc(i).gt.1.0) then
+                 tmp_relsmc(i) = 1.0
+              endif
+              if (tmp_relsmc(i).lt.0.01) then
+                 tmp_relsmc(i) = 0.01
+              endif
+
+! J.Case (9/11/2014) -- Set relative soil moisture to missing (LIS_rc%udef)
+! if the vegetation type is urban class.
+              if (tmp_vegetype.eq.tmp_urban_vegetype) then
+                 tmp_relsmc(i) = LIS_rc%udef
+              endif
+              call LIS_diagnoseSurfaceOutputVar(n,t,LIS_MOC_RELSMC,vlevel=i, &
+                       value=tmp_relsmc(i),unit='-',direction="-",surface_type=LIS_rc%lsm_index)
+              if (tmp_relsmc(i).eq.LIS_rc%udef) then
+                 tempval = tmp_relsmc(i)
+              else
+                 tempval = tmp_relsmc(i)*100.0
+              endif
+              call LIS_diagnoseSurfaceOutputVar(n,t,LIS_MOC_RELSMC,vlevel=i, &
+                       value=tempval,unit='%',direction="-",surface_type=LIS_rc%lsm_index)
+            enddo
 
             ! reset forcing variables to zeros
             NOAHMP401_struc(n)%noahmp401(t)%tair = 0.0

--- a/lis/surfacemodels/land/noahmp.4.0.1/noahmp_driver_401.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/noahmp_driver_401.F90
@@ -47,7 +47,7 @@ subroutine noahmp_driver_401(n, ttile, itimestep, &
                             bgap    , wgap    , tgb     , tgv     , chv     , chb     , & ! out Noah MP only
                             shg     , shc     , shb     , evg     , evb     , ghv     , & ! out Noah MP only
                             ghb     , irg     , irc     , irb     , tr      , evc     , & ! out Noah MP only
-                            chleaf  , chuc    , chv2    , chb2                          ) ! out Noah MP only
+                            chleaf  , chuc    , chv2    , chb2    , relsmc              ) ! out Noah MP only
 
   use module_sf_noahmpdrv_401, only: noahmplsm_401
   use LIS_coreMod, only    : LIS_rc
@@ -243,6 +243,7 @@ subroutine noahmp_driver_401(n, ttile, itimestep, &
   real, intent(out) :: chuc                   ! under canopy exchange coefficient 
   real, intent(out) :: chv2                   ! veg 2m exchange coefficient
   real, intent(out) :: chb2                   ! bare 2m exchange coefficient
+  real, intent(out) :: relsmc(nsoil)          ! relative soil moisture [-]
 
 ! real, intent(inout) :: sfcheadrt,INFXSRT,soldrain   ! for WRF-Hydro
 !--------------------------------------------------------------------------------
@@ -440,6 +441,7 @@ subroutine noahmp_driver_401(n, ttile, itimestep, &
   real, dimension(1,1) :: chucout
   real, dimension(1,1) :: chv2out
   real, dimension(1,1) :: chb2out
+  real, dimension(1,nsoil,1) :: relsmcout
   real, dimension(1,1) :: rsout
 
    ids = 1
@@ -691,6 +693,7 @@ subroutine noahmp_driver_401(n, ttile, itimestep, &
   chucout(1,1)  = chuc
   chv2out(1,1)  = chv2
   chb2out(1,1)  = chb2
+  relsmcout(1,:,1)  = relsmc(:)
   rsout(1,1)    = rs
 
 ! Code from module_NoahMP_hrldas_driver.F.  Initial guess only.
@@ -731,7 +734,7 @@ subroutine noahmp_driver_401(n, ttile, itimestep, &
                        pgsinout     ,                                                   & ! in/out Noah MP only
                        gecros_stateinout,                                               & ! in/out gecros model
 
-                       t2mvout , t2mbout , q2mvout , q2mbout ,                     & ! out Noah MP only
+                       t2mvout , t2mbout , q2mvout , q2mbout , relsmcout,          & ! out Noah MP only
                        tradout , neeout  , gppout  , nppout  , fvegout , runsfout, & ! out Noah MP only
                        runsbout, ecanout , edirout , etranout, fsaout  , firaout , & ! out Noah MP only
                        aparout , psnout  , savout  , sagout  , rssunout, rsshaout, & ! out Noah MP only
@@ -858,6 +861,7 @@ subroutine noahmp_driver_401(n, ttile, itimestep, &
   chuc = chucout(1,1)
   chv2 = chv2out(1,1)
   chb2 = chb2out(1,1)
+  relsmc(:) = relsmcout(1,:,1)
   rs = rsout(1,1)
 
   rainf = prcp * (1.0 - fpice)/dt  ! added by Shugong for LIS output 

--- a/lis/surfacemodels/land/noahmp.4.0.1/phys/module_sf_noahmpdrv_401.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/phys/module_sf_noahmpdrv_401.F90
@@ -35,7 +35,7 @@ CONTAINS
 	        WOODXY, STBLCPXY, FASTCPXY,    XLAIXY,   XSAIXY,   TAUSSXY, & ! IN/OUT Noah MP only
 	       SMOISEQ, SMCWTDXY,DEEPRECHXY,   RECHXY,  GRAINXY,    GDDXY,PGSXY,  & ! IN/OUT Noah MP only
                GECROS_STATE,                                                & ! IN/OUT gecros model
-	        T2MVXY,   T2MBXY,    Q2MVXY,   Q2MBXY,                      & ! OUT Noah MP only
+	        T2MVXY,   T2MBXY,    Q2MVXY,   Q2MBXY, RELSMCXY,            & ! OUT Noah MP only
 	        TRADXY,    NEEXY,    GPPXY,     NPPXY,   FVEGXY,   RUNSFXY, & ! OUT Noah MP only
 	       RUNSBXY,   ECANXY,   EDIRXY,   ETRANXY,    FSAXY,    FIRAXY, & ! OUT Noah MP only
 	        APARXY,    PSNXY,    SAVXY,     SAGXY,  RSSUNXY,   RSSHAXY, & ! OUT Noah MP only
@@ -267,6 +267,7 @@ CONTAINS
     REAL,    DIMENSION( ims:ime,          jms:jme ), INTENT(OUT  ) ::  CHUCXY    ! under canopy exchange coefficient 
     REAL,    DIMENSION( ims:ime,          jms:jme ), INTENT(OUT  ) ::  CHV2XY    ! veg 2m exchange coefficient 
     REAL,    DIMENSION( ims:ime,          jms:jme ), INTENT(OUT  ) ::  CHB2XY    ! bare 2m exchange coefficient 
+    REAL,    DIMENSION( ims:ime, 1:nsoil, jms:jme ), INTENT(OUT  ) ::  RELSMCXY  ! relative soil moisture [-]
     REAL,    INTENT(OUT) :: FPICE                                                ! snow fraction of precip
     INTEGER,  INTENT(IN   )   ::     ids,ide, jds,jde, kds,kde,  &  ! d -> domain
          &                           ims,ime, jms,jme, kms,kme,  &  ! m -> memory
@@ -406,6 +407,7 @@ CONTAINS
     REAL                                :: CHUC         ! under canopy exchange coefficient 
     REAL                                :: CHV2         ! veg 2m exchange coefficient 
     REAL                                :: CHB2         ! bare 2m exchange coefficient 
+    REAL,   DIMENSION( 1:NSOIL)         :: RELSMC       ! relative soil moisture [-]
   REAL   :: PAHV    !precipitation advected heat - vegetation net (W/m2)
   REAL   :: PAHG    !precipitation advected heat - under canopy net (W/m2)
   REAL   :: PAHB    !precipitation advected heat - bare ground net (W/m2)
@@ -844,6 +846,7 @@ CONTAINS
          Z0WRF  = 0.002
          QFX(I,J) = ESOIL
          LH (I,J) = FGEV
+         RELSMC = 1.0
 
         ELSE
 
@@ -870,7 +873,7 @@ CONTAINS
             Z0WRF   ,                                                   &
             FSA     , FSR     , FIRA    , FSH     , SSOIL   , FCEV    , & ! OUT : 
             FGEV    , FCTR    , ECAN    , ETRAN   , ESOIL   , TRAD    , & ! OUT : 
-            SUBSNOW ,                                                   & ! OUT : 
+            SUBSNOW , RELSMC  ,                                       & ! OUT : 
             TGB     , TGV     , T2MV    , T2MB    , Q2MV    , Q2MB    , & ! OUT : 
             RUNSF   , RUNSB   , APAR    , PSN     , SAV     , SAG     , & ! OUT : 
             FSNO    , NEE     , GPP     , NPP     , FVEGMP  , SALB    , & ! OUT : 
@@ -1020,6 +1023,7 @@ CONTAINS
              CHUCXY   (I,J)                = CHUC
              CHV2XY   (I,J)                = CHV2
              CHB2XY   (I,J)                = CHB2
+             RELSMCXY (I,      1:NSOIL,J)  = RELSMC   (      1:NSOIL)
              RECHXY   (I,J)                = RECHXY(I,J) + RECH*1.E3 !RECHARGE TO THE WATER TABLE
              DEEPRECHXY(I,J)               = DEEPRECHXY(I,J) + DEEPRECH
              SMCWTDXY(I,J)                 = SMCWTD

--- a/lis/surfacemodels/land/noahmp.4.0.1/phys/module_sf_noahmplsm_401.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/phys/module_sf_noahmplsm_401.F90
@@ -372,7 +372,7 @@ contains
 		   Z0WRF   , &
                    FSA     , FSR     , FIRA    , FSH     , SSOIL   , FCEV    , & ! OUT : 
                    FGEV    , FCTR    , ECAN    , ETRAN   , EDIR    , TRAD    , & ! OUT :
-                   SUBSNOW ,                                                   & ! OUT :
+                   SUBSNOW , RELSMC  ,                                         & ! OUT :
                    TGB     , TGV     , T2MV    , T2MB    , Q2V     , Q2B     , & ! OUT :
                    RUNSRF  , RUNSUB  , APAR    , PSN     , SAV     , SAG     , & ! OUT :
                    FSNO    , NEE     , GPP     , NPP     , FVEG    , ALBEDO  , & ! OUT :
@@ -494,6 +494,7 @@ contains
   REAL                           , INTENT(OUT)   :: ETRAN  !transpiration rate (mm/s)
   REAL                           , INTENT(OUT)   :: EDIR   !soil surface evaporation rate (mm/s]
   REAL                           , INTENT(OUT)   :: SUBSNOW !snow sublimation rate (mm/s)
+  REAL, DIMENSION(       1:NSOIL), INTENT(OUT)   :: RELSMC !relative soil moisture [-]
   REAL                           , INTENT(OUT)   :: RUNSRF !surface runoff [mm/s] 
   REAL                           , INTENT(OUT)   :: RUNSUB !baseflow (saturation excess) [mm/s]
   REAL                           , INTENT(OUT)   :: PSN    !total photosynthesis (umol co2/m2/s) [+]
@@ -836,6 +837,10 @@ contains
       ALBEDO = -999.9
     END IF
     
+! David Mocko - Added RELSMC after Noah-3.X code
+    RELSMC(:) = (SMC(:)               - parameters%SMCWLT(:)) /        &
+                (parameters%SMCMAX(:) - parameters%SMCWLT(:))
+
   END SUBROUTINE NOAHMP_SFLX
 
 !== begin atm ======================================================================================


### PR DESCRIPTION
This commit adds some missing output variables or units to the
output of the Noah-MP-4.0.1 LSM in LIS.  Added are the option
to output Qs/Qsb in units of [kg m-2], output Albedo in units
of [%], and the new output of RelSMC (relative soil moisture).

The RelSMC code was borrowed from its calculation in Noah-3.X
LSMs within LIS.

Resolves: #389