### PR TITLE
Fix RHMin calculation in Noah 3.9; add to NoahMP 4.0.1

### DIFF
--- a/lis/core/LIS_historyMod.F90
+++ b/lis/core/LIS_historyMod.F90
@@ -483,6 +483,8 @@ contains
 
     call LIS_rescaleCount(n,group_temp)
 
+    write(LIS_logunit,*)'[INFO] Writing to ',trim(lsmoutfile) ! EMK
+
     if(LIS_rc%wout.eq."binary") then 
        if(LIS_masterproc) then 
           open(ftn,file=lsmoutfile,form='unformatted')

--- a/lis/core/LIS_historyMod.F90
+++ b/lis/core/LIS_historyMod.F90
@@ -483,7 +483,8 @@ contains
 
     call LIS_rescaleCount(n,group_temp)
 
-    write(LIS_logunit,*)'[INFO] Writing to ',trim(lsmoutfile) ! EMK
+    write(LIS_logunit,*)'[INFO] Writing surface model output to:  ', &
+         trim(lsmoutfile) ! EMK
 
     if(LIS_rc%wout.eq."binary") then 
        if(LIS_masterproc) then 

--- a/lis/surfacemodels/land/noah.3.9/noah39_lsmMod.F90
+++ b/lis/surfacemodels/land/noah.3.9/noah39_lsmMod.F90
@@ -259,7 +259,7 @@ contains
 
        ! Initialize min/max values to implausible values.
        noah39_struc(n)%noah(:)%tair_agl_min = 999.0
-       noah39_struc(n)%noah(:)%tair_agl_min = 999.0
+       noah39_struc(n)%noah(:)%rhmin = 999.0
 
 
        noah39_struc(n)%z0brd_upd = 0 

--- a/lis/surfacemodels/land/noah.3.9/noah39_lsmMod.F90
+++ b/lis/surfacemodels/land/noah.3.9/noah39_lsmMod.F90
@@ -184,7 +184,7 @@ contains
     use LIS_surfaceModelDataMod, only : LIS_sfmodel_struc
     use LIS_timeMgrMod,   only : LIS_clock, LIS_calendar, &
          LIS_update_timestep, LIS_registerAlarm
-    use LIS_logMod,       only : LIS_verify
+    use LIS_logMod,       only : LIS_verify, LIS_logunit
 ! !DESCRIPTION:
 !
 !  This routine creates the datatypes and allocates memory for
@@ -245,12 +245,20 @@ contains
             noah39_struc(n)%ts,&
             noah39_struc(n)%rstInterval)
 
-       ! EMK Add alarm to reset tair_agl_min.  We will use 3 hours.
-       call LIS_registerAlarm("Noah39 RHMin alarm "//trim(fnest),&
-            noah39_struc(n)%ts,&
-            10800.)
+       ! EMK Add alarm to reset tair_agl_min for RHMin.  This should match the 
+       ! output interval, since that is used for calculating Tair_F_min.
+       call LIS_registerAlarm("Noah39 RHMin alarm "//trim(fnest), &
+            noah39_struc(n)%ts, &
+            LIS_sfmodel_struc(n)%outInterval)
+       if (LIS_sfmodel_struc(n)%outInterval .gt. 86400 .or. &
+            trim(LIS_sfmodel_struc(n)%outIntervalType) .eq. "dekad") then
+          write(LIS_logunit,*) &
+               '[WARN] If RHMin is selected for output, please reset ', &
+               'surface model output interval to no more than 24 hours.'
+       end if
 
        ! Initialize min/max values to implausible values.
+       noah39_struc(n)%noah(:)%tair_agl_min = 999.0
        noah39_struc(n)%noah(:)%tair_agl_min = 999.0
 
 

--- a/lis/surfacemodels/land/noah.3.9/noah39_lsmMod.F90
+++ b/lis/surfacemodels/land/noah.3.9/noah39_lsmMod.F90
@@ -245,6 +245,11 @@ contains
             noah39_struc(n)%ts,&
             noah39_struc(n)%rstInterval)
 
+       ! EMK Add alarm to reset tair_agl_min.  We will use 3 hours.
+       call LIS_registerAlarm("Noah39 RHMin alarm "//trim(fnest),&
+            noah39_struc(n)%ts,&
+            10800.)
+
        ! Initialize min/max values to implausible values.
        noah39_struc(n)%noah(:)%tair_agl_min = 999.0
 

--- a/lis/surfacemodels/land/noah.3.9/noah39_main.F90
+++ b/lis/surfacemodels/land/noah.3.9/noah39_main.F90
@@ -243,6 +243,7 @@ subroutine noah39_main(n)
   write(fnest,'(i3.3)') n
   alarmCheck = LIS_isAlarmRinging(LIS_rc,"Noah39 model alarm "//trim(fnest))
   if(alarmCheck) then
+
      ! Get Julian day of year
      call LIS_tbotTimeUtil(julian_in,yr)
      Bondvillecheck = .false.
@@ -1505,6 +1506,18 @@ subroutine noah39_main(n)
 !$OMP END PARALLEL 
      noah39_struc(n)%forc_count = 0 
   endif
+
+  ! EMK...See if noah39_struc(n)%noah(t)%tair_agl_min needs to be reset
+  ! for calculating RHMin.  
+  write(fnest,'(i3.3)') n
+  alarmCheck = LIS_isAlarmRinging(LIS_rc,"Noah39 RHMin alarm "//trim(fnest))
+  if (alarmCheck) then
+     write(LIS_logunit,*)'[INFO] Resetting tair_agl_min for RHMin calculation'
+     do t = 1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+        noah39_struc(n)%noah(t)%tair_agl_min = 999.
+     end do
+  end if
+
 end subroutine noah39_main
 
 !

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_lsmMod.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_lsmMod.F90
@@ -217,7 +217,7 @@ contains
     subroutine NoahMP401_ini()
 ! !USES:
         use LIS_coreMod, only : LIS_rc
-        use LIS_logMod, only : LIS_verify
+        use LIS_logMod, only : LIS_verify, LIS_logunit
         use LIS_timeMgrMod, only : LIS_clock,  LIS_calendar, &
             LIS_update_timestep, LIS_registerAlarm
         use LIS_surfaceModelDataMod, only : LIS_sfmodel_struc
@@ -297,13 +297,23 @@ contains
                                    NOAHMP401_struc(n)%ts,&
                                    NOAHMP401_struc(n)%rstInterval)
             
-            ! EMK Add alarm to reset tair_agl_min.  We will use 3 hours.
+            ! EMK Add alarm to reset tair_agl_min for RHMin.  This should 
+            ! match the output interval, since that is used for calculating 
+            ! Tair_F_min.            
             write(fnest,'(i3.3)') n
             call LIS_registerAlarm("NoahMP401 RHMin alarm "//trim(fnest),&
                  NOAHMP401_struc(n)%ts,&
-                 10800.)
+                 LIS_sfmodel_struc(n)%outInterval)
+            if (LIS_sfmodel_struc(n)%outInterval .gt. 86400 .or. &
+                 trim(LIS_sfmodel_struc(n)%outIntervalType) .eq. "dekad") then
+               write(LIS_logunit,*) &
+                    '[WARN] If RHMin is selected for output, please reset ', &
+                    'surface model output interval to no more than 24 hours.'
+            end if
+
             ! Initialize min/max values to implausible values.
             NOAHMP401_struc(n)%noahmp401(:)%tair_agl_min = 999.0
+            NOAHMP401_struc(n)%noahmp401(:)%rhmin = 999.0
 
             !------------------------------------------------------------------------
             ! TODO: setup number of soil moisture/temperature layers and depth here  

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_lsmMod.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_lsmMod.F90
@@ -236,6 +236,7 @@ contains
         implicit none        
         integer  :: n, t     
         integer  :: status   
+        character*3 :: fnest ! EMK for RHMin
 
         ! allocate memory for nest 
         allocate(NOAHMP401_struc(LIS_rc%nnest))
@@ -295,6 +296,15 @@ contains
             call LIS_registerAlarm("NoahMP401 restart alarm", &
                                    NOAHMP401_struc(n)%ts,&
                                    NOAHMP401_struc(n)%rstInterval)
+            
+            ! EMK Add alarm to reset tair_agl_min.  We will use 3 hours.
+            write(fnest,'(i3.3)') n
+            call LIS_registerAlarm("NoahMP401 RHMin alarm "//trim(fnest),&
+                 NOAHMP401_struc(n)%ts,&
+                 10800.)
+            ! Initialize min/max values to implausible values.
+            NOAHMP401_struc(n)%noahmp401(:)%tair_agl_min = 999.0
+
             !------------------------------------------------------------------------
             ! TODO: setup number of soil moisture/temperature layers and depth here  
             !------------------------------------------------------------------------

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_module.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_module.F90
@@ -489,5 +489,9 @@ module NoahMP401_module
         real               :: chv2
         real               :: chb2
 
+        !EMK for 557WW
+        real :: tair_agl_min
+        real :: rhmin
+
     end type noahmp401dec
 end module NoahMP401_module


### PR DESCRIPTION
Changed code to reset minimum air temperature threshold for RHMin every 3 hours in Noah 3.9.  Added RHMin to NoahMP 4.0.1.

This will allow RHMin to be calculated every three hours even if a long-term simulation is made.  Previously the temperature threshold (and RHMin) was only updated when a colder air temperature was encountered, which could lead to wrong answers.