### PR TITLE
Add snowcover output in percentage for LIS Noah-MP-4.0.1 LSM

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
@@ -819,6 +819,9 @@ subroutine NoahMP401_main(n)
             call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_SNOWCOVER, value = NOAHMP401_struc(n)%noahmp401(t)%snowc, &
                                               vlevel=1, unit="-", direction="-", surface_type = LIS_rc%lsm_index)
 
+            call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_SNOWCOVER, value = (NOAHMP401_struc(n)%noahmp401(t)%snowc*100.0), &
+                                              vlevel=1, unit="%", direction="-", surface_type = LIS_rc%lsm_index)
+
             ![ 7] output variable: smc (unit=m3/m3). ***  volumetric soil moisture
             do i=1, NOAHMP401_struc(n)%nsoil
                 call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_SOILMOIST, value = NOAHMP401_struc(n)%noahmp401(t)%smc(i), &


### PR DESCRIPTION
This commit adds the ability of snowcover to be output in units
of [%] (percentage) for the Noah-MP-4.0.1 LSM in LIS.  Previously,
only units of [fraction] were possible with this LSM.

Resolves: #399