### PR TITLE
Fix/410 ldtbuffer

### DIFF
--- a/ldt/core/LDT_SurfaceTypeMod.F90
+++ b/ldt/core/LDT_SurfaceTypeMod.F90
@@ -556,11 +556,10 @@ contains
    integer :: c, r, t, l, i
 
    if( LDT_rc%waterclass == 0. ) then
-     write(*,*) "[ERR] No water class for associated landcover ..."
-     write(*,*) " Stopping for now until solution entered."
+     write(LDT_logunit,*) "[ERR] No water class for associated landcover ..."
+     write(LDT_logunit,*) " Stopping for now until solution entered."
      call LDT_endrun
    endif
-
    write(LDT_logunit,fmt=*) '[INFO] SURFACETYPE -- Assigning openwater surface types'
 
    openwaterfgrd = 0.

--- a/ldt/core/LDT_SurfaceTypeMod.F90
+++ b/ldt/core/LDT_SurfaceTypeMod.F90
@@ -556,7 +556,7 @@ contains
    integer :: c, r, t, l, i
 
    if( LDT_rc%waterclass == 0. ) then
-     write(*,*) "No water class for associated landcover ...."
+     write(*,*) "[ERR] No water class for associated landcover ..."
      write(*,*) " Stopping for now until solution entered."
      call LDT_endrun
    endif

--- a/ldt/core/LDT_domainMod.F90
+++ b/ldt/core/LDT_domainMod.F90
@@ -1269,7 +1269,7 @@ end subroutine LDT_timeInit
      ! Locals
      integer :: c, r, t, m, mm, tt
      real    :: maxv
-     real :: model_type_fractions(LDT_rc%max_model_types)
+     real    :: model_type_fractions(LDT_rc%max_model_types)
 
      ! Sanity check
      if (maxt > 1) then
@@ -1520,7 +1520,6 @@ end subroutine LDT_timeInit
              if(rsum.lt.0.9999.or.rsum.gt.1.0001)then  !check renormalization
                 write(LDT_logunit,*) &
                      'Renormalization failed in calculate_domdistribution'
-!                print*, c,r,fgrd(c,r,:)
                 call LDT_endrun()
              endif
           endif

--- a/ldt/core/LDT_gridmappingMod.F90
+++ b/ldt/core/LDT_gridmappingMod.F90
@@ -136,7 +136,7 @@ contains
    lisdom_max_lat = min((rlat(LDT_rc%lnc(n),LDT_rc%lnr(n))+(5*lisdom_yres_ll)),90.0)
 
    ! Account for crossing IDL:
-   if( rlon(LDT_rc%lnc(n),LDT_rc%lnr(n)) >= rlon(1,1) ) then
+   if( rlon(1,1) <= rlon(LDT_rc%lnc(n),LDT_rc%lnr(n)) ) then
      lisdom_min_lon = max((rlon(1,1)-(5*lisdom_xres_ll)),-180.0)
      lisdom_max_lon = min((rlon(LDT_rc%lnc(n),LDT_rc%lnr(n))+(5*lisdom_xres_ll)),180.0)
    else  
@@ -388,7 +388,6 @@ contains
                               rlat(c,r), rlon(c,r) )
            lat_line(c,r) = nint((rlat(c,r)-param_grid(4))/param_grid(10))+1
            lon_line(c,r) = nint((rlon(c,r)-param_grid(5))/param_grid(9))+1
-!           lon_line(c,r) = nint(diff_lon(rlon(c,r),param_grid(5))/param_grid(9))+1
         enddo
      enddo
      deallocate(rlat,rlon)

--- a/ldt/core/LDT_gridmappingMod.F90
+++ b/ldt/core/LDT_gridmappingMod.F90
@@ -122,13 +122,8 @@ contains
    enddo
 
 !- Set bounding points for LIS run domain for subsetting step:
-  ! Fixed code below to address IDL issue ...
-!   lisdom_min_lat = rlat(1,1)
-!   lisdom_min_lon = rlon(1,1)
-!   lisdom_max_lat = rlat(LDT_rc%lnc(n),LDT_rc%lnr(n))
-!   lisdom_max_lon = rlon(LDT_rc%lnc(n),LDT_rc%lnr(n))
 
-!- Calculate LIS run domain corner point resolutions: 
+   ! Calculate LIS run domain corner point resolutions: 
    lisdom_xres_ll = abs(rlon(2,1)-rlon(1,1))
    lisdom_yres_ll = abs(rlat(1,2)-rlat(1,1))
    lisdom_xres_ur = abs(rlon(LDT_rc%lnc(n),  LDT_rc%lnr(n))  &
@@ -394,8 +389,6 @@ contains
            lat_line(c,r) = nint((rlat(c,r)-param_grid(4))/param_grid(10))+1
            lon_line(c,r) = nint((rlon(c,r)-param_grid(5))/param_grid(9))+1
 !           lon_line(c,r) = nint(diff_lon(rlon(c,r),param_grid(5))/param_grid(9))+1
-
-!           write(600,*) c, r, rlon(c,r), rlat(c,r), lon_line(c,r), lat_line(c,r)  ! KRA
         enddo
      enddo
      deallocate(rlat,rlon)

--- a/ldt/core/LDT_gridmappingMod.F90
+++ b/ldt/core/LDT_gridmappingMod.F90
@@ -14,6 +14,7 @@ module LDT_gridmappingMod
 !  10 Jul 2012;  Kristi Arsenault;  Initial Specification
 !  10 Feb 2014;  Kristi Arsenault;  Updated routines to include add. options
 !  14 Aug 2019;  Kristi Arsenault;  Updated to account for crossing IDL
+!  21 Nov 2019;  Kristi Arsenault;  Add buffer to target domain for subsetting
 ! 
   implicit none
   PRIVATE
@@ -50,7 +51,7 @@ contains
    integer, intent(out)     :: subparam_nc, subparam_nr
    integer, allocatable, intent(out) :: lat_line(:,:)
    integer, allocatable, intent(out) :: lon_line(:,:)
-
+!
 ! !DESCRIPTION: 
 !  This subroutine creates the input parameter grid information
 !  required for reading in just a subsetted or the full global
@@ -58,6 +59,7 @@ contains
 !
 ! REVISION HISTORY:
 !  13FEB2014 -- K.R. Arsenault: Initial Specification
+!  13NOV2019 -- K.R. Arsenault: Added new buffer for LIS domain
 ! 
 !EOP      
    type(proj_info)  :: subset_paramproj
@@ -119,10 +121,12 @@ contains
       enddo
    enddo
 
-   lisdom_min_lat = rlat(1,1)
-   lisdom_min_lon = rlon(1,1)
-   lisdom_max_lat = rlat(LDT_rc%lnc(n),LDT_rc%lnr(n))
-   lisdom_max_lon = rlon(LDT_rc%lnc(n),LDT_rc%lnr(n))
+!- Set bounding points for LIS run domain for subsetting step:
+  ! Fixed code below to address IDL issue ...
+!   lisdom_min_lat = rlat(1,1)
+!   lisdom_min_lon = rlon(1,1)
+!   lisdom_max_lat = rlat(LDT_rc%lnc(n),LDT_rc%lnr(n))
+!   lisdom_max_lon = rlon(LDT_rc%lnc(n),LDT_rc%lnr(n))
 
 !- Calculate LIS run domain corner point resolutions: 
    lisdom_xres_ll = abs(rlon(2,1)-rlon(1,1))
@@ -131,6 +135,19 @@ contains
                   - rlon(LDT_rc%lnc(n)-1,LDT_rc%lnr(n)) )
    lisdom_yres_ur = abs(rlat(LDT_rc%lnc(n),  LDT_rc%lnr(n))  &
                   - rlat(LDT_rc%lnc(n),  LDT_rc%lnr(n)-1) )
+
+   ! Incorporate buffer for target grid (e.g., helps with curvilinear projections)
+   lisdom_min_lat = max((rlat(1,1)-(5*lisdom_yres_ll)),-90.0)
+   lisdom_max_lat = min((rlat(LDT_rc%lnc(n),LDT_rc%lnr(n))+(5*lisdom_yres_ll)),90.0)
+
+   ! Account for crossing IDL:
+   if( rlon(LDT_rc%lnc(n),LDT_rc%lnr(n)) >= rlon(1,1) ) then
+     lisdom_min_lon = max((rlon(1,1)-(5*lisdom_xres_ll)),-180.0)
+     lisdom_max_lon = min((rlon(LDT_rc%lnc(n),LDT_rc%lnr(n))+(5*lisdom_xres_ll)),180.0)
+   else  
+     lisdom_min_lon = max((rlon(1,1)-(5*lisdom_xres_ll)),0.0)
+     lisdom_max_lon = min((rlon(LDT_rc%lnc(n),LDT_rc%lnr(n))+(5*lisdom_xres_ll)),0.0)
+   endif
 
 ! -------------------------------------------------------------
 !  Select Parameter File Projection Type
@@ -165,10 +182,11 @@ contains
           elseif( param_grid(9) < (LDT_rc%gridDesc(n,9)/LDT_rc%lis_map_resfactor)) then
              subparm_lllat_ext = lisdom_min_lat - (lisdom_yres_ll/2.) + &
                   (param_grid(10)/2.0)
-             subparm_lllon_ext = lisdom_min_lon - (lisdom_xres_ll/2.) + &
-                  (param_grid(9)/2.0)
              subparm_urlat_ext = lisdom_max_lat + (lisdom_yres_ur/2.) - &
                   (param_grid(10)/2.0)
+
+             subparm_lllon_ext = lisdom_min_lon - (lisdom_xres_ll/2.) + &
+                  (param_grid(9)/2.0)
              subparm_urlon_ext = lisdom_max_lon + (lisdom_xres_ur/2.) - &
                   (param_grid(9)/2.0)
 
@@ -178,6 +196,7 @@ contains
              subparm_urlat_ext = param_grid(7)
              subparm_lllon_ext = param_grid(5)
              subparm_urlon_ext = param_grid(8)
+
           endif
  
    !- Lambert conformal LIS run domain:
@@ -375,6 +394,8 @@ contains
            lat_line(c,r) = nint((rlat(c,r)-param_grid(4))/param_grid(10))+1
            lon_line(c,r) = nint((rlon(c,r)-param_grid(5))/param_grid(9))+1
 !           lon_line(c,r) = nint(diff_lon(rlon(c,r),param_grid(5))/param_grid(9))+1
+
+!           write(600,*) c, r, rlon(c,r), rlat(c,r), lon_line(c,r), lat_line(c,r)  ! KRA
         enddo
      enddo
      deallocate(rlat,rlon)
@@ -422,7 +443,7 @@ contains
      subparam_gridDesc(10) = param_grid(10)
      subparam_gridDesc(11) = 64.
      subparam_gridDesc(20) = 64.
-  
+
      ! Set up map_set parameter array ...
 !    subset_paramproj = LDT_domain(n)%ldtproj
      call map_set( PROJ_GAUSS, subparam_gridDesc(4), subparam_gridDesc(5), &

--- a/ldt/core/LDT_topoMod.F90
+++ b/ldt/core/LDT_topoMod.F90
@@ -188,7 +188,7 @@ contains
       else
          write(LDT_logunit,*) "[ERR] Fill option for Elevation is not valid: ",trim(elev%filltype)
          write(LDT_logunit,*) "  Please select one of these:  none, neighbor or average "
-         write(LDT_logunit,*) "  Programming stopping ..."
+         write(LDT_logunit,*) "  Program stopping ..."
          call LDT_endrun
       end if
 

--- a/ldt/domains/latlon/readinput_latlon.F90
+++ b/ldt/domains/latlon/readinput_latlon.F90
@@ -148,8 +148,8 @@ subroutine readinput_latlon
         call LDT_endrun
      endif
      if(LDT_rc%gridDesc(n,8).lt.LDT_rc%gridDesc(n,5)) then
-        write(LDT_logunit,*) '[ERR] lon2 should  be greater than lon1 ...'
-        write(LDT_logunit,*) LDT_rc%gridDesc(n,8),LDT_rc%gridDesc(n,5)
+        write(LDT_logunit,*) '[INFO] lon2 < lon1 ... ', &
+                             LDT_rc%gridDesc(n,8),LDT_rc%gridDesc(n,5)
      endif
      
      ! Difference in number of longitudes (dx):

--- a/ldt/interp/compute_earth_coord.F90
+++ b/ldt/interp/compute_earth_coord.F90
@@ -24,6 +24,7 @@ subroutine compute_earth_coord(gridDesc,npts,fill,xpts,ypts,rlon,rlat,nret,&
   real        :: rlon(npts)
   integer     :: nret
   logical     :: gen_xypts
+!
 ! !DESCRIPTION: 
 !  This subroutine computes the earth coordinates (lat/lon values) 
 !  of the specified domain. This routine is based on the grid
@@ -134,8 +135,9 @@ subroutine compute_earth_coord(gridDesc,npts,fill,xpts,ypts,rlon,rlat,nret,&
      call compute_earth_coord_ease(gridDesc,npts,fill,xpts,ypts,&
           rlon,rlat,nret)
   else
-     print*, 'Unrecognized Projection .... '
-     print*, 'Program stopping ..'
+     print *, '[ERR] Unrecognized Projection ... '
+     print *, 'Program stopping ...'
      stop
   endif
+
 end subroutine compute_earth_coord

--- a/ldt/interp/compute_earth_coord.F90
+++ b/ldt/interp/compute_earth_coord.F90
@@ -14,6 +14,9 @@
 subroutine compute_earth_coord(gridDesc,npts,fill,xpts,ypts,rlon,rlat,nret,&
                                gen_xypts)
 
+! Use:
+  use LDT_logMod
+
   implicit none
 ! !ARGUMENTS: 
   real        :: gridDesc(20)
@@ -135,9 +138,9 @@ subroutine compute_earth_coord(gridDesc,npts,fill,xpts,ypts,rlon,rlat,nret,&
      call compute_earth_coord_ease(gridDesc,npts,fill,xpts,ypts,&
           rlon,rlat,nret)
   else
-     print *, '[ERR] Unrecognized Projection ... '
-     print *, 'Program stopping ...'
-     stop
+     write(LDT_logunit,*) '[ERR] Unrecognized Projection ... '
+     write(LDT_logunit,*) 'Program stopping ...'
+     call LDT_endrun
   endif
 
 end subroutine compute_earth_coord

--- a/ldt/interp/compute_earth_coord_latlon.F90
+++ b/ldt/interp/compute_earth_coord_latlon.F90
@@ -87,6 +87,9 @@ subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
      ymax=jm+1
      nret=0
 
+     if( rlon1 < 0 ) then
+       rlon1 = 360+rlon1
+     endif
      ! translate grid coordinates to earth coordinates
      do n=1,npts
         if( xpts(n).ge.xmin.and.xpts(n).le.xmax.and. & 
@@ -98,9 +101,6 @@ subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
 !              rlon(n) = 360+rlon(n)
 !           endif
 !  new code (KRA)
-           if( rlon1 < 0 ) then
-             rlon1 = 360+rlon1
-           endif
            rlon(n) = rlon1+dlon*(xpts(n)-1)
            if( rlon(n) > 360. ) then
              rlon(n) = dlon*(xpts(n)-1)  ! rlon1 reset to 0. in this case

--- a/ldt/interp/compute_earth_coord_latlon.F90
+++ b/ldt/interp/compute_earth_coord_latlon.F90
@@ -10,7 +10,7 @@
 ! !REVISION HISTORY: 
 !   04-10-96 Mark Iredell;  Initial Specification
 !   05-27-04 Sujay Kumar;   Modified verision with floating point arithmetic. 
-!   11-25-19 K. Arsenault;  Ensure longitude orientation (E->W) 
+!   11-25-19 K. Arsenault;  Ensure longitude orientation (W->E)
 !
 ! !INTERFACE:
 subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,& 
@@ -69,16 +69,14 @@ subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
      else
         dlat=gridDesc(10)    ! S-N
      endif
-#if 0
      ! Original long. orientation code:
-     if(rlon1.gt.rlon2) then 
-        dlon=-gridDesc(9)    ! W-E
-     else
-        dlon = gridDesc(9)   ! E-W
-     endif
-#endif
-     ! Updated code:
-     dlon = gridDesc(9)      ! E-W orientation
+!     if(rlon1.gt.rlon2) then 
+!        dlon=-gridDesc(9)    ! E-W
+!     else
+!        dlon = gridDesc(9)   ! W-E
+!     endif
+     ! Updated code (KRA):
+     dlon = gridDesc(9)      ! W-E orientation
 
      xmin=0
      xmax=im+1
@@ -94,7 +92,7 @@ subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
         if( xpts(n).ge.xmin.and.xpts(n).le.xmax.and. & 
             ypts(n).ge.ymin.and.ypts(n).le.ymax ) then
 
-!  original code (KRA)
+!  original code 
 !           rlon(n)=rlon1+dlon*(xpts(n)-1)
 !           if(rlon(n).lt.0) then 
 !              rlon(n) = 360+rlon(n)
@@ -107,7 +105,6 @@ subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
            if( rlon(n) > 360. ) then
              rlon(n) = dlon*(xpts(n)-1)  ! rlon1 reset to 0. in this case
            endif
-!            write(601,*) n, rlon(n)  ! KRA
 
            rlat(n)=rlat1+dlat*(ypts(n)-1)
            nret=nret+1

--- a/ldt/interp/compute_earth_coord_latlon.F90
+++ b/ldt/interp/compute_earth_coord_latlon.F90
@@ -105,7 +105,6 @@ subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
            if( rlon(n) > 360. ) then
              rlon(n) = dlon*(xpts(n)-1)  ! rlon1 reset to 0. in this case
            endif
-
            rlat(n)=rlat1+dlat*(ypts(n)-1)
            nret=nret+1
         else

--- a/ldt/interp/compute_earth_coord_latlon.F90
+++ b/ldt/interp/compute_earth_coord_latlon.F90
@@ -9,7 +9,8 @@
 !
 ! !REVISION HISTORY: 
 !   04-10-96 Mark Iredell;  Initial Specification
-!   05-27-04 Sujay Kumar; Modified verision with floating point arithmetic. 
+!   05-27-04 Sujay Kumar;   Modified verision with floating point arithmetic. 
+!   11-25-19 K. Arsenault;  Ensure longitude orientation (E->W) 
 !
 ! !INTERFACE:
 subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,& 
@@ -28,8 +29,9 @@ subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
 ! !DESCRIPTION:
 !  This subroutine computes the earth coordinates of 
 !  the specified domain for an equidistant cylindrical projection.
-!  This routine is based on the grid
-!  decoding routines in the NCEP interoplation package. 
+!
+!  This routine is based on the grid decoding routines
+!  in the NCEP interoplation package. 
 !  
 !  \begin{description}
 !    \item[gridDesc]
@@ -61,31 +63,52 @@ subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
      rlon1=gridDesc(5)
      rlat2=gridDesc(7)
      rlon2=gridDesc(8)
+     ! Lat. orientation:
      if(rlat1.gt.rlat2) then 
-        dlat=-gridDesc(10)
+        dlat=-gridDesc(10)   ! N-S
      else
-        dlat=gridDesc(10)
+        dlat=gridDesc(10)    ! S-N
      endif
+#if 0
+     ! Original long. orientation code:
      if(rlon1.gt.rlon2) then 
-        dlon=-gridDesc(9)
+        dlon=-gridDesc(9)    ! W-E
      else
-        dlon = gridDesc(9)
+        dlon = gridDesc(9)   ! E-W
      endif
+#endif
+     ! Updated code:
+     dlon = gridDesc(9)      ! E-W orientation
+
      xmin=0
      xmax=im+1
-     if(im.eq.nint(360/abs(dlon))) xmax=im+2
+     if(im.eq.nint(360/abs(dlon))) then
+        xmax=im+2
+     endif
      ymin=0
      ymax=jm+1
      nret=0
 
-!  translate grid coordinates to earth coordinates
+     ! translate grid coordinates to earth coordinates
      do n=1,npts
-        if(xpts(n).ge.xmin.and.xpts(n).le.xmax.and. & 
-             ypts(n).ge.ymin.and.ypts(n).le.ymax) then
-           rlon(n)=rlon1+dlon*(xpts(n)-1)
-           if(rlon(n).lt.0) then 
-              rlon(n) = 360+rlon(n)
+        if( xpts(n).ge.xmin.and.xpts(n).le.xmax.and. & 
+            ypts(n).ge.ymin.and.ypts(n).le.ymax ) then
+
+!  original code (KRA)
+!           rlon(n)=rlon1+dlon*(xpts(n)-1)
+!           if(rlon(n).lt.0) then 
+!              rlon(n) = 360+rlon(n)
+!           endif
+!  new code (KRA)
+           if( rlon1 < 0 ) then
+             rlon1 = 360+rlon1
            endif
+           rlon(n) = rlon1+dlon*(xpts(n)-1)
+           if( rlon(n) > 360. ) then
+             rlon(n) = dlon*(xpts(n)-1)  ! rlon1 reset to 0. in this case
+           endif
+!            write(601,*) n, rlon(n)  ! KRA
+
            rlat(n)=rlat1+dlat*(ypts(n)-1)
            nret=nret+1
         else
@@ -94,7 +117,7 @@ subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
         endif
      enddo
 
-!  projection unrecognized
+  ! projection unrecognized
   else
      iret=-1
      do n=1,npts
@@ -102,4 +125,5 @@ subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
         rlat(n)=fill
      enddo
   endif
+
 end subroutine compute_earth_coord_latlon

--- a/ldt/interp/compute_grid_coord.F90
+++ b/ldt/interp/compute_grid_coord.F90
@@ -13,6 +13,9 @@
 ! !INTERFACE:
 subroutine compute_grid_coord(gridDesc,npts,fill,xpts,ypts,rlon,rlat,nret)
 
+! Use:
+  use LDT_logMod
+
   implicit none
 ! !ARGUMENTS: 
   real        :: gridDesc(20)
@@ -99,9 +102,9 @@ subroutine compute_grid_coord(gridDesc,npts,fill,xpts,ypts,rlon,rlat,nret)
      call compute_grid_coord_ease(gridDesc,npts,fill,xpts,ypts,&
           rlon,rlat,nret)
   else
-     print *, '[ERR] Unrecognized Projection .... '
-     print *, 'Program stopping ..'
-     stop
+     write(LDT_logunit,*) '[ERR] Unrecognized Projection .... '
+     write(LDT_logunit,*) 'Program stopping ..'
+     call LDT_endrun
   endif
 
 end subroutine compute_grid_coord

--- a/ldt/interp/compute_grid_coord.F90
+++ b/ldt/interp/compute_grid_coord.F90
@@ -99,8 +99,8 @@ subroutine compute_grid_coord(gridDesc,npts,fill,xpts,ypts,rlon,rlat,nret)
      call compute_grid_coord_ease(gridDesc,npts,fill,xpts,ypts,&
           rlon,rlat,nret)
   else
-     print*, 'Unrecognized Projection .... '
-     print*, 'Program stopping ..'
+     print *, '[ERR] Unrecognized Projection .... '
+     print *, 'Program stopping ..'
      stop
   endif
 

--- a/ldt/interp/compute_grid_coord_latlon.F90
+++ b/ldt/interp/compute_grid_coord_latlon.F90
@@ -7,8 +7,9 @@
 !  \label{compute_grid_coord_latlon}
 !
 ! !REVISION HISTORY: 
-!   04-10-96 Mark Iredell;  Initial Specification
-!   05-27-04 Sujay Kumar; Modified verision with floating point arithmetic. 
+!   04-10-1996 Mark Iredell; Initial Specification
+!   05-27-2004 Sujay Kumar;  Modified verision with floating point arithmetic. 
+!   11-25-2019 K. Arsenault; Ensure longitude orientation (E->W) 
 !
 ! !INTERFACE:
 subroutine compute_grid_coord_latlon(gridDesc,npts,fill,xpts,ypts,& 
@@ -27,8 +28,9 @@ subroutine compute_grid_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
 ! !DESCRIPTION:
 !  This subroutine computes the grid coordinates of 
 !  the specified domain for an equidistant cylindrical rojection.
-!  This routine is based on the grid
-!  decoding routines in the NCEP interoplation package. 
+!
+!  This routine is based on the grid decoding routines
+!  in the NCEP interoplation package. 
 !  
 !  \begin{description}
 !    \item[gridDesc]
@@ -59,30 +61,43 @@ subroutine compute_grid_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
      rlon1=gridDesc(5)
      rlat2=gridDesc(7)
      rlon2=gridDesc(8)
+     ! Lat. orientation:
      if(rlat1.gt.rlat2) then 
-        dlat=-gridDesc(10)
+        dlat=-gridDesc(10)   ! N-S
      else
-        dlat=gridDesc(10)
+        dlat=gridDesc(10)    ! S-N
      endif
+#if 0 
+     ! Original long. orientation code:
      if(rlon1.gt.rlon2) then 
-        dlon=-gridDesc(9)
+        dlon =-gridDesc(9)  ! W-E
      else
-        dlon = gridDesc(9)
+        dlon = gridDesc(9)  ! E-W
      endif
+#endif
+     ! Updated code:
+     dlon = gridDesc(9)     ! E-W orientation
+
      xmin=0
      xmax=im+1
-     if(im.eq.nint(360/abs(dlon))) xmax=im+2
+     if(im.eq.nint(360/abs(dlon))) then 
+       xmax=im+2
+     endif
      ymin=0
      ymax=jm+1
      nret=0
 
      do n=1,npts
         if(abs(rlon(n)).le.360.and.abs(rlat(n)).le.90) then
+
+           ! Account for 0-360 domain
            if(rlon(n).gt.180) then 
-              xpts(n)=1+(rlon(n)-360-rlon1)/dlon
+              xpts(n) = 1+(rlon(n)-360-rlon1)/dlon
            else
               xpts(n) = 1+(rlon(n)-rlon1)/dlon
            endif
+!           write(602,*) n, rlon(n), rlon1, dlon, xpts(n)
+
            ypts(n)=1+(rlat(n)-rlat1)/dlat
 
            if(xpts(n).ge.xmin.and.xpts(n).le.xmax.and. & 
@@ -100,4 +115,5 @@ subroutine compute_grid_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
   else
      iret=-1
   endif
+
 end subroutine compute_grid_coord_latlon

--- a/ldt/interp/compute_grid_coord_latlon.F90
+++ b/ldt/interp/compute_grid_coord_latlon.F90
@@ -9,11 +9,11 @@
 ! !REVISION HISTORY: 
 !   04-10-1996 Mark Iredell; Initial Specification
 !   05-27-2004 Sujay Kumar;  Modified verision with floating point arithmetic. 
-!   11-25-2019 K. Arsenault; Ensure longitude orientation (E->W) 
+!   11-25-2019 K. Arsenault; Ensure longitude orientation (W->E)
 !
 ! !INTERFACE:
 subroutine compute_grid_coord_latlon(gridDesc,npts,fill,xpts,ypts,& 
-     rlon,rlat,nret)
+              rlon,rlat,nret)
 
   implicit none
 ! !ARGUMENTS: 
@@ -67,16 +67,14 @@ subroutine compute_grid_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
      else
         dlat=gridDesc(10)    ! S-N
      endif
-#if 0 
      ! Original long. orientation code:
-     if(rlon1.gt.rlon2) then 
-        dlon =-gridDesc(9)  ! W-E
-     else
-        dlon = gridDesc(9)  ! E-W
-     endif
-#endif
-     ! Updated code:
-     dlon = gridDesc(9)     ! E-W orientation
+!     if(rlon1.gt.rlon2) then 
+!        dlon =-gridDesc(9)  ! E-W
+!     else
+!        dlon = gridDesc(9)  ! W-E
+!     endif
+     ! Updated code (KRA):
+     dlon = gridDesc(9)     ! W-E orientation
 
      xmin=0
      xmax=im+1
@@ -96,7 +94,6 @@ subroutine compute_grid_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
            else
               xpts(n) = 1+(rlon(n)-rlon1)/dlon
            endif
-!           write(602,*) n, rlon(n), rlon1, dlon, xpts(n)
 
            ypts(n)=1+(rlat(n)-rlat1)/dlat
 

--- a/ldt/interp/compute_grid_coord_latlon.F90
+++ b/ldt/interp/compute_grid_coord_latlon.F90
@@ -90,11 +90,15 @@ subroutine compute_grid_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
 
            ! Account for 0-360 domain
            if(rlon(n).gt.180) then 
-              xpts(n) = 1+(rlon(n)-360-rlon1)/dlon
+              ! Updated code (KRA):
+              if( rlon1 <= 0. ) then
+                xpts(n) = 1+(rlon(n)-360-rlon1)/dlon
+              elseif( rlon1 > 0. ) then
+                xpts(n) = 1+(rlon(n)-rlon1)/dlon
+              endif
            else
               xpts(n) = 1+(rlon(n)-rlon1)/dlon
            endif
-
            ypts(n)=1+(rlat(n)-rlat1)/dlat
 
            if(xpts(n).ge.xmin.and.xpts(n).le.xmax.and. & 

--- a/ldt/interp/get_fieldpos.F90
+++ b/ldt/interp/get_fieldpos.F90
@@ -27,6 +27,7 @@ function get_fieldpos(i,j,gridDesc) result(field_pos)
 ! !DESCRIPTION: 
 !  This subprogram returns the field position for a given grid point
 !  based on the input grid definition.
+!
 !  The arguments are: 
 !  \begin{description}
 !    \item[i]
@@ -39,7 +40,6 @@ function get_fieldpos(i,j,gridDesc) result(field_pos)
 !     integer position in grid field to locate grid point
 !    \end{description}
 !EOP
-
  
   integer :: im, jm
   integer :: kscan
@@ -123,4 +123,5 @@ function get_fieldpos(i,j,gridDesc) result(field_pos)
   else
      field_pos=0
   endif
+
 end function get_fieldpos

--- a/ldt/interp/upscaleByAveraging_input.F90
+++ b/ldt/interp/upscaleByAveraging_input.F90
@@ -28,7 +28,7 @@ subroutine upscaleByAveraging_input( gridDesci, gridDesco, mi, mo, n11 )
 !  Note that the input grid needs to be setup either as a global 
 !  grid or with halos padded around it (if using a subset of the
 !  global grid), for the algorithm to work properly in a 
-!  multiprocessor environment.This is to avoid a case where the 
+!  multiprocessor environment. This is to avoid a case where the 
 !  required input grid points are split across different processors.  
 !  
 !  The grid description arrays are based on the decoding 
@@ -81,7 +81,7 @@ subroutine upscaleByAveraging_input( gridDesci, gridDesco, mi, mo, n11 )
   allocate( xpts(mi), ypts(mi), rlat(mi), rlon(mi) )
 
   if(gridDesci(1).ge.0) then 
-     call compute_earth_coord(gridDesci,mi,fill, xpts, ypts, rlon, rlat,nv,.true.)
+     call compute_earth_coord(gridDesci,mi,fill, xpts, ypts, rlon, rlat, nv,.true.)
   endif
   call compute_grid_coord(gridDesco,mi,fill, xpts, ypts, rlon, rlat, nv)
 

--- a/ldt/interp/upscaleByAveraging_input.F90
+++ b/ldt/interp/upscaleByAveraging_input.F90
@@ -13,12 +13,8 @@ subroutine upscaleByAveraging_input( gridDesci, gridDesco, mi, mo, n11 )
 ! 
 ! !USES:   
 !
-! !INPUT PARAMETERS: 
-! 
-! !OUTPUT PARAMETERS:
-!
 ! !DESCRIPTION: 
-!  This subprogram performs issues calls to compute the 
+!  This subprogram performs and issues calls to compute the 
 !  neighbor information for upscaling data for scalar fields
 !  The grids are defined by their grid description arrays. 
 !  

--- a/ldt/interp/upscaleByCnt.F90
+++ b/ldt/interp/upscaleByCnt.F90
@@ -33,9 +33,6 @@ subroutine upscaleByCnt( mi, mo, nt, udef, n11,li, gi, lo, go )
 !   by their grid description arrays, which are based on the decoding 
 !   schemes used by NCEP. 
 !  
-!  The grid description arrays are based on the decoding 
-!  schemes used by NCEP. 
-!   
 !  The current code recognizes the following projections: \newline
 !             (gridDesc(1)=0) equidistant cylindrical \newline
 !            

--- a/ldt/params/landcover/read_MODISNative_lc.F90
+++ b/ldt/params/landcover/read_MODISNative_lc.F90
@@ -88,7 +88,7 @@ subroutine read_MODISNative_lc(n, num_types, fgrd, maskarray )
    inquire( file=trim(LDT_rc%vfile(n)), exist=file_exists )
    if(.not. file_exists) then
       write(LDT_logunit,*)"[ERR] The landcover map: ",trim(LDT_rc%vfile(n))," does not exist."
-      write(LDT_logunit,*)"Program stopping ..."
+      write(LDT_logunit,*)" Program stopping ..."
       call LDT_endrun
    endif
 

--- a/ldt/params/landcover/read_MODISNative_lc.F90
+++ b/ldt/params/landcover/read_MODISNative_lc.F90
@@ -184,8 +184,15 @@ subroutine read_MODISNative_lc(n, num_types, fgrd, maskarray )
    do r = 1, subpnr
       do c = 1, subpnc
          subset_veg(c,r) = input_vegtype(lon_line(c,r),lat_line(c,r))
+!KRA        if( subset_veg(c,r) .ne. 17 )then
+!           write(701,*) c, r, lon_line(c,r), input_vegtype(lon_line(c,r),lat_line(c,r))
+!         endif
       enddo
    enddo
+!   print *, subpnc, subpnr
+!   open( 10, file="temp.gbin", form="unformatted", access="sequential" )
+!   write(10) subset_veg
+!   close(10)
 
 ! -------------------------------------------------------------------
 !     AGGREGATING FINE-SCALE GRIDS TO COARSER LIS OUTPUT GRID
@@ -232,6 +239,11 @@ subroutine read_MODISNative_lc(n, num_types, fgrd, maskarray )
         call LDT_transform_paramgrid(n, LDT_rc%lc_gridtransform(n), &
                  subparam_gridDesc, mi, LDT_rc%nt, gi, li, mo, go2, lo2 )
 
+! KRA
+!   print *, LDT_rc%lnc(n), LDT_rc%lnr(n)
+!   open( 10, file="temp.gbin", form="unformatted", access="sequential" )
+! KRA
+
      !- Convert 1D vegcnt to 2D grid arrays:
         i = 0
         do r = 1, LDT_rc%lnr(n) 
@@ -242,6 +254,13 @@ subroutine read_MODISNative_lc(n, num_types, fgrd, maskarray )
               end do
            enddo
         enddo
+
+! KRA
+!    do t = 1, LDT_rc%nt
+!       write(10) vegcnt(:,:,t)
+!    enddo
+!    close(10)
+! KRA
 
    end select  ! End vegtype/cnt aggregation method
    deallocate( gi, li )

--- a/ldt/params/landcover/read_MODISNative_lc.F90
+++ b/ldt/params/landcover/read_MODISNative_lc.F90
@@ -184,15 +184,8 @@ subroutine read_MODISNative_lc(n, num_types, fgrd, maskarray )
    do r = 1, subpnr
       do c = 1, subpnc
          subset_veg(c,r) = input_vegtype(lon_line(c,r),lat_line(c,r))
-!KRA        if( subset_veg(c,r) .ne. 17 )then
-!           write(701,*) c, r, lon_line(c,r), input_vegtype(lon_line(c,r),lat_line(c,r))
-!         endif
       enddo
    enddo
-!   print *, subpnc, subpnr
-!   open( 10, file="temp.gbin", form="unformatted", access="sequential" )
-!   write(10) subset_veg
-!   close(10)
 
 ! -------------------------------------------------------------------
 !     AGGREGATING FINE-SCALE GRIDS TO COARSER LIS OUTPUT GRID
@@ -239,11 +232,6 @@ subroutine read_MODISNative_lc(n, num_types, fgrd, maskarray )
         call LDT_transform_paramgrid(n, LDT_rc%lc_gridtransform(n), &
                  subparam_gridDesc, mi, LDT_rc%nt, gi, li, mo, go2, lo2 )
 
-! KRA
-!   print *, LDT_rc%lnc(n), LDT_rc%lnr(n)
-!   open( 10, file="temp.gbin", form="unformatted", access="sequential" )
-! KRA
-
      !- Convert 1D vegcnt to 2D grid arrays:
         i = 0
         do r = 1, LDT_rc%lnr(n) 
@@ -254,13 +242,6 @@ subroutine read_MODISNative_lc(n, num_types, fgrd, maskarray )
               end do
            enddo
         enddo
-
-! KRA
-!    do t = 1, LDT_rc%nt
-!       write(10) vegcnt(:,:,t)
-!    enddo
-!    close(10)
-! KRA
 
    end select  ! End vegtype/cnt aggregation method
    deallocate( gi, li )

--- a/lis/core/LIS_domainMod.F90
+++ b/lis/core/LIS_domainMod.F90
@@ -978,13 +978,13 @@ end subroutine LIS_quilt_b_domain
      
      ! Locals
      integer :: c, r, t, m, mm, tt
-     real    :: maxv
-     real :: model_type_fractions(LIS_rc%max_model_types)
+     real    :: maxv, maxtilefrac
+     real    :: model_type_fractions(LIS_rc%max_model_types)
 
      ! Sanity check
      if (maxt > 1) then
         write(LIS_logunit,*) &
-             '[ERR], calculate_dominant_sfctile only works for maxt = 1!'
+             '[ERR] Calculate_dominant_sfctile only works for maxt = 1!'
         call LIS_endrun()
      end if
      
@@ -1006,7 +1006,7 @@ end subroutine LIS_quilt_b_domain
               model_type_fractions(m) = &
                    model_type_fractions(m) + fgrd(c,r,t)
            end do ! t
-           
+
            ! Now find which surface model type has the highest fraction.
            maxv = 0
            mm = 0
@@ -1038,6 +1038,7 @@ end subroutine LIS_quilt_b_domain
 
            ! At this point, remaining tiles are associated with only a single 
            ! surface model type. Exclude tiles below minimum tile grid area). 
+           maxtilefrac=maxval(fgrd(c,r,:))
            do t=1,ntypes
               if (fgrd(c,r,t).lt.minp) then
                  fgrd(c,r,t)=0.0 
@@ -1057,7 +1058,13 @@ end subroutine LIS_quilt_b_domain
            ! Sanity check: Make sure we still have one tile left!
            if (tt .eq. 0) then
               write(LIS_logunit,*) &
-                   '[ERR] No surface tiles remain!'
+                "[ERR] No surface model tile fraction >= minp,",minp
+              write(LIS_logunit,*) &
+                "  which is the 'Minimum cutoff percentage (surface type tiles):'"
+              write(LIS_logunit,*) &
+                "  value set in your lis.config file. Highest tile fraction value is:",maxtilefrac
+              write(LIS_logunit,*) &
+                "  Thus, surface tiles set to '0' for gridpoint:"
               write(LIS_logunit,*) &
                    'c,r,fgrd: ',c,r,fgrd(c,r,:)
               call LIS_flush(LIS_logunit)

--- a/lis/testcases/domains/lambert_buffer/MODEL_OUTPUT_LIST.TBL
+++ b/lis/testcases/domains/lambert_buffer/MODEL_OUTPUT_LIST.TBL
@@ -1,0 +1,105 @@
+#short_name select? units signconv timeavg? min/max? std? vert.levels grib_id grib_scalefactor longname
+
+#Energy balance components
+Swnet:         1  W/m2    DN   1 0 0 1 111 10      # Net Shortwave Radiation (W/m2)
+Lwnet:         1  W/m2    DN   1 0 0 1 112 10      # Net Longwave Radiation (W/m2)
+Qle:           1  W/m2    UP   1 0 0 1 121 10      # Latent Heat Flux (W/m2)
+Qh:            1  W/m2    UP   1 0 0 1 122 10      # Sensible Heat Flux (W/m2)
+Qg:            1  W/m2    DN   1 0 0 1 155 10      # Ground Heat Flux (W/m2)
+Qf:            0  W/m2    S2L  1 0 0 1 229 10      # Energy of fusion (W/m2)
+Qv:            0  W/m2    S2V  1 0 0 1 134 10      # Energy of sublimation (W/m2)
+Qa:            0  W/m2    DN   1 0 0 1 136 10      # Advective Energy (W/m2)
+Qtau:          0  N/m2    DN   1 0 0 1 135 10      # Momentum flux (N/m2)
+DelSurfHeat:   0  J/m2    INC  1 0 0 1 137 10      # Change in surface heat storage (J/m2)
+DelColdCont:   0  J/m2    INC  1 0 0 1 138 10      # Change in snow cold content (J/m2)
+BR:            0  -       -    1 0 1 1 256 10      # Bowen ratio
+EF:            0  -       -    1 0 1 1 256 10      # Evaporative fraction
+
+#Water balance components
+Snowf:         0  kg/m2s  DN   1 0 0 1 161 10000   # Snowfall rate (kg/m2s)
+Rainf:         0  kg/m2s  DN   1 0 0 1 162 10000   # Rainfall rate (kg/m2s)
+RainfConv:     0  kg/m2s  DN   1 0 0 1 163 10000   # Convective Rainfall rate (kg/m2s)
+TotalPrecip:   1  kg/m2s  DN   1 0 0 1 164 10000   # Total Precipitation rate (kg/m2s)
+Evap:          1  kg/m2s  UP   1 0 0 1  57 10000   # Total Evapotranspiration (kg/m2s)
+Qs:            1  kg/m2s  OUT  1 0 0 1 235 10000   # Surface runoff (kg/m2s)
+Qsb:           1  kg/m2s  OUT  1 0 0 1 254 10000   # Subsurface runoff (kg/m2s)
+Qrec:          0  kg/m2s  IN   1 0 0 1 143 10000   # Recharge (kg/m2s)
+Qsm:           0  kg/m2s  S2L  1 0 0 1  99 10000   # Snowmelt (kg/m2s)
+Qfz:           0  kg/m2s  L2S  1 0 0 1 146 10000   # Refreezing of water in the snowpack (kg/m2s)
+Qst:           0  kg/m2s  -    1 0 0 1 147 10000   # Snow throughfall (kg/m2s)
+DelSoilMoist:  0  kg/m2   INC  0 0 0 1 148 10000   # Change in soil moisture (kg/m2)
+DelSWE:        0  kg/m2   INC  0 0 0 1 149 1000    # Change in snow water equivalent (kg/m2)
+DelSurfStor:   0  kg/m2   INC  1 0 0 1 150 1000    # Change in surface water storage (kg/m2)
+DelIntercept:  0  kg/m2   INC  1 0 0 1 151 1000    # Change in interception storage (kg/m2)
+RHMin:         0   -      -    0 0 0 1  51 10      # Minimum 2 meter relative humidity (-)
+
+#Surface state variables
+SnowT:         0  K       -    1 0 0 1 152 10      # Snow surface temperature (K)
+VegT:          0  K       -    1 0 0 1 153 10      # Vegetation canopy temperature (K)
+BareSoilT:     0  K       -    1 0 0 1 154 10      # Temperature of bare soil (K)
+AvgSurfT:      0  K       -    0 0 0 1 148 10      # Average surface temperature (K)
+RadT:          0  K       -    1 0 0 1 156 10      # Surface Radiative Temperature (K)
+Albedo:        0  -       -    0 0 0 1  84 100     # Surface Albedo (-)
+SWE:           1  kg/m2   -    0 0 0 1  65 1000    # Snow Water Equivalent (kg/m2)
+SWEVeg:        0  kg/m2   -    1 0 0 1 159 1000    # SWE intercepted by vegetation (kg/m2)
+SurfStor:      0  kg/m2   -    1 0 0 1 160 1000    # Surface water storage (kg/m2)
+
+#Subsurface state variables
+SoilMoist:     1  m3/m3   -    1 0 0 4  86 1000    # Average layer soil moisture (kg/m2)
+SoilTemp:      1  K       -    0 0 0 4  85 1000    # Average layer soil temperature (K)
+SmLiqFrac:     0  -       -    1 0 0 4  85 100     # Average layer fraction of liquid moisture (-)
+SmFrozFrac:    0  -       -    1 0 0 4  85 100     # Average layer fraction of frozen moisture (-)
+SoilWet:       0  -       -    0 0 0 1  85 100     # Total soil wetness (-)
+RelSMC:        0  m3/m3   -    0 0 0 1  86 1000    # Relative soil moisture
+RootTemp:      0  K       -    0 0 0 1  85 1000    # Rootzone temperature (K)
+
+#Evaporation components
+PotEvap:       0  kg/m2s  UP   3 0 0 1 166 1       # Potential Evapotranspiration (kg/m2s)
+TVeg:          0  kg/m2s  UP   1 0 0 1 210 1       # Vegetation transpiration (kg/m2s)
+ECanop:        0  kg/m2s  UP   1 0 0 1 200 1       # Interception evaporation (kg/m2s)
+ESoil:         0  kg/m2s  UP   1 0 0 1 199 1       # Bare soil evaporation (kg/m2s)
+EWater:        0  kg/m2s  UP   1 0 0 1 170 1       # Open water evaporation (kg/m2s)
+RootMoist:     0  kg/m2   -    0 0 0 1 171 1       # Root zone soil moisture (kg/m2)
+CanopInt:      0  kg/m2   -    0 0 0 1 223 1000    # Total canopy water storage (kg/m2)
+EvapSnow:      0  kg/m2s  -    1 0 0 1 173 1000    # Snow evaporation (kg/m2s)
+SubSnow:       0  kg/m2s  -    1 0 0 1 198 1000    # Snow sublimation (kg/m2s)
+SubSurf:       0  kg/m2s  -    1 0 0 1 175 1000    # Sublimation of the snow free area (kg/m2s)
+ACond:         0  m/s     -    1 0 0 1 179 100000  # Aerodynamic conductance
+CCond:         0  m/s     -    1 0 0 1 179 1000000 # Canopy conductance
+
+#Cold season processes
+Snowcover:     0  -       -    0 0 0 1  66 100     # Snow Cover (-)
+SnowDepth:     0  m       -    0 0 0 1  66 1000    # Snow Depth (m)
+SLiqFrac:      0  -       -    0 0 0 1  65 1000    # Fraction of SWE in the liquid phase
+
+#Forcings
+Wind_f:        1  m/s     -    0 0 0 1 177 10      # Near Surface Wind (m/s)
+Rainf_f:       1  kg/m2s  DN   0 0 0 1 162 1000    # Average rainfall rate
+Snowf_f:       0  kg/m2s  DN   0 0 0 1 161 1000    # Average snowfall rate
+Tair_f:        1  K       -    0 0 0 1  11 10      # Near surface air temperature
+Qair_f:        0  kg/kg   -    0 0 0 1  51 1000    # Near surface specific humidity
+Psurf_f:       0  Pa      -    0 0 0 1   1 10      # Surface pressure
+SWdown_f:      1  W/m2    DN   0 0 0 1 204 10      # Surface incident shortwave radiation
+LWdown_f:      1  W/m2    DN   0 0 0 1 205 10      # Surface incident longwave radiation
+
+#Parameters
+Landmask:      0  -       -    0 0 0 1  81 1       # Land Mask (0 - Water, 1- Land)
+Landcover:     0  -       -    0 0 0 1 186 1       # Land cover
+Soiltype:      0  -       -    0 0 0 1 187 1       # Soil type
+SandFrac:      0  -       -    0 0 0 1 999 1       # Sand fraction
+ClayFrac:      0  -       -    0 0 0 1 999 1       # Clay fraction
+SiltFrac:      0  -       -    0 0 0 1 999 1       # Silt fraction
+Porosity:      0  -       -    3 0 0 1 999 1       # Porosity
+Soilcolor:     0  -       -    0 0 0 1 188 1       # Soil color
+Elevation:     0  m       -    0 0 0 1 189 10      # Elevation
+Slope:         0  -       -    0 0 0 1 999 10      # Slope
+LAI:           0  -       -    0 0 0 1 190 100     # LAI
+SAI:           0  -       -    0 0 0 1 191 100     # SAI
+Snfralbedo:    0  -       -    0 0 0 1 192 100     # Snow fraction albedo
+Mxsnalbedo:    0  -       -    0 0 0 1 192 100     # Maximum snow albedo
+Greenness:     1  -       -    0 0 0 1  87 100     # Greenness
+Tempbot:       0  K       -    0 0 0 1 194 10      # Bottom soil temperature
+
+#Irrigation
+Irrigated water:   0 kg/m2s    -     1 0 0 1 333 10      #Irrigation amount
+

--- a/lis/testcases/domains/lambert_buffer/README
+++ b/lis/testcases/domains/lambert_buffer/README
@@ -1,0 +1,36 @@
+Lambert-Domain Fix/Buffer Testcase
+
+This is a testcase that uses:
+  (a) Lambert conformal projection 
+  (b) A small domain in California, U.S.
+  (c) The Noah-MP version 3.6 land surface model
+  (d) NLDAS2 forcing files
+  (e) A time period from 00:30Z 1 Jan 2001 to 23:30Z 1 Jan 2001
+  (f) 3-hourly output files, written as binary-formatted (*.gs4r)
+
+This directory contains:
+  (a) This README file
+  (b) The "ldt.config" file to generate the parameters using LDT
+  (c) An "input.ctl" file used to open the LDT parameters in GrADS
+  (d) The "lis.config" file used for this testcase
+  (e) The "MODEL_OUTPUT_LIST.TBL" file used by the lis.config file
+      to select the output variables
+  (f) An "output.ctl" file used to display the output in GrADS from
+      the LIS run
+  (g) A "testcase.ctl" file used to display the packaged output in
+      GrADS from the OUTPUT tar file provided by the testcase
+
+To run this testcase:
+  (a) Generate the LDT and the LIS executables and copy to local 
+      working directory
+  (b) Run the LDT executable using the "ldt.config" file and the
+      file with the testcase input data
+  (c) Run the LIS executable using the "lis.config" file with the
+      testcase input data
+  (d) View the netcdf output using the testcase GrADS files
+
+Caveats:
+  (a) Please note that this is a simple functional test and the output
+      from the testcase is not expected to be used for any scientific
+      evaluation.
+

--- a/lis/testcases/domains/lambert_buffer/input.ctl
+++ b/lis/testcases/domains/lambert_buffer/input.ctl
@@ -1,0 +1,126 @@
+dset ^lis_input.d01.nc
+dtype netcdf
+options template
+undef -9999
+* Lambert conformal:
+*pdef 215 110 lcc 37.50 -120.20 1 1 37 38 -120 1000 1000 
+*xdef 215 linear -121.20 0.02
+*ydef 110 linear   37.00 0.02
+* Latlon grid-equivalent:
+xdef 215 linear -121.20 0.01
+ydef 110 linear   37.50 0.01
+zdef 1 linear 1 1
+* dummy tdef
+tdef 1 linear 00z01jan2012 1hr
+vars 110
+LANDMASK=>LANDMASK 1 y,x description
+DOMAINMASK=>DOMAINMASK 1 y,x description
+SURFACETYPE=>SURFACETYPE1 0 0,y,x description
+SURFACETYPE=>SURFACETYPE2 0 1,y,x description
+SURFACETYPE=>SURFACETYPE3 0 2,y,x description
+SURFACETYPE=>SURFACETYPE4 0 3,y,x description
+SURFACETYPE=>SURFACETYPE5 0 4,y,x description
+SURFACETYPE=>SURFACETYPE6 0 5,y,x description
+SURFACETYPE=>SURFACETYPE7 0 6,y,x description
+SURFACETYPE=>SURFACETYPE8 0 7,y,x description
+SURFACETYPE=>SURFACETYPE9 0 8,y,x description
+SURFACETYPE=>SURFACETYPE10 0 9,y,x description
+SURFACETYPE=>SURFACETYPE11 0 10,y,x description
+SURFACETYPE=>SURFACETYPE12 0 11,y,x description
+SURFACETYPE=>SURFACETYPE13 0 12,y,x description
+SURFACETYPE=>SURFACETYPE14 0 13,y,x description
+SURFACETYPE=>SURFACETYPE15 0 14,y,x description
+SURFACETYPE=>SURFACETYPE16 0 15,y,x description
+SURFACETYPE=>SURFACETYPE17 0 16,y,x description
+SURFACETYPE=>SURFACETYPE18 0 17,y,x description
+SURFACETYPE=>SURFACETYPE19 0 18,y,x description
+SURFACETYPE=>SURFACETYPE20 0 19,y,x description
+LANDCOVER=>LANDCOVER1 0 0,y,x description
+LANDCOVER=>LANDCOVER2 0 1,y,x description
+LANDCOVER=>LANDCOVER3 0 2,y,x description
+LANDCOVER=>LANDCOVER4 0 3,y,x description
+LANDCOVER=>LANDCOVER5 0 4,y,x description
+LANDCOVER=>LANDCOVER6 0 5,y,x description
+LANDCOVER=>LANDCOVER7 0 6,y,x description
+LANDCOVER=>LANDCOVER8 0 7,y,x description
+LANDCOVER=>LANDCOVER9 0 8,y,x description
+LANDCOVER=>LANDCOVER10 0 9,y,x description
+LANDCOVER=>LANDCOVER11 0 10,y,x description
+LANDCOVER=>LANDCOVER12 0 11,y,x description
+LANDCOVER=>LANDCOVER13 0 12,y,x description
+LANDCOVER=>LANDCOVER14 0 13,y,x description
+LANDCOVER=>LANDCOVER15 0 14,y,x description
+LANDCOVER=>LANDCOVER16 0 15,y,x description
+LANDCOVER=>LANDCOVER17 0 16,y,x description
+LANDCOVER=>LANDCOVER18 0 17,y,x description
+LANDCOVER=>LANDCOVER19 0 18,y,x description
+LANDCOVER=>LANDCOVER20 0 19,y,x description
+TEXTURE=>TEXTURE1 0 0,y,x description
+TEXTURE=>TEXTURE2 0 1,y,x description
+TEXTURE=>TEXTURE3 0 2,y,x description
+TEXTURE=>TEXTURE4 0 3,y,x description
+TEXTURE=>TEXTURE5 0 4,y,x description
+TEXTURE=>TEXTURE6 0 5,y,x description
+TEXTURE=>TEXTURE7 0 6,y,x description
+TEXTURE=>TEXTURE8 0 7,y,x description
+TEXTURE=>TEXTURE9 0 8,y,x description
+TEXTURE=>TEXTURE10 0 9,y,x description
+TEXTURE=>TEXTURE11 0 10,y,x description
+TEXTURE=>TEXTURE12 0 11,y,x description
+TEXTURE=>TEXTURE13 0 12,y,x description
+TEXTURE=>TEXTURE14 0 13,y,x description
+TEXTURE=>TEXTURE15 0 14,y,x description
+TEXTURE=>TEXTURE16 0 15,y,x description
+ELEVFGRD=>ELEVFGRD 1 y,x description
+ELEVATION=>ELEVATION 1 y,x description
+ASPECTFGRD=>ASPECTFGRD 1 y,x description
+ASPECT=>ASPECT 1 y,x description
+SLOPEFGRD=>SLOPEFGRD 1 y,x description
+SLOPE=>SLOPE 1 y,x description
+GREENNESS=>GREENNESS1 0 0,y,x description
+GREENNESS=>GREENNESS2 0 1,y,x description
+GREENNESS=>GREENNESS3 0 2,y,x description
+GREENNESS=>GREENNESS4 0 3,y,x description
+GREENNESS=>GREENNESS5 0 4,y,x description
+GREENNESS=>GREENNESS6 0 5,y,x description
+GREENNESS=>GREENNESS7 0 6,y,x description
+GREENNESS=>GREENNESS8 0 7,y,x description
+GREENNESS=>GREENNESS9 0 8,y,x description
+GREENNESS=>GREENNESS10 0 9,y,x description
+GREENNESS=>GREENNESS11 0 10,y,x description
+GREENNESS=>GREENNESS12 0 11,y,x description
+SHDMIN=>SHDMIN 1 y,x description
+SHDMAX=>SHDMAX 1 y,x description
+ALBEDO=>ALBEDO1 0 0,y,x description
+ALBEDO=>ALBEDO2 0 1,y,x description
+ALBEDO=>ALBEDO3 0 2,y,x description
+ALBEDO=>ALBEDO4 0 3,y,x description
+ALBEDO=>ALBEDO5 0 4,y,x description
+ALBEDO=>ALBEDO6 0 5,y,x description
+ALBEDO=>ALBEDO7 0 6,y,x description
+ALBEDO=>ALBEDO8 0 7,y,x description
+ALBEDO=>ALBEDO9 0 8,y,x description
+ALBEDO=>ALBEDO10 0 9,y,x description
+ALBEDO=>ALBEDO11 0 10,y,x description
+ALBEDO=>ALBEDO12 0 11,y,x description
+MXSNALBEDO=>MXSNALBEDO 1 y,x description
+TBOT=>TBOT 1 y,x description
+SLOPETYPE=>SLOPETYPE 1 y,x description
+NOAHMP36_PBLH=>NOAHMP36PBLH 1 y,x description
+PPTCLIM=>PPTCLIM1 0 0,y,x description
+PPTCLIM=>PPTCLIM2 0 1,y,x description
+PPTCLIM=>PPTCLIM3 0 2,y,x description
+PPTCLIM=>PPTCLIM4 0 3,y,x description
+PPTCLIM=>PPTCLIM5 0 4,y,x description
+PPTCLIM=>PPTCLIM6 0 5,y,x description
+PPTCLIM=>PPTCLIM7 0 6,y,x description
+PPTCLIM=>PPTCLIM8 0 7,y,x description
+PPTCLIM=>PPTCLIM9 0 8,y,x description
+PPTCLIM=>PPTCLIM10 0 9,y,x description
+PPTCLIM=>PPTCLIM11 0 10,y,x description
+PPTCLIM=>PPTCLIM12 0 11,y,x description
+ELEV_NLDAS2=>ELEVNLDAS2 0 y,x description
+ELEVDIFF_NLDAS2=>ELEVDIFFNLDAS2 0 y,x description
+lat=>lat 1 y,x description
+lon=>lon 1 y,x description
+endvars

--- a/lis/testcases/domains/lambert_buffer/input_testcase.ctl
+++ b/lis/testcases/domains/lambert_buffer/input_testcase.ctl
@@ -1,0 +1,126 @@
+dset ^lis_input_testcase.d01.nc
+dtype netcdf
+options template
+undef -9999
+* Lambert conformal:
+*pdef 215 110 lcc 37.50 -120.20 1 1 37 38 -120 1000 1000 
+*xdef 215 linear -121.20 0.02
+*ydef 110 linear   37.00 0.02
+* Latlon grid-equivalent:
+xdef 215 linear -121.20 0.01
+ydef 110 linear   37.50 0.01
+zdef 1 linear 1 1
+* dummy tdef
+tdef 1 linear 00z01jan2012 1hr
+vars 110
+LANDMASK=>LANDMASK 1 y,x description
+DOMAINMASK=>DOMAINMASK 1 y,x description
+SURFACETYPE=>SURFACETYPE1 0 0,y,x description
+SURFACETYPE=>SURFACETYPE2 0 1,y,x description
+SURFACETYPE=>SURFACETYPE3 0 2,y,x description
+SURFACETYPE=>SURFACETYPE4 0 3,y,x description
+SURFACETYPE=>SURFACETYPE5 0 4,y,x description
+SURFACETYPE=>SURFACETYPE6 0 5,y,x description
+SURFACETYPE=>SURFACETYPE7 0 6,y,x description
+SURFACETYPE=>SURFACETYPE8 0 7,y,x description
+SURFACETYPE=>SURFACETYPE9 0 8,y,x description
+SURFACETYPE=>SURFACETYPE10 0 9,y,x description
+SURFACETYPE=>SURFACETYPE11 0 10,y,x description
+SURFACETYPE=>SURFACETYPE12 0 11,y,x description
+SURFACETYPE=>SURFACETYPE13 0 12,y,x description
+SURFACETYPE=>SURFACETYPE14 0 13,y,x description
+SURFACETYPE=>SURFACETYPE15 0 14,y,x description
+SURFACETYPE=>SURFACETYPE16 0 15,y,x description
+SURFACETYPE=>SURFACETYPE17 0 16,y,x description
+SURFACETYPE=>SURFACETYPE18 0 17,y,x description
+SURFACETYPE=>SURFACETYPE19 0 18,y,x description
+SURFACETYPE=>SURFACETYPE20 0 19,y,x description
+LANDCOVER=>LANDCOVER1 0 0,y,x description
+LANDCOVER=>LANDCOVER2 0 1,y,x description
+LANDCOVER=>LANDCOVER3 0 2,y,x description
+LANDCOVER=>LANDCOVER4 0 3,y,x description
+LANDCOVER=>LANDCOVER5 0 4,y,x description
+LANDCOVER=>LANDCOVER6 0 5,y,x description
+LANDCOVER=>LANDCOVER7 0 6,y,x description
+LANDCOVER=>LANDCOVER8 0 7,y,x description
+LANDCOVER=>LANDCOVER9 0 8,y,x description
+LANDCOVER=>LANDCOVER10 0 9,y,x description
+LANDCOVER=>LANDCOVER11 0 10,y,x description
+LANDCOVER=>LANDCOVER12 0 11,y,x description
+LANDCOVER=>LANDCOVER13 0 12,y,x description
+LANDCOVER=>LANDCOVER14 0 13,y,x description
+LANDCOVER=>LANDCOVER15 0 14,y,x description
+LANDCOVER=>LANDCOVER16 0 15,y,x description
+LANDCOVER=>LANDCOVER17 0 16,y,x description
+LANDCOVER=>LANDCOVER18 0 17,y,x description
+LANDCOVER=>LANDCOVER19 0 18,y,x description
+LANDCOVER=>LANDCOVER20 0 19,y,x description
+TEXTURE=>TEXTURE1 0 0,y,x description
+TEXTURE=>TEXTURE2 0 1,y,x description
+TEXTURE=>TEXTURE3 0 2,y,x description
+TEXTURE=>TEXTURE4 0 3,y,x description
+TEXTURE=>TEXTURE5 0 4,y,x description
+TEXTURE=>TEXTURE6 0 5,y,x description
+TEXTURE=>TEXTURE7 0 6,y,x description
+TEXTURE=>TEXTURE8 0 7,y,x description
+TEXTURE=>TEXTURE9 0 8,y,x description
+TEXTURE=>TEXTURE10 0 9,y,x description
+TEXTURE=>TEXTURE11 0 10,y,x description
+TEXTURE=>TEXTURE12 0 11,y,x description
+TEXTURE=>TEXTURE13 0 12,y,x description
+TEXTURE=>TEXTURE14 0 13,y,x description
+TEXTURE=>TEXTURE15 0 14,y,x description
+TEXTURE=>TEXTURE16 0 15,y,x description
+ELEVFGRD=>ELEVFGRD 1 y,x description
+ELEVATION=>ELEVATION 1 y,x description
+ASPECTFGRD=>ASPECTFGRD 1 y,x description
+ASPECT=>ASPECT 1 y,x description
+SLOPEFGRD=>SLOPEFGRD 1 y,x description
+SLOPE=>SLOPE 1 y,x description
+GREENNESS=>GREENNESS1 0 0,y,x description
+GREENNESS=>GREENNESS2 0 1,y,x description
+GREENNESS=>GREENNESS3 0 2,y,x description
+GREENNESS=>GREENNESS4 0 3,y,x description
+GREENNESS=>GREENNESS5 0 4,y,x description
+GREENNESS=>GREENNESS6 0 5,y,x description
+GREENNESS=>GREENNESS7 0 6,y,x description
+GREENNESS=>GREENNESS8 0 7,y,x description
+GREENNESS=>GREENNESS9 0 8,y,x description
+GREENNESS=>GREENNESS10 0 9,y,x description
+GREENNESS=>GREENNESS11 0 10,y,x description
+GREENNESS=>GREENNESS12 0 11,y,x description
+SHDMIN=>SHDMIN 1 y,x description
+SHDMAX=>SHDMAX 1 y,x description
+ALBEDO=>ALBEDO1 0 0,y,x description
+ALBEDO=>ALBEDO2 0 1,y,x description
+ALBEDO=>ALBEDO3 0 2,y,x description
+ALBEDO=>ALBEDO4 0 3,y,x description
+ALBEDO=>ALBEDO5 0 4,y,x description
+ALBEDO=>ALBEDO6 0 5,y,x description
+ALBEDO=>ALBEDO7 0 6,y,x description
+ALBEDO=>ALBEDO8 0 7,y,x description
+ALBEDO=>ALBEDO9 0 8,y,x description
+ALBEDO=>ALBEDO10 0 9,y,x description
+ALBEDO=>ALBEDO11 0 10,y,x description
+ALBEDO=>ALBEDO12 0 11,y,x description
+MXSNALBEDO=>MXSNALBEDO 1 y,x description
+TBOT=>TBOT 1 y,x description
+SLOPETYPE=>SLOPETYPE 1 y,x description
+NOAHMP36_PBLH=>NOAHMP36PBLH 1 y,x description
+PPTCLIM=>PPTCLIM1 0 0,y,x description
+PPTCLIM=>PPTCLIM2 0 1,y,x description
+PPTCLIM=>PPTCLIM3 0 2,y,x description
+PPTCLIM=>PPTCLIM4 0 3,y,x description
+PPTCLIM=>PPTCLIM5 0 4,y,x description
+PPTCLIM=>PPTCLIM6 0 5,y,x description
+PPTCLIM=>PPTCLIM7 0 6,y,x description
+PPTCLIM=>PPTCLIM8 0 7,y,x description
+PPTCLIM=>PPTCLIM9 0 8,y,x description
+PPTCLIM=>PPTCLIM10 0 9,y,x description
+PPTCLIM=>PPTCLIM11 0 10,y,x description
+PPTCLIM=>PPTCLIM12 0 11,y,x description
+ELEV_NLDAS2=>ELEVNLDAS2 0 y,x description
+ELEVDIFF_NLDAS2=>ELEVDIFFNLDAS2 0 y,x description
+lat=>lat 1 y,x description
+lon=>lon 1 y,x description
+endvars

--- a/lis/testcases/domains/lambert_buffer/ldt.config
+++ b/lis/testcases/domains/lambert_buffer/ldt.config
@@ -1,0 +1,194 @@
+
+# == LDT Main Entry Options == 
+
+LDT running mode:     "LSM parameter processing"   
+
+Processed LSM parameter filename:  ./lis_input.d01.nc   # Final output file read by LIS-7
+
+LIS number of nests:                   1                # Total number of nests run by LIS
+Number of surface model types:         1                # Total number of desired surface model types
+Surface model types:                 "LSM"              # Surface models:  LSM | Openwater
+Land surface model:                  "Noah-MP.3.6"      # Enter LSM(s) of choice
+Lake model:                          "none"             # Enter Lake model(s) of choice
+Water fraction cutoff value:          0.5               # Fraction at which gridcell is designated as 'water
+
+Number of met forcing sources:         1                # Enter number of forcing types
+Met forcing sources:                 "NLDAS2"           # Enter 'none' if no forcing selected
+Blending method for forcings:        "overlay"
+Met spatial transform methods:       "bilinear"         # bilinear | budget-bilinear | neighbor | average
+Topographic correction method (met forcing): "lapse-rate"   # "lapse-rate"     # none | lapse-rate
+
+LDT diagnostic file:                  ldtlog            # Log-based diagnostic output file
+Mask-parameter fill diagnostic file:  MaskParamFill.log
+Undefined value:                     -9999.0            # Universal undefined value
+LDT output directory:                 OUTPUT            # If metrics or stats are written out
+Number of ensembles per tile:          1                # The number of ensemble members per tile
+
+# Processor layout 
+Number of processors along x:       2
+Number of processors along y:       2
+
+# LIS domain:  (See LDT User's Guide for other projection information)
+
+#LDT/LIS domain and grid:
+Map projection of the LIS domain: lambert
+Run domain lower left lat:        37.5   
+Run domain lower left lon:      -121.20  
+Run domain true lat1:             38.0   
+Run domain true lat2:             37.0      
+Run domain standard lon:        -120.0   
+Run domain resolution:             1.0
+Run domain x-dimension size:       215  
+Run domain y-dimension size:       110   
+
+
+# == Landcover, Landmask and Soil Texture Parameters ==
+
+# Landcover/Mask Parameter Inputs
+Landcover data source:           "MODIS_Native"
+Landcover metadata variable name: "LANDUSEF"
+Landcover classification:         "IGBPNCEP"              # Enter land cover classification type
+Landcover file:            ./input/noah_2dparms/igbp.bin      # Landcover map path
+Landcover spatial transform:      tile                  # none | mode | neighbor | tile
+Landcover fill option:            none                  # none | neighbor (Not needed if creating landmask)
+Landcover map projection:        latlon
+
+# Create landmask field from readin landcover map or read in separate landmask file
+Create or readin landmask:      "create"                # create | readin
+Landmask data source:           "MODIS_Native"          # If 'created', recommended to put Landcover source name here
+Landmask file:                   none                   # Land mask file (if needed to be read-in)
+Landmask spatial transform:      none                   # none | mode | neighbor
+
+#Soil texture map:
+Soil texture data source:    STATSGOFAO_Native
+Soil texture map:         ./input/noah_2dparms/topsoil30snew  # Enter soil texture map
+Soil texture spatial transform:   mode                  # none | mode | neighbor | tile
+Soil texture fill option:       neighbor                # none | neighbor
+Soil texture fill radius:         5                     # Number of pixels to search for neighbor
+Soil texture fill value:          6                     # Static value to fill where missing 
+Soil texture map projection:     latlon
+
+Soils spatial transform:        none            # Note: do not use mode with soil fractions
+Soils map projection:          latlon
+
+# SRTM Elevation data entries:
+Elevation data source:     "SRTM_LIS"
+Elevation metadata variable name: "HGT_M"
+Elevation map:        ./input/topo_parms/SRTM/SRTM30/srtm_elev1km.1gd4r
+Elevation number of bands:     1
+Slope data source:         "SRTM_LIS"
+Slope map:            ./input/topo_parms/SRTM/SRTM30/srtm_slope1km.1gd4r
+Slope number of bands:         1
+Aspect data source:        "SRTM_LIS"
+Aspect map:           ./input/topo_parms/SRTM/SRTM30/srtm_aspect1km.1gd4r
+Aspect number of bands:        1
+
+#Elevation data source:    "SRTM_Native"
+#Elevation map:       ./input/topo_parms/SRTM/SRTM30/raw/
+#Elevation number of bands:     1
+#Slope data source:        "SRTM_Native"
+#Slope map:           ./input/topo_parms/SRTM/SRTM30/raw/
+#Slope number of bands:         1
+#Aspect data source:       "SRTM_Native"
+#Aspect map:          ./input/topo_parms/SRTM/SRTM30/raw/
+#Aspect number of bands:        1
+
+Topography spatial transform:  neighbor
+Elevation fill option:         neighbor
+Elevation fill radius:         5
+Elevation fill value:          0
+Slope fill option:             neighbor
+Slope fill radius:             5
+Slope fill value:              0.1
+Aspect fill option:            neighbor
+Aspect fill radius:            5
+Aspect fill value:             0
+Topography map projection:     latlon
+Topography lower left lat:     -59.995
+Topography lower left lon:    -179.995
+Topography upper right lat:     89.995
+Topography upper right lon:    179.995
+Topography resolution (dx):      0.01
+Topography resolution (dy):      0.01
+   
+# == Main Noah LSM Parameters ==
+
+# Albedo maps:
+Albedo data source:            NCEP_Native
+Albedo metadata variable name: "ALBEDO12M"
+Albedo map:                 ./input/noah_2dparms/albedo       # Albedo files
+Albedo climatology interval:     monthly                # monthly | quarterly
+Albedo spatial transform:        bilinear               # average | neighbor | bilinear | budget-bilinear
+Albedo fill option:              neighbor               # none | neighbor | average
+Albedo fill radius:                5                    # Number of pixels to search for neighbor
+Albedo fill value:                0.14                  # Static value to fill where missing
+Albedo map projection:           latlon                  
+
+Max snow albedo data source:    NCEP_Native
+Max snow albedo metadata variable name: "SNOALB"
+Max snow albedo map:      ./input/noah_2dparms/maxsnoalb.asc  # Max. snow albedo map
+Max snow albedo spatial transform:  budget-bilinear     # average | neighbor | bilinear | budget-bilinear
+Max snow albedo fill option:        neighbor            # none | neighbor | average
+Max snow albedo fill radius:         5                  # Number of pixels to search for neighbor
+Max snow albedo fill value:         0.3                 # Static value to fill where missing
+Max snow albedo map projection:    latlon
+
+# Greenness fraction maps:
+Greenness data source:        NCEP_Native
+Greenness fraction metadata variable name: "GREENFRAC"
+Greenness fraction map:   ./input/noah_2dparms/gfrac          # Greenness fraction map        
+Greenness climatology interval:   monthly               # monthly
+Calculate min-max greenness fraction: .false.
+Greenness maximum map:    ./input/noah_2dparms/gfrac_max.asc  # Maximum greenness fraction map
+Greenness minimum map:    ./input/noah_2dparms/gfrac_min.asc  # Minimum greenness fraction map
+Greenness spatial transform:   bilinear                 # average | neighbor | bilinear | budget-bilinear
+Greenness fill option:         neighbor                 # none | neighbor | average
+Greenness fill radius:           5                      # Number of pixels to search for neighbor
+Greenness fill value:           0.30                    # Static value to fill where missing
+Greenness maximum fill value:   0.40                    # Static value to fill where missing
+Greenness minimum fill value:   0.20                    # Static value to fill where missing
+Greenness map projection:      latlon
+
+# Slope type map:
+Slope type data source:       NCEP_Native
+Slope type map:           ./input/noah_2dparms/islope         # Slope type map
+Slope type spatial transform:   neighbor                # none | neighbor | mode
+Slope type fill option:         neighbor                # none | neighbor
+Slope type fill radius:           5                     # Number of pixels to search for neighbor
+Slope type fill value:            3                     # Static value to fill where missing
+Slope type map projection:      latlon
+
+# Bottom temperature map (lapse-rate correction option):
+Bottom temperature data source:     ISLSCP1
+Bottom temperature map:     ./input/noah_2dparms/SOILTEMP.60     # Bottom soil temperature file
+Bottom temperature topographic downscaling:  "lapse-rate"  # none | lapse-rate
+Bottom temperature spatial transform:  bilinear            # average | neighbor | bilinear | budget-bilinear
+Bottom temperature fill option:        average             # none | average | neighbor
+Bottom temperature fill radius:        5                   # Number of pixels to search for neighbor
+Bottom temperature fill value:         287.                # Static value to fill where missing
+Bottom temperature map projection:     latlon              # Projection type
+
+# Noah-MP Specific Parameters:
+
+Noah-MP PBL Height Value:   900.     # Planetary Boundary layer height (in meters)
+
+# ---------------------------------------------------------------------
+
+### Crop information (used also in conjuction with irrigation modeling)
+
+Incorporate crop information:  .false.      # Option to modify LSM parameters if crop info present
+
+# ---------------------------------------------------------------------
+
+# Metforcing elevation maps
+
+NLDAS2 elevation difference map: ./input/NLDAS_0.125/NARR_elev-diff.1gd4r 
+NARR terrain height map:         ./input/NLDAS_0.125/NARR_elevation.1gd4r 
+
+PPT climatology data source:      PRISM
+PPT climatology maps:          ./input/climate_maps/PRISM/1KM/ppt/ppt_1981_2010
+PPT climatology interval:         monthly
+Climate params spatial transform: average
+
+# ---------------------------------------------------------------------
+

--- a/lis/testcases/domains/lambert_buffer/lis.config
+++ b/lis/testcases/domains/lambert_buffer/lis.config
@@ -1,0 +1,254 @@
+#Overall driver options
+Running mode: 		                     "retrospective"
+Map projection of the LIS domain:            "lambert"
+Number of nests:                             1 
+Number of surface model types:               1
+Surface model types:                         "LSM"
+Land surface model:                          "NoahMP.3.6"
+Surface model output interval:               "3hr" 
+
+Number of met forcing sources:               1
+Blending method for forcings:                "overlay"  # overlay or ensemble
+Met forcing sources:                         "NLDAS2" 
+Topographic correction method (met forcing): "lapse-rate" 
+Enable spatial downscaling of precipitation: 0          # 0 or 1
+Spatial interpolation method (met forcing):  "bilinear" # “budget-bilinear”,“bilinear” or “neighbor”
+Spatial upscaling method (met forcing):      "none"     # “average” - only option for now 
+Temporal interpolation method (met forcing): "linear"   # linear or trilinear 
+
+Enable new zterp correction (met forcing):   .true. # .false. or .true.
+
+#Runtime options
+Forcing variables list file:               "./input/forcing_variables.txt"
+Output forcing:                            1   # 1-yes
+Output parameters:                         0   # 0- no
+Output model restart files:                1
+Output methodology:                        "2d gridspace"  #  for OL run: "2d gridspace"
+#Output data format:                        "netcdf"
+Output data format:                        "binary"
+Output naming style:                       "3 level hierarchy"
+Start mode:                                coldstart  # restart or coldstart
+Starting year:                             2001
+Starting month:                            1
+Starting day:                              1
+Starting hour:                             0
+Starting minute:                           30
+Starting second:                           0
+Ending year:                               2001
+Ending month:                              1
+Ending day:                                1 
+Ending hour:                               23
+Ending minute:                             30
+Ending second:                             0
+Undefined value:                          -9999
+Output directory:                          "OUTPUT"      # 'OUTPUT' 
+Diagnostic output file:                    "OUTPUT/lislog" 
+Number of ensembles per tile:              1
+
+#The following options are used for subgrid tiling based on vegetation
+Maximum number of surface type tiles per grid:     1
+Minimum cutoff percentage (surface type tiles):    0.10 
+Maximum number of soil texture tiles per grid:     1
+Minimum cutoff percentage (soil texture tiles):    0.10
+Maximum number of soil fraction tiles per grid:    1
+Minimum cutoff percentage (soil fraction tiles):   0.10
+Maximum number of elevation bands per grid:        1
+Minimum cutoff percentage (elevation bands):       0.10
+Maximum number of slope bands per grid:            1
+Minimum cutoff percentage (slope bands):           0.10
+Maximum number of aspect bands per grid:           1
+Minimum cutoff percentage (aspect bands):          0.10
+
+#Processor Layout	
+#Should match the total number of processors used
+
+Number of processors along x:    2
+Number of processors along y:    2
+Halo size along x: 0 
+Halo size along y: 0 
+
+#------------------------ ROUTING -------------------------------------
+
+Routing model:              "none"
+
+#-------------------------IRRIGATION-----------------------------------
+
+Irrigation scheme:          "none"
+Irrigation ouput interval:  "1da"
+
+#------------------------RADIATIVE TRANSFER MODELS--------------------------
+
+Radiative transfer model:   "none"
+
+#------------------------APPLICATION MODELS---------------------------------
+
+Number of application models: 0
+
+
+#------------------------DOMAIN SPECIFICATION--------------------------
+
+#The following options list the choice of parameter maps to be used
+
+LIS domain and parameter data file: "lis_input.d01.nc"
+
+Landmask data source:            "LDT"
+Landcover data source:           "LDT"
+Soil texture data source:        "LDT"
+Soil fraction data source:       "none"
+Soil color data source:          "none"
+Elevation data source:           "LDT"
+Slope data source:               "LDT"
+Aspect data source:              "LDT"
+Curvature data source:           "none"
+LAI data source:                 "none"
+SAI data source:                 "none"
+Albedo data source:              "LDT"
+Max snow albedo data source:     "LDT"
+Greenness data source:           "LDT"  
+Roughness data source:           "none"  
+Porosity data source:            "none"
+Ksat data source:                "none"
+B parameter data source:         "none"
+Quartz data source:              "none"
+Emissivity data source:          "none"
+
+#--------------------------------FORCINGS----------------------------------
+
+NLDAS2 forcing directory:               "./input/MET_FORCING/NLDAS2.FORCING" 
+NLDAS2 data center source:              "GES-DISC"
+NLDAS2 use model level data:            0 
+NLDAS2 use model based swdown:          0 
+NLDAS2 use model based precip:          0
+NLDAS2 use model based pressure:        0
+
+#-----------------------LAND SURFACE MODELS--------------------------
+
+# Noah-MP (3.6) Input Settings
+
+#  Model time step in string format (eg. 1hr, 3600s)
+Noah-MP.3.6 model timestep:     "15mn"
+#
+### Restart Settings of NOAH-MP.3.6:
+Noah-MP.3.6 restart file:             none
+Noah-MP.3.6 restart file format:     "netcdf"       # netcdf | binary
+Noah-MP.3.6 restart output interval:   1mo
+# Restart output interval in string format (eg. 1 hr, 3600s)
+###
+### Constant Parameters for Noah-MP.3.6 
+###
+Noah-MP.3.6 number of soil layers:               4      # number of soil layers
+Noah-MP.3.6 number of snow layers:               3      # maximum number of snow layers
+Noah-MP.3.6 landuse parameter table:  "./input/LS_PARAMETERS/noahmp36_parms/VEGPARM.TBL"   
+Noah-MP.3.6 soil parameter table:     "./input/LS_PARAMETERS/noahmp36_parms/SOILPARM.TBL.WRF-3.9"  
+Noah-MP.3.6 general parameter table:  "./input/LS_PARAMETERS/noahmp36_parms/GENPARM.TBL"  
+Noah-MP.3.6 MP parameter table:       "./input/LS_PARAMETERS/noahmp36_parms/MPTABLE.TBL" 
+Noah-MP.3.6 vegetation model option:                4      # 1-prescr. LAI/SHDFAC; 2-dynamic; 3-SHDFAC=f(LAI); 4-LAI,const(SHDFAC)
+Noah-MP.3.6 canopy stomatal resistance option:      1      # 1=Ball-Berry; 2=Jarvis
+Noah-MP.3.6 soil moisture factor for stomatal resistance option:   1   # 1=Noah; 2=CLM; 3=SSiB
+Noah-MP.3.6 runoff and groundwater option:          1      # 1=SIMGM; 2=SIMTOP; 3=Schaake96; 4=BATS
+Noah-MP.3.6 surface layer drag coefficient option:  1      # 1=M-O; 2=Chen97
+Noah-MP.3.6 supercooled liquid water option:        1      # 1=NY06; 2=Koren99
+Noah-MP.3.6 frozen soil permeability option:        1      # 1=NY06; 2=Koren99
+Noah-MP.3.6 radiation transfer option:              1      # 1=gap=F(3D;cosz); 2=gap=0; 3=gap=1-Fveg
+Noah-MP.3.6 snow surface albedo option:             2      # 1=BATS; 2=CLASS
+Noah-MP.3.6 rainfall and snowfall option:           1      # 1=Jordan91; 2=BATS; 3=Noah
+Noah-MP.3.6 lower boundary of soil temperature option:  2  # 1=zero-flux; 2=Noah
+Noah-MP.3.6 snow and soil temperature time scheme:      1  # 1=semi-implicit; 2=fully implicit
+Noah-MP.3.6 soil layer thickness:      0.1 0.3 0.6 1.0     # Soil layer thicknesses (m)
+Noah-MP.3.6 soil color index:          4                   # Soil color
+Noah-MP.3.6 CZIL option (iz0tlnd):     0                   # Option of Chen adjustment of Czil
+Noah-MP.3.6 initial reference height of temperature and humidity:       10.0
+###
+### Initial Conditions of Noah-MP.3.6 ("coldstart")
+###
+Noah-MP.3.6 initial value of snow albedo at the last timestep:  0.2
+Noah-MP.3.6 initial value of snow mass at the last timestep:    0.0
+Noah-MP.3.6 initial soil temperatures:                      288.0  288.0  288.0  288.0
+Noah-MP.3.6 initial total soil moistures:                    0.20   0.20   0.20   0.20
+Noah-MP.3.6 initial liquid soil moistures:                   0.20   0.20   0.20   0.20
+Noah-MP.3.6 initial canopy air temperature:                288.0
+Noah-MP.3.6 initial canopy air vapor pressure:             261.68518
+Noah-MP.3.6 initial wetted or snowed fraction of canopy:     0.0
+Noah-MP.3.6 initial intercepted liquid water:                0.0
+Noah-MP.3.6 initial intercepted ice mass:                    0.0
+Noah-MP.3.6 initial vegetation temperature:                288.0
+Noah-MP.3.6 initial ground temperature:                    288.0
+Noah-MP.3.6 initial snowfall on the ground:                  0.0
+Noah-MP.3.6 initial snow height:                             0.0
+Noah-MP.3.6 initial snow water equivalent:                   0.0
+Noah-MP.3.6 initial depth to water table:                    2.5
+Noah-MP.3.6 initial water storage in aquifer:             4900.0
+Noah-MP.3.6 initial water in aquifer and saturated soil:  4900.0
+Noah-MP.3.6 initial lake water storage:                      0.0
+Noah-MP.3.6 initial leaf mass:                               9.0
+Noah-MP.3.6 initial mass of fine roots:                    500.0
+Noah-MP.3.6 initial stem mass:                               3.33
+Noah-MP.3.6 initial mass of wood including woody roots:    500.0
+Noah-MP.3.6 initial stable carbon in deep soil:           1000.0
+Noah-MP.3.6 initial short-lived carbon in shallow soil:   1000.0
+Noah-MP.3.6 initial LAI:                                     0.5
+Noah-MP.3.6 initial SAI:                                     0.1
+Noah-MP.3.6 initial momentum drag coefficient:               0.0
+Noah-MP.3.6 initial sensible heat exchange coefficient:      0.0
+Noah-MP.3.6 initial snow aging term:                         0.0
+Noah-MP.3.6 initial soil water content between bottom of the soil and water table:  0.0
+Noah-MP.3.6 initial recharge to or from the water table when deep:                  0.0
+Noah-MP.3.6 initial recharge to or from the water table when shallow:               0.0
+Noah-MP.3.6 initial reference height of temperature and humidity:                  10.0
+
+
+#---------------------------MODEL OUTPUT CONFIGURATION-----------------------
+
+#Specify the list of ALMA variables that need to be featured in the 
+#LSM model output
+Model output attributes file:   './MODEL_OUTPUT_LIST.TBL'
+
+Output start year:
+Output start month:
+Output start day:
+Output start hour:
+Output start minutes:
+Output start seconds:
+
+#---------------------DATA ASSIMILATION ----------------------------------
+
+#Data Assimilation Options
+Number of data assimilation instances:               0
+Data assimilation algorithm:                         "none"
+Data assimilation set:                               "none"
+Data assimilation exclude analysis increments:       0
+Data assimilation output interval for diagnostics:   "1da"
+Data assimilation number of observation types:       0
+Data assimilation output ensemble members:           0
+Data assimilation output processed observations:     0
+Data assimilation output innovations:                0
+Number of state variables:                           0
+
+Apply perturbation bias correction:        0
+Bias estimation algorithm:                "none"
+Bias estimation attributes file:          "none"
+Bias estimation restart output frequency:
+Bias estimation start mode:
+Bias estimation restart file:
+
+#Perturbation options
+Perturbations start mode:                 "coldstart"
+Perturbations restart output interval:    "1mo"
+Perturbations restart filename:           "none" #./LIS_DAPERT_200906302330.d01.bin 
+
+
+Forcing perturbation algorithm:           "none"
+Forcing perturbation frequency:           "1hr"
+Forcing attributes file:                  "none" #./forcing_attribs.txt
+Forcing perturbation attributes file:     "none" #./forcing_pert_attribs.txt
+
+State perturbation algorithm:             "none"
+State perturbation frequency:             "3hr"
+State attributes file:                    "none" #./noah_sm_attribs.txt
+State perturbation attributes file:       "none" #./noah_sm_pertattribs.txt
+
+Observation perturbation algorithm:       "none"
+Observation perturbation frequency:       "6hr"
+Observation attributes file:              "none" #./LPRMobs_attribs.txt
+Observation perturbation attributes file: "none" #./LPRMobs_pertattribs.txt
+

--- a/lis/testcases/domains/lambert_buffer/output.ctl
+++ b/lis/testcases/domains/lambert_buffer/output.ctl
@@ -1,0 +1,41 @@
+DSET       ^OUTPUT/SURFACEMODEL/%y4%m2/LIS_HIST_%y4%m2%d2%h200.d01.gs4r
+TITLE       LIS NoahMP-3.6 output
+OPTIONS     template
+OPTIONS     sequential
+OPTIONS     big_endian
+UNDEF       -9999.
+* Lambert conformal:
+*pdef 215 110 lcc 37.50 -120.20 1 1 37 38 -120 1000 1000
+*xdef 215 linear -121.20 0.02
+*ydef 110 linear   37.00 0.02
+* Latlon grid-equivalent:
+xdef 215 linear -121.20 0.01
+ydef 110 linear   37.50 0.01
+ZDEF          1 LINEAR          1.0     1.0
+TDEF          7 LINEAR 03Z01jan2001     3hr
+VARS         24
+SWnet         1  99  ** Net shortwave radiation [W m-2]
+LWnet         1  99  ** Net longwave radiation [W m-2]
+Qle           1  99  ** Latent heat flux [W m-2]
+Qh            1  99  ** Sensible heat flux [W m-2]
+Qg            1  99  ** Ground heat flux [W m-2]
+Evap          1  99  ** Total evapotranspiration [kg m-2 sec-1]
+Qs            1  99  ** Surface runoff [kg m-2 sec-1]
+Qsb           1  99  ** Subsurface runoff [kg m-2 sec-1]
+SWE           1  99  ** Snow water equivalent [kg m-2]
+SoilMoist1    1  99  ** Soil water content layer 1 [kg m-2]
+SoilMoist2    1  99  ** Soil water content layer 2 [kg m-2]
+SoilMoist3    1  99  ** Soil water content layer 3 [kg m-2]
+SoilMoist4    1  99  ** Soil water content layer 4 [kg m-2]
+SoilTemp1     1  99  ** Soil temperature layer 1 [K]
+SoilTemp2     1  99  ** Soil temperature layer 2 [K]
+SoilTemp3     1  99  ** Soil temperature layer 3 [K]
+SoilTemp4     1  99  ** Soil temperature layer 4 [K]
+Wind_f        1  99  ** Near-surface wind magnitude [m sec-1]
+Rainf_f       1  99  ** Rainfall rate [kg m-2 sec-1]
+Tair_f        1  99  ** Near-surface air temperature [K]
+SWdown_f      1  99  ** Surface incident shortwave radiation [W m-2]
+LWdown_f      1  99  ** Surface incident longwave radiation [W m-2]
+Greenness     1  99  ** Green vegetation (shade) fraction [-]
+TotalPrecip   1  99  ** Total precipitation rate [kg m-2 sec-1]
+ENDVARS

--- a/lis/testcases/domains/lambert_buffer/testcase.ctl
+++ b/lis/testcases/domains/lambert_buffer/testcase.ctl
@@ -1,0 +1,41 @@
+DSET       ^TARGET_OUTPUT/SURFACEMODEL/%y4%m2/LIS_HIST_%y4%m2%d2%h200.d01.gs4r
+TITLE       LIS NoahMP-3.6 output
+OPTIONS     template
+OPTIONS     sequential
+OPTIONS     big_endian
+UNDEF       -9999.
+* Lambert conformal:
+*pdef 215 110 lcc 37.50 -120.20 1 1 37 38 -120 1000 1000
+*xdef 215 linear -121.20 0.02
+*ydef 110 linear   37.00 0.02
+* Latlon grid-equivalent:
+xdef 215 linear -121.20 0.01
+ydef 110 linear   37.50 0.01
+ZDEF          1 LINEAR             1.0     1.0
+TDEF          7 LINEAR 03Z01jan2001     3hr
+VARS         24
+SWnet         1  99  ** Net shortwave radiation [W m-2]
+LWnet         1  99  ** Net longwave radiation [W m-2]
+Qle           1  99  ** Latent heat flux [W m-2]
+Qh            1  99  ** Sensible heat flux [W m-2]
+Qg            1  99  ** Ground heat flux [W m-2]
+Evap          1  99  ** Total evapotranspiration [kg m-2 sec-1]
+Qs            1  99  ** Surface runoff [kg m-2 sec-1]
+Qsb           1  99  ** Subsurface runoff [kg m-2 sec-1]
+SWE           1  99  ** Snow water equivalent [kg m-2]
+SoilMoist1    1  99  ** Soil water content layer 1 [kg m-2]
+SoilMoist2    1  99  ** Soil water content layer 2 [kg m-2]
+SoilMoist3    1  99  ** Soil water content layer 3 [kg m-2]
+SoilMoist4    1  99  ** Soil water content layer 4 [kg m-2]
+SoilTemp1     1  99  ** Soil temperature layer 1 [K]
+SoilTemp2     1  99  ** Soil temperature layer 2 [K]
+SoilTemp3     1  99  ** Soil temperature layer 3 [K]
+SoilTemp4     1  99  ** Soil temperature layer 4 [K]
+Wind_f        1  99  ** Near-surface wind magnitude [m sec-1]
+Rainf_f       1  99  ** Rainfall rate [kg m-2 sec-1]
+Tair_f        1  99  ** Near-surface air temperature [K]
+SWdown_f      1  99  ** Surface incident shortwave radiation [W m-2]
+LWdown_f      1  99  ** Surface incident longwave radiation [W m-2]
+Greenness     1  99  ** Green vegetation (shade) fraction [-]
+TotalPrecip   1  99  ** Total precipitation rate [kg m-2 sec-1]
+ENDVARS

--- a/lis/testcases/domains/latlon_idlcross/lis.config
+++ b/lis/testcases/domains/latlon_idlcross/lis.config
@@ -48,7 +48,7 @@ Diagnostic output file:                   './OUTPUT/lislog'
 
 #The following options are used for subgrid tiling based on vegetation
 Maximum number of surface type tiles per grid:     1
-Minimum cutoff percentage (surface type tiles):    0.10 
+Minimum cutoff percentage (surface type tiles):    0.07
 Maximum number of soil texture tiles per grid:     1
 Minimum cutoff percentage (soil texture tiles):    0.10
 Maximum number of soil fraction tiles per grid:    1


### PR DESCRIPTION
Add new buffer area to LIS target domains in LIS when subsetting parameters and reinterpolating them to the new target grid. 

This new code was applied to remove a bug involved with curvilinear projections (e.g., Lambert conformal). 

Also, an outdated longitude ordering (from E->W) was discovered in some of the ipolates routines, which were corrected to allow longitudinal ordering to go from W->E, as LIS convention follows, fixing issues for projections, like latlon grids crossing the International Dateline.

Testcase was also setup and instructions provided.