### PR TITLE
Changed NoahMP soil thickness units to centimeters in history output.

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_lsmMod.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_lsmMod.F90
@@ -323,7 +323,11 @@ contains
             ! TODO: set number of soil temperature layers in surface model
             LIS_sfmodel_struc(n)%nst_layers = NOAHMP401_struc(n)%nsoil
             allocate(LIS_sfmodel_struc(n)%lyrthk(NOAHMP401_struc(n)%nsoil))
-            LIS_sfmodel_struc(n)%lyrthk(:) = NOAHMP401_struc(n)%sldpth(:)
+            !LIS_sfmodel_struc(n)%lyrthk(:) = NOAHMP401_struc(n)%sldpth(:)
+            !EMK...Output soil layer thicknesses in centimeters for 
+            !consistency with other LSMs.  
+            LIS_sfmodel_struc(n)%lyrthk(:) = &
+                 100*NOAHMP401_struc(n)%sldpth(:)
             LIS_sfmodel_struc(n)%ts = NOAHMP401_struc(n)%ts
         enddo
     end subroutine NoahMP401_ini


### PR DESCRIPTION
This change is for consistency with other LSMs, and for LVT (in 557 post mode).
Note that the units in the internal variable (used by NoahMP itself) remain in
meters.