### PR TITLE
Update netcdf references to recent LDT paper

### DIFF
--- a/ldt/LDTSI/LDTSI_netcdfMod.F90
+++ b/ldt/LDTSI/LDTSI_netcdfMod.F90
@@ -351,7 +351,7 @@ contains
               '[ERR] nf90_put_att failed')
 #endif
          call LDT_verify(nf90_put_att(ncid,nf90_global,"references", &
-              "Kumar_etal_EMS_2006, Peters-Lidard_etal_ISSE_2007"), &
+              "Arsenault_etal_GMD_2018, Kumar_etal_EMS_2006"),&
               '[ERR] nf90_put_att failed')
          call LDT_verify(nf90_put_att(ncid,nf90_global,"comment", &
               "website: http://lis.gsfc.nasa.gov/"), &

--- a/ldt/core/LDT_ANNMod.F90
+++ b/ldt/core/LDT_ANNMod.F90
@@ -1132,7 +1132,7 @@ contains
          "created on date: "//date(1:4)//"-"//date(5:6)//"-"//&
          date(7:8)//"T"//time(1:2)//":"//time(3:4)//":"//time(5:10)))
     call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"references", &
-         "Kumar_etal_EMS_2006, Peters-Lidard_etal_ISSE_2007"))
+         "Arsenault_etal_GMD_2018, Kumar_etal_EMS_2006"))
     call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"comment", &
          "website: http://lis.gsfc.nasa.gov/"))
 
@@ -1347,7 +1347,7 @@ contains
          "created on date: "//date(1:4)//"-"//date(5:6)//"-"//&
          date(7:8)//"T"//time(1:2)//":"//time(3:4)//":"//time(5:10)))
     call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"references", &
-         "Kumar_etal_EMS_2006, Peters-Lidard_etal_ISSE_2007"))
+         "Arsenault_etal_GMD_2018, Kumar_etal_EMS_2006"))
     call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"comment", &
          "website: http://lis.gsfc.nasa.gov/"))
 

--- a/ldt/core/LDT_DAmetricsMod.F90
+++ b/ldt/core/LDT_DAmetricsMod.F90
@@ -266,7 +266,7 @@ contains
             "created on date: "//date(1:4)//"-"//date(5:6)//"-"//&
             date(7:8)//"T"//time(1:2)//":"//time(3:4)//":"//time(5:10)))
        call LDT_verify(nf90_put_att(LDT_rc%ftn_DAobs_domain,NF90_GLOBAL,"references", &
-            "Kumar_etal_EMS_2006, Peters-Lidard_etal_ISSE_2007"))
+            "Arsenault_etal_GMD_2018, Kumar_etal_EMS_2006"))
        call LDT_verify(nf90_put_att(LDT_rc%ftn_DAobs_domain,NF90_GLOBAL,"comment", &
             "website: http://lis.gsfc.nasa.gov/"))
        
@@ -812,7 +812,7 @@ contains
          "created on date: "//date(1:4)//"-"//date(5:6)//"-"//&
          date(7:8)//"T"//time(1:2)//":"//time(3:4)//":"//time(5:10)))
     call LDT_verify(nf90_put_att(LDT_rc%ftn_cdf,NF90_GLOBAL,"references", &
-         "Kumar_etal_EMS_2006, Peters-Lidard_etal_ISSE_2007"))
+         "Arsenault_etal_GMD_2018, Kumar_etal_EMS_2006"))
     call LDT_verify(nf90_put_att(LDT_rc%ftn_cdf,NF90_GLOBAL,"comment", &
          "website: http://lis.gsfc.nasa.gov/"))
 #endif
@@ -971,7 +971,7 @@ contains
          "created on date: "//date(1:4)//"-"//date(5:6)//"-"//&
          date(7:8)//"T"//time(1:2)//":"//time(3:4)//":"//time(5:10)))
     call LDT_verify(nf90_put_att(LDT_rc%ftn_DAobs_domain,NF90_GLOBAL,"references", &
-         "Kumar_etal_EMS_2006, Peters-Lidard_etal_ISSE_2007"))
+         "Arsenault_etal_GMD_2018, Kumar_etal_EMS_2006"))
     call LDT_verify(nf90_put_att(LDT_rc%ftn_DAobs_domain,NF90_GLOBAL,"comment", &
          "website: http://lis.gsfc.nasa.gov/"))
 

--- a/ldt/core/LDT_ensRstMod.F90
+++ b/ldt/core/LDT_ensRstMod.F90
@@ -949,7 +949,7 @@ module LDT_ensRstMod
            date(7:8)//"T"//time(1:2)//":"//time(3:4)//":"//time(5:10)),&
            'nf90_put_att failed for history')
       call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"references", &
-           "Kumar_etal_EMS_2006, Peters-Lidard_etal_ISSE_2007"),&
+           "Arsenault_etal_GMD_2018, Kumar_etal_EMS_2006"),&
            'nf90_put_att failed for references')
       call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"conventions", &
            "CF-1.6"),'nf90_put_att failed for conventions') !CF version 1.6

--- a/ldt/core/LDT_metforcingMod.F90
+++ b/ldt/core/LDT_metforcingMod.F90
@@ -2738,7 +2738,7 @@ contains
             date(7:8)//"T"//time(1:2)//":"//time(3:4)//":"//time(5:10)),&
             'nf90_put_att for history failed in LDT_metforcingMod')
        call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"references", &
-            "Kumar_etal_EMS_2006, Peters-Lidard_etal_ISSE_2007"),&
+            "Arsenault_etal_GMD_2018, Kumar_etal_EMS_2006"),&
             'nf90_put_att for references failed in LDT_metforcingMod')
        call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"conventions", &
             "CF-1.6"),'nf90_put_att for conventions failed in LDT_metforcingMod')

--- a/ldt/core/LDT_paramProcMod.F90
+++ b/ldt/core/LDT_paramProcMod.F90
@@ -774,7 +774,7 @@ contains
             date(7:8)//"T"//time(1:2)//":"//time(3:4)//":"//time(5:10)))
 #endif
        call LDT_verify(nf90_put_att(LDT_LSMparam_struc(n)%param_file_ftn,NF90_GLOBAL,"references", &
-            "Kumar_etal_EMS_2006, Peters-Lidard_etal_ISSE_2007"))
+            "Arsenault_etal_GMD_2018, Kumar_etal_EMS_2006"))
        call LDT_verify(nf90_put_att(LDT_LSMparam_struc(n)%param_file_ftn,NF90_GLOBAL,"comment", &
             "website: http://lis.gsfc.nasa.gov/"))
        

--- a/ldt/core/LDT_rstProcMod.F90
+++ b/ldt/core/LDT_rstProcMod.F90
@@ -1036,7 +1036,7 @@ module LDT_rstProcMod
            date(7:8)//"T"//time(1:2)//":"//time(3:4)//":"//time(5:10)),&
            'nf90_put_att failed for history')
       call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"references", &
-           "Kumar_etal_EMS_2006, Peters-Lidard_etal_ISSE_2007"),&
+           "Arsenault_etal_GMD_2018, Kumar_etal_EMS_2006"),&
            'nf90_put_att failed for references')
       call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"conventions", &
            "CF-1.6"),'nf90_put_att failed for conventions') !CF version 1.6

--- a/ldt/statDscale/Climo/forcingClimoMod.F90
+++ b/ldt/statDscale/Climo/forcingClimoMod.F90
@@ -412,7 +412,7 @@ contains
             date(7:8)//"T"//time(1:2)//":"//time(3:4)//":"//time(5:10)),&
             'nf90_put_att for history failed in LDT_metforcingMod')
        call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"references", &
-            "Kumar_etal_EMS_2006, Peters-Lidard_etal_ISSE_2007"),&
+            "Arsenault_etal_GMD_2018, Kumar_etal_EMS_2006"),&
             'nf90_put_att for references failed in LDT_metforcingMod')
        call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"conventions", &
             "CF-1.6"),'nf90_put_att for conventions failed in LDT_metforcingMod')


### PR DESCRIPTION
 Included the LDT description paper citation within
 routines that generate any netcdf files that contain
 references for LDT and LIS as global attributes.