### PR TITLE
Fix for domains crossing PM in LDT

### DIFF
--- a/ldt/core/LDT_fileIOMod.F90
+++ b/ldt/core/LDT_fileIOMod.F90
@@ -1054,9 +1054,9 @@ subroutine LDT_create_daobs_filename(n, fname)
          array_out(:,1) = array_in(:)
 
       case default
-         write(*,*) "[ERR] This spatial transformation option ("//trim(gridtransform_opt)//") "
-         write(*,*) " is not currently supported."
-         write(*,*) " Program stopping ..."
+         write(LDT_logunit,*) "[ERR] This spatial transformation option ("//trim(gridtransform_opt)//") "
+         write(LDT_logunit,*) " is not currently supported."
+         write(LDT_logunit,*) " Program stopping ..."
          call LDT_endrun
     end select
 
@@ -1250,8 +1250,8 @@ subroutine LDT_create_daobs_filename(n, fname)
       enddo
 #endif
     case default
-      write(*,*) "[ERR] This parameter projection is not supported (in readparam_real_2d)"
-      write(*,*) " Program stopping ..."
+      write(LDT_logunit,*) "[ERR] This parameter projection is not supported (in readparam_real_2d)"
+      write(LDT_logunit,*) " Program stopping ..."
       call LDT_endrun
    end select 
 
@@ -1431,8 +1431,8 @@ subroutine LDT_create_daobs_filename(n, fname)
       enddo
 #endif
     case default
-      write(*,*) "[ERR] This parameter projection is not supported (in readparam_int_2d)"
-      write(*,*) " Program stopping ..."
+      write(LDT_logunit,*) "[ERR] This parameter projection is not supported (in readparam_int_2d)"
+      write(LDT_logunit,*) " Program stopping ..."
       call LDT_endrun
    end select 
 

--- a/ldt/interp/compute_earth_coord_latlon.F90
+++ b/ldt/interp/compute_earth_coord_latlon.F90
@@ -86,7 +86,6 @@ subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
      ymin=0
      ymax=jm+1
      nret=0
-
      if( rlon1 < 0 ) then
        rlon1 = 360+rlon1
      endif
@@ -94,7 +93,6 @@ subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
      do n=1,npts
         if( xpts(n).ge.xmin.and.xpts(n).le.xmax.and. & 
             ypts(n).ge.ymin.and.ypts(n).le.ymax ) then
-
 !  original code 
 !           rlon(n)=rlon1+dlon*(xpts(n)-1)
 !           if(rlon(n).lt.0) then 
@@ -103,7 +101,7 @@ subroutine compute_earth_coord_latlon(gridDesc,npts,fill,xpts,ypts,&
 !  new code (KRA)
            rlon(n) = rlon1+dlon*(xpts(n)-1)
            if( rlon(n) > 360. ) then
-             rlon(n) = dlon*(xpts(n)-1)  ! rlon1 reset to 0. in this case
+             rlon(n) = rlon(n)-360. 
            endif
            rlat(n)=rlat1+dlat*(ypts(n)-1)
            nret=nret+1


### PR DESCRIPTION
 With the latest LDT updates made to the interp routines,
  one more fix is required to compute_earth_coord_latlon.F90
  to address an issue related to crossing the Prime Meridian (PM).

 This should be the last fix committed for this Git fix/410
  issue.

 For the other routine committed, I simply changed some write statements
  to write to the LDT log unit file.

For testing, I tested over three different domains throughout the globe and for both latlon and lambert projections. This latest commit fixes an issue and worked for all the tests run.