### PR TITLE
Revise list of LIS variables to smooth

### DIFF
--- a/lvt/utils/afwa/run_ncks.py
+++ b/lvt/utils/afwa/run_ncks.py
@@ -29,6 +29,7 @@
 #               support for NoahMP
 # 03 Dec 2019:  Eric Kemp (SSAI), added Greenness_inst for Noah and NoahMP.
 #               Not included for JULES since that LSM doesn't use it.
+# 09 Jan 2020:  Eric Kemp (SSAI), added Tair_f_min for JULES for 3hr.
 #
 #------------------------------------------------------------------------------
 
@@ -41,8 +42,8 @@ import sys
 #------------------------------------------------------------------------------
 
 # Path to NCO ncks program
-_NCKS_PATH = "/app/nco/4.5.2-gnu/bin/ncks" # On Conrad
-#_NCKS_PATH = "/usr/local/other/SLES11.1/nco/4.4.4/intel-12.1.0.233/bin/ncks"
+#_NCKS_PATH = "/app/nco/4.5.2-gnu/bin/ncks" # On Conrad
+_NCKS_PATH = "/usr/local/other/SLES11.1/nco/4.4.4/intel-12.1.0.233/bin/ncks"
 
 # Supported LIS LSMs
 _LIS_LSMS = ["NOAH", "NOAHMP", "JULES"] 
@@ -201,7 +202,10 @@ for var in _LVT_NOAHMP_INVOCATIONS_24HR_LATEST:
 # The JULES variables handled by each LVT invocation.
 _LIS_JULES_VARIABLES_3HR = {}
 for var in _LVT_JULES_INVOCATIONS_3HR:
-    _LIS_JULES_VARIABLES_3HR[var] = [var]
+    if var == "RHMin_inst":
+        _LIS_JULES_VARIABLES_3HR[var] = [var,"Tair_f_min"]
+    else:
+        _LIS_JULES_VARIABLES_3HR[var] = [var]
 
 # The JULES variables handled by each LVT invocation.
 _LIS_JULES_VARIABLES_24HR = {}

--- a/lvt/utils/afwa/templates/make_lvt_config_24hr_jules.py
+++ b/lvt/utils/afwa/templates/make_lvt_config_24hr_jules.py
@@ -6,15 +6,11 @@ import sys
 
 template = "lvt.config.template"
 
-#startdt = datetime.datetime(2008,5,15,0)
-#enddt = datetime.datetime(2008,5,16,0)
-#startdt = datetime.datetime(2018,2,28,0)
-#enddt =   datetime.datetime(2018,3, 1,0)
 startdt = datetime.datetime(2018,  7,30, 0)
 enddt =   datetime.datetime(2018,  7,31, 0)
 
-#output = "netcdf"
-output = "grib2"
+output = "netcdf"
+#output = "grib2"
 
 # Most variables are processed independently, and are listed below.
 var_attributes = {
@@ -45,6 +41,14 @@ var_attributes_special = {
     "RHMin_inst" : \
         "RHMin       1  1  %      -  0  1 RHMin       1  1  %      -  0  1",
 }
+
+# Smooth variables that are perturbed, derived from perturbed variables,
+# or are LSM outputs that are affected by perturbed variables via physics.
+smooth_vars = ["Evap_tavg", "LWdown_f_tavg", "SoilMoist_tavg", 
+               "SoilTemp_tavg", "SWdown_f_tavg", 
+               "Tair_f_max", "Tair_f_tavg", 
+               "TotalPrecip_acc", "Tair_f_min", "RHMin_inst"]
+
 lines = open(template,'r').readlines()
 
 vars = var_attributes.keys()
@@ -56,7 +60,12 @@ for var in vars:
         if "LVT output format:" in line:
             line = "LVT output format: %s\n" %(output)
         elif "Process HYCOM data:" in line:
-                line = "Process HYCOM data: 0\n"
+            line = "Process HYCOM data: 0\n"
+        elif "Apply noise reduction filter:" in line:
+            if var in smooth_vars:
+                line = "Apply noise reduction filter: 1\n"
+            else:
+                line = "Apply noise reduction filter: 0\n"
         elif "Starting year:" in line:
             line = "Starting year: %s\n" %(startdt.year)
         elif "Starting month:" in line:

--- a/lvt/utils/afwa/templates/make_lvt_config_24hr_noah.py
+++ b/lvt/utils/afwa/templates/make_lvt_config_24hr_noah.py
@@ -9,8 +9,8 @@ template = "lvt.config.template"
 startdt = datetime.datetime(2018,9,13,12)
 enddt =   datetime.datetime(2018,9,14,12)
 
-#output = "netcdf"
-output = "grib2"
+output = "netcdf"
+#output = "grib2"
 
 # Most variables are processed independently, and are listed below.
 var_attributes = {
@@ -43,6 +43,15 @@ var_attributes_special = {
     "RHMin_inst" : \
         "RHMin       1  1  %      -  0  1 RHMin       1  1  %      -  0  1",
 }
+
+# Smooth variables that are perturbed, derived from perturbed variables,
+# or are LSM outputs that are affected by perturbed variables via physics.
+smooth_vars = ["Evap_tavg", "LWdown_f_tavg", "PotEvap_tavg",
+               "SoilMoist_tavg",
+               "SoilTemp_tavg", "SWdown_f_tavg",
+               "Tair_f_max", "Tair_f_tavg",
+               "TotalPrecip_acc", "Tair_f_min", "RHMin_inst"]
+
 lines = open(template,'r').readlines()
 
 vars = var_attributes.keys()
@@ -54,7 +63,12 @@ for var in vars:
         if "LVT output format:" in line:
             line = "LVT output format: %s\n" %(output)
         elif "Process HYCOM data:" in line:
-                line = "Process HYCOM data: 0\n"
+            line = "Process HYCOM data: 0\n"
+        elif "Apply noise reduction filter:" in line:
+            if var in smooth_vars:
+                line = "Apply noise reduction filter: 1\n"
+            else:
+                line = "Apply noise reduction filter: 0\n"
         elif "Starting year:" in line:
             line = "Starting year: %s\n" %(startdt.year)
         elif "Starting month:" in line:

--- a/lvt/utils/afwa/templates/make_lvt_config_24hr_noahmp.py
+++ b/lvt/utils/afwa/templates/make_lvt_config_24hr_noahmp.py
@@ -9,8 +9,8 @@ template = "lvt.config.template"
 startdt = datetime.datetime(2018,9,13,12)
 enddt =   datetime.datetime(2018,9,14,12)
 
-#output = "netcdf"
-output = "grib2"
+output = "netcdf"
+#output = "grib2"
 
 # Most variables are processed independently, and are listed below.
 var_attributes = {
@@ -41,6 +41,15 @@ var_attributes_special = {
     "RHMin_inst" : \
         "RHMin       1  1  %      -  0  1 RHMin       1  1  %      -  0  1",
 }
+
+# Smooth variables that are perturbed, derived from perturbed variables,
+# or are LSM outputs that are affected by perturbed variables via physics.
+smooth_vars = ["Evap_tavg", "LWdown_f_tavg",
+               "SoilMoist_tavg",
+               "SoilTemp_tavg", "SWdown_f_tavg",
+               "Tair_f_max", "Tair_f_tavg",
+               "TotalPrecip_acc", "Tair_f_min", "RHMin_inst"]
+
 lines = open(template,'r').readlines()
 
 vars = var_attributes.keys()
@@ -52,7 +61,12 @@ for var in vars:
         if "LVT output format:" in line:
             line = "LVT output format: %s\n" %(output)
         elif "Process HYCOM data:" in line:
-                line = "Process HYCOM data: 0\n"
+            line = "Process HYCOM data: 0\n"
+        elif "Apply noise reduction filter:" in line:
+            if var in smooth_vars:
+                line = "Apply noise reduction filter: 1\n"
+            else:
+                line = "Apply noise reduction filter: 0\n"
         elif "Starting year:" in line:
             line = "Starting year: %s\n" %(startdt.year)
         elif "Starting month:" in line:

--- a/lvt/utils/afwa/templates/make_lvt_config_3hr_jules.py
+++ b/lvt/utils/afwa/templates/make_lvt_config_3hr_jules.py
@@ -6,19 +6,11 @@ import sys
 
 template = "lvt.config.template"
 
-#startdt = datetime.datetime(2008,5,15,0)
-#enddt = datetime.datetime(2008,5,16,0)
-#startdt = datetime.datetime(2018, 2,28, 0)
-#enddt =   datetime.datetime(2018, 3, 1, 0)
-#startdt = datetime.datetime(2011, 2, 28, 21)
-#enddt =   datetime.datetime(2011, 3,  1, 21)
-#startdt = datetime.datetime(2011, 8, 31, 21)
-#enddt =   datetime.datetime(2011, 9,  1, 21)
 startdt = datetime.datetime(2018,  7, 29,  0)
 enddt =   datetime.datetime(2018,  7, 31,  0)
 
-#output = "netcdf"
-output = "grib2"
+output = "netcdf"
+#output = "grib2"
 
 # Most variables are processed independently, and are listed below.
 var_attributes = {
@@ -102,6 +94,22 @@ var_attributes_special = {
         "RHMin       1  1  %      -  0  1 RHMin       1  1  %      -  0  1",
 }
 
+# Smooth variables that are perturbed, derived from perturbed variables,
+# or are LSM outputs that are affected by perturbed variables via physics.
+smooth_vars = ["AvgSurfT_inst", "AvgSurfT_tavg", 
+               "Albedo_tavg", "CanopInt_inst",
+               "Evap_tavg", "LWdown_f_inst", 
+               "LWdown_f_tavg", "Qh_tavg", "Qle_tavg", 
+               "Qs_acc", "Qsb_acc", "RelSMC_inst", 
+               "SmLiqFrac_inst", "SnowDepth_inst",
+               "Snowcover_inst", "SoilMoist_inst",
+               "SoilMoist_tavg", "SoilTemp_inst", 
+               "SoilTemp_tavg", "SWdown_f_inst",
+               "SWdown_f_tavg", "SWE_inst",
+               "Tair_f_inst", "Tair_f_max",
+               "Tair_f_tavg", "TotalPrecip_acc",
+               "Tair_f_min", "RHMin_inst"]
+
 lines = open(template,'r').readlines()
 
 vars = var_attributes.keys()
@@ -118,6 +126,11 @@ for var in vars:
                 line = "Process HYCOM data: 1\n"
             else:
                 line = "Process HYCOM data: 0\n"
+        elif "Apply noise reduction filter:" in line:
+            if var in smooth_vars:
+                line = "Apply noise reduction filter: 1\n"
+            else:
+                line = "Apply noise reduction filter: 0\n"
         elif "Starting year:" in line:
             line = "Starting year: %s\n" %(startdt.year)
         elif "Starting month:" in line:

--- a/lvt/utils/afwa/templates/make_lvt_config_3hr_noah.py
+++ b/lvt/utils/afwa/templates/make_lvt_config_3hr_noah.py
@@ -9,8 +9,8 @@ template = "lvt.config.template"
 startdt = datetime.datetime(2018, 9,13, 12)
 enddt =   datetime.datetime(2018, 9,14, 12)
 
-#output = "netcdf"
-output = "grib2"
+output = "netcdf"
+#output = "grib2"
 
 # Most variables are processed independently, and are listed below.
 var_attributes = {
@@ -102,6 +102,24 @@ var_attributes_special = {
         "RHMin       1  1  %      -  0  1 RHMin       1  1  %      -  0  1",
 }
 
+# Smooth variables that are perturbed, derived from perturbed variables,
+# or are LSM outputs that are affected by perturbed variables via physics.
+smooth_vars = ["AvgSurfT_inst", "AvgSurfT_tavg",
+               "Albedo_tavg", "CanopInt_inst",
+               "Evap_tavg", "LWdown_f_inst",
+               "LWdown_f_tavg", "PotEvap_tavg",
+               "Qg_tavg",
+               "Qh_tavg", "Qle_tavg",
+               "Qs_acc", "Qsb_acc", "RelSMC_inst",
+               "SmLiqFrac_inst", "SnowDepth_inst",
+               "Snowcover_inst", "SoilMoist_inst",
+               "SoilMoist_tavg", "SoilTemp_inst",
+               "SoilTemp_tavg", "SWdown_f_inst",
+               "SWdown_f_tavg", "SWE_inst",
+               "Tair_f_inst", "Tair_f_max",
+               "Tair_f_tavg", "TotalPrecip_acc",
+               "Tair_f_min", "RHMin_inst"]
+
 lines = open(template,'r').readlines()
 
 vars = var_attributes.keys()
@@ -118,6 +136,11 @@ for var in vars:
                 line = "Process HYCOM data: 1\n"
             else:
                 line = "Process HYCOM data: 0\n"
+        elif "Apply noise reduction filter:" in line:
+            if var in smooth_vars:
+                line = "Apply noise reduction filter: 1\n"
+            else:
+                line = "Apply noise reduction filter: 0\n"
         elif "Starting year:" in line:
             line = "Starting year: %s\n" %(startdt.year)
         elif "Starting month:" in line:

--- a/lvt/utils/afwa/templates/make_lvt_config_3hr_noahmp.py
+++ b/lvt/utils/afwa/templates/make_lvt_config_3hr_noahmp.py
@@ -9,8 +9,8 @@ template = "lvt.config.template"
 startdt = datetime.datetime(2018, 9,13, 12)
 enddt =   datetime.datetime(2018, 9,14, 12)
 
-#output = "netcdf"
-output = "grib2"
+output = "netcdf"
+#output = "grib2"
 
 # Most variables are processed independently, and are listed below.
 var_attributes = {
@@ -100,6 +100,24 @@ var_attributes_special = {
         "RHMin       1  1  %      -  0  1 RHMin       1  1  %      -  0  1",
 }
 
+# Smooth variables that are perturbed, derived from perturbed variables,
+# or are LSM outputs that are affected by perturbed variables via physics.
+smooth_vars = ["AvgSurfT_inst", "AvgSurfT_tavg",
+               "Albedo_tavg", "CanopInt_inst",
+               "Evap_tavg", "LWdown_f_inst",
+               "LWdown_f_tavg", 
+               "Qg_tavg",
+               "Qh_tavg", "Qle_tavg",
+               "Qs_acc", "Qsb_acc", "RelSMC_inst",
+               "SmLiqFrac_inst", "SnowDepth_inst",
+               "Snowcover_inst", "SoilMoist_inst",
+               "SoilMoist_tavg", "SoilTemp_inst",
+               "SoilTemp_tavg", "SWdown_f_inst",
+               "SWdown_f_tavg", "SWE_inst",
+               "Tair_f_inst", "Tair_f_max",
+               "Tair_f_tavg", "TotalPrecip_acc",
+               "Tair_f_min", "RHMin_inst"]
+
 lines = open(template,'r').readlines()
 
 vars = var_attributes.keys()
@@ -116,6 +134,11 @@ for var in vars:
                 line = "Process HYCOM data: 1\n"
             else:
                 line = "Process HYCOM data: 0\n"
+        elif "Apply noise reduction filter:" in line:
+            if var in smooth_vars:
+                line = "Apply noise reduction filter: 1\n"
+            else:
+                line = "Apply noise reduction filter: 0\n"
         elif "Starting year:" in line:
             line = "Starting year: %s\n" %(startdt.year)
         elif "Starting month:" in line:


### PR DESCRIPTION
This changes a number of scripts for automating LVT in "557 post" mode.  New philosophy is to smooth a variable if:
(1) it is perturbed;
(2) it is derived from a perturbed variable; or
(3) it is output by an LSM, and thus may be affected by perturbations.

In addition, the run_ncks.py script is updated to support Tair_f_min for 3-hr JULES output.