### PR TITLE
Add residual snow fix option to Noah.3.6

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -7283,6 +7283,11 @@ height in meters of air temperature and specific humidity observations.
 `Noah.3.6 reference height for forcing u and v:` specifies the
 height in meters of u and v wind forcings.
 
+`Noah.3.6 removal of residual snow fix:` specifies whether or not
+a snow fix is used (1 - fix is active, 0 - inactive). The land-surface
+model was found to keep very small amounts of snow in rare cases. This
+fix zeros out snow values that are under a predetermined threshold.
+
 .Example _lis.config_ entry
 ....
 Noah.3.6 model timestep:                  15mn
@@ -7325,6 +7330,7 @@ Noah.3.6 background albedo:   0.18  0.17  0.16  0.15  0.15  0.15  0.15  0.16  0.
 Noah.3.6 background roughness length: 0.020 0.020 0.025 0.030 0.035 0.036 0.035 0.030 0.027 0.025 0.020 0.020
 Noah.3.6 reference height for forcing T and q:   2.0      # (m) - negative=use height from forcing data
 Noah.3.6 reference height for forcing u and v:  10.0      # (m) - negative=use height from forcing data
+Noah.3.6 removal of residual snow fix: 0
 ....
 
 

--- a/lis/surfacemodels/land/noah.3.6/noah36_lsmMod.F90
+++ b/lis/surfacemodels/land/noah.3.6/noah36_lsmMod.F90
@@ -107,6 +107,7 @@ module noah36_lsmMod
      real                       :: albedo_monthly(12)
      real                       :: z0brd_monthly(12)
      integer                    :: iz0tlnd
+     integer                    :: snowfix
      integer                    :: sfcdifoption
      logical                    :: ua_phys
      real                       :: rstInterval

--- a/lis/surfacemodels/land/noah.3.6/noah36_main.F90
+++ b/lis/surfacemodels/land/noah.3.6/noah36_main.F90
@@ -801,7 +801,7 @@ subroutine noah36_main(n)
                 noah36_struc(n)%noah(t)%frzx,                                      &
                 noah36_struc(n)%noah(t)%sndens, & !added for use in SCF DA, yliu 
                 noah36_struc(n)%noah(t)%lvcoef, tsoil,                           &
-                sfhead1rt, infxs1rt, etpnd1)
+                sfhead1rt, infxs1rt, etpnd1, noah36_struc(n)%snowfix)
 
            noah36_struc(n)%noah(t)%sca = sncovr ! EMK NUWRF
            noah36_struc(n)%noah(t)%z0_old = noah36_struc(n)%noah(t)%z0

--- a/lis/surfacemodels/land/noah.3.6/noah36_readcrd.F90
+++ b/lis/surfacemodels/land/noah.3.6/noah36_readcrd.F90
@@ -39,6 +39,7 @@ subroutine noah36_readcrd()
   integer :: rc
   integer :: n,i
   character*10 :: time
+  character*255 :: msg
 
   call ESMF_ConfigFindLabel(LIS_config,"Noah.3.6 model timestep:",rc=rc)
   do n=1,LIS_rc%nnest
@@ -237,16 +238,31 @@ subroutine noah36_readcrd()
      call LIS_verify(rc,'Noah.3.6 reference height for forcing u and v: not defined')
   enddo
 
-  call ESMF_ConfigFindLabel(LIS_config,"Noah.3.6 removal of residual snow fix:",rc=rc)
-  do n=1,LIS_rc%nnest
-    call ESMF_ConfigGetAttribute(LIS_config,noah36_struc(n)%snowfix,rc=rc)
-    if (noah36_struc(n)%snowfix .ne. 1) then
-      noah36_struc(n)%snowfix = 0
-      write(LIS_logunit,*) "[INFO] Custom Noah 3.6 snow fix option IS NOT active."
-    else
-      write(LIS_logunit,*) "[INFO] Custom Noah 3.6 snow fix option is active."
-    endif
-  enddo
+  call ESMF_ConfigFindLabel(LIS_config, &
+       "Noah.3.6 removal of residual snow fix:", rc=rc)
+  call LIS_verify(rc, 'Noah.3.6 removal of residual snow fix: not defined')
+  do n = 1, LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config, noah36_struc(n)%snowfix, rc=rc)
+     write(msg,'(1X,A,I1)') &
+          '[ERR] Noah.3.6 removal of residual snow fix: not defined for ' &
+          //'nest ', n
+     call LIS_verify(rc, trim(msg))
+     select case (noah36_struc(n)%snowfix)
+     case (0)
+        write(LIS_logunit,*) &
+             "[INFO] Custom Noah 3.6 snow fix option IS NOT active" &
+             //" for nest ", n
+     case (1)
+        write(LIS_logunit,*) &
+             "[INFO] Custom Noah 3.6 snow fix option is active" &
+             //" for nest ", n
+     case default
+        write(LIS_logunit,*) &
+             "[ERR] Invalid value for nest ",n," for " &
+             //"'Noah.3.6 removal of residual snow fix:'"
+        call LIS_verify(1,'') 
+     end select
+  end do ! n
   
   write(LIS_logunit,*) '[INFO] Running Noah-3.6 LSM:'
 

--- a/lis/surfacemodels/land/noah.3.6/noah36_readcrd.F90
+++ b/lis/surfacemodels/land/noah.3.6/noah36_readcrd.F90
@@ -237,6 +237,17 @@ subroutine noah36_readcrd()
      call LIS_verify(rc,'Noah.3.6 reference height for forcing u and v: not defined')
   enddo
 
+  call ESMF_ConfigFindLabel(LIS_config,"Noah.3.6 removal of residual snow fix:",rc=rc)
+  do n=1,LIS_rc%nnest
+    call ESMF_ConfigGetAttribute(LIS_config,noah36_struc(n)%snowfix,rc=rc)
+    if (noah36_struc(n)%snowfix .ne. 1) then
+      noah36_struc(n)%snowfix = 0
+      write(LIS_logunit,*) "[INFO] Custom Noah 3.6 snow fix option IS NOT active."
+    else
+      write(LIS_logunit,*) "[INFO] Custom Noah 3.6 snow fix option is active."
+    endif
+  enddo
+  
   write(LIS_logunit,*) '[INFO] Running Noah-3.6 LSM:'
 
 end subroutine noah36_readcrd


### PR DESCRIPTION
This commit adds a fix to Noah.3.6 that will remove small amounts
of snow that should normally be cleared but are not in Noah v3.6.

This fix will zero out snow on a model point if it is below a certain
threshold. Since this fix is not an official NCAR release, the fix
is added as a config option.
The user must specify 'Noah.3.6 removal of residual snow fix: 1'
to turn the fix on. The fix is turned off (option 0) by default.

Resolves: #407 