### PR TITLE
Fix/410 ldtbuffer

### DIFF
--- a/ldt/configs/ldt.config.adoc
+++ b/ldt/configs/ldt.config.adoc
@@ -407,6 +407,28 @@ The default value is 1.
 Add buffer to parameter grid domain:     0
 ....
 
+`Buffer count in x-direction:` adds a set number of pixels that buffer 
+around a parameter file target domain, both in the x- and y-directions.
+Acceptable values are:
+
+[cols="<,<",]
+|===
+|Value |Description
+
+|"0" |No buffer added
+|"1 (or greater)" |Buffer points included
+|===
+
+The default value is 5.
+
+.Example _ldt.config_ entry
+....
+Buffer count in x-direction:   10 
+Buffer count in y-direction:   10
+....
+
+
+
 `Number of ensembles per tile:` specifies the number of ensembles of tiles to be used. The value should be greater than or equal to 1.
 
 .Example _ldt.config_ entry

--- a/ldt/core/LDT_PRIV_rcMod.F90
+++ b/ldt/core/LDT_PRIV_rcMod.F90
@@ -34,7 +34,9 @@ module LDT_PRIV_rcMod
      character*100, allocatable :: paramAttribsFile(:)
      character*50           :: lis_map_proj
      real                   :: lis_map_resfactor
-     integer                :: add_buffer
+     integer                :: add_buffer   ! KA
+     integer                :: x_buffer
+     integer                :: y_buffer
 
 ! -- Land surface input parameters:
      integer                :: max_model_types 

--- a/ldt/core/LDT_gridmappingMod.F90
+++ b/ldt/core/LDT_gridmappingMod.F90
@@ -161,15 +161,17 @@ contains
    ! Incorporate buffer for target grid (e.g., helps with curvilinear projections)
    if( buffer_flag == 1 ) then 
      write(LDT_logunit,*) "[INFO] Incorporating buffer around subsetted grid domain ... "
-     lisdom_min_lat = max((rlat(1,1)-(5*lisdom_yres_ll)),-90.0)
-     lisdom_max_lat = min((rlat(LDT_rc%lnc(n),LDT_rc%lnr(n))+(5*lisdom_yres_ll)),90.0)
+     lisdom_min_lat = max((rlat(1,1)-(LDT_rc%y_buffer*lisdom_yres_ll)),-90.0)
+     lisdom_max_lat = min((rlat(LDT_rc%lnc(n),LDT_rc%lnr(n))+(LDT_rc%y_buffer*lisdom_yres_ll)),90.0)
      ! Account for crossing IDL:
      if( rlon(1,1) <= rlon(LDT_rc%lnc(n),LDT_rc%lnr(n)) ) then
-       lisdom_min_lon = max((rlon(1,1)-(5*lisdom_xres_ll)),-180.0)
-       lisdom_max_lon = min((rlon(LDT_rc%lnc(n),LDT_rc%lnr(n))+(5*lisdom_xres_ll)),180.0)
+       lisdom_min_lon = max((rlon(1,1)-(LDT_rc%x_buffer*lisdom_xres_ll)),-180.0)
+       lisdom_max_lon = min((rlon(LDT_rc%lnc(n),&
+                             LDT_rc%lnr(n))+(LDT_rc%x_buffer*lisdom_xres_ll)),180.0)
      else  
-       lisdom_min_lon = max((rlon(1,1)-(5*lisdom_xres_ll)),0.0)
-       lisdom_max_lon = min((rlon(LDT_rc%lnc(n),LDT_rc%lnr(n))+(5*lisdom_xres_ll)),0.0)
+       lisdom_min_lon = max((rlon(1,1)-(LDT_rc%x_buffer*lisdom_xres_ll)),0.0)
+       lisdom_max_lon = min((rlon(LDT_rc%lnc(n),&
+                            LDT_rc%lnr(n))+(LDT_rc%x_buffer*lisdom_xres_ll)),0.0)
      endif
    else  ! No buffer applied
 !     write(LDT_logunit,*) "[INFO] No buffer incorporated ... "

--- a/ldt/core/LDT_metforcingParmsMod.F90
+++ b/ldt/core/LDT_metforcingParmsMod.F90
@@ -195,7 +195,6 @@ contains
                  LDT_force_struc(n,m)%forcelevdiff%vlevels))       
              LDT_force_struc(n,m)%forcelevdiff%value = LDT_rc%udef
 
-
           !- Account for GDAS fields:
              gdas_check  = LDT_rc%metforc_parms(m)
              ecmwf_check = LDT_rc%metforc_parms(m)
@@ -220,6 +219,13 @@ contains
              endif
  
              write(LDT_logunit,*) "Done reading forcing elevation field. "
+
+          else
+             write(LDT_logunit,*) "[WARN] "//trim(LDT_rc%metforc_parms(m))//&
+                " forcing elevation is turned on, but the "
+             write(LDT_logunit,*) " 'Topographic correction method' is set to 'none'."
+             write(LDT_logunit,*) " Change this option to 'lapse-rate' to write out "       
+             write(LDT_logunit,*) " the metforcing elevation field. "
 
           end if ! End elevation check
         end do   ! end nest loop

--- a/ldt/core/LDT_readConfig.F90
+++ b/ldt/core/LDT_readConfig.F90
@@ -388,6 +388,17 @@ subroutine LDT_readConfig(configfile)
        default=1,rc=rc)
   call LDT_verify(rc,'Add buffer to parameter grid domain: not defined')
 
+  call ESMF_ConfigGetAttribute(LDT_config,LDT_rc%x_buffer,&
+       label="Buffer count in x-direction:",&
+       default=5,rc=rc)
+  call LDT_verify(rc,'Buffer count in x-direction: not defined')
+
+  call ESMF_ConfigGetAttribute(LDT_config,LDT_rc%y_buffer,&
+       label="Buffer count in y-direction:",&
+       default=5,rc=rc)
+  call LDT_verify(rc,'Buffer count in y-direction: not defined')
+
+
 ! Set number of processors along x and y directions:
   call ESMF_ConfigGetAttribute(LDT_config,LDT_rc%npesx,&
        label="Number of processors along x:", &

--- a/ldt/metforcing/gdas/gdas_forcingMod.F90
+++ b/ldt/metforcing/gdas/gdas_forcingMod.F90
@@ -208,7 +208,7 @@ contains
     LDT_rc%met_proj(findex) = "gaussian"
 
  != T126:
-    write(LDT_logunit,*)"MSG: Initializing GDAS grid-1 for: 1991-2000 grid (T126)"
+    write(LDT_logunit,*)"[INFO] Initializing GDAS grid-1 for: 1991-2000 grid (T126)"
     gdas_struc(:)%nc = 384
     gdas_struc(:)%nr = 190
     gridDesci = 0
@@ -229,7 +229,7 @@ contains
     LDT_rc%met_gridDesc(findex,1:20) = gridDesci(1:20)
    
  != T170:
-    write(LDT_logunit,*)"MSG: Initializing GDAS grid-2 for: 2000-2002 grid (T170)"
+    write(LDT_logunit,*)"[INFO] Initializing GDAS grid-2 for: 2000-2002 grid (T170)"
     LDT_rc%met_nc(findex+1) = 512
     LDT_rc%met_nr(findex+1) = 256
     LDT_rc%met_proj(findex+1)  = "gaussian"
@@ -246,7 +246,7 @@ contains
     LDT_rc%met_gridDesc(findex+1,20) = 0
 
  != T254:
-    write(LDT_logunit,*)"MSG: Initializing GDAS grid-3 for: 2002-2005 grid (T254)"
+    write(LDT_logunit,*)"[INFO] Initializing GDAS grid-3 for: 2002-2005 grid (T254)"
     LDT_rc%met_nc(findex+2) = 768
     LDT_rc%met_nr(findex+2) = 384
     LDT_rc%met_proj(findex+2)  = "gaussian"
@@ -263,7 +263,7 @@ contains
     LDT_rc%met_gridDesc(findex+2,20) = 0
 
  != T382:
-    write(LDT_logunit,*)"MSG: Initializing GDAS grid-4 for: 2005-2010 grid (T382)"
+    write(LDT_logunit,*)"[INFO] Initializing GDAS grid-4 for: 2005-2010 grid (T382)"
     LDT_rc%met_nc(findex+3) = 1152
     LDT_rc%met_nr(findex+3) = 576
     LDT_rc%met_proj(findex+3)  = "gaussian"
@@ -280,7 +280,7 @@ contains
     LDT_rc%met_gridDesc(findex+3,20) = 0
 
  != T574:
-    write(LDT_logunit,*)"MSG: Initializing GDAS grid-5 for: 2010-2015 grid (T574)"
+    write(LDT_logunit,*)"[INFO] Initializing GDAS grid-5 for: 2010-2015 grid (T574)"
     LDT_rc%met_nc(findex+4) = 1760
     LDT_rc%met_nr(findex+4) = 880
     LDT_rc%met_proj(findex+4)  = "gaussian"
@@ -297,7 +297,7 @@ contains
     LDT_rc%met_gridDesc(findex+4,20) = 0
 
  != T1534:
-    write(LDT_logunit,*)"MSG: Initializing GDAS grid-6 for: 2015-present grid (T1534)"
+    write(LDT_logunit,*)"[INFO] Initializing GDAS grid-6 for: 2015-present grid (T1534)"
     LDT_rc%met_nc(findex+5) = 3072
     LDT_rc%met_nr(findex+5) = 1536
     LDT_rc%met_proj(findex+5)  = "gaussian"

--- a/ldt/metforcing/merra2/merra2_forcingMod.F90
+++ b/ldt/metforcing/merra2/merra2_forcingMod.F90
@@ -152,7 +152,7 @@ contains
     real    :: upgmt
 
     allocate(merra2_struc(LDT_rc%nnest))
-    write(LDT_logunit,fmt=*)"MSG: Initializing MERRA-2 forcing grid ... "
+    write(LDT_logunit,fmt=*)"[INFO] Initializing MERRA-2 forcing grid ... "
 
  !- Read in config file entries:
     call readcrd_merra2()

--- a/ldt/metforcing/nldas1/nldas1_forcingMod.F90
+++ b/ldt/metforcing/nldas1/nldas1_forcingMod.F90
@@ -188,7 +188,7 @@ contains
     
     allocate(nldas1_struc(LDT_rc%nnest))
 
-    write(LDT_logunit,fmt=*)"MSG: Initializing NLDAS-1 forcing grid ... "
+    write(LDT_logunit,fmt=*)"[INFO] Initializing NLDAS-1 forcing grid ... "
 
 ! - Read LDT config NLDAS-1 entries:
     call readcrd_nldas1( findex )

--- a/ldt/metforcing/nldas2/nldas2_forcingMod.F90
+++ b/ldt/metforcing/nldas2/nldas2_forcingMod.F90
@@ -164,7 +164,7 @@ contains
     
     allocate(nldas2_struc(LDT_rc%nnest))
 
-    write(unit=LDT_logunit,fmt=*)"MSG: Initializing NLDAS-2 forcing grid ... "
+    write(unit=LDT_logunit,fmt=*)"[INFO] Initializing NLDAS-2 forcing grid ... "
 
 ! - Read LDT config NLDAS-2 entries:
     call readcrd_nldas2(findex)
@@ -214,7 +214,7 @@ contains
            nldas2_struc(n)%gridDesc(10) == LDT_rc%gridDesc(n,10).and. &
            LDT_rc%gridDesc(n,1) == proj_latlon .and. &
            LDT_rc%met_gridtransform(findex) .ne. "neighbor" ) then
-         write(LDT_logunit,*) "WARNING MSG:  The NLDAS-2 0.125 deg grid was selected for the"
+         write(LDT_logunit,*) "[ERR]  The NLDAS-2 0.125 deg grid was selected for the"
          write(LDT_logunit,*) "  LDT run domain; however, 'bilinear', 'budget-bilinear',"
          write(LDT_logunit,*) "  or some other unknown option was selected to spatially"
          write(LDT_logunit,*) "  downscale the grid, which will cause errors during runtime."


### PR DESCRIPTION
Added new LDT config file options and documentation to support user-specified x- and y-direction number of buffer points when needing to add a buffer for grid transforms and such. This completes final commits for issue #410 and #422 