### PR TITLE
Adjust irrigation window timing in NoahMP3.6

### DIFF
--- a/lis/irrigation/sprinkler/sprinkler_irrigationMod.F90
+++ b/lis/irrigation/sprinkler/sprinkler_irrigationMod.F90
@@ -16,7 +16,7 @@ module sprinkler_irrigationMod
 ! !REVISION HISTORY:
 !
 !  11 Nov 2012: Sujay Kumar; Initial implementation
-!
+!  25 Feb 2020: Jessica Erlingis; Update irrigation window
 ! !USES: 
   use ESMF
   use LIS_coreMod
@@ -172,6 +172,8 @@ contains
 
     integer             :: tmpval
 
+    real                 :: timestep, shift_otimes, shift_otimee
+
     allocate(irrigAmt(LIS_rc%npatch(n,LIS_rc%lsm_index)))
     call ESMF_StateGet(irrigState,&
          "Irrigation rate",&
@@ -195,6 +197,15 @@ contains
          'ESMF_FieldGet failed for rainf in sprinkler_irrigation')
 
     irrigAmt = 0.0
+
+    timestep = LIS_rc%ts
+
+    ! Adjust bounds by timestep to account for the fact that LIS_rc%hr, etc. will
+    ! represents the END of the integration timestep window
+
+    shift_otimes = otimes + (timestep/3600.)
+    shift_otimee = otimee + (timestep/3600.)
+
     do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
 
        gid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%index
@@ -207,7 +218,7 @@ contains
        if(lhr.lt.0) lhr = lhr+24
        
        ltime = real(lhr)+real(LIS_rc%mn)/60.0+real(LIS_rc%ss)/3600.0
-       if((ltime.ge.otimes).and.(ltime.lt.otimee)) then           
+       if((ltime.ge.shift_otimes).and.(ltime.lt.shift_otimee)) then           
           tmpval = LIS_domain(n)%tile(t)%index
           prcp(t)=prcp(t)+irrigRate(t)
           irrigAmt(t) = irrigRate(t)

--- a/lis/surfacemodels/land/noah.3.3/irrigation/noah33_getirrigationstates.F90
+++ b/lis/surfacemodels/land/noah.3.3/irrigation/noah33_getirrigationstates.F90
@@ -144,16 +144,11 @@ subroutine noah33_getirrigationstates(n,irrigState)
 
      timestep = LIS_rc%ts
 
-!     write(LIS_logunit,*) 'Orig window ', otimes, otimee
-
-     ! Adjust bounds by timestep to account for the fact that LIS_rc%hr, etc. will
-     ! represents the END of the integration timestep window
+     ! Adjust bounds by timestep to account for the fact that LIS_rc%hr, etc.
+     ! will represents the END of the integration timestep window
 
      shift_otimes = otimes + (timestep/3600.)
      shift_otimee = otimee + (timestep/3600.)
-
-!     write(LIS_logunit,*) 'Timestep ', timestep
-!     write(LIS_logunit,*) 'Shift window ', shift_otimes, shift_otimee
 
      irrig_check_frozen_soil = .false.
      
@@ -217,8 +212,6 @@ subroutine noah33_getirrigationstates(n,irrigState)
                 
      ltime = real(lhr)+real(LIS_rc%mn)/60.0+real(LIS_rc%ss)/3600.0
 
-!     write(LIS_logunit,*) 'local time:', ltime
-      
      shdfac =  noah33_struc(n)%noah(t)%shdfac
        
 ! Calculate vegetation and root depth parameters
@@ -226,7 +219,6 @@ subroutine noah33_getirrigationstates(n,irrigState)
    ! If we are outside of the irrigation window, set rate to 0
      if ((ltime.ge.shift_otimee).or.(ltime.lt.shift_otimes)) then
        irrigRate(t) = 0.0
-!       write(LIS_logunit,*) ltime, 'is outside the irrigation window'
      endif
    
      if((ltime.ge.shift_otimes).and.(ltime.lt.shift_otimee)) then 
@@ -339,7 +331,8 @@ subroutine noah33_getirrigationstates(n,irrigState)
 !     Compute irrigation rate
 !-----------------------------------------------------------------------------
                                 irrigRate(t) = twater/(irrhr*3600.0)
-                                write(LIS_logunit,*) 'Irrigating',ltime, twater
+                                write(LIS_logunit,*) '[INFO] Irrigating', &
+                                     ltime, twater
                              endif
                           endif
                        endif

--- a/lis/surfacemodels/land/noah.3.3/irrigation/noah33_getirrigationstates.F90
+++ b/lis/surfacemodels/land/noah.3.3/irrigation/noah33_getirrigationstates.F90
@@ -51,6 +51,7 @@ subroutine noah33_getirrigationstates(n,irrigState)
 ! Aug 2008: Hiroko Kato; Initial code
 ! Nov 2012: Sujay Kumar, Incorporated into LIS
 ! Jun 2014: Ben Zaitchik; Added flood scheme
+! Feb 2020: Jessica Erlingis; Fix sprinkler irrigation winodw 
 !EOP
   implicit none
   ! Sprinkler parameters
@@ -90,6 +91,7 @@ subroutine noah33_getirrigationstates(n,irrigState)
   integer              :: lroot,veg_index1,veg_index2
   real                 :: gsthresh, ltime
   logical              :: irrig_check_frozen_soil
+  real                 :: timestep, shift_otimes, shift_otimee
 ! _______________________________________________________
 
   call ESMF_StateGet(irrigState, "Irrigation rate",irrigRateField,rc=rc)
@@ -118,7 +120,7 @@ subroutine noah33_getirrigationstates(n,irrigState)
        farrayPtr=irrigScale,rc=rc)
   call LIS_verify(rc,'ESMF_FieldGet failed for Irrigation scale')  
 
-  irrigRate = 0.0  
+!JE  irrigRate = 0.0  
 
 !----------------------------------------------------------------------
 ! Set start and end times for selected irrigation type
@@ -139,7 +141,20 @@ subroutine noah33_getirrigationstates(n,irrigState)
   
  
   do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
-     
+
+     timestep = LIS_rc%ts
+
+!     write(LIS_logunit,*) 'Orig window ', otimes, otimee
+
+     ! Adjust bounds by timestep to account for the fact that LIS_rc%hr, etc. will
+     ! represents the END of the integration timestep window
+
+     shift_otimes = otimes + (timestep/3600.)
+     shift_otimee = otimee + (timestep/3600.)
+
+!     write(LIS_logunit,*) 'Timestep ', timestep
+!     write(LIS_logunit,*) 'Shift window ', shift_otimes, shift_otimee
+
      irrig_check_frozen_soil = .false.
      
      if((noah33_struc(n)%noah(t)%smc(1) - &
@@ -201,12 +216,20 @@ subroutine noah33_getirrigationstates(n,irrigState)
      if(lhr.lt.0) lhr = lhr+24
                 
      ltime = real(lhr)+real(LIS_rc%mn)/60.0+real(LIS_rc%ss)/3600.0
+
+!     write(LIS_logunit,*) 'local time:', ltime
       
      shdfac =  noah33_struc(n)%noah(t)%shdfac
        
 ! Calculate vegetation and root depth parameters
+
+   ! If we are outside of the irrigation window, set rate to 0
+     if ((ltime.ge.shift_otimee).or.(ltime.lt.shift_otimes)) then
+       irrigRate(t) = 0.0
+!       write(LIS_logunit,*) ltime, 'is outside the irrigation window'
+     endif
    
-     if((ltime.ge.otimes).and.(ltime.lt.otimee)) then 
+     if((ltime.ge.shift_otimes).and.(ltime.lt.shift_otimee)) then 
         vegt = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%vegt
        !----------------------------------------------------------------------       
        !    Proceed if it is non-forest, non-baresoil, non-urban
@@ -272,7 +295,7 @@ subroutine noah33_getirrigationstates(n,irrigState)
 !    If local time at the tile fall in the irrigation check
 !    hour then check the root zone average soil moisture
 !----------------------------------------------------------------------       
-                       if(ltime.eq.otimes) then 
+                       if(ltime.eq.shift_otimes) then 
                           irrigRate(t) = 0.0
 !-------------------------------------------------------------
 !     Compute the root zone accumlative soil moisture [mm], 
@@ -316,6 +339,7 @@ subroutine noah33_getirrigationstates(n,irrigState)
 !     Compute irrigation rate
 !-----------------------------------------------------------------------------
                                 irrigRate(t) = twater/(irrhr*3600.0)
+                                write(LIS_logunit,*) 'Irrigating',ltime, twater
                              endif
                           endif
                        endif

--- a/lis/surfacemodels/land/noahmp.3.6/irrigation/noahmp36_getirrigationstates.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/irrigation/noahmp36_getirrigationstates.F90
@@ -165,16 +165,12 @@ subroutine noahmp36_getirrigationstates(n,irrigState)
 
      timestep = NOAHMP36_struc(n)%dt
      
-     ! Adjust bounds by timestep to account for the fact that LIS_rc%hr, etc. will
-     ! represents the END of the integration timestep window
+     ! Adjust bounds by timestep to account for the fact that LIS_rc%hr, etc. 
+     ! will represents the END of the integration timestep window
 
-     !write(LIS_logunit,*) 'Orig window ', otimes, otimee
 
      shift_otimes = otimes + (timestep/3600.)
      shift_otimee = otimee + (timestep/3600.)
-
-     !write(LIS_logunit,*) 'Timestep ', timestep
-     !write(LIS_logunit,*) 'Shift window ', shift_otimes, shift_otimee
 
      twater  = 0.0
      water   = 0.0
@@ -197,24 +193,11 @@ subroutine noahmp36_getirrigationstates(n,irrigState)
      zdpth(3) = sldpth(1) + sldpth(2) + sldpth(3)
      zdpth(4) = sldpth(1) + sldpth(2) + sldpth(3) + sldpth(4)
 
-     !smcmax =  NOAHMP36_struc(n)%noahmp36(t)%smcmax
-     !psisat =  NOAHMP36_struc(n)%noahmp36(t)%psisat
-     !dksat  =  NOAHMP36_struc(n)%noahmp36(t)%dksat
-     !bexp   =  NOAHMP36_struc(n)%noahmp36(t)%bexp
-     !smlow = 0.5
-     !smhigh = 6.0
-     !smcref1 = SMCMAX*(5.79e-9/DKSAT)**(1.0/(2.0*BEXP+3.0))
-     !smcref = smcref1 + (SMCMAX-smcref1) / smhigh
-     !smcwlt1 = SMCMAX * (200.0/PSISAT)**(-1.0/BEXP)
-     !smcwlt = smcwlt1 - smlow * smcwlt1
-     
      smcmax = MAXSMC(NOAHMP36_struc(n)%noahmp36(t)%soiltype) 
      smcref = REFSMC(NOAHMP36_struc(n)%noahmp36(t)%soiltype)
      smcwlt = WLTSMC(NOAHMP36_struc(n)%noahmp36(t)%soiltype)
      sfctemp = NOAHMP36_struc(n)%noahmp36(t)%sfctmp
      tempcheck = 273.16 + 2.5
-
-     !write(*,*) 'test for use:', smcmax, smcref, smcwlt
 
      gid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%index
      chhr = nint(24.0*(LIS_domain(n)%grid(gid)%lon/360.0))
@@ -226,25 +209,23 @@ subroutine noahmp36_getirrigationstates(n,irrigState)
      if(lhr.lt.0) lhr = lhr+24
                 
      ltime = real(lhr)+real(LIS_rc%mn)/60.0+real(LIS_rc%ss)/3600.0
-!     write(LIS_logunit,*) 'local time:', ltime
     
      shdfac =  NOAHMP36_struc(n)%noahmp36(t)%shdfac_monthly(LIS_rc%mo)
 
    ! If we are outside of the irrigation window, set rate to 0
      if ((ltime.gt.shift_otimee).or.(ltime.lt.shift_otimes)) then
        irrigRate(t) = 0.0
-       write(LIS_logunit,*) ltime, 'is outside the irrigation window'     
+       write(LIS_logunit,*) '[INFO] ',ltime, &
+            'is outside the irrigation window'     
      endif
 
 ! Calculate vegetation and root depth parameters
    
-     !if((ltime.ge.otimes).and.(ltime.lt.otimee)) then 
 !---------wanshu----add temp check----
 ! JE This temperature check avoids irrigating at temperatures near or below 0C
      if((ltime.ge.shift_otimes).and.(ltime.le.shift_otimee).and. &
          (sfctemp.gt.tempcheck)) then 
 !------------------------------------
-        !write(LIS_logunit,*) ltime, 'is inside the irrigation window ', irrigRate(t)
         vegt = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%vegt
        !----------------------------------------------------------------------       
        !    Proceed if it is non-forest, non-baresoil, non-urban
@@ -252,15 +233,16 @@ subroutine noahmp36_getirrigationstates(n,irrigState)
         if(LIS_rc%lcscheme.eq."UMD") then !UMD
            veg_index1 = 6
            veg_index2 = 11
-        elseif(LIS_rc%lcscheme.eq."MODIS".or.LIS_rc%lcscheme.eq."IGBPNCEP") then 
+        elseif(LIS_rc%lcscheme.eq."MODIS".or.LIS_rc%lcscheme.eq."IGBPNCEP") &
+             then 
            veg_index1 = 6
            veg_index2 = 14
         elseif(LIS_rc%lcscheme.eq."USGS") then !UMD
            veg_index1 = 2
            veg_index2 = 10
         else
-           write(LIS_logunit,*) 'The landcover scheme ',trim(LIS_rc%lcscheme)
-           write(LIS_logunit,*) 'is not supported for irrigation '
+           write(LIS_logunit,*) '[ERR] The landcover scheme ',&
+                trim(LIS_rc%lcscheme),' is not supported for irrigation '
            call LIS_endrun()
         endif
         
@@ -367,9 +349,7 @@ subroutine noahmp36_getirrigationstates(n,irrigState)
                                 twater = twater*(100.0/(100.0-efcor))
                              !-----------------------------------------------------------------------------
                              !     Compute irrigation rate
-                             !    irrigRate(t)=twater/((otimee-ltime)*3600.0) !For checking each time step
-                                 irrigRate(t) = twater/(irrhr*3600.0)
-                                 !write(LIS_logunit,*) 'twater', twater
+                                irrigRate(t) = twater/(irrhr*3600.0)
 
                            endif
                         endif
@@ -473,15 +453,11 @@ subroutine noahmp36_getirrigationstates(n,irrigState)
            ! Remove irrigated water from groundwater 
            !JE Add in flag to turn groundwater abstraction on/off
            if (LIS_rc%irrigation_GWabstraction.eq.1) then
-              !write(LIS_logunit,*) 'Withdrawing irrigation from groundwater'
               AWS = NOAHMP36_struc(n)%noahmp36(t)%wa
               Dtime = NOAHMP36_struc(n)%dt
               NOAHMP36_struc(n)%noahmp36(t)%wa = AWS - irrigRate(t)*Dtime
            end if
        end if
-
-      !write(LIS_logunit,*) 'irrigRate:', irrigRate(t)
-      ! write(LIS_logunit,*) 'AWS',AWS
 
     enddo
   end subroutine noahmp36_getirrigationstates


### PR DESCRIPTION
This pull request reverts noahmp36_getirrigationstates to checking the soil moisture availability in the soil column for sprinkler irrigation once at the beginning of the irrigation window and applying a constant rate over irrhrs. It fixes a previous bug where this check was performed but then the irrigation was turned off at subsequent integration time steps. 

This also adjusts the irrigation timing so that the irrigation falls neatly into LIS_HIST irrigation files for the irrigation window (see figure). 

This resolves issue #464 

Testcase in /discover/nobackup/projects/wldas/share/noahmp36_irrigation_bugfix/

![SM_TestCase_y103_x27_Zoom_Shift](https://user-images.githubusercontent.com/42619691/75362156-54cffc00-5886-11ea-8ed5-64f8d60a87a1.png)

