### PR TITLE
Fixed the issue of incorrect lat/lons in the LVT output

### DIFF
--- a/lvt/core/LVT_domainMod.F90
+++ b/lvt/core/LVT_domainMod.F90
@@ -560,12 +560,12 @@ contains
        do c=1,LVT_rc%lnc
           LVT_domain%gindex(c,r) = -1
 
-          ! EMK...Bug fix to gridDesc indices
-!          locallat = LVT_rc%gridDesc(4)+(r-1)*LVT_rc%gridDesc(9)
-!          locallon = LVT_rc%gridDesc(5)+(c-1)*LVT_rc%gridDesc(10)
-          locallat = LVT_rc%gridDesc(4)+(r-1)*LVT_rc%gridDesc(10)
-          locallon = LVT_rc%gridDesc(5)+(c-1)*LVT_rc%gridDesc(9)
-          
+!          locallat = LVT_rc%gridDesc(4)+(r-1)*LVT_rc%gridDesc(10)
+!          locallon = LVT_rc%gridDesc(5)+(c-1)*LVT_rc%gridDesc(9)
+
+          call ij_to_latlon(LVT_domain%lvtproj,float(c),float(r),&
+               locallat,locallon)          
+
           if(mask_out(c+(r-1)*LVT_rc%lnc).gt.0.99 .and. & 
                mask_out(c+(r-1)*LVT_rc%lnc).lt.3.01) then
              LVT_domain%grid(count1)%lat = locallat


### PR DESCRIPTION
This bug fix resolves the the encoding of wrong lat/lons in the LVT
output if the analysis is conducted on a non lat/lon domain.

Resolves #470