### PR TITLE
cleaned up leftover debugging statements

### DIFF
--- a/lis/dataassim/obs/GLASS_LAI/read_GLASSlai.F90
+++ b/lis/dataassim/obs/GLASS_LAI/read_GLASSlai.F90
@@ -205,13 +205,6 @@ subroutine read_GLASSlai(n, k, OBS_State, OBS_Pert_State)
   endif
   if(dataCheck) then 
         
-        !        open(100,file='test_out.bin',form='unformatted')
-        !        write(100) GLASSlai_struc(n)%laiobs1 
-        !        write(100) GLASSlai_struc(n)%laiobs2
-        !        write(100) laiobs
-        !        close(100)
-        !        stop
-        
      call ESMF_StateGet(OBS_State,"Observation01",laifield,&
           rc=status)
      call LIS_verify(status, 'Error: StateGet Observation01')
@@ -425,10 +418,6 @@ subroutine read_GLASS_LAI_data(n, k, fname, laiobs_ip)
 
   endif
 
-!  open(100,file='test_inp.bin',form='unformatted')
-!  write(100) lai_in
-!  close(100)
-
 
   iret=gddetach(grid_id)
   iret=gdclose(file_id)
@@ -453,11 +442,6 @@ subroutine read_GLASS_LAI_data(n, k, fname, laiobs_ip)
           lai_data_b,lai_in, laiobs_b_ip, laiobs_ip)
   endif
   
-!  open(100,file='test_out.bin',form='unformatted')
-!  write(100) laiobs_ip
-!  close(100)
-!  stop
-
 #endif
 
 end subroutine read_GLASS_LAI_data

--- a/lis/dataassim/obs/NASA_SMAPvod/read_NASASMAPvod.F90
+++ b/lis/dataassim/obs/NASA_SMAPvod/read_NASASMAPvod.F90
@@ -261,8 +261,6 @@ subroutine read_NASASMAPvod(n, k, OBS_State, OBS_Pert_State)
 
   if(LIS_rc%dascaloption(k).eq."CDF matching".and.fnd.ne.0) then
      
-     open(100,file='test_out.bin',form='unformatted')
-     write(100) lai_current
      call LIS_rescale_with_CDF_matching(     &
           n,k,                               & 
           NASASMAPvod_struc(n)%nbins,         & 


### PR DESCRIPTION
In the GLASS LAI reader, the left over (commented out) print and output
statements were removed

In the NASA SMAP vod reader, the left over output statement was removed

Resolves #472