### PR TITLE
Enable build tools to use either Python2 or Python3

### DIFF
--- a/lis/make/makedep.py
+++ b/lis/make/makedep.py
@@ -348,19 +348,19 @@ def process_fortran90_file(fname, prereqs):
       print(e)
    else:
       for line in f:
-         fname = find_use_module_statement(line)
-         if fname:
-            prereqs = add_prerequisite(prereqs, fname, '.o')
-         fname = find_f_include_statement(line)
-         if fname:
-            prereqs = add_prerequisite(prereqs, fname)
+         name = find_use_module_statement(line)
+         if name:
+            prereqs = add_prerequisite(prereqs, name, '.o')
+         name = find_f_include_statement(line)
+         if name:
+            prereqs = add_prerequisite(prereqs, name)
             print_dbg('recursing')
-            prereqs = process_fortran90_file(fname, prereqs)
-         fname = find_c_include_statement(line)
-         if fname:
-            prereqs = add_prerequisite(prereqs, fname)
+            prereqs = process_fortran90_file(name, prereqs)
+         name = find_c_include_statement(line)
+         if name:
+            prereqs = add_prerequisite(prereqs, name)
             print_dbg('recursing')
-            prereqs = process_fortran90_file(fname, prereqs)
+            prereqs = process_fortran90_file(name, prereqs)
       f.close()
    finally:
       return prereqs
@@ -383,14 +383,14 @@ def process_fortran77_file(fname, prereqs):
       print(e)
    else:
       for line in f:
-         fname = find_f_include_statement(line)
-         if fname:
-            prereqs = add_prerequisite(prereqs, fname)
-            prereqs = process_fortran77_file(fname, prereqs)
-         fname = find_c_include_statement(line)
-         if fname:
-            prereqs = add_prerequisite(prereqs, fname)
-            prereqs = process_fortran77_file(fname, prereqs)
+         name = find_f_include_statement(line)
+         if name:
+            prereqs = add_prerequisite(prereqs, name)
+            prereqs = process_fortran77_file(name, prereqs)
+         name = find_c_include_statement(line)
+         if name:
+            prereqs = add_prerequisite(prereqs, name)
+            prereqs = process_fortran77_file(name, prereqs)
       f.close()
    finally:
       return prereqs

--- a/lis/make/makedep.py
+++ b/lis/make/makedep.py
@@ -5,6 +5,26 @@ import os
 import re
 import glob
 
+#
+# Note that an issue was encountered processing (with Python3) a Fortran90 source file
+# that was not UTF-8 encoded.  Because the purpose of this program in to scan C and
+# Fortran source files to generate prerequisites/dependencies and because for these
+# languages keywords are ASCII, this program deals with encoding issues using the
+# "errors=replace" option of the open function.  Any encoding errors will occur within
+# comments and can be ignored.
+#
+# Note that to support using both Python2 and Python3, the open function has been
+# aliased.  Use the input_open function to open input files; use the output_open
+# function to open output files.
+#
+if sys.version_info.major == 2:
+   import io
+   input_open = io.open
+   output_open = open
+else:
+   input_open = open
+   output_open = open
+
 
 def print_err(*pargs, **kwargs):
    """
@@ -240,7 +260,7 @@ def contains_module_definition(file_name, desired_mod):
    Return whether file_name contains the module definition for desired_mod.
    """
    desired_mod = desired_mod.lower()
-   with open(file_name, 'r') as f:
+   with input_open(file_name, 'r', errors='replace') as f:
       for line in f:
          result = module_def_pattern.match(line)
          if result:
@@ -341,7 +361,7 @@ def process_fortran90_file(fname, prereqs):
    """
    try:
       ffname = find_file(fname)
-      f = open(ffname, 'r')
+      f = input_open(ffname, 'r', errors='replace')
    except IOError as e:
       print_err("Cannot open file '{}'; skipping.".format(fname))
    except Exception as e:
@@ -376,7 +396,7 @@ def process_fortran77_file(fname, prereqs):
    """
    try:
       ffname = find_file(fname)
-      f = open(ffname, 'r')
+      f = input_open(ffname, 'r', errors='replace')
    except IOError as e:
       print_err("Cannot open file '{}'; skipping.".format(fname))
    except Exception as e:
@@ -406,7 +426,7 @@ def process_c_file(fname, prereqs):
    """
    try:
       ffname = find_file(fname)
-      f = open(ffname, 'r')
+      f = input_open(ffname, 'r', errors='replace')
    except IOError as e:
       print_err("Cannot open file '{}'; skipping.".format(fname))
    except Exception as e:
@@ -538,7 +558,7 @@ for full_filename in files:
    target = basename_new_suffix(base_filename,'.o')
 
    # open and initialize the dependency list
-   depfile = open(depname, 'w')
+   depfile = output_open(depname, 'w')
    prereqs = set()
 
    try:

--- a/lis/make/plugins.py
+++ b/lis/make/plugins.py
@@ -1,7 +1,15 @@
 #!/usr/bin/env python
 from __future__ import print_function
-import StringIO
-import ConfigParser
+import sys
+
+if sys.version_info.major == 2:
+   import StringIO as io
+   import ConfigParser
+   configparser = ConfigParser.SafeConfigParser
+else:
+   import io
+   import configparser
+   configparser = configparser.ConfigParser
 
 '''
    This program processes the default configuration file, default.cfg,
@@ -54,7 +62,8 @@ interp
 #
 # Process sections and enable/disable table
 #
-config = ConfigParser.SafeConfigParser()
+#config = configparser.ConfigParser()
+config = configparser()
 config.read('default.cfg')
 
 try:
@@ -131,7 +140,7 @@ fpath = ' ../{0}'
 dentry = '#{0} {1}\n'
 
 filepath.write('dirs := .')
-paths = StringIO.StringIO(required_filepath)
+paths = io.StringIO(required_filepath)
 for line in paths:
    filepath.write(fpath.format(line.strip()))
 

--- a/lvt/make/makedep.py
+++ b/lvt/make/makedep.py
@@ -5,6 +5,26 @@ import os
 import re
 import glob
 
+#
+# Note that an issue was encountered processing (with Python3) a Fortran90 source file
+# that was not UTF-8 encoded.  Because the purpose of this program in to scan C and
+# Fortran source files to generate prerequisites/dependencies and because for these
+# languages keywords are ASCII, this program deals with encoding issues using the
+# "errors=replace" option of the open function.  Any encoding errors will occur within
+# comments and can be ignored.
+#
+# Note that to support using both Python2 and Python3, the open function has been
+# aliased.  Use the input_open function to open input files; use the output_open
+# function to open output files.
+#
+if sys.version_info.major == 2:
+   import io
+   input_open = io.open
+   output_open = open
+else:
+   input_open = open
+   output_open = open
+
 
 def print_err(*pargs, **kwargs):
    """
@@ -240,7 +260,7 @@ def contains_module_definition(file_name, desired_mod):
    Return whether file_name contains the module definition for desired_mod.
    """
    desired_mod = desired_mod.lower()
-   with open(file_name, 'r') as f:
+   with input_open(file_name, 'r', errors='replace') as f:
       for line in f:
          result = module_def_pattern.match(line)
          if result:
@@ -341,26 +361,26 @@ def process_fortran90_file(fname, prereqs):
    """
    try:
       ffname = find_file(fname)
-      f = open(ffname, 'r')
+      f = input_open(ffname, 'r', errors='replace')
    except IOError as e:
       print_err("Cannot open file '{}'; skipping.".format(fname))
    except Exception as e:
       print(e)
    else:
       for line in f:
-         fname = find_use_module_statement(line)
-         if fname:
-            prereqs = add_prerequisite(prereqs, fname, '.o')
-         fname = find_f_include_statement(line)
-         if fname:
-            prereqs = add_prerequisite(prereqs, fname)
+         name = find_use_module_statement(line)
+         if name:
+            prereqs = add_prerequisite(prereqs, name, '.o')
+         name = find_f_include_statement(line)
+         if name:
+            prereqs = add_prerequisite(prereqs, name)
             print_dbg('recursing')
-            prereqs = process_fortran90_file(fname, prereqs)
-         fname = find_c_include_statement(line)
-         if fname:
-            prereqs = add_prerequisite(prereqs, fname)
+            prereqs = process_fortran90_file(name, prereqs)
+         name = find_c_include_statement(line)
+         if name:
+            prereqs = add_prerequisite(prereqs, name)
             print_dbg('recursing')
-            prereqs = process_fortran90_file(fname, prereqs)
+            prereqs = process_fortran90_file(name, prereqs)
       f.close()
    finally:
       return prereqs
@@ -376,21 +396,21 @@ def process_fortran77_file(fname, prereqs):
    """
    try:
       ffname = find_file(fname)
-      f = open(ffname, 'r')
+      f = input_open(ffname, 'r', errors='replace')
    except IOError as e:
       print_err("Cannot open file '{}'; skipping.".format(fname))
    except Exception as e:
       print(e)
    else:
       for line in f:
-         fname = find_f_include_statement(line)
-         if fname:
-            prereqs = add_prerequisite(prereqs, fname)
-            prereqs = process_fortran77_file(fname, prereqs)
-         fname = find_c_include_statement(line)
-         if fname:
-            prereqs = add_prerequisite(prereqs, fname)
-            prereqs = process_fortran77_file(fname, prereqs)
+         name = find_f_include_statement(line)
+         if name:
+            prereqs = add_prerequisite(prereqs, name)
+            prereqs = process_fortran77_file(name, prereqs)
+         name = find_c_include_statement(line)
+         if name:
+            prereqs = add_prerequisite(prereqs, name)
+            prereqs = process_fortran77_file(name, prereqs)
       f.close()
    finally:
       return prereqs
@@ -406,7 +426,7 @@ def process_c_file(fname, prereqs):
    """
    try:
       ffname = find_file(fname)
-      f = open(ffname, 'r')
+      f = input_open(ffname, 'r', errors='replace')
    except IOError as e:
       print_err("Cannot open file '{}'; skipping.".format(fname))
    except Exception as e:
@@ -531,7 +551,6 @@ print_dbg('cli_args: ',cli_args)
 files = cli_args.files
 
 for full_filename in files:
-   #print_status('\nGenerating dependencies for {}'.format(full_filename))
    print_status('Generating dependencies for {}'.format(full_filename))
    # derivatives of full_filename
    base_filename = os.path.basename(full_filename)
@@ -539,7 +558,7 @@ for full_filename in files:
    target = basename_new_suffix(base_filename,'.o')
 
    # open and initialize the dependency list
-   depfile = open(depname, 'w')
+   depfile = output_open(depname, 'w')
    prereqs = set()
 
    try:


### PR DESCRIPTION
The build tools for LISF (plugins.py and makedep.py) have been updated to work with either Python 2.7 or Python 3.

I plan to support both Python2 and Python3 until after the LISF public 7.3 release and after the migration to SLES12.  Then the build scripts will be updated to Python3 only.