### PR TITLE
Adds a config option to GOME2 plugin

### DIFF
--- a/lvt/datastreams/GOME2_SIF/GOME2_SIFobsMod.F90
+++ b/lvt/datastreams/GOME2_SIF/GOME2_SIFobsMod.F90
@@ -42,6 +42,7 @@ module GOME2_SIFobsMod
 
   type, public :: gome2sifdec
      character*100           :: odir
+     character*20            :: version
      integer                 :: nc, nr
      real,    allocatable    :: rlat(:)
      real,    allocatable    :: rlon(:)
@@ -99,6 +100,13 @@ contains
     call ESMF_ConfigGetAttribute(LVT_Config, GOME2SIFobs(i)%odir, &
          label='GOME2 SIF data directory:',rc=status)
     call LVT_verify(status, 'GOME2 SIF data directory: not defined')
+    call ESMF_ConfigGetAttribute(LVT_Config, GOME2SIFobs(i)%version, &
+         label='GOME2 SIF data version:',rc=status)
+    if(status.ne.0) then 
+       write(LVT_logunit,*) '[ERR] GOME2 SIF data version: not defined'
+       write(LVT_logunit,*) "[ERR] supported options are 'v26', 'v27' or 'v28'"
+       call LVT_endrun()
+    endif
 
     call LVT_update_timestep(LVT_rc, 2592000)
 

--- a/lvt/datastreams/GOME2_SIF/readGOME2_SIFObs.F90
+++ b/lvt/datastreams/GOME2_SIF/readGOME2_SIFObs.F90
@@ -78,6 +78,7 @@ subroutine readGOME2_SIFObs(source)
      GOME2sifobs(source)%mo = LVT_rc%d_nmo(source)
 
      call create_GOME2sif_filename(GOME2sifobs(Source)%odir, &
+          GOME2sifobs(source)%version,&
           LVT_rc%dyr(source),LVT_rc%dmo(source),&
           fname)
      
@@ -217,7 +218,7 @@ end subroutine readGOME2_SIFObs
 ! \label{create_GOME2sif_filename}
 !
 ! !INTERFACE: 
-subroutine create_GOME2sif_filename(odir,yr,mo,filename)
+subroutine create_GOME2sif_filename(odir,version,yr,mo,filename)
 ! 
 ! !USES:   
   implicit none
@@ -245,6 +246,7 @@ subroutine create_GOME2sif_filename(odir,yr,mo,filename)
 !BOP
 ! !ARGUMENTS: 
   character(len=*)             :: odir
+  character(len=*)             :: version
   integer                      :: yr
   integer                      :: mo
   character(len=*)             :: filename
@@ -262,7 +264,7 @@ subroutine create_GOME2sif_filename(odir,yr,mo,filename)
 !       '/ret_f_nr5_nsvd12_v26_waves734_nolog.grid_SIF__v20_1x1_'//&
 !       trim(fyr)//trim(fmo)//'01_31.nc'
   filename = trim(odir)//'/'//trim(fyr)//&
-       '/ret_f_nr5_nsvd12_v26_waves734_nolog.grid_SIF_v27_'//&
+       '/ret_f_nr5_nsvd12_v26_waves734_nolog.grid_SIF_'//trim(version)//'_'//&
        trim(fyr)//trim(fmo)//'01_31.nc'
   
 end subroutine create_GOME2sif_filename


### PR DESCRIPTION
Adds a new config entry to support different versions of GOME2 SIF data.
GOME2 SIF data version:
The allowed options are 'v26','v27' or 'v28'

Resolves #477