### PR TITLE
Added "AGRMET GFS filename version:" to lis.config.

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -4910,7 +4910,7 @@ Acceptable values are:
 |====
 |Value  | Description
 |1      | Example: MT.avn_CY.00_fh.0000_tl.press_gr.0p5deg
-!2      | Example: PS.NCEP_SC.U_DI.A_DC.GRID_GP.GFS_SP.SIMPLE_GR.C0P5DEG_AR.GLOBAL_PA.GFS_DD.20200213_CY.00_FH.000_DF.GR2
+|2      | Example: PS.NCEP_SC.U_DI.A_DC.GRID_GP.GFS_SP.SIMPLE_GR.C0P5DEG_AR.GLOBAL_PA.GFS_DD.20200213_CY.00_FH.000_DF.GR2
 |====
 
 `AGRMET analysis directory:` specifies the location where temporary

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -4903,6 +4903,16 @@ Acceptable values are:
 |10     | 10-km (proposed operational resolution upgrade for 2020)
 |====
 
+`AGRMET GFS filename version:` specifies which filename version convention
+is used for the GFS GRIB files.
+Acceptable values are:
+
+|====
+|Value  | Description
+|1      | Example: MT.avn_CY.00_fh.0000_tl.press_gr.0p5deg
+!2      | Example: PS.NCEP_SC.U_DI.A_DC.GRID_GP.GFS_SP.SIMPLE_GR.C0P5DEG_AR.GLOBAL_PA.GFS_DD.20200213_CY.00_FH.000_DF.GR2
+|====
+
 `AGRMET analysis directory:` specifies the location where temporary
 precip analysis fields will be written.
 


### PR DESCRIPTION
This is to support expected change in GFS file names used at 557WW.

NOTE:  The Fortran code changes are in the usaf RESTRICTED code, and will be contained in a separate pull request.