### PR TITLE
Fixes the bug in the LVT SMAP soil moisture reader

### DIFF
--- a/lvt/datastreams/SMAPsm/readSMAPsmobs.F90
+++ b/lvt/datastreams/SMAPsm/readSMAPsmobs.F90
@@ -271,7 +271,6 @@ subroutine read_SMAPL2sm_data(source, fname, smobs_inp, time)
 
   integer                        :: status,ios,iret
 
-  smobs_inp = LVT_rc%udef
 
   call h5open_f(status)
   call LVT_verify(status, 'Error opening HDF fortran interface')


### PR DESCRIPTION
Removes the extraneous initialization statement that causes a bug with L2 retrievals

Resolves #487