### PR TITLE
New fix to LDT grid domains (Issue #410)

### DIFF
--- a/ldt/configs/ldt.config.adoc
+++ b/ldt/configs/ldt.config.adoc
@@ -400,7 +400,7 @@ Acceptable values are:
 |"1" |Buffer included
 |===
 
-The default value is 1.
+The default value is 0.
 
 .Example _ldt.config_ entry
 ....
@@ -419,7 +419,7 @@ Acceptable values are:
 |"1 (or greater)" |Buffer points included
 |===
 
-The default value is 5.
+The default value is 5, and only activated if buffer option is selected.
 
 .Example _ldt.config_ entry
 ....

--- a/ldt/core/LDT_readConfig.F90
+++ b/ldt/core/LDT_readConfig.F90
@@ -385,7 +385,7 @@ subroutine LDT_readConfig(configfile)
 ! Option to add buffer around parameter grid domain:
   call ESMF_ConfigGetAttribute(LDT_config,LDT_rc%add_buffer,&
        label="Add buffer to parameter grid domain:",&
-       default=1,rc=rc)
+       default=0,rc=rc)
   call LDT_verify(rc,'Add buffer to parameter grid domain: not defined')
 
   call ESMF_ConfigGetAttribute(LDT_config,LDT_rc%x_buffer,&


### PR DESCRIPTION
 This commit provides new updates to LDT in relation
  to the "buffer" outer domain option and support for domains
  that cross the International Dateline (IDL).

 - Resorted code to original lisdom_min|max calculations,
    which more correctly specifies outer domain required
    for curvilinear projections (e.g., Lambert);
 - Removed recently added code for these buffer and IDL domain
    issues, and replaced with simple code addition for when
    accounting for crossing the IDL.
 - Simplified the buffer code option and left the options in,
    however, they will not be triggered unless the user wants
    to turn them on. Default option is "off".
 - Made modifications to the LDT configs *adoc file.

 The new code was tested with a suite of six different test cases,
  which span continental US, global domain, and IDL domains, in both
  latlon and Lambert projections. All passed the checks and no
  buffer is required for any of the six cases.

 The new code has also been tested with SLES11/Intel18, GCC/Gfortran,
  SLES/Intel19 systems and all 6 test cases.