### PR TITLE
Makes the choice of ecCodes the default option in LISF

### DIFF
--- a/ldt/arch/Config.pl
+++ b/ldt/arch/Config.pl
@@ -190,11 +190,11 @@ else{
 }
 
 
-print "Use GRIBAPI/ECCODES? (0-neither, 1-gribapi, 2-eccodes, default=1): ";
+print "Use GRIBAPI/ECCODES? (0-neither, 1-gribapi, 2-eccodes, default=2): ";
 $use_gribapi=<stdin>;
 chomp($use_gribapi);
 if($use_gribapi eq ""){
-   $use_gribapi=1;
+   $use_gribapi=2;
 }
 
 if($use_gribapi == 1) {

--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -298,11 +298,11 @@ else{
 }
 
 
-print "Use GRIBAPI/ECCODES? (0-neither, 1-gribapi, 2-eccodes, default=1): ";
+print "Use GRIBAPI/ECCODES? (0-neither, 1-gribapi, 2-eccodes, default=2): ";
 $use_gribapi=<stdin>;
 chomp($use_gribapi);
 if($use_gribapi eq ""){
-   $use_gribapi=1;
+   $use_gribapi=2;
 }
 
 if($use_gribapi == 1) {

--- a/lvt/arch/Config.pl
+++ b/lvt/arch/Config.pl
@@ -176,11 +176,11 @@ else{
    exit 1;
 }
 
-print "Use GRIBAPI/ECCODES? (1-gribapi, 2-eccodes, default=1): ";
+print "Use GRIBAPI/ECCODES? (1-gribapi, 2-eccodes, default=2): ";
 $use_gribapi=<stdin>;
 chomp($use_gribapi);
 if($use_gribapi eq ""){
-   $use_gribapi=1;
+   $use_gribapi=2;
 }
 
 if($use_gribapi == 1) {


### PR DESCRIPTION
The config file has been updated to make the choice of
ecCodes library (instead of the older grib_api) the default
option while compiling LDT, LIS, or LVT.

Resolves #499