### PR TITLE
Corrects the inconsistent time referencing in the LVT readers

### DIFF
--- a/lvt/configs/lvt.config.master
+++ b/lvt/configs/lvt.config.master
@@ -1839,8 +1839,31 @@ ISMN observation directory:             ./ISMN
 #latex: BEGIN_DESCRIPTION
 #latex: \var{LPRM AMSR-E soil moisture observation directory:}  specifies the location of the LPRM AMSR-E soil moisture retrievals
 #latex: 
+#latex: \var{LPRM AMSR-E data version:}  specifies the version of LPRM 
+#latex: soil moisture data to be used
+#latex: Acceptable values are:
+#latex: 
+#latex: \begin{tabular}{ll}
+#latex: Value & Description \\
+#latex: GES-DISC     & NASA GES-DISC version  \\
+#latex: V5     & version 5 data (from VU)         \\
+#latex: \end{tabular}
+#latex: 
+#latex: \var{LPRM AMSR-E data channel:}  specifies the frequency 
+#latex: channel of the soil moisture retrieval (This option is 
+#latex: only needed for the GES-DISC data version)
+#latex:
+#latex: Acceptable values are:
+#latex: 
+#latex: \begin{tabular}{ll}
+#latex: Value & Description \\
+#latex: X-band    & X-band retrieval \\ 
+#latex: C-band    & C-band retrieval \\
+#latex: \end{tabular}
+#latex: 
 #latex: \var{LPRM AMSR-E use raw data:}  specifies whether to use
-#latex: the LPRM AMSR-E raw data.
+#latex: the LPRM AMSR-E raw data (This option is only used for 
+#latex: V5 data)
 #latex: Acceptable values are:
 #latex: 
 #latex: \begin{tabular}{ll}
@@ -1848,11 +1871,14 @@ ISMN observation directory:             ./ISMN
 #latex: 0     & Do not use  \\
 #latex: 1     & Use         \\
 #latex: \end{tabular}
+
 #latex: 
 #latex: END_DESCRIPTION
 
 #latex: BEGIN_CONFIG
 LPRM AMSR-E soil moisture observation directory: ./LPRM-AMSRE
+LPRM AMSR-E soil moisture data version:  GES-DISC
+LPRM AMSR-E soil moisture data channel: X-band
 LPRM AMSR-E use raw data:                        0
 #latex: END_CONFIG
 

--- a/lvt/datastreams/ANSA_SNWD/readANSASNWDobs.F90
+++ b/lvt/datastreams/ANSA_SNWD/readANSASNWDobs.F90
@@ -110,7 +110,7 @@ subroutine readANSASNWDobs(source)
 
         call LVT_verify(status, 'Error opening ANSA file ')
 
-        if(LVT_rc%yr.ge.2010) then 
+        if(LVT_rc%dyr(source).ge.2010) then 
            call h5dopen_f(file_id,snwd_field_name1,snwd_field_id, status)
            call LVT_verify(status, 'Error opening SNWD field in ANSA file')
         else

--- a/lvt/datastreams/GHCN/readGHCNObs.F90
+++ b/lvt/datastreams/GHCN/readGHCNObs.F90
@@ -73,7 +73,7 @@ subroutine readGHCNObs(source)
 
      ghcnobs(source)%prcp = LVT_rc%udef
      
-     call ESMF_TimeSet(ghcnobs(source)%startTime,  yy=LVT_rc%yr, &
+     call ESMF_TimeSet(ghcnobs(source)%startTime,  yy=LVT_rc%dyr(source), &
           mm = 1, &
           dd = 1, &
           h = 0, &

--- a/lvt/datastreams/GRACE/readGRACEObs.F90
+++ b/lvt/datastreams/GRACE/readGRACEObs.F90
@@ -157,8 +157,8 @@ subroutine readGRACEObs(source)
   endif
   
   ! Estimate available time point (accounting for missing data)
-  call LVT_get_julhr(LVT_rc%yr,LVT_rc%mo,LVT_rc%da,&
-       LVT_rc%hr,LVT_rc%mn,LVT_rc%ss,currTime)
+  call LVT_get_julhr(LVT_rc%dyr(source),LVT_rc%dmo(source),LVT_rc%dda(source),&
+       LVT_rc%dhr(source),LVT_rc%dmn(source),LVT_rc%dss(source),currTime)
   
   dt =  float((currTime-GRACEobs(source)%refTime))/24.0
   

--- a/lvt/datastreams/LISDAdiag/readLISDAdiagOutput.F90
+++ b/lvt/datastreams/LISDAdiag/readLISDAdiagOutput.F90
@@ -63,10 +63,11 @@ subroutine readLISDAdiagOutput(source)
   
   if(lisdadiagoutput(source)%computeSpread.eq.1) then 
      write(unit=cdate1, fmt='(i4.4, i2.2, i2.2, i2.2, i2.2)') &
-          LVT_rc%yr, LVT_rc%mo, LVT_rc%da, LVT_rc%hr, LVT_rc%mn
+          LVT_rc%dyr(source), LVT_rc%dmo(source), LVT_rc%dda(source), &
+          LVT_rc%dhr(source), LVT_rc%dmn(source)
      
      write(unit=cdate, fmt='(i4.4, i2.2)') &
-          LVT_rc%yr, LVT_rc%mo
+          LVT_rc%dyr(source), LVT_rc%dmo(source)
      
      fname = trim(lisdadiagoutput(source)%odir)//'/EnKF/'//trim(cdate)//'/'&
           //'LIS_DA_EnKF_'//trim(cdate1)//'_spread.a'//trim(cda)//'.d01.nc'
@@ -105,10 +106,11 @@ subroutine readLISDAdiagOutput(source)
 
   if(lisdadiagoutput(source)%computeAnlIncr.eq.1) then 
      write(unit=cdate1, fmt='(i4.4, i2.2, i2.2, i2.2, i2.2)') &
-          LVT_rc%yr, LVT_rc%mo, LVT_rc%da, LVT_rc%hr, LVT_rc%mn
+          LVT_rc%dyr(source), LVT_rc%dmo(source), &
+          LVT_rc%dda(source), LVT_rc%dhr(source), LVT_rc%dmn(source)
      
      write(unit=cdate, fmt='(i4.4, i2.2)') &
-          LVT_rc%yr, LVT_rc%mo
+          LVT_rc%dyr(source), LVT_rc%dmo(source)
      
      fname = trim(lisdadiagoutput(source)%odir)//'/EnKF/'//trim(cdate)//'/'&
           //'LIS_DA_EnKF_'//trim(cdate1)//'_incr.a'//trim(cda)//'.d01.nc'
@@ -151,10 +153,11 @@ subroutine readLISDAdiagOutput(source)
 
   if(lisdadiagoutput(source)%computeInnovDist.eq.1) then 
      write(unit=cdate1, fmt='(i4.4, i2.2, i2.2, i2.2, i2.2)') &
-          LVT_rc%yr, LVT_rc%mo, LVT_rc%da, LVT_rc%hr, LVT_rc%mn
+          LVT_rc%dyr(source), LVT_rc%dmo(source), LVT_rc%dda(source), &
+          LVT_rc%dhr(source), LVT_rc%dmn(source)
      
      write(unit=cdate, fmt='(i4.4, i2.2)') &
-          LVT_rc%yr, LVT_rc%mo
+          LVT_rc%dyr(source), LVT_rc%dmo(source)
      
      fname = trim(lisdadiagoutput(source)%odir)//'/EnKF/'//trim(cdate)//'/'&
           //'LIS_DA_EnKF_'//trim(cdate1)//'_innov.a'//trim(cda)//'.d01.nc'

--- a/lvt/datastreams/LPRM_AMSRE_sm/LPRM_AMSREsm_obsMod.F90
+++ b/lvt/datastreams/LPRM_AMSRE_sm/LPRM_AMSREsm_obsMod.F90
@@ -45,6 +45,8 @@ module LPRM_AMSREsm_obsMod
 
      character*100           :: odir
      integer                 :: rawdata
+     character*10            :: version
+     character*10            :: channel
      real                    :: gridDesci(50)
      integer                :: lprmnc, lprmnr
      type(proj_info)        :: lprmproj
@@ -112,9 +114,31 @@ contains
     call LVT_verify(status, &
          'LPRM AMSR-E soil moisture observation directory: not defined')
     
-    call ESMF_ConfigGetAttribute(LVT_config, LPRM_AMSREsmobs(i)%rawdata, &
-         label='LPRM AMSR-E use raw data:', rc=status)
-    call LVT_verify(status, 'LPRM AMSR-E use raw data: not defined')
+
+    call ESMF_ConfigGetAttribute(LVT_config, LPRM_AMSREsmobs(i)%version, &
+         label='LPRM AMSR-E soil moisture data version:', rc=status)
+    if(status.ne.0) then 
+       write(LVT_logunit,*) "[ERR] 'LPRM AMSR-E soil moisture data version:' not defined"
+       write(LVT_logunit,*) "[ERR] supported options are: "
+       write(LVT_logunit,*) "[ERR] 'V05' or 'GES-DISC'"
+       call LVT_endrun()
+    endif
+
+    if(LPRM_AMSREsmobs(i)%version.eq."GES-DISC") then 
+       call ESMF_ConfigGetAttribute(LVT_config, LPRM_AMSREsmobs(i)%channel, &
+            label='LPRM AMSR-E soil moisture data channel:', rc=status)
+       if(status.ne.0) then 
+          write(LVT_logunit,*) "[ERR] 'LPRM AMSR-E soil moisture data channel:' not defined"
+          write(LVT_logunit,*) "[ERR] supported options are: "
+          write(LVT_logunit,*) "[ERR] 'X-band' or 'C-band'"
+          call LVT_endrun()
+       endif
+    elseif(LPRM_AMSREsmobs(i)%version.eq."V05") then 
+       call ESMF_ConfigGetAttribute(LVT_config, LPRM_AMSREsmobs(i)%rawdata, &
+            label='LPRM AMSR-E soil moisture use raw data:', rc=status)
+       call LVT_verify(status, 'LPRM AMSR-E soil moisture use raw data: not defined')
+       
+    endif
 
     LPRM_AMSREsmobs(i)%startmode = .true. 
 

--- a/lvt/datastreams/LPRM_AMSRE_sm/readLPRM_AMSREsmObs.F90
+++ b/lvt/datastreams/LPRM_AMSRE_sm/readLPRM_AMSREsmObs.F90
@@ -48,9 +48,10 @@ subroutine readLPRM_AMSREsmObs(source)
   logical           :: alarmCheck
   logical           :: file_exists
   integer           :: c,r,i,j
-  character*100     :: fname_A, fname_D
+  character*100     :: fname_A, fname_D,fname
   real              :: smobs_A(LVT_rc%lnc*LVT_rc%lnr)
   real              :: smobs_D(LVT_rc%lnc*LVT_rc%lnr)
+  real              :: smobs(LVT_rc%lnc*LVT_rc%lnr)
   real              :: lat,lon
 !-----------------------------------------------------------------------
 ! It is assumed that CDF is computed using daily observations. 
@@ -59,51 +60,85 @@ subroutine readLPRM_AMSREsmObs(source)
   timenow = float(LVT_rc%dhr(source))*3600 + 60*LVT_rc%dmn(source) + &
        LVT_rc%dss(source)
   alarmcheck = (mod(timenow, 86400.0).eq.0)
-
-  LPRM_AMSREsmobs(source)%smobs = LVT_rc%udef
-  smobs_A= LVT_rc%udef
-  smobs_D= LVT_rc%udef
-        
-  if(LPRM_AMSREsmobs(source)%startmode.or.alarmCheck.or.&
-       LVT_rc%resetFlag(source)) then 
+  smobs  = LVT_rc%udef
+  if(LPRM_AMSREsmobs(source)%version.eq."V05") then 
+     LPRM_AMSREsmobs(source)%smobs = LVT_rc%udef
+     smobs_A= LVT_rc%udef
+     smobs_D= LVT_rc%udef
      
-     LVT_rc%resetFlag(source) = .false. 
-     LPRM_AMSREsmobs(source)%startmode = .false. 
-
-     call create_LPRM_AMSREsm_filename(LPRM_AMSREsmobs(source)%odir, &
-          'A',LVT_rc%dyr(source), LVT_rc%dmo(source), &
-          LVT_rc%dda(source), fname_A)
-
-     inquire(file=trim(fname_A),exist=file_exists)
-
-     if(file_exists) then
-
-        write(LVT_logunit,*) '[INFO] Reading ..',trim(fname_A)
-        call read_LPRM_data(source, fname_A,smobs_A)
-     endif
-
-     call create_LPRM_AMSREsm_filename(LPRM_AMSREsmobs(source)%odir, &
-          'D',LVT_rc%dyr(source), LVT_rc%dmo(source), &
-          LVT_rc%dda(source), fname_D)
-
-     inquire(file=trim(fname_D),exist=file_exists)
-     if(file_exists) then
-
-        write(LVT_logunit,*) '[INFO] Reading ..',trim(fname_D)
-        call read_LPRM_data(source, fname_D,smobs_D)
-     endif
-     do r=1,LVT_rc%lnr
-        do c=1,LVT_rc%lnc
-           if(smobs_A(c+(r-1)*LVT_rc%lnc).ne.-9999.0) then 
-              LPRM_AMSREsmobs(source)%smobs(c,r) = smobs_A(c+(r-1)*LVT_rc%lnc)
-           endif
-           if(smobs_D(c+(r-1)*LVT_rc%lnc).ne.-9999.0) then 
-              LPRM_AMSREsmobs(source)%smobs(c,r) = smobs_D(c+(r-1)*LVT_rc%lnc)
-           endif
-
+     if(LPRM_AMSREsmobs(source)%startmode.or.alarmCheck.or.&
+          LVT_rc%resetFlag(source)) then 
+        
+        LVT_rc%resetFlag(source) = .false. 
+        LPRM_AMSREsmobs(source)%startmode = .false. 
+        
+        call create_LPRM_AMSREsm_filename(LPRM_AMSREsmobs(source)%odir, &
+             'A',LVT_rc%dyr(source), LVT_rc%dmo(source), &
+             LVT_rc%dda(source), fname_A)
+        
+        inquire(file=trim(fname_A),exist=file_exists)
+        
+        if(file_exists) then
+           
+           write(LVT_logunit,*) '[INFO] Reading ..',trim(fname_A)
+           call read_LPRM_data(source, fname_A,smobs_A)
+        endif
+        
+        call create_LPRM_AMSREsm_filename(LPRM_AMSREsmobs(source)%odir, &
+             'D',LVT_rc%dyr(source), LVT_rc%dmo(source), &
+             LVT_rc%dda(source), fname_D)
+        
+        inquire(file=trim(fname_D),exist=file_exists)
+        if(file_exists) then
+           
+           write(LVT_logunit,*) '[INFO] Reading ..',trim(fname_D)
+           call read_LPRM_data(source, fname_D,smobs_D)
+        endif
+        do r=1,LVT_rc%lnr
+           do c=1,LVT_rc%lnc
+              if(smobs_A(c+(r-1)*LVT_rc%lnc).ne.-9999.0) then 
+                 LPRM_AMSREsmobs(source)%smobs(c,r) = smobs_A(c+(r-1)*LVT_rc%lnc)
+              endif
+              if(smobs_D(c+(r-1)*LVT_rc%lnc).ne.-9999.0) then 
+                 LPRM_AMSREsmobs(source)%smobs(c,r) = smobs_D(c+(r-1)*LVT_rc%lnc)
+              endif
+              
+           enddo
         enddo
-     enddo
+     endif
+  elseif(LPRM_AMSREsmobs(source)%version.eq."GES-DISC") then 
+     LPRM_AMSREsmobs(source)%smobs = LVT_rc%udef
+     
+     if(LPRM_AMSREsmobs(source)%startmode.or.alarmCheck.or.&
+          LVT_rc%resetFlag(source)) then 
+        
+        LVT_rc%resetFlag(source) = .false. 
+        LPRM_AMSREsmobs(source)%startmode = .false. 
+        
+        call create_LPRM_AMSREsm_GESDISC_filename(&
+             LPRM_AMSREsmobs(source)%odir, &
+             LVT_rc%dyr(source), LVT_rc%dmo(source), &
+             LVT_rc%dda(source), fname)
+        
+        inquire(file=trim(fname),exist=file_exists)
+        
+        if(file_exists) then
+           
+           write(LVT_logunit,*) '[INFO] Reading ..',trim(fname)
+           call read_LPRM_GESDISC_data(source, fname,smobs)
+        endif
+        
+        do r=1,LVT_rc%lnr
+           do c=1,LVT_rc%lnc
+              if(smobs(c+(r-1)*LVT_rc%lnc).ne.-9999.0) then 
+                 LPRM_AMSREsmobs(source)%smobs(c,r) = smobs(c+(r-1)*LVT_rc%lnc)
+              endif
+           enddo
+        enddo
+     endif
+
   endif
+
   call LVT_logSingleDataStreamVar(LVT_MOC_soilmoist, source, &
        LPRM_AMSREsmobs(source)%smobs,vlevel=1,units="m3/m3")
 
@@ -397,6 +432,188 @@ subroutine read_LPRM_data(source, fname, smobs_ip)
 end subroutine read_LPRM_data
 
 !BOP
+! 
+! !ROUTINE: read_LPRM_GESDISC_data
+! \label(read_LPRM_GESDISC_data)
+!
+! !INTERFACE:
+subroutine read_LPRM_GESDISC_data(source, fname, smobs_ip)
+! 
+! !USES:   
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)
+  use netcdf
+#endif
+  use LVT_coreMod,  only : LVT_rc
+  use LVT_logMod,   only : LVT_verify
+  use map_utils,    only : latlon_to_ij
+  use LPRM_AMSREsm_obsMod, only : LPRM_AMSREsmobs
+
+  implicit none
+!
+! !INPUT PARAMETERS: 
+! 
+  integer                       :: source
+  character (len=*)             :: fname
+  real                          :: smobs_ip(LVT_rc%lnc*LVT_rc%lnr)
+
+
+! !OUTPUT PARAMETERS:
+!
+! !DESCRIPTION: 
+!  This subroutine reads the LPRM NETCDF file and applies the data
+!  quality flags to filter the data. The retrievals are rejected when 
+!  land surface temperature is below freezing, if rain is present, if 
+!  RFI is present, if residual error is above 0.5 or if optical depth
+!  is above 0.8. Finally the routine combines both the C-band and X-band
+!  retrievals. 
+! 
+!  The arguments are: 
+!  \begin{description}
+!  \item[n]            index of the nest
+!  \item[fname]        name of the LPRM AMSR-E file
+!  \item[smobs\_ip]    soil moisture data processed to the LVT domain
+! \end{description}
+!
+! !FILES USED:
+!
+! !REVISION HISTORY: 
+! 
+!EOP
+  real                        :: smerrc(LPRM_AMSREsmobs(source)%lprmnr,&
+       LPRM_AMSREsmobs(source)%lprmnc)
+  real                        :: smerrx(LPRM_AMSREsmobs(source)%lprmnr,&
+       LPRM_AMSREsmobs(source)%lprmnc)
+  real                        :: smc(LPRM_AMSREsmobs(source)%lprmnr,&
+       LPRM_AMSREsmobs(source)%lprmnc)
+  real                        :: smx(LPRM_AMSREsmobs(source)%lprmnr,&
+       LPRM_AMSREsmobs(source)%lprmnc)
+  real                        :: sm_combined(LPRM_AMSREsmobs(source)%lprmnc,&
+       LPRM_AMSREsmobs(source)%lprmnr)
+
+  real                        :: sm_data(LPRM_AMSREsmobs(source)%lprmnc* & 
+       LPRM_AMSREsmobs(source)%lprmnr)
+  logical*1                   :: sm_data_b(LPRM_AMSREsmobs(source)%lprmnc* & 
+       LPRM_AMSREsmobs(source)%lprmnr)
+  logical*1                   :: smobs_b_ip(LVT_rc%lnc*LVT_rc%lnr)
+
+  integer                     :: c,r,i,j
+  real                        :: rlat,rlon,ri,rj
+  integer                     :: nid
+  integer                     :: smcombId
+  integer                     :: tskinId
+  integer                     :: smerrCid, smerrXid, smcId, smXId
+  integer                     :: ios
+
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)
+
+  if(LPRM_AMSREsmobs(source)%channel.eq."C-band") then 
+     ios = nf90_open(path=trim(fname),mode=NF90_NOWRITE,ncid=nid)
+     call LVT_verify(ios,'Error opening file '//trim(fname))
+
+     ios = nf90_inq_varid(nid, 'sm_c_error',smerrCid)
+     call LVT_verify(ios, &
+          'Error nf90_inq_varid: sm_c_error')
+     ios = nf90_get_var(nid, smerrcid, smerrc)
+     call LVT_verify(ios, 'Error nf90_get_var: sm_c_error')
+     
+     ios = nf90_inq_varid(nid, 'soil_moisture_c',smcid)
+     call LVT_verify(ios, 'Error nf90_inq_varid: soil_moisture_c')
+     
+     ios = nf90_get_var(nid, smcid, smc)
+     call LVT_verify(ios, 'Error nf90_get_var: soil_moisture_c')
+
+     ios = nf90_close(ncid=nid)
+     call LVT_verify(ios,'Error closing file '//trim(fname))
+     
+     sm_combined = LVT_rc%udef
+
+     do r=1, LPRM_AMSREsmobs(source)%lprmnr
+        do c=1, LPRM_AMSREsmobs(source)%lprmnc
+!--------------------------------------------------------------------------
+! Reject retrievals when residual error is large (> 0.2)
+!-------------------------------------------------------------------------- 
+           if(smerrc(r,c)*0.01.gt.0.2.or.smerrc(r,c)*0.01.lt.0) smc(r,c) = -1
+!--------------------------------------------------------------------------
+! Apply the QC flags 
+!-------------------------------------------------------------------------- 
+           if(smc(r,c).gt.0) then 
+              sm_combined(c,LPRM_AMSREsmobs(source)%lprmnr-r+1)  = &
+                   smc(r,c)/100.0
+           else
+              sm_combined(c,LPRM_AMSREsmobs(source)%lprmnr-r+1) =LVT_rc%udef
+           endif
+        enddo
+     enddo
+  elseif(LPRM_AMSREsmobs(source)%channel.eq."X-band") then 
+     ios = nf90_open(path=trim(fname),mode=NF90_NOWRITE,ncid=nid)
+     call LVT_verify(ios,'Error opening file '//trim(fname))
+
+     ios = nf90_inq_varid(nid, 'sm_x_error',smerrXid)
+     call LVT_verify(ios, &
+          'Error nf90_inq_varid: sm_x_error')
+     ios = nf90_get_var(nid, smerrxid,smerrx)
+     call LVT_verify(ios, 'Error nf90_get_var: sm_x_error')
+
+     ios = nf90_inq_varid(nid, 'soil_moisture_x',smxid)
+     call LVT_verify(ios, 'Error nf90_inq_varid: soil_moisture_x')
+     
+     ios = nf90_get_var(nid, smxid, smx)
+     call LVT_verify(ios, 'Error nf90_get_var: soil_moisture_x')
+
+     ios = nf90_close(ncid=nid)
+     call LVT_verify(ios,'Error closing file '//trim(fname))
+     
+     sm_combined = LVT_rc%udef
+
+     do r=1, LPRM_AMSREsmobs(source)%lprmnr
+        do c=1, LPRM_AMSREsmobs(source)%lprmnc
+!--------------------------------------------------------------------------
+! Reject retrievals when residual error is large (> 0.2)
+!-------------------------------------------------------------------------- 
+           if(smerrx(r,c)*0.01.gt.0.2.or.smerrx(r,c)*0.01.lt.0) smx(r,c) = -1
+!--------------------------------------------------------------------------
+! Apply the QC flags 
+!-------------------------------------------------------------------------- 
+           if(smx(r,c).gt.0) then 
+              sm_combined(c,LPRM_AMSREsmobs(source)%lprmnr-r+1)  = &
+                   smx(r,c)/100.0
+           else
+              sm_combined(c,LPRM_AMSREsmobs(source)%lprmnr-r+1) =LVT_rc%udef
+           endif
+        enddo
+     enddo
+  endif
+
+  do r=1, LPRM_AMSREsmobs(source)%lprmnr
+     do c=1, LPRM_AMSREsmobs(source)%lprmnc
+        sm_data(c+(r-1)*LPRM_AMSREsmobs(source)%lprmnc) = sm_combined(c,r)
+        if(sm_combined(c,r).ne.LVT_rc%udef) then 
+           sm_data_b(c+(r-1)*LPRM_AMSREsmobs(source)%lprmnc) = .true. 
+        else
+           sm_data_b(c+(r-1)*LPRM_AMSREsmobs(source)%lprmnc) = .false.
+        endif
+     enddo
+  enddo
+  
+!--------------------------------------------------------------------------
+! Interpolate to the LVT running domain
+!-------------------------------------------------------------------------- 
+  call bilinear_interp(LVT_rc%gridDesc(:),&
+       sm_data_b, sm_data, smobs_b_ip, smobs_ip, &
+       LPRM_AMSREsmobs(source)%lprmnc*LPRM_AMSREsmobs(source)%lprmnr, &
+       LVT_rc%lnc*LVT_rc%lnr, &
+       LPRM_AMSREsmobs(source)%rlat, LPRM_AMSREsmobs(source)%rlon, &
+       LPRM_AMSREsmobs(source)%w11, LPRM_AMSREsmobs(source)%w12, &
+       LPRM_AMSREsmobs(source)%w21, LPRM_AMSREsmobs(source)%w22, &
+       LPRM_AMSREsmobs(source)%n11, LPRM_AMSREsmobs(source)%n12, &
+       LPRM_AMSREsmobs(source)%n21, LPRM_AMSREsmobs(source)%n22, &
+       LVT_rc%udef, ios)
+
+#endif
+  
+end subroutine read_LPRM_GESDISC_data
+
+!BOP
 ! !ROUTINE: create_LPRM_AMSREsm_filename
 ! \label{create_LPRM_AMSREsm_filename}
 ! 
@@ -438,3 +655,45 @@ subroutine create_LPRM_AMSREsm_filename(ndir, path,yr, mo,da, filename)
        //trim(fyr)//trim(fmo)//trim(fda)//'T235959D.v05.nc'
   
 end subroutine create_LPRM_AMSREsm_filename
+
+
+!BOP
+! !ROUTINE: create_LPRM_AMSREsm_GESDISC_filename
+! \label{create_LPRM_AMSREsm_GESDISC_filename}
+! 
+! !INTERFACE: 
+subroutine create_LPRM_AMSREsm_GESDISC_filename(ndir, yr, mo,da, filename)
+! !USES:   
+
+  implicit none
+! !ARGUMENTS: 
+  character(len=*)  :: filename
+  integer           :: yr, mo, da
+  character (len=*) :: ndir
+! 
+! !DESCRIPTION: 
+!  This subroutine creates the LPRM AMSRE filename based on the time and date 
+! 
+!  The arguments are: 
+!  \begin{description}
+!  \item[ndir] name of the LPRM AMSRE soil moisture directory
+!  \item[path] name of the sensor path (A-ascending, D-descending)
+!  \item[yr]  current year
+!  \item[mo]  current month
+!  \item[da]  current day
+!  \item[filename] Generated LPRM filename
+! \end{description}
+!EOP
+
+  character (len=4) :: fyr
+  character (len=2) :: fmo,fda
+  
+  write(unit=fyr, fmt='(i4.4)') yr
+  write(unit=fmo, fmt='(i2.2)') mo
+  write(unit=fda, fmt='(i2.2)') da
+ 
+  filename = trim(ndir)//'/'//trim(fyr)//'/'//&
+       '/LPRM-AMSR_E_L3_A_SOILM3_V002_' &
+       //trim(fyr)//trim(fmo)//trim(fda)//'.nc'
+  
+end subroutine create_LPRM_AMSREsm_GESDISC_filename

--- a/lvt/datastreams/LPRMvod/readLPRMvodobs.F90
+++ b/lvt/datastreams/LPRMvod/readLPRMvodobs.F90
@@ -80,9 +80,9 @@ subroutine readLPRMvodobs(source)
      call create_LPRM_vodfilename(&
           LPRM_vodobs(source)%odir,&
           LPRM_vodobs(source)%data_designation,&
-          LVT_rc%yr,&
-          LVT_rc%mo,&
-          LVT_rc%da,&
+          LVT_rc%dyr(source),&
+          LVT_rc%dmo(source),&
+          LVT_rc%dda(source),&
           lprm_filename)
 
      inquire(file=lprm_filename,exist=file_exists)

--- a/lvt/datastreams/NASMD/readNASMDObs.F90
+++ b/lvt/datastreams/NASMD/readNASMDObs.F90
@@ -92,7 +92,7 @@ subroutine readNASMDObs(source)
           rc=status)
      call LVT_verify(status, 'error in setting nasmd start time')
 
-     nasmdobs(source)%yr = LVT_rc%yr
+     nasmdobs(source)%yr = LVT_rc%dyr(source)
      nasmdobs(source)%sfsm = LVT_rc%udef
      nasmdobs(source)%rzsm = LVT_rc%udef
 

--- a/lvt/datastreams/SCAN/readSCANObs.F90
+++ b/lvt/datastreams/SCAN/readSCANObs.F90
@@ -106,7 +106,7 @@ subroutine readSCANObs(source)
           rc=status)
      call LVT_verify(status, 'error in setting scan start time')
 
-     scanobs(source)%yr = LVT_rc%yr
+     scanobs(source)%yr = LVT_rc%dyr(source)
      scanobs(source)%sm = LVT_rc%udef
      scanobs(source)%rootsm = LVT_rc%udef
      scanobs(source)%soilt = LVT_rc%udef

--- a/lvt/datastreams/SCANGMAO/readSCANGMAOObs.F90
+++ b/lvt/datastreams/SCANGMAO/readSCANGMAOObs.F90
@@ -106,7 +106,7 @@ subroutine readSCANGMAOObs(source)
           rc=status)
      call LVT_verify(status, 'error in setting scan start time')
 
-     scangmaoobs(source)%yr = LVT_rc%yr
+     scangmaoobs(source)%yr = LVT_rc%dyr(source)
      scangmaoobs(source)%sm = LVT_rc%udef
      scangmaoobs(source)%rootsm = LVT_rc%udef
      scangmaoobs(source)%soilt = LVT_rc%udef

--- a/lvt/datastreams/SMAP_L3TB/readSMAP_L3TB.F90
+++ b/lvt/datastreams/SMAP_L3TB/readSMAP_L3TB.F90
@@ -69,9 +69,9 @@ subroutine readSMAP_L3TB(source)
 !----------------------------------------------------------------------------------------------------------------
 ! create filename for 9 km product
 !----------------------------------------------------------------------------------------------------------------
-         write (yyyy, '(i4.4)') LVT_rc%yr
-         write (mm, '(i2.2)') LVT_rc%mo
-         write (dd, '(i2.2)') LVT_rc%da
+         write (yyyy, '(i4.4)') LVT_rc%dyr(source)
+         write (mm, '(i2.2)') LVT_rc%dmo(source)
+         write (dd, '(i2.2)') LVT_rc%dda(source)
          write (CRID, '(a)') SMAP_L3TB(source)%release_number
 
          list_files = 'ls '//trim(SMAP_L3TB(source)%odir)//'/'//trim(yyyy)//'.'//trim(mm)//'.'// &
@@ -103,17 +103,18 @@ subroutine readSMAP_L3TB(source)
 !----------------------------------------------------------------------------------------------------------------
 ! create filename for 36 km product
 !----------------------------------------------------------------------------------------------------------------
-         write (yyyy, '(i4.4)') LVT_rc%yr
-         write (mm, '(i2.2)') LVT_rc%mo
-         write (dd, '(i2.2)') LVT_rc%da
+         write (yyyy, '(i4.4)') LVT_rc%dyr(source)
+         write (mm, '(i2.2)') LVT_rc%dmo(source)
+         write (dd, '(i2.2)') LVT_rc%dda(source)
          write (CRID, '(a)') SMAP_L3TB(source)%release_number
 
-         list_files = 'ls '//trim(SMAP_L3TB(source)%odir)//'/'//trim(yyyy)//'.'//trim(mm)//'.'// &
-                      trim(dd)//'/SMAP_L3_SM_P_' &
-                      //trim(yyyy)//trim(mm)//trim(dd)//'_'// &
-                         trim(CRID)//'*.h5> SMAP_filelist'// &
-                         '.dat'
-
+         list_files = 'ls '//trim(SMAP_L3TB(source)%odir)//'/'&
+              //trim(yyyy)//'.'//trim(mm)//'.'// &
+              trim(dd)//'/SMAP_L3_SM_P_' &
+              //trim(yyyy)//trim(mm)//trim(dd)//'_'// &
+              trim(CRID)//'*.h5> SMAP_filelist'// &
+              '.dat'
+         
          call system(trim(list_files))
          ftn = LVT_getNextUnitNumber()
          open (ftn, file="./SMAP_filelist.dat", &

--- a/lvt/datastreams/SMAPvwc/readSMAPvwcobs.F90
+++ b/lvt/datastreams/SMAPvwc/readSMAPvwcobs.F90
@@ -70,16 +70,17 @@ subroutine readSMAPvwcobs(source)
 !----------------------------------------------------------------------------------------------------------------
 ! create filename for 9 km product
 !----------------------------------------------------------------------------------------------------------------
-         write (yyyy, '(i4.4)') LVT_rc%yr
-         write (mm, '(i2.2)') LVT_rc%mo
-         write (dd, '(i2.2)') LVT_rc%da
+         write (yyyy, '(i4.4)') LVT_rc%dyr(source)
+         write (mm, '(i2.2)') LVT_rc%dmo(source)
+         write (dd, '(i2.2)') LVT_rc%dda(source)
          write (CRID, '(a)') SMAP_vwcobs(source)%release_number
 
-         list_files = 'ls '//trim(SMAP_vwcobs(source)%odir)//'/'//trim(yyyy)//'.'//trim(mm)//'.'// &
-                      trim(dd)//'/SMAP_L3_SM_P_E_' &
-                      //trim(yyyy)//trim(mm)//trim(dd)//'_'// &
-                         trim(CRID)//'*.h5> SMAP_filelist'// &
-                         '.dat'
+         list_files = 'ls '//trim(SMAP_vwcobs(source)%odir)//'/'&
+              //trim(yyyy)//'.'//trim(mm)//'.'// &
+              trim(dd)//'/SMAP_L3_SM_P_E_' &
+              //trim(yyyy)//trim(mm)//trim(dd)//'_'// &
+              trim(CRID)//'*.h5> SMAP_filelist'// &
+              '.dat'
 
          call system(trim(list_files))
          ftn = LVT_getNextUnitNumber()
@@ -104,17 +105,18 @@ subroutine readSMAPvwcobs(source)
 !----------------------------------------------------------------------------------------------------------------
 ! create filename for 36 km product
 !----------------------------------------------------------------------------------------------------------------
-         write (yyyy, '(i4.4)') LVT_rc%yr
-         write (mm, '(i2.2)') LVT_rc%mo
-         write (dd, '(i2.2)') LVT_rc%da
+         write (yyyy, '(i4.4)') LVT_rc%dyr(source)
+         write (mm, '(i2.2)') LVT_rc%dmo(source)
+         write (dd, '(i2.2)') LVT_rc%dda(source)
          write (CRID, '(a)') SMAP_vwcobs(source)%release_number
 
-         list_files = 'ls '//trim(SMAP_vwcobs(source)%odir)//'/'//trim(yyyy)//'.'//trim(mm)//'.'// &
-                      trim(dd)//'/SMAP_L3_SM_P_' &
-                      //trim(yyyy)//trim(mm)//trim(dd)//'_'// &
-                         trim(CRID)//'*.h5> SMAP_filelist'// &
-                         '.dat'
-
+         list_files = 'ls '//trim(SMAP_vwcobs(source)%odir)//'/'&
+              //trim(yyyy)//'.'//trim(mm)//'.'// &
+              trim(dd)//'/SMAP_L3_SM_P_' &
+              //trim(yyyy)//trim(mm)//trim(dd)//'_'// &
+              trim(CRID)//'*.h5> SMAP_filelist'// &
+              '.dat'
+         
          call system(trim(list_files))
          ftn = LVT_getNextUnitNumber()
          open (ftn, file="./SMAP_filelist.dat", &

--- a/lvt/datastreams/SMOPS/readSMOPSsmObs.F90
+++ b/lvt/datastreams/SMOPS/readSMOPSsmObs.F90
@@ -428,11 +428,11 @@ subroutine read_SMOPS_data(source, fname, smobs_ip)
    elseif ( SMOPSsmobs(source)%version == '3.0' ) then
       timenow = SMOPSsmobs(source)%version3_time
    else
-      yr1 = LVT_rc%yr
-      mo1 = LVT_rc%mo
-      da1 = LVT_rc%da
-      hr1 = LVT_rc%hr
-      mn1 = LVT_rc%mn
+      yr1 = LVT_rc%dyr(source)
+      mo1 = LVT_rc%dmo(source)
+      da1 = LVT_rc%dda(source)
+      hr1 = LVT_rc%dhr(source)
+      mn1 = LVT_rc%dmn(source)
       ss1 = 0
       call LVT_date2time(timenow,updoy,upgmt,yr1,mo1,da1,hr1,mn1,ss1)
    endif

--- a/lvt/datastreams/SNOTEL/readSNOTELObs.F90
+++ b/lvt/datastreams/SNOTEL/readSNOTELObs.F90
@@ -74,7 +74,7 @@ subroutine readSNOTELObs(source)
 
   if((LVT_rc%dyr(source).ne.snotelobs(source)%yr).or.&
        LVT_rc%resetFlag(source)) then 
-     
+
      LVT_rc%resetFlag(source) = .false. 
      snotelobs(source)%yr = LVT_rc%dyr(source)
      snotelobs(source)%swe = LVT_rc%udef
@@ -90,202 +90,200 @@ subroutine readSNOTELObs(source)
      call LVT_verify(status, 'error in setting snotel start time')
 
      do jj=1,2 !repeat twice -- once to read the current year and one to read
-               ! the previous -This is done because the snotel data is provided
-               ! in water years. 
-     do i=1,snotelobs(source)%nstns
-        if(jj.eq.1) then 
-           call create_SNOTEL_filename(snotelobs(source)%odir, &
-                snotelobs(source)%statename(i), &
-                snotelobs(source)%stnid(i),LVT_rc%dyr(source), snotelfilename)
-        elseif(jj.eq.2) then 
-           call create_SNOTEL_filename(snotelobs(source)%odir, &
-                snotelobs(source)%statename(i), &
-                snotelobs(source)%stnid(i),LVT_rc%dyr(source)+1, snotelfilename)
-        endif
+        ! the previous -This is done because the snotel data is provided
+        ! in water years. 
+        do i=1,snotelobs(source)%nstns
+           if(jj.eq.1) then 
+              call create_SNOTEL_filename(snotelobs(source)%odir, &
+                   snotelobs(source)%statename(i), &
+                   snotelobs(source)%stnid(i),LVT_rc%dyr(source), snotelfilename)
+           elseif(jj.eq.2) then 
+              call create_SNOTEL_filename(snotelobs(source)%odir, &
+                   snotelobs(source)%statename(i), &
+                   snotelobs(source)%stnid(i),LVT_rc%dyr(source)+1, snotelfilename)
+           endif
 
-        inquire(file=trim(snotelfilename),exist=file_exists)
+           inquire(file=trim(snotelfilename),exist=file_exists)
 
-        if(file_exists) then 
-           write(LVT_logunit,*) '[INFO] Reading SNOTEL data ',trim(snotelfilename)
-           ftn=LVT_getNextUnitNumber()
-           open(ftn,file=trim(snotelfilename),form='formatted')
-           read(ftn,*) ! skip the header line
-           
-           readflag = .true. 
-           do while(readflag) 
-!              read(ftn,fmt='(i2.2,i2.2,i2.2,F5.2)', iostat=ios) mo,da,yr,swe_data
-!              read(ftn,fmt='(i2.2,i2.2,i2.2,a)', iostat=ios) mo,da,yr,cswe_data
-!              read(cswe_data,*,iostat=ios1) swe_data
-              read(ftn,'(a)',iostat=ios) line
-              if(ios.ne.0) then 
-                 readflag = .false. 
-                 exit
-              endif
-              do kk=1,len(line)
-                 if(line(kk:kk)==achar(9)) line(kk:kk) =';'
-              enddo
-              
-              iloc = index(line,";")
-              read(line(1:iloc-1),*) datestring
-              line = line(iloc+1:len(line))
-              
-              read(datestring,'(i2.2,i2.2,i2.2)') mo,da,yr
+           if(file_exists) then 
+              write(LVT_logunit,*) '[INFO] Reading SNOTEL data ',trim(snotelfilename)
+              ftn=LVT_getNextUnitNumber()
+              open(ftn,file=trim(snotelfilename),form='formatted')
+              read(ftn,*) ! skip the header line
 
-              iloc = index(line,";")
-              read(line(1:iloc-1),*,iostat=ios1) swe_data
-              line = line(iloc+1:len(line))
-              if(ios1.ne.0) swe_data = -9999.0
+              readflag = .true. 
+              do while(readflag) 
+                 !              read(ftn,fmt='(i2.2,i2.2,i2.2,F5.2)', iostat=ios) mo,da,yr,swe_data
+                 !              read(ftn,fmt='(i2.2,i2.2,i2.2,a)', iostat=ios) mo,da,yr,cswe_data
+                 !              read(cswe_data,*,iostat=ios1) swe_data
+                 read(ftn,'(a)',iostat=ios) line
+                 if(ios.ne.0) then 
+                    readflag = .false. 
+                    exit
+                 endif
+                 do kk=1,len(line)
+                    if(line(kk:kk)==achar(9)) line(kk:kk) =';'
+                 enddo
 
-              do kk=1,4 !skip
                  iloc = index(line,";")
+                 read(line(1:iloc-1),*) datestring
                  line = line(iloc+1:len(line))
-              enddo
 
-              read(line,*,iostat=ios1) prcp_data
-              if(ios1.ne.0) prcp_data = -9999.0
+                 read(datestring,'(i2.2,i2.2,i2.2)') mo,da,yr
 
-              if(ios.ne.0) then 
-                 readflag = .false. 
-              else
-                 if(yr.gt.60) then 
-                    yr = yr + 1900 
+                 iloc = index(line,";")
+                 read(line(1:iloc-1),*,iostat=ios1) swe_data
+                 line = line(iloc+1:len(line))
+                 if(ios1.ne.0) swe_data = -9999.0
+
+                 do kk=1,4 !skip
+                    iloc = index(line,";")
+                    line = line(iloc+1:len(line))
+                 enddo
+
+                 read(line,*,iostat=ios1) prcp_data
+                 if(ios1.ne.0) prcp_data = -9999.0
+
+                 if(ios.ne.0) then 
+                    readflag = .false. 
                  else
-                    yr = yr + 2000
-                 endif
-                 
-                 call ESMF_TimeSet(snoteltime,yy=yr,&
-                      mm=mo, dd=da, h=0,calendar=LVT_calendar,&
-                      rc=status)
-                 call LVT_verify(status,'ESMF_TimeSet in readSnotelobs(Source)')
-                 
-                 t = nint((snoteltime-snotelobs(source)%starttime)/&
-                      snotelobs(source)%timestep)+1
-                 if(t.ge.1.and.t.le.366) then 
-!                 print*, 'snotel ',yr, mo, da, 'st ', snotelobs(source)%yr, LVT_rc%mo, t
-
-                    if(swe_data.ge.0) then 
-                       snotelobs(source)%swe(i,t) = swe_data*0.0254 !convert from inches to m
+                    if(yr.gt.60) then 
+                       yr = yr + 1900 
                     else
-                       snotelobs(source)%swe(i,t) = LVT_rc%udef
+                       yr = yr + 2000
                     endif
-                    
-                    if(snotelobs(source)%swe(i,t).gt.20) then 
-                       print*, 'error?',i,t,snotelobs(source)%swe(i,t)
-                       stop
-                    endif
-                 endif
 
-                 if(t.ge.1.and.t.le.366) then 
-                    if(prcp_data.ge.0) then 
-                       snotelobs(source)%prcp(i,t) = prcp_data*0.0254 !convert from inches to m
-                    else
-                       snotelobs(source)%prcp(i,t) = LVT_rc%udef
+                    call ESMF_TimeSet(snoteltime,yy=yr,&
+                         mm=mo, dd=da, h=0,calendar=LVT_calendar,&
+                         rc=status)
+                    call LVT_verify(status,'ESMF_TimeSet in readSnotelobs(Source)')
+
+                    t = nint((snoteltime-snotelobs(source)%starttime)/&
+                         snotelobs(source)%timestep)+1
+                    if(t.ge.1.and.t.le.366) then 
+                       !                 print*, 'snotel ',yr, mo, da, 'st ', snotelobs(source)%yr, LVT_rc%mo, t
+
+                       if(swe_data.ge.0) then 
+                          snotelobs(source)%swe(i,t) = swe_data*0.0254 !convert from inches to m
+                       else
+                          snotelobs(source)%swe(i,t) = LVT_rc%udef
+                       endif
+
+                       if(snotelobs(source)%swe(i,t).gt.20) then 
+                          print*, 'error?',i,t,snotelobs(source)%swe(i,t)
+                          stop
+                       endif
                     endif
-                    
-                    if(snotelobs(source)%prcp(i,t).gt.20) then 
-                       print*, 'error?',i,t,snotelobs(source)%prcp(i,t)
-                       stop
+
+                    if(t.ge.1.and.t.le.366) then 
+                       if(prcp_data.ge.0) then 
+                          snotelobs(source)%prcp(i,t) = prcp_data*0.0254 !convert from inches to m
+                       else
+                          snotelobs(source)%prcp(i,t) = LVT_rc%udef
+                       endif
+
+                       if(snotelobs(source)%prcp(i,t).gt.20) then 
+                          print*, 'error?',i,t,snotelobs(source)%prcp(i,t)
+                          stop
+                       endif
                     endif
                  endif
-              endif
-              if(ios.ne.0) then 
-                 readflag = .false. 
-              endif
-           enddo
-           call LVT_releaseUnitNumber(ftn)
+                 if(ios.ne.0) then 
+                    readflag = .false. 
+                 endif
+              enddo
+              call LVT_releaseUnitNumber(ftn)
+           endif
+        enddo
+     enddo
+  endif
+
+  call ESMF_TimeSet(snoteltime1,yy=LVT_rc%dyr(source), &
+       mm=LVT_rc%dmo(source), dd=LVT_rc%dda(source), &
+       h=LVT_rc%dhr(source), m=LVT_rc%dmn(source), &
+       s = LVT_rc%dss(source), calendar=LVT_calendar, rc=status)
+  call LVT_verify(status, 'snoteltime1 set failed')
+
+  offset = (snoteltime1-snotelobs(source)%starttime)/snotelobs(source)%timestep
+
+  if((nint(offset)-offset).eq.0) then !only when LIS time matches the observation
+
+     tind = nint((snoteltime1-snotelobs(source)%starttime)/snotelobs(source)%timestep)+1
+
+     do i=1,snotelobs(source)%nstns
+        call latlon_to_ij(LVT_domain%lvtproj, &
+             snotelobs(source)%stnlat(i),snotelobs(source)%stnlon(i),&
+             col,row)
+        stn_col = nint(col)
+        stn_row = nint(row)
+
+        if(stn_col.gt.0.and.stn_row.gt.0.and.tind.ge.0.and.&
+             stn_col.le.LVT_rc%lnc.and.stn_row.le.LVT_rc%lnr) then 
+           if(snotelobs(source)%swe(i,tind).ne.LVT_rc%udef) then 
+              swe(stn_col, stn_row) = swe(stn_col, stn_row) + & 
+                   snotelobs(source)%swe(i,tind)
+              nswe(stn_col, stn_row) = nswe(stn_col, stn_row) + 1
+           endif
+           if(snotelobs(source)%prcp(i,tind).ne.LVT_rc%udef) then 
+              prcp(stn_col, stn_row) = prcp(stn_col, stn_row) + & 
+                   snotelobs(source)%prcp(i,tind)
+              nprcp(stn_col, stn_row) = nprcp(stn_col, stn_row) + 1
+           endif
+        endif
+     enddo
+  endif
+
+  do r=1,LVT_rc%lnr
+     do c=1,LVT_rc%lnc
+        if(nswe(c,r).gt.0) then 
+           swe(c,r) = swe(c,r)/nswe(c,r)
+        else
+           swe(c,r) = LVT_rc%udef
         endif
      enddo
   enddo
-endif
 
-call ESMF_TimeSet(snoteltime1,yy=LVT_rc%dyr(source), &
-     mm=LVT_rc%dmo(source), dd=LVT_rc%dda(source), &
-     h=LVT_rc%dhr(source), m=LVT_rc%dmn(source), &
-     s = LVT_rc%dss(source), calendar=LVT_calendar, rc=status)
-call LVT_verify(status, 'snoteltime1 set failed')
+  call LVT_logSingleDataStreamVar(LVT_MOC_SWE,source, swe,vlevel=1,units="m")
 
-offset = (snoteltime1-snotelobs(source)%starttime)/snotelobs(source)%timestep
+  do r=1,LVT_rc%lnr
+     do c=1,LVT_rc%lnc
+        if(nswe(c,r).gt.0) then 
+           swe(c,r) =swe(c,r)*1000.0 !to mm
+        else
+           swe(c,r) = LVT_rc%udef
+        endif
+     enddo
+  enddo
 
-if((nint(offset)-offset).eq.0) then !only when LIS time matches the observation
-!     print*, 'offset ',LVT_rc%yr, LVT_rc%mo, LVT_rc%da, LVT_rc%hr, &
-!          LVT_rc%mn, LVT_rc%ss, offset
-   
-   tind = nint((snoteltime1-snotelobs(source)%starttime)/snotelobs(source)%timestep)+1
-   
-   do i=1,snotelobs(source)%nstns
-      call latlon_to_ij(LVT_domain%lvtproj, &
-           snotelobs(source)%stnlat(i),snotelobs(source)%stnlon(i),&
-           col,row)
-      stn_col = nint(col)
-      stn_row = nint(row)
-      
-      if(stn_col.gt.0.and.stn_row.gt.0.and.tind.ge.0.and.&
-           stn_col.le.LVT_rc%lnc.and.stn_row.le.LVT_rc%lnr) then 
-         if(snotelobs(source)%swe(i,tind).ne.LVT_rc%udef) then 
-            swe(stn_col, stn_row) = swe(stn_col, stn_row) + & 
-                 snotelobs(source)%swe(i,tind)
-            nswe(stn_col, stn_row) = nswe(stn_col, stn_row) + 1
-         endif
-         if(snotelobs(source)%prcp(i,tind).ne.LVT_rc%udef) then 
-            prcp(stn_col, stn_row) = prcp(stn_col, stn_row) + & 
-                 snotelobs(source)%prcp(i,tind)
-            nprcp(stn_col, stn_row) = nprcp(stn_col, stn_row) + 1
-         endif
-      endif
-   enddo
-endif
+  call LVT_logSingleDataStreamVar(LVT_MOC_SWE,source, swe,vlevel=1,units="kg/m2")
 
-do r=1,LVT_rc%lnr
-   do c=1,LVT_rc%lnc
-      if(nswe(c,r).gt.0) then 
-         swe(c,r) = swe(c,r)/nswe(c,r)
-      else
-         swe(c,r) = LVT_rc%udef
-      endif
-   enddo
-enddo
+  do r=1,LVT_rc%lnr
+     do c=1,LVT_rc%lnc
+        if(nprcp(c,r).gt.0) then 
+           prcp(c,r) = prcp(c,r)*1000.0/nprcp(c,r) !mm
+        else
+           prcp(c,r) = LVT_rc%udef
+        endif
+     enddo
+  enddo
 
-call LVT_logSingleDataStreamVar(LVT_MOC_SWE,source, swe,vlevel=1,units="m")
+  call LVT_logSingleDataStreamVar(LVT_MOC_rainf,source, prcp,vlevel=1,units='kg/m2')
+  call LVT_logSingleDataStreamVar(LVT_MOC_rainfforc,source, prcp,vlevel=1,units='kg/m2')
+  call LVT_logSingleDataStreamVar(LVT_MOC_totalprecip,source, prcp,vlevel=1,units='kg/m2')
 
-do r=1,LVT_rc%lnr
-   do c=1,LVT_rc%lnc
-      if(nswe(c,r).gt.0) then 
-         swe(c,r) =swe(c,r)*1000.0 !to mm
-      else
-         swe(c,r) = LVT_rc%udef
-      endif
-   enddo
-enddo
+  do r=1,LVT_rc%lnr
+     do c=1,LVT_rc%lnc
+        if(nprcp(c,r).gt.0) then 
+           prcp(c,r) = prcp(c,r)/86400.0 !kg/m2s
+        else
+           prcp(c,r) = LVT_rc%udef
+        endif
+     enddo
+  enddo
 
-call LVT_logSingleDataStreamVar(LVT_MOC_SWE,source, swe,vlevel=1,units="kg/m2")
-
-do r=1,LVT_rc%lnr
-   do c=1,LVT_rc%lnc
-      if(nprcp(c,r).gt.0) then 
-         prcp(c,r) = prcp(c,r)*1000.0/nprcp(c,r) !mm
-      else
-         prcp(c,r) = LVT_rc%udef
-      endif
-   enddo
-enddo
-
-call LVT_logSingleDataStreamVar(LVT_MOC_rainf,source, prcp,vlevel=1,units='kg/m2')
-call LVT_logSingleDataStreamVar(LVT_MOC_rainfforc,source, prcp,vlevel=1,units='kg/m2')
-call LVT_logSingleDataStreamVar(LVT_MOC_totalprecip,source, prcp,vlevel=1,units='kg/m2')
-
-do r=1,LVT_rc%lnr
-   do c=1,LVT_rc%lnc
-      if(nprcp(c,r).gt.0) then 
-         prcp(c,r) = prcp(c,r)/86400.0 !kg/m2s
-      else
-         prcp(c,r) = LVT_rc%udef
-      endif
-   enddo
-enddo
-
-call LVT_logSingleDataStreamVar(LVT_MOC_rainf,source, prcp,vlevel=1,units='kg/m2s')
-call LVT_logSingleDataStreamVar(LVT_MOC_rainfforc,source, prcp,vlevel=1,units='kg/m2s')
-call LVT_logSingleDataStreamVar(LVT_MOC_totalprecip,source, prcp,vlevel=1,units='kg/m2s') 
+  call LVT_logSingleDataStreamVar(LVT_MOC_rainf,source, prcp,vlevel=1,units='kg/m2s')
+  call LVT_logSingleDataStreamVar(LVT_MOC_rainfforc,source, prcp,vlevel=1,units='kg/m2s')
+  call LVT_logSingleDataStreamVar(LVT_MOC_totalprecip,source, prcp,vlevel=1,units='kg/m2s') 
 
 end subroutine readSNOTELObs
 

--- a/lvt/datastreams/SNOTEL/readSNOTELObs.F90
+++ b/lvt/datastreams/SNOTEL/readSNOTELObs.F90
@@ -161,8 +161,6 @@ subroutine readSNOTELObs(source)
                     t = nint((snoteltime-snotelobs(source)%starttime)/&
                          snotelobs(source)%timestep)+1
                     if(t.ge.1.and.t.le.366) then 
-                       !                 print*, 'snotel ',yr, mo, da, 'st ', snotelobs(source)%yr, LVT_rc%mo, t
-
                        if(swe_data.ge.0) then 
                           snotelobs(source)%swe(i,t) = swe_data*0.0254 !convert from inches to m
                        else
@@ -170,8 +168,8 @@ subroutine readSNOTELObs(source)
                        endif
 
                        if(snotelobs(source)%swe(i,t).gt.20) then 
-                          print*, 'error?',i,t,snotelobs(source)%swe(i,t)
-                          stop
+                          write(LVT_logunit,*) '[ERR]',i,t,snotelobs(source)%swe(i,t)
+                          call LVT_endrun()
                        endif
                     endif
 
@@ -183,8 +181,8 @@ subroutine readSNOTELObs(source)
                        endif
 
                        if(snotelobs(source)%prcp(i,t).gt.20) then 
-                          print*, 'error?',i,t,snotelobs(source)%prcp(i,t)
-                          stop
+                          write(LVT_logunit,*) i,t,snotelobs(source)%prcp(i,t)
+                          call LVT_endrun()
                        endif
                     endif
                  endif

--- a/lvt/datastreams/SURFRAD/readSURFRADObs.F90
+++ b/lvt/datastreams/SURFRAD/readSURFRADObs.F90
@@ -52,8 +52,6 @@ subroutine readSURFRADObs(source)
 
 ! read the data and then use the log-method (see below) to map the relevant variable(s)
 ! to the LVT data structures.
-!  print*, 'reading surfrad', LVT_rc%yr, LVT_rc%mo, LVT_rc%da, LVT_rc%hr, LVT_rc%mn, LVT_rc%ss
-!  call LVT_logSingleVar(LVT_obsData(k)%snowdepth_obs,snowdepth)
 !
     real  		:: time
     integer 		:: yr, mo, da, hr, mn, ss, doy

--- a/lvt/datastreams/USCRNsm/readUSCRNsmObs.F90
+++ b/lvt/datastreams/USCRNsm/readUSCRNsmObs.F90
@@ -114,7 +114,7 @@ subroutine readUSCRNsmObs(source)
           rc=status)
      call LVT_verify(status, 'error in setting USCRNsm start time')
 
-     uscrnsmobs(source)%yr = LVT_rc%yr
+     uscrnsmobs(source)%yr = LVT_rc%dyr(source)
      uscrnsmobs(source)%sm = LVT_rc%udef
      uscrnsmobs(source)%rootsm = LVT_rc%udef
      uscrnsmobs(source)%soilt = LVT_rc%udef


### PR DESCRIPTION
Several readers use the LVT_rc%yr, LVT_rc%mo, LVT_rc%da ... variables for accessing time information, which is fine in normal circumstances. However, if LVT is used for time lagged computations, these variables should instead use LVT_rc%dyr(source), LVT_rc%dmo(source), .. etc. This commit correct

Resolves #527