### PR TITLE
LDT: HyMAP2, Support flexible grid setting (dx~=dy)

### DIFF
--- a/ldt/params/HYMAP/read_HYMAP_basin.F90
+++ b/ldt/params/HYMAP/read_HYMAP_basin.F90
@@ -43,7 +43,7 @@ subroutine read_HYMAP_basin(n, array)
   integer :: ftn
   integer :: c,r
   logical :: file_exists
-  integer :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1)
+  real    :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1)
 
   inquire(file=trim(HYMAP_struc(n)%basinfile), exist=file_exists)
   if(.not.file_exists) then 

--- a/ldt/params/HYMAP/read_HYMAP_basin_mask.F90
+++ b/ldt/params/HYMAP/read_HYMAP_basin_mask.F90
@@ -43,7 +43,7 @@ subroutine read_HYMAP_basin_mask(n, array)
   integer :: ftn
   integer :: c,r
   logical :: file_exists
-  integer :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1)
+  real    :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1)
 
   inquire(file=trim(HYMAP_struc(n)%basinmaskfile), exist=file_exists)
   if(.not.file_exists) then 

--- a/ldt/params/HYMAP/read_HYMAP_fld_height.F90
+++ b/ldt/params/HYMAP/read_HYMAP_fld_height.F90
@@ -70,11 +70,12 @@ subroutine read_HYMAP_fld_height(n, array)
              rlat(c,r),rlon(c,r))
      enddo
   enddo
-  
+
+  ! Yeosang Yoon: fix typo
   nc_dom = nint((HYMAP_struc(n)%hymapparms_gridDesc(8)-&
-       HYMAP_struc(n)%hymapparms_gridDesc(5))/(HYMAP_struc(n)%hymapparms_gridDesc(10)))+1
+       HYMAP_struc(n)%hymapparms_gridDesc(5))/(HYMAP_struc(n)%hymapparms_gridDesc(9)))+1
   nr_dom = nint((HYMAP_struc(n)%hymapparms_gridDesc(7)-&
-       HYMAP_struc(n)%hymapparms_gridDesc(4))/(HYMAP_struc(n)%hymapparms_gridDesc(9)))+1
+       HYMAP_struc(n)%hymapparms_gridDesc(4))/(HYMAP_struc(n)%hymapparms_gridDesc(10)))+1
 
   do k=1,HYMAP_struc(n)%hymap_fld_height%vlevels
 !     call readLISdata(n, ftn, LDT_rc%hymap_proj, &
@@ -83,14 +84,14 @@ subroutine read_HYMAP_fld_height(n, array)
      do r=1,LDT_rc%lnr(n)
         do c=1,LDT_rc%lnc(n)
            line1 = nint((rlat(c,r)-HYMAP_struc(n)%hymapparms_gridDesc(4))/&
-                HYMAP_struc(n)%hymapparms_gridDesc(9))+1
-           line2 = nint((rlon(c,r)-HYMAP_struc(n)%hymapparms_gridDesc(5))/&
                 HYMAP_struc(n)%hymapparms_gridDesc(10))+1
+           line2 = nint((rlon(c,r)-HYMAP_struc(n)%hymapparms_gridDesc(5))/&
+                HYMAP_struc(n)%hymapparms_gridDesc(9))+1
            line = (k-1)*nc_dom*nr_dom + (line1-1)*nc_dom + line2
            read(ftn,rec=line) array(c,r,k)
         enddo
      enddo
-     
+
      do r=1,LDT_rc%lnr(n)
         do c=1,LDT_rc%lnc(n)
            if(array(c,r,k).lt.0) then

--- a/ldt/params/HYMAP/read_HYMAP_flow_dir_x.F90
+++ b/ldt/params/HYMAP/read_HYMAP_flow_dir_x.F90
@@ -44,7 +44,7 @@ subroutine read_HYMAP_flow_dir_x(n, array)
   integer :: ftn
   integer :: c,r
   logical :: file_exists
-  integer :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1)
+  real    :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1)
 
   inquire(file=trim(HYMAP_struc(n)%flowdirxfile), exist=file_exists)
   if(.not.file_exists) then 

--- a/ldt/params/HYMAP/read_HYMAP_flow_dir_y.F90
+++ b/ldt/params/HYMAP/read_HYMAP_flow_dir_y.F90
@@ -44,7 +44,7 @@ subroutine read_HYMAP_flow_dir_y(n, array)
   integer :: ftn
   integer :: c,r
   logical :: file_exists
-  integer :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1)
+  real    :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1)
 ! __________________________________________________
 
   inquire(file=trim(HYMAP_struc(n)%flowdiryfile), exist=file_exists)

--- a/ldt/params/HYMAP/read_HYMAP_grid_elev.F90
+++ b/ldt/params/HYMAP/read_HYMAP_grid_elev.F90
@@ -61,7 +61,9 @@ subroutine read_HYMAP_grid_elev(n, array)
   call readLISdata(n, ftn, HYMAP_struc(n)%hymap_proj, &
        HYMAP_struc(n)%hymap_gridtransform, &
        HYMAP_struc(n)%hymapparms_gridDesc(:), 1, array)   ! 1 indicates 2D layer
-  
+
+! Yeosang Yoon: Keep negative value
+#if 0  
   do r=1,LDT_rc%lnr(n)
      do c=1,LDT_rc%lnc(n)
         if(array(c,r,1).lt.0) then
@@ -69,6 +71,8 @@ subroutine read_HYMAP_grid_elev(n, array)
         endif
      enddo
   enddo
+#endif
+
   call LDT_releaseUnitNumber(ftn)
 
 end subroutine read_HYMAP_grid_elev


### PR DESCRIPTION
Updated LDT hymap2 codes to support a flexible grid setting (especially to support current 557WW 10-km LIS run), as well as fixing minor typos.

**Testcase**:
/discover/nobackup/yyoon4/lis7/Testcase/ldt_hymap2   

