### PR TITLE
Fix LIS soil moisture DA QC checks for Noah-MP-4.0.1 LSM

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/da_soilm/noahmp401_qc_soilmobs.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/da_soilm/noahmp401_qc_soilmobs.F90
@@ -134,8 +134,8 @@ subroutine NoahMP401_qc_soilmobs(n,k,OBS_State)
      !SMCMAX(t)  =  parameters%SMCMAX(SOILTYP)  !  SMCMAX(t)  = MAXSMC (SOILTYP) 
      !SMCWLT(t)  =  parameters%SMCWLT(SOILTYP)   ! SMCWLT(t) = WLTSMC (SOILTYP)
      SOILTYP = NOAHMP401_struc(n)%noahmp401(t)%soiltype
-     SMCMAX  = SMCMAX_TABLE(SOILTYP)
-     SMCWLT  = SMCWLT_TABLE(SOILTYP)
+     SMCMAX(t)  = SMCMAX_TABLE(SOILTYP)
+     SMCWLT(t)  = SMCWLT_TABLE(SOILTYP)
      
   enddo
 


### PR DESCRIPTION
This commit fixes a bug in the soil moisture DA quality
control (QC) codes for the Noah-MP-4.0.1 LSM.  The code
was setting the value for all patches of variables SMCMAX
and SMCWLT to the same value.  This fix correctly sets
the values for all patches for these variables.

A review was done for Noah-MP-3.6 and Noah-3.X quality
control soil moisture DA codes, and it was determined
that no fixes are required to these other LSMs.

Resolves: #534