### PR TITLE
LDT, HyMAP: Fixed variable declaration

### DIFF
--- a/ldt/params/HYMAP/read_HYMAP_basin.F90
+++ b/ldt/params/HYMAP/read_HYMAP_basin.F90
@@ -43,7 +43,7 @@ subroutine read_HYMAP_basin(n, array)
   integer :: ftn
   integer :: c,r
   logical :: file_exists
-  real    :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1)
+  integer :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1) ! precision of binary file is int32
 
   inquire(file=trim(HYMAP_struc(n)%basinfile), exist=file_exists)
   if(.not.file_exists) then 

--- a/ldt/params/HYMAP/read_HYMAP_basin_mask.F90
+++ b/ldt/params/HYMAP/read_HYMAP_basin_mask.F90
@@ -43,7 +43,7 @@ subroutine read_HYMAP_basin_mask(n, array)
   integer :: ftn
   integer :: c,r
   logical :: file_exists
-  real    :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1)
+  integer :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1) ! precision of binary file is int32
 
   inquire(file=trim(HYMAP_struc(n)%basinmaskfile), exist=file_exists)
   if(.not.file_exists) then 

--- a/ldt/params/HYMAP/read_HYMAP_flow_dir_x.F90
+++ b/ldt/params/HYMAP/read_HYMAP_flow_dir_x.F90
@@ -44,7 +44,7 @@ subroutine read_HYMAP_flow_dir_x(n, array)
   integer :: ftn
   integer :: c,r
   logical :: file_exists
-  real    :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1)
+  integer :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1) ! precision of binary file is int32
 
   inquire(file=trim(HYMAP_struc(n)%flowdirxfile), exist=file_exists)
   if(.not.file_exists) then 

--- a/ldt/params/HYMAP/read_HYMAP_flow_dir_y.F90
+++ b/ldt/params/HYMAP/read_HYMAP_flow_dir_y.F90
@@ -44,7 +44,7 @@ subroutine read_HYMAP_flow_dir_y(n, array)
   integer :: ftn
   integer :: c,r
   logical :: file_exists
-  real    :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1)
+  integer :: iarray(LDT_rc%lnc(n),LDT_rc%lnr(n),1) ! precision of binary file is int32
 ! __________________________________________________
 
   inquire(file=trim(HYMAP_struc(n)%flowdiryfile), exist=file_exists)


### PR DESCRIPTION
Hi @bmcandr 

I recently changed a few variable declarations in the HyMAP reader (#532). However, the changes are not compatible with old HyMAP parameters (e.g., parameters in LIS repository). Thus, I roll back the changes.

I test the code using NLDAS HyMAP parameters.
/discover/nobackup/yyoon4/lis7/Testcase/ldt_hymap2

Thanks,
Yeosang
