### PR TITLE
Fix bug in index of loop in LVT_MaxTimeMod.F90

### DIFF
--- a/lvt/metrics/LVT_MaxTimeMod.F90
+++ b/lvt/metrics/LVT_MaxTimeMod.F90
@@ -300,7 +300,7 @@ contains
 !----------------------------------------------------------------
 !It is assumed temporal lag is not chosen in this setup
 !----------------------------------------------------------------
-    do k=1,LVT_rc%nDataStreams
+    do kk=1,LVT_rc%nDataStreams
        if(LVT_rc%tlag(kk).gt.0) then 
           write(LVT_logunit,*) "[ERR] "
           write(LVT_logunit,*) "[ERR] Non-zero temporal lag specification is not "


### PR DESCRIPTION
The do loop is indexed by "k", but the new variable "kk" is used within the loop.  The corresponding file LVT_MinTimeMod.F90 correctly has this do loop indexed by "kk".

This bug was introduced by pull request #542 .