### PR TITLE
Remove SMAP(NASA) LIS DA QC check config entry

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -3008,6 +3008,7 @@ NOTE: Select 0 for yearly CDF data.
 ....
 SMAP(NASA) soil moisture data directory:
 SMAP(NASA) soil moisture data designation:
+SMAP(NASA) soil moisture Composite Release ID:
 SMAP(NASA) soil moisture use scaled standard deviation model:
 SMAP(NASA) model CDF file:
 SMAP(NASA) observation CDF file:

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -2960,19 +2960,22 @@ AMSR2(GCOMW) snow depth input mask file:
 anchor:sssec_smapnasasmda[SMAP (NASA) soil moisture assimilation]
 
 `SMAP(NASA) soil moisture data directory:` specifies the SMAP(NASA) soil
-moisture data directory
+moisture data directory.
 
 `SMAP(NASA) soil moisture data designation:`  specifies the 
-designation of the SMAP data 
+designation of the SMAP data.
 
 Acceptable values are:
 
 |====
 |Value    | Description
 
-|SPL3SMAP | Level3 active passive SMAP data
-|SPL3SMP  | Level3 passive SMAP data 
+|SPL3SMAP | Level 3 active passive SMAP data
+|SPL3SMP  | Level 3 passive SMAP data 
 |====
+
+`SMAP(NASA) soil moisture Composite Release ID:` specifies the SMAP NASA
+composite release ID included within the filename (e.g., R16).
 
 `SMAP(NASA) soil moisture use scaled standard deviation model:` specifies
 whether the observation error standard deviation is to be scaled using model
@@ -3019,11 +3022,6 @@ anchor:sssec_smapnrtsmda[SMAP (NRT) soil moisture assimilation]
 `SMAP(NRT) soil moisture data directory:` specifies the SMAP(NRT) soil
 moisture data directory
 
-`SMAP(NRT) soil moisture apply SMAP QC flags:` specifies whether to apply
-SMAP QC flags.
-
-NOTE: This is no longer used.  Set it to 0.
-
 `SMAP(NRT) soil moisture use scaled standard deviation model:` specifies
 whether the observation error standard deviation is to be scaled using model
 and observation standard deviation.
@@ -3054,7 +3052,6 @@ NOTE: Select 0 for yearly CDF data.
 .Example _lis.config_ entry
 ....
 SMAP(NRT) soil moisture data directory:
-SMAP(NRT) soil moisture apply SMAP QC flags:
 SMAP(NRT) soil moisture use scaled standard deviation model:
 SMAP(NRT) model CDF file:
 SMAP(NRT) observation CDF file:

--- a/lis/dataassim/obs/NASA_SMAPsm/NASASMAPsm_Mod.F90
+++ b/lis/dataassim/obs/NASA_SMAPsm/NASASMAPsm_Mod.F90
@@ -16,8 +16,10 @@
 ! !REVISION HISTORY: 
 !  22 Aug 2016    Sujay Kumar; initial specification
 !  1  Apr 2019  Yonghwan Kwon: Upated for reading monthy CDF for the current month
-!  31 July 2019 Mahdi Navari : SMAP Composite Release ID was added (this option asks a user to 
-!         enter the part of Composite Release ID a three-character string like R16 )
+! 31 July 2019 Mahdi Navari: SMAP Composite Release ID was added (this option asks a user
+!           to enter the part of Composite Release ID a three-character string like R16).
+!  8 July 2020: David Mocko: Removed config entry to toggle the QC check.
+!                            The QC is now always ON for NASA SMAP SM DA.
 !
 module NASASMAPsm_Mod
 ! !USES: 
@@ -40,7 +42,6 @@ module NASASMAPsm_Mod
   type, public:: NASASMAPsm_dec
      
      integer                :: useSsdevScal
-     integer                :: qcFlag
      logical                :: startMode
      integer                :: nc
      integer                :: nr
@@ -179,7 +180,7 @@ contains
        call LIS_verify(status, 'SMAP(NASA) soil moisture data designation: is missing')
     enddo
 
-    call ESMF_ConfigFindLabel(LIS_config,"SMAP(NASA) soil moisture Composite Release ID (e.g., R16):",&
+    call ESMF_ConfigFindLabel(LIS_config,"SMAP(NASA) soil moisture Composite Release ID:",&
          rc=status)
     do n=1,LIS_rc%nnest
        call ESMF_ConfigGetAttribute(LIS_config,&
@@ -197,14 +198,6 @@ contains
        
     enddo
 
-    call ESMF_ConfigFindLabel(LIS_config,"SMAP(NASA) soil moisture apply SMAP QC flags:",&
-         rc=status)
-    do n=1,LIS_rc%nnest
-       call ESMF_ConfigGetAttribute(LIS_config,NASASMAPsm_struc(n)%qcFlag,&
-            rc=status)
-       call LIS_verify(status, 'SMAP(NASA) soil moisture apply SMAP QC flags: is missing')
-       
-    enddo
     call ESMF_ConfigFindLabel(LIS_config,"SMAP(NASA) model CDF file:",&
          rc=status)
     do n=1,LIS_rc%nnest

--- a/lis/dataassim/obs/NASA_SMAPsm/read_NASASMAPsm.F90
+++ b/lis/dataassim/obs/NASA_SMAPsm/read_NASASMAPsm.F90
@@ -19,7 +19,9 @@
 ! 11 July 2019: Mahdi Navari, There are several version of SMAP sm data available in each directory
 !                  with different Release number and different CRID Version Number. The reader was
 !                  modified to read the latest version of data (the reader no longer reads the symbolic
-!                  link to the SMAP sm data)
+!                  link to the SMAP sm data).
+!  8 July 2020: David Mocko: Removed config entry to toggle the QC check.
+!                            The QC is now always ON for NASA SMAP SM DA.
 !
 ! !INTERFACE:
 subroutine read_NASASMAPsm(n, k, OBS_State, OBS_Pert_State)
@@ -169,10 +171,10 @@ subroutine read_NASASMAPsm(n, k, OBS_State, OBS_Pert_State)
                exit
             endif
 
-            write (LIS_logunit, *) '[INFO] reading ', trim(fname)
+            write (LIS_logunit, *) '[INFO] Reading descending pass ', trim(fname)
             call read_NASASMAP_E_data(n, k, 'D', fname, smobs_D)
 
-            write (LIS_logunit, *) '[INFO] reading ', trim(fname)
+            write (LIS_logunit, *) '[INFO] Reading ascending pass ', trim(fname)
             call read_NASASMAP_E_data(n, k, 'A', fname, smobs_A)
          enddo
 
@@ -262,10 +264,10 @@ subroutine read_NASASMAPsm(n, k, OBS_State, OBS_Pert_State)
                exit
             endif
 
-            write (LIS_logunit, *) '[INFO] reading ', trim(fname)
+            write (LIS_logunit, *) '[INFO] Reading descending pass ', trim(fname)
             call read_NASASMAP_data(n, k, 'D', fname, smobs_D)
 
-            write (LIS_logunit, *) '[INFO] reading ', trim(fname)
+            write (LIS_logunit, *) '[INFO] Reading ascending pass ', trim(fname)
             call read_NASASMAP_data(n, k, 'A', fname, smobs_A)
          enddo
 
@@ -782,8 +784,7 @@ subroutine read_NASASMAP_E_data(n, k, pass, fname, smobs_ip)
 ! that indicate whether retrieval is performed or not at a given grid cell. 
 ! When retrieval is performed, it contains additional bits to further 
 ! indicate the exit status and quality of the retrieval. The first bit 
-! indicates the recommended quality (0-means retrieval has recommended quality
-!
+! indicates the recommended quality (0-means retrieval has recommended quality).
 
   do r=1,NASASMAPsm_struc(n)%nr
      do c=1,NASASMAPsm_struc(n)%nc        
@@ -794,14 +795,10 @@ subroutine read_NASASMAP_E_data(n, k, pass, fname, smobs_ip)
 	 else 
 
            if(sm_data(t).ne.-9999.0) then 
-              if(NASASMAPsm_struc(n)%qcFlag.eq.1) then 
-                 if(ibits(sm_qa(c,r),0,1).eq.0) then 
-                    sm_data_b(t) = .true.
-                 else
-                    sm_data(t) = -9999.0
-                 endif
-              else
+              if(ibits(sm_qa(c,r),0,1).eq.0) then 
                  sm_data_b(t) = .true.
+              else
+                 sm_data(t) = -9999.0
               endif
            endif
         endif
@@ -1059,8 +1056,7 @@ subroutine read_NASASMAP_data(n, k, pass, fname, smobs_ip)
 ! that indicate whether retrieval is performed or not at a given grid cell. 
 ! When retrieval is performed, it contains additional bits to further 
 ! indicate the exit status and quality of the retrieval. The first bit 
-! indicates the recommended quality (0-means retrieval has recommended quality
-!
+! indicates the recommended quality (0-means retrieval has recommended quality).
 
   do r=1,NASASMAPsm_struc(n)%nr
      do c=1,NASASMAPsm_struc(n)%nc        
@@ -1071,14 +1067,10 @@ subroutine read_NASASMAP_data(n, k, pass, fname, smobs_ip)
 	 else 
 
            if(sm_data(t).ne.-9999.0) then 
-              if(NASASMAPsm_struc(n)%qcFlag.eq.1) then 
-                 if(ibits(sm_qa(c,r),0,1).eq.0) then 
-                    sm_data_b(t) = .true.
-                 else
-                    sm_data(t) = -9999.0
-                 endif
-              else
+              if(ibits(sm_qa(c,r),0,1).eq.0) then 
                  sm_data_b(t) = .true.
+              else
+                 sm_data(t) = -9999.0
               endif
            endif
         endif


### PR DESCRIPTION
This commit removes the SMAP(NASA) LIS soil moisture DA QC
(quality control) check config entry.  After this commit,
the SMAP QC will always be on for this product.

Changes to the lis.config were also made, along with a small
tweak to lislog messages, and to the exact specification of
another SMAP(NASA) config entry.

Resolves: #551 