### PR TITLE
Fix LVT IMERG hard-coded filename option

### DIFF
--- a/lvt/configs/lvt.config.adoc
+++ b/lvt/configs/lvt.config.adoc
@@ -1246,12 +1246,15 @@ CPC PCP use real time data:               0
 
 `IMERG data directory:` specifies the location of the GPM IMERG precipitation product
 
-`IMERG version:` specifies the version of the GPM IMERG precipitation product. The valid options are: early, late, or final
+`IMERG version:` specifies the version of the GPM IMERG precipitation product. Most current version is V06B.
+
+`IMERG product:` specifies the GPM IMERG precipitation product. Current options are: early, late, or final.
 
 .Example _lvt.config_ entry
 ....
 IMERG data directory:            ../IMERG
-IMERG version:                   final
+IMERG version:                   V06B
+IMERG product:                   final
 ....
 
 ==== ESA CCI soil moisture data

--- a/lvt/configs/lvt.config.master
+++ b/lvt/configs/lvt.config.master
@@ -1718,14 +1718,18 @@ CPC PCP use real time data:               0
 #latex: GPM IMERG precipitation product
 #latex:
 #latex: \var{IMERG version:} specifies the version of the GPM
-#latex: IMERG precipitation product. The valid options are:
-#latex: early, late, or final
+#latex: IMERG precipitation product. Most current version is:
+#latex: V06B
 #latex:
+#latex: \var{IMERG product:} specifies the product of the GPM
+#latex: IMERG precipitation product. Current options are:
+#latex: early, late, final
 #latex: END_DESCRIPTION
 
 #latex: BEGIN_CONFIG
 IMERG data directory:            ../IMERG
-IMERG version:                   final
+IMERG version:                   V06B
+IMERG product:                   final
 #latex: END_CONFIG
 
 #latex: BEGIN_DESCRIPTION

--- a/lvt/datastreams/IMERG/IMERG_dataMod.F90
+++ b/lvt/datastreams/IMERG/IMERG_dataMod.F90
@@ -76,7 +76,7 @@ contains
       call ESMF_ConfigFindLabel(LVT_config,"IMERG product:",rc=status)
       if(status /= 0) then
          write(LVT_logunit,*) "[WARN] --------------------------------------------------------------"
-         write(LVT_logunit,*) "[WARN] IMERG product not specified. Defauling to 'final' version."
+         write(LVT_logunit,*) "[WARN] IMERG product not specified. Defaulting to 'final' version."
          write(LVT_logunit,*) "[WARN] --------------------------------------------------------------"
          imergdata(i)%imergprd = 'final'
       else
@@ -86,7 +86,7 @@ contains
       call ESMF_ConfigFindLabel(LVT_config,"IMERG version:",rc=status)
       if(status /= 0) then
          write(LVT_logunit,*) "[WARN] --------------------------------------------------------------"
-         write(LVT_logunit,*) "[WARN] IMERG version not specified. Defauling to 'V06B' version."
+         write(LVT_logunit,*) "[WARN] IMERG version not specified. Defaulting to 'V06B' version."
          write(LVT_logunit,*) "[WARN] --------------------------------------------------------------"
          imergdata(i)%imergver = 'V06B'
       else

--- a/lvt/datastreams/IMERG/IMERG_dataMod.F90
+++ b/lvt/datastreams/IMERG/IMERG_dataMod.F90
@@ -17,7 +17,7 @@ module IMERG_dataMod
 
    type, public :: imergdatadec
       character*100 :: odir
-      character*5   :: imergver
+      character*10  :: imergver, imergprd
       real          :: datares
       real, allocatable           :: rlat(:)
       real, allocatable           :: rlon(:)
@@ -72,16 +72,27 @@ contains
       call ESMF_ConfigGetAttribute(LVT_Config, imergdata(i)%odir, &
            label='IMERG data directory:', rc=status)
       call LVT_verify(status, 'IMERG data directory: not defined')
+      ! Get IMERG product
+      call ESMF_ConfigFindLabel(LVT_config,"IMERG product:",rc=status)
+      if(status /= 0) then
+         write(LVT_logunit,*) "[WARN] --------------------------------------------------------------"
+         write(LVT_logunit,*) "[WARN] IMERG product not specified. Defauling to 'final' version."
+         write(LVT_logunit,*) "[WARN] --------------------------------------------------------------"
+         imergdata(i)%imergprd = 'final'
+      else
+         call ESMF_ConfigGetAttribute(LVT_config,imergdata(i)%imergprd,rc=status)
+      endif
       ! Get IMERG version
       call ESMF_ConfigFindLabel(LVT_config,"IMERG version:",rc=status)
       if(status /= 0) then
          write(LVT_logunit,*) "[WARN] --------------------------------------------------------------"
-         write(LVT_logunit,*) "[WARN] IMERG version not specified. Defauling to 'final' version."
+         write(LVT_logunit,*) "[WARN] IMERG version not specified. Defauling to 'V06B' version."
          write(LVT_logunit,*) "[WARN] --------------------------------------------------------------"
-         imergdata(i)%imergver = 'final'
+         imergdata(i)%imergver = 'V06B'
       else
          call ESMF_ConfigGetAttribute(LVT_config,imergdata(i)%imergver,rc=status)
       endif
+
       ! Allocate arrays on LVT grid
       allocate(imergdata(i)%rlat(LVT_rc%lnc*LVT_rc%lnr))
       allocate(imergdata(i)%rlon(LVT_rc%lnc*LVT_rc%lnr))     

--- a/lvt/datastreams/IMERG/readIMERGdata.F90
+++ b/lvt/datastreams/IMERG/readIMERGdata.F90
@@ -83,7 +83,7 @@ subroutine readIMERGdata(source)
 
    if (alarmCheck) then
       call create_IMERG_filename(imergdata(source)%odir, &
-                             yr1,mo1,da1,hr1,mn1,filename)
+                             yr1,mo1,da1,hr1,mn1,filename,imergdata(source)%imergver)
       inquire(file=trim(filename),exist=file_exists)
 
       if(file_exists) then 
@@ -265,7 +265,7 @@ subroutine read_imerghdf(filename, col, row, precipout, ireaderr)
 end subroutine read_imerghdf
 !------------------------------------------------------------------------------
 subroutine create_IMERG_filename(odir, &
-                             yr,mo,da,hr,mn,filename)
+                             yr,mo,da,hr,mn,filename,imVer)
    use IMERG_dataMod
    use LVT_logMod
 
@@ -273,7 +273,7 @@ subroutine create_IMERG_filename(odir, &
    implicit none
 
    ! Arguments
-   character(len=*), intent(in) :: odir
+   character(len=*), intent(in) :: odir, imVer
    integer, intent(in) :: yr, mo, da, hr, mn
    character(len=*), intent(out) :: filename
 
@@ -281,8 +281,8 @@ subroutine create_IMERG_filename(odir, &
    integer :: uyr, umo, uda, uhr, umn, umnadd, umnday, uss
    character*4   :: cyr, cmnday
    character*2   :: cmo, cda, chr, cmn, cmnadd
-   character*100 :: fbase, ftimedir, fstem
-
+   character*100 :: fbase, ftimedir, fstem, fext
+   
    uyr = yr
    umo = mo
    uda = da
@@ -303,17 +303,21 @@ subroutine create_IMERG_filename(odir, &
    write(cmnadd, '(I2.2)') umnadd
    write(cmnday, '(I4.4)')umnday
 
-   if(imergdata(1)%imergver == 'early') then
+   if(imergdata(1)%imergprd == 'early') then
       fstem = '/3B-HHR-E.MS.MRG.3IMERG.'
-   elseif(imergdata(1)%imergver == 'late') then
+      fext = '.RT-H5'
+   elseif(imergdata(1)%imergprd == 'late') then
       fstem = '/3B-HHR-L.MS.MRG.3IMERG.'
-   elseif(imergdata(1)%imergver == 'final') then
+      fext = '.RT-H5'
+   elseif(imergdata(1)%imergprd == 'final') then
       fstem = '/3B-HHR.MS.MRG.3IMERG.'
+      fext = '.HDF5'
    else
-      write(LVT_logunit,*) "[ERR] Invalid IMERG version option was chosen."
+      write(LVT_logunit,*) "[ERR] Invalid IMERG product option was chosen."
       write(LVT_logunit,*) "[ERR] Please choose either 'early', 'late', or 'final'."
       call LVT_endrun()
    endif
+   
    filename = trim(odir)//"/"//cyr//cmo//trim(fstem)// &
-         cyr//cmo//cda//"-S"//chr//cmn//"00-E"//chr//cmnadd//"59."//cmnday//".V05B.HDF5"
+         cyr//cmo//cda//"-S"//chr//cmn//"00-E"//chr//cmnadd//"59."//cmnday//"."//trim(imVer)//fext
 end subroutine create_IMERG_filename


### PR DESCRIPTION
The IMERG reader in LVT was still hard-coded to V05B and an old
filename extension convention. This fix will add an option for the
user to specify the version and product of IMERG data (similar to
the IMERG reader in LIS). The default options will be set to version
V06B and 'final' product.

Resolves: #180