### PR TITLE
Fix HYMAP2 routing write ensemble restart routine to compile serial

### DIFF
--- a/lis/routing/HYMAP2_router/HYMAP2_routing_writerst.F90
+++ b/lis/routing/HYMAP2_router/HYMAP2_routing_writerst.F90
@@ -691,15 +691,15 @@ subroutine HYMAP2_dump_restart(n, ftn)
     else
        allocate(gtmp1(1,LIS_rc%nensem(n)))
     endif
-#if (defined SPMD)    
     do m=1,LIS_rc%nensem(n)  
+#if (defined SPMD)
        call MPI_GATHERV(var(:,m),LIS_rc%nroutinggrid(n),&
             MPI_REAL,gtmp1(:,m),&
             LIS_routing_gdeltas(n,:),&
             LIS_routing_goffsets(n,:),&
             MPI_REAL,0,LIS_mpi_comm,ierr)
-#else 
-       gtmp1(:,m) = var(:)
+#else
+       gtmp1(:,m) = var(:,m)
 #endif
     enddo
     if(LIS_masterproc) then


### PR DESCRIPTION
Small changes to the routine that writes the HYMAP2 routing scheme
ensemble restart files that allow LIS to compile both for parallel
and serial modes.  Previously, LIS would not compile in serial mode.

Two changes were made:

1) Move the "#if (defined SPMD)" compile directive outside a do loop.

2) Include the second ensemble dimension of the "var" variable.

Thanks to @nmizukami for finding this issue, identifying a fix, and reporting it.