### PR TITLE
Fix LVT SMAP readers

### DIFF
--- a/lvt/datastreams/SMAPTB/readSMAPTBobs.F90
+++ b/lvt/datastreams/SMAPTB/readSMAPTBobs.F90
@@ -345,7 +345,6 @@ subroutine read_SMAPTB(source, filename, TBobs)
   deallocate(tbv_a_field)
   deallocate(tbh_f_field)
   deallocate(tbv_f_field)
-#endif
 
   do r=1,LVT_rc%lnr
      do c=1,LVT_rc%lnc
@@ -357,6 +356,7 @@ subroutine read_SMAPTB(source, filename, TBobs)
         endif
      enddo
   enddo
+#endif
 
 end subroutine read_SMAPTB
 

--- a/lvt/datastreams/SMAP_L3TB/readSMAP_L3TB.F90
+++ b/lvt/datastreams/SMAP_L3TB/readSMAP_L3TB.F90
@@ -191,6 +191,8 @@ subroutine read_SMAP_L3Tb(source, fname, L3TB)
 
   implicit none
 
+  integer                        :: source 
+  character(len=*)               :: fname
   real                           :: L3TB(LVT_rc%lnc,LVT_rc%lnr,4)
   
 !
@@ -209,8 +211,6 @@ subroutine read_SMAP_L3Tb(source, fname, L3TB)
 
 #if (defined USE_HDF5)
 
-  integer                       :: source 
-  character(len=*)              :: fname
   character*100,   parameter    :: Tb_gr_name = "Soil_Moisture_Retrieval_Data"
   character*100,   parameter    :: Tbv_field_name = "soil_moisture"
 

--- a/lvt/datastreams/SMAPvod/readSMAPvodobs.F90
+++ b/lvt/datastreams/SMAPvod/readSMAPvodobs.F90
@@ -398,7 +398,6 @@ subroutine read_SMAPvod(source, fname, vodobs)
 !BOP
 
 #if (defined USE_HDF5)
-
  
   character*100,   parameter    :: vod_gr_name = "Soil_Moisture_Retrieval_Data"
   character*100,   parameter    :: vod_field_name = "vegetation_opacity"

--- a/lvt/datastreams/SMAPvod/readSMAPvodobs.F90
+++ b/lvt/datastreams/SMAPvod/readSMAPvodobs.F90
@@ -379,6 +379,8 @@ subroutine read_SMAPvod(source, fname, vodobs)
 
   implicit none
 
+  integer                        :: source 
+  character(len=*)               :: fname
   real                           :: vodobs(LVT_rc%lnc,LVT_rc%lnr)
   
 !
@@ -397,8 +399,7 @@ subroutine read_SMAPvod(source, fname, vodobs)
 
 #if (defined USE_HDF5)
 
-  integer                       :: source 
-  character(len=*)              :: fname
+ 
   character*100,   parameter    :: vod_gr_name = "Soil_Moisture_Retrieval_Data"
   character*100,   parameter    :: vod_field_name = "vegetation_opacity"
 


### PR DESCRIPTION
HDF5 is listed as an optional library in the LVT documentation, but LVT would fail to compile without it.

Change in datastreams/SMAPTB/readSMAPTBobs.F90:
   * For-loop at line 350 of `read_SMAPTB` subroutine moved inside `if (defined USE_HDF5)` block

After making the above fix, compilation failed again due to similar errors in datastreams/SMAP_L3TB/readSMAP_L3TB.F90 and datastreams/SMAPvod/readSMAPvodobs.F90. The fixes were simple:
   * Moved variable declarations for `source` and `filename` above `if (defined USE_HDF5)` which is consistent with readSMAPTBobs.F90

LVT now compiles successfully without HDF5 on Intel and GNU compilers.

Resolves #578 