### PR TITLE
Fix instructions for compiling w/ user.cfg

### DIFF
--- a/docs/LIS_users_guide/plugins.adoc
+++ b/docs/LIS_users_guide/plugins.adoc
@@ -41,5 +41,5 @@ After creating a _user.cfg_ file you must recompile the LIS source code.  First 
 % cd ..
 ....
 
-Then re-run the _compile_ script.  This will process your _user.cfg_ file and then compile the LIS source code accordingly.
+Re-run the _configure_ script to process your _user.cfg_ file. Then compile the LIS source code accordingly.
 


### PR DESCRIPTION
The documentation for compiling LIS with a custom `user.cfg` file currently instructs users to run the *compile* script and then compile:

>**Then re-run the compile script.** This will process your user.cfg file and **then compile** the LIS source
code accordingly.

The instructions contained in `default.cfg` instruct users to re-run the *configure* script before compiling:

```sh
# The plugins.py program is run by the configure script.  If you modify
# this file or the user.cfg file, you must either rerun the configure script
# or manually run `python plugins.py` for your updates to affect compiling.
```

This change updates the docs to clarify that users must re-run *configure* before compiling. Otherwise, a Python error is thrown.