### PR TITLE
Add max snow depth option for NoahMP 4.0.1 glacier model

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -8359,6 +8359,10 @@ Noah-MP-4.0.1 LSM initial water storage in the aquifer (mm).
 specifies the Noah-MP-4.0.1 LSM initial water in the aquifer
 and in the saturated soil (mm).
  
+'Noah-MP.4.0.1 snow depth glacier model option:' specifies the
+maximum snow depth that is used in the Noah-MP-4.0.1 glacier model (mm).
+The default is set to 2000 mm.
+
 .Example _lis.config_ entry
 ....
 Noah-MP.4.0.1 model timestep:                15mn
@@ -8399,6 +8403,7 @@ Noah-MP.4.0.1 initial leaf area index:                      2.0
 Noah-MP.4.0.1 initial water table depth:                    2.5
 Noah-MP.4.0.1 initial water in the aquifer:                 4900.0
 Noah-MP.4.0.1 initial water in aquifer and saturated soil:  4900.0
+Noah-MP.4.0.1 snow depth glacier model option:              2000
 ....
 
 

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_lsmMod.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_lsmMod.F90
@@ -196,6 +196,7 @@ module NoahMP401_lsmMod
         integer            :: tbot_opt
         integer            :: stc_opt
         integer            :: gla_opt
+        integer            :: sndpth_gla_opt
         integer            :: rsf_opt
         integer            :: soil_opt
         integer            :: pedo_opt

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
@@ -95,6 +95,7 @@ subroutine NoahMP401_main(n)
     integer              :: tmp_tbot_opt           ! lower boundary of soil temperature [-]
     integer              :: tmp_stc_opt            ! snow/soil temperature time scheme [-]
     integer              :: tmp_gla_opt            ! glacier option (1->phase change; 2->simple) [-]
+    integer              :: tmp_sndpth_gla_opt     ! snow depth max for glacier model [mm]
     integer              :: tmp_rsf_opt            ! surface resistance (1->Sakaguchi/Zeng;2->Seller;3->mod Sellers;4->1+snow) [-]
     integer              :: tmp_soil_opt           ! soil configuration option [-]
     integer              :: tmp_pedo_opt           ! soil pedotransfer function option [-]
@@ -379,6 +380,7 @@ subroutine NoahMP401_main(n)
             tmp_tbot_opt          = NOAHMP401_struc(n)%tbot_opt
             tmp_stc_opt           = NOAHMP401_struc(n)%stc_opt
             tmp_gla_opt           = NOAHMP401_struc(n)%gla_opt
+            tmp_sndpth_gla_opt    = NOAHMP401_struc(n)%sndpth_gla_opt
             tmp_rsf_opt           = NOAHMP401_struc(n)%rsf_opt
             tmp_soil_opt          = NOAHMP401_struc(n)%soil_opt
             tmp_pedo_opt          = NOAHMP401_struc(n)%pedo_opt
@@ -526,6 +528,7 @@ subroutine NoahMP401_main(n)
                                    tmp_tbot_opt          , & ! in    - lower boundary of soil temperature [-]
                                    tmp_stc_opt           , & ! in    - snow/soil temperature time scheme [-]
                                    tmp_gla_opt           , & ! in    - glacier option (1->phase change; 2->simple) [-]
+                                   tmp_sndpth_gla_opt    , & ! in    - Snow depth max for glacier model [mm]
                                    tmp_rsf_opt           , & ! in    - surface resistance(1->Sakaguchi/Zeng;2->Seller;3->mod Sellers;4->1+snow) [-]
                                    tmp_soil_opt          , & ! in    - soil configuration option [-]
                                    tmp_pedo_opt          , & ! in    - soil pedotransfer function option [-]

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readcrd.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readcrd.F90
@@ -317,7 +317,24 @@ subroutine NoahMP401_readcrd()
              "Noah-MP.4.0.1 glacier option: not defined")
         write(LIS_logunit,33) "glacier:",NOAHMP401_struc(n)%gla_opt
     enddo
- 
+
+    ! Custom snowpack depth for glacier model (in mm)
+    call ESMF_ConfigFindLabel(LIS_config, &
+         "Noah-MP.4.0.1 snow depth glacier model option:", rc = rc)
+    if(rc /= 0) then
+        write(LIS_logunit,33) "[WARN] Max snow depth not defined."
+        write(LIS_logunit,33) "[WARN] Setting to default value of 2000."
+        do n=1, LIS_rc%nnest
+            NOAHMP401_struc(n)%sndpth_gla_opt = 2000
+            write(LIS_logunit,33) "snow depth for glacier model: ",NOAHMP401_struc(n)%sndpth_gla_opt
+        enddo
+    else
+        do n=1, LIS_rc%nnest
+            call ESMF_ConfigGetAttribute(LIS_config, NOAHMP401_struc(n)%sndpth_gla_opt, rc=rc)
+            write(LIS_logunit,33) "snow depth for glacier model: ",NOAHMP401_struc(n)%sndpth_gla_opt
+        enddo
+    endif
+
     ! surface resistance (1->Sakaguchi/Zeng;2->Seller;3->mod Sellers;4->1+snow)
     call ESMF_ConfigFindLabel(LIS_config, &
          "Noah-MP.4.0.1 surface resistance option:", rc = rc)

--- a/lis/surfacemodels/land/noahmp.4.0.1/noahmp_driver_401.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/noahmp_driver_401.F90
@@ -21,8 +21,8 @@ subroutine noahmp_driver_401(n, ttile, itimestep, &
      cropcat,  planting, harvest ,season_gdd,                    & ! in : Vegetation/Soil characteristics
      dveg_opt, crs_opt, btr_opt, run_opt, sfc_opt, frz_opt,      & ! in : User options
      inf_opt, rad_opt, alb_opt , snf_opt, tbot_opt, stc_opt,     & ! in : User options
-     gla_opt, rsf_opt, soil_opt, pedo_opt, crop_opt, iz0tlnd   , & ! in : new options
-     urban_opt,                                                  & ! in : new options
+     gla_opt, sndpth_gla_opt, rsf_opt, soil_opt, pedo_opt,       & ! in : new options
+     crop_opt, iz0tlnd, urban_opt,                               & ! in : new options
      soilcomp, soilcL1, soilcL2, soilcL3, soilcL4,               & ! in : new options
      tair    , psurf   , wind_e   , wind_n   , qair    ,         & ! in : forcing
      swdown  , lwdown  , prcp    ,                               & ! in : forcing
@@ -112,6 +112,7 @@ subroutine noahmp_driver_401(n, ttile, itimestep, &
 
   ! Added by Zhuo Wang and Shugong Wang
   integer, intent(in) :: gla_opt              ! glacier option (1->phase change; 2->simple)
+  integer, intent(in) :: sndpth_gla_opt       ! snow depth max for glacier model [mm]
   integer, intent(in) :: rsf_opt              ! surface resistance (1->Sakaguchi/Zeng; 2->Seller; 3->mod Sellers; 4->1+snow)
   integer, intent(in) :: soil_opt             ! soil configuration option
   integer, intent(in) :: pedo_opt             ! soil pedotransfer function option
@@ -716,7 +717,7 @@ subroutine noahmp_driver_401(n, ttile, itimestep, &
        cropcatin , plantingin, harvestin ,season_gddin,                    &
        dveg_opt, crs_opt , btr_opt ,run_opt  , sfc_opt , frz_opt,  & ! in : user options
        inf_opt , rad_opt , alb_opt ,snf_opt  , tbot_opt, stc_opt,  & ! in : user options
-       gla_opt , rsf_opt , soil_opt,pedo_opt , crop_opt,           & ! in : user options
+       gla_opt , sndpth_gla_opt, rsf_opt , soil_opt,pedo_opt , crop_opt,           & ! in : user options
        iz0tlnd , urban_opt,                                        & ! in : user options
        soilcompin, soilcL1in, soilcL2in, soilcL3in, soilcL4in,               & ! in : user options
        sfctmp(1)  , q2(1)  , uu(1)    , vv(1) , soldnin , lwdnin  , & ! in : forcing 

--- a/lis/surfacemodels/land/noahmp.4.0.1/phys/module_sf_noahmpdrv_401.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/phys/module_sf_noahmpdrv_401.F90
@@ -10,15 +10,15 @@ public noahmplsm_401
 !
 CONTAINS
 ! The subroutine name has been modifed for LIS implemenation Oct 22 2018
-  SUBROUTINE noahmplsm_401(LIS_undef_value,                                 & ! IN : LIS undefined value
-             ITIMESTEP,        YR,   JULIAN,   COSZIN,XLAT,XLONG,           & ! IN : Time/Space-related
-                  DZ8W,       DT,       DZS,    NSOIL,       DX,            & ! IN : Model configuration 
-	        IVGTYP,   ISLTYP,    VEGFRA,   VEGMAX,      TMN,            & ! IN : Vegetation/Soil characteristics
-		 XLAND,     XICE,XICE_THRES,  CROPCAT,                      & ! IN : Vegetation/Soil characteristics
-	       PLANTING,  HARVEST,SEASON_GDD,                               &
-                 IDVEG, IOPT_CRS,  IOPT_BTR, IOPT_RUN, IOPT_SFC, IOPT_FRZ,  & ! IN : User options
-              IOPT_INF, IOPT_RAD,  IOPT_ALB, IOPT_SNF,IOPT_TBOT, IOPT_STC,  & ! IN : User options
-              IOPT_GLA, IOPT_RSF, IOPT_SOIL,IOPT_PEDO,IOPT_CROP,            & ! IN : User options
+  SUBROUTINE noahmplsm_401(LIS_undef_value,                                       & ! IN : LIS undefined value
+             ITIMESTEP,        YR,   JULIAN,   COSZIN,XLAT,XLONG,                 & ! IN : Time/Space-related
+                  DZ8W,       DT,       DZS,    NSOIL,       DX,                  & ! IN : Model configuration 
+	        IVGTYP,   ISLTYP,    VEGFRA,   VEGMAX,      TMN,                  & ! IN : Vegetation/Soil characteristics
+		 XLAND,     XICE,XICE_THRES,  CROPCAT,                            & ! IN : Vegetation/Soil characteristics
+	       PLANTING,  HARVEST,SEASON_GDD,                                     &
+                 IDVEG, IOPT_CRS,  IOPT_BTR, IOPT_RUN, IOPT_SFC, IOPT_FRZ,        & ! IN : User options
+              IOPT_INF, IOPT_RAD,  IOPT_ALB, IOPT_SNF,IOPT_TBOT, IOPT_STC,        & ! IN : User options
+              IOPT_GLA, IOPT_SNDPTH, IOPT_RSF, IOPT_SOIL,IOPT_PEDO,IOPT_CROP, & ! IN : User options
               IZ0TLND, SF_URBAN_PHYSICS,                                    & ! IN : User options
 	      SOILCOMP,  SOILCL1,  SOILCL2,   SOILCL3,  SOILCL4,            & ! IN : User options
                    T3D,     QV3D,     U_PHY,    V_PHY,   SWDOWN,      GLW,  & ! IN : Forcing
@@ -103,6 +103,7 @@ CONTAINS
     INTEGER,                                         INTENT(IN   ) ::  IOPT_TBOT ! lower boundary of soil temperature (1->zero-flux; 2->Noah)
     INTEGER,                                         INTENT(IN   ) ::  IOPT_STC  ! snow/soil temperature time scheme
     INTEGER,                                         INTENT(IN   ) ::  IOPT_GLA  ! glacier option (1->phase change; 2->simple)
+    INTEGER,                                         INTENT(IN   ) ::  IOPT_SNDPTH !snow depth max for glacier model [mm]
     INTEGER,                                         INTENT(IN   ) ::  IOPT_RSF  ! surface resistance (1->Sakaguchi/Zeng; 2->Seller; 3->mod Sellers; 4->1+snow)
     INTEGER,                                         INTENT(IN   ) ::  IOPT_SOIL ! soil configuration option
     INTEGER,                                         INTENT(IN   ) ::  IOPT_PEDO ! soil pedotransfer function option
@@ -765,12 +766,13 @@ CONTAINS
 
        IF ( VEGTYP == ISICE_TABLE ) THEN
          ICE = -1                           ! Land-ice point
-         CALL NOAHMP_OPTIONS_GLACIER(IOPT_ALB  ,IOPT_SNF  ,IOPT_TBOT, IOPT_STC, IOPT_GLA )
+         CALL NOAHMP_OPTIONS_GLACIER(IOPT_ALB  ,IOPT_SNF  ,IOPT_TBOT, IOPT_STC, IOPT_GLA , IOPT_SNDPTH)
       
          TBOT = MIN(TBOT,263.15)                      ! set deep temp to at most -10C
          CALL NOAHMP_GLACIER(     I,       J,    COSZ,   NSNOW,   NSOIL,      DT, & ! IN : Time/Space/Model-related
                                T_ML,    P_ML,    U_ML,    V_ML,    Q_ML,    SWDN, & ! IN : Forcing
                                PRCP,    LWDN,    TBOT,    Z_ML, FICEOLD,   ZSOIL, & ! IN : Forcing
+                               IOPT_SNDPTH,                                        & ! IN : User Option
                               QSNOW,  SNEQVO,  ALBOLD,      CM,      CH,   ISNOW, & ! IN/OUT :
                                 SWE,     SMC,   ZSNSO,  SNDPTH,   SNICE,   SNLIQ, & ! IN/OUT :
                                  TG,     STC,   SMH2O,   TAUSS,  QSFC1D,          & ! IN/OUT :


### PR DESCRIPTION
This commit adds a config option that allows the user to set the
maximum snow depth (in mm) limit that is used in the Noah MP 4.0.1 
glacier model. This value was hard-coded to 2000. If the user does not
specify a value, the max snow depth will be set to the default value of 2000.
This change only affects NoahMP 4.0.1.

Resolves: #569