### PR TITLE
Add support to process locally installed TIFF library

### DIFF
--- a/ldt/arch/Config.pl
+++ b/ldt/arch/Config.pl
@@ -683,9 +683,20 @@ if($enable_geotiff== 1){
 
 # EMK...Added LIGBEOTIFF for Air Force
 if($enable_libgeotiff== 1){
-    $cflags = $cflags." -I\$(INC_LIBGEOTIFF)";
+    # Kluge for koehr; locally installed the tiff library.
+    if(defined($ENV{LDT_TIFF})){
+       $INC_LIBTIFF = $ENV{LDT_TIFF}."/include";
+       $cflags = $cflags." -I".$INC_LIBTIFF." -I\$(INC_LIBGEOTIFF)";
+    }
+    else {
+       $cflags = $cflags." -I\$(INC_LIBGEOTIFF)";
+    }
     $tiffpath = "";
     $tiffdeps = "";
+    # Kluge for koehr; locally installed the tiff library.
+    if(defined($ENV{LDT_TIFF})){
+       $tiffpath = " -L".$ENV{LDT_TIFF}."/lib";
+    }
     if ( $cray_modifications == 1 ) {
        $tiffpath = " -L".$sys_libtiff_path;
        $tiffdeps = " -L".$sys_libjbig_path." -ljbig "." -L".$sys_liblzma_path." -llzma ";


### PR DESCRIPTION
The system installation of the TIFF library on koehr is missing the
development/header files, so I locally installed TIFF.

To trigger this special support, you must define an environment variable
named LDT_TIFF that points to the local installation of TIFF.