### PR TITLE
Remove unnecessary [ERR]s from LIS_verify calls

### DIFF
--- a/lis/surfacemodels/land/awral.6.0.0/AWRAL600_setup.F90
+++ b/lis/surfacemodels/land/awral.6.0.0/AWRAL600_setup.F90
@@ -288,50 +288,50 @@ subroutine AWRAL600_read_MULTILEVEL_param(n, ncvar_name, level, placeholder)
 
         ! open NetCDF parameter file
         ios = nf90_open(path=trim(LIS_rc%paramfile(n)), mode=NF90_NOWRITE, ncid=nid)
-        call LIS_verify(ios, '[ERR] Error in nf90_open in AWRAL600_read_MULTILEVEL_param')
+        call LIS_verify(ios, 'Error in nf90_open in AWRAL600_read_MULTILEVEL_param')
 
         ! inquire the ID of east-west dimension
         ios = nf90_inq_dimid(nid, 'east_west', nc_ID)
-        call LIS_verify(ios, '[ERR] Error in nf90_inq_dimid in AWRAL600_read_MULTILEVEL_param')
+        call LIS_verify(ios, 'Error in nf90_inq_dimid in AWRAL600_read_MULTILEVEL_param')
 
         ! inquire the ID of north-south dimension
         ios = nf90_inq_dimid(nid, 'north_south', nr_ID)
-        call LIS_verify(ios, '[ERR] Error in nf90_inq_dimid in AWRAL600_read_MULTILEVEL_param')
+        call LIS_verify(ios, 'Error in nf90_inq_dimid in AWRAL600_read_MULTILEVEL_param')
 
         ! inquire the length of east-west dimension
         ios = nf90_inquire_dimension(nid, nc_ID, len=nc)
-        call LIS_verify(ios, '[ERR] Error in nf90_inquire_dimension in AWRAL600_read_MULTILEVEL_param')
+        call LIS_verify(ios, 'Error in nf90_inquire_dimension in AWRAL600_read_MULTILEVEL_param')
 
         ! inquire the length of north-south dimension
         ios = nf90_inquire_dimension(nid, nr_ID, len=nr)
-        call LIS_verify(ios, '[ERR] Error in nf90_inquire_dimension in AWRAL600_read_MULTILEVEL_param')
+        call LIS_verify(ios, 'Error in nf90_inquire_dimension in AWRAL600_read_MULTILEVEL_param')
 
         ! inquire the ID of parameter. 
         ios = nf90_inq_varid(nid, Trim(ncvar_name), param_ID)
-        call LIS_verify(ios, trim(ncvar_name)//'[ERR] field not found in the LIS param file')
+        call LIS_verify(ios, trim(ncvar_name)//'field not found in the LIS param file')
 
         ! inquire the IDs of all dimensions. The third dimension is the level dimension
         ios = nf90_inquire_variable(nid, param_ID, dimids = dimids)
-        call LIS_verify(ios, trim(ncvar_name)//'[ERR] failed to inquire dimensions')
+        call LIS_verify(ios, trim(ncvar_name)//'failed to inquire dimensions')
 
         ! inquire the length of the level dimension
         ios = nf90_inquire_dimension(nid, dimids(3), len=nlevel)
-        call LIS_verify(ios, trim(ncvar_name)//'[ERR] failed to inquire the length of the 3rd dimension')
+        call LIS_verify(ios, trim(ncvar_name)//'failed to inquire the length of the 3rd dimension')
 
         ! allocate memory
         allocate(level_data (LIS_rc%gnc(n), LIS_rc%gnr(n), nlevel))
 
         ! inquire the variable ID of parameter 
         ios = nf90_inq_varid(nid, trim(ncvar_name), param_ID)
-        call LIS_verify(ios, trim(ncvar_name)//'[ERR] field not found in the LIS param file')
+        call LIS_verify(ios, trim(ncvar_name)//'field not found in the LIS param file')
 
         ! read parameter 
         ios = nf90_get_var(nid, param_ID, level_data)
-        call LIS_verify(ios, '[ERR] Error in nf90_get_var in AWRAL600_read_MULTILEVEL_param')
+        call LIS_verify(ios, 'Error in nf90_get_var in AWRAL600_read_MULTILEVEL_param')
 
         ! close netcdf file 
         ios = nf90_close(nid)
-        call LIS_verify(ios, '[ERR] Error in nf90_close in AWRAL600_read_MULTILEVEL_param')
+        call LIS_verify(ios, 'Error in nf90_close in AWRAL600_read_MULTILEVEL_param')
 
         ! grab parameter at specific level
         placeholder(:, :) = & 

--- a/lis/surfacemodels/land/awral.6.0.0/AWRAL600_writerst.F90
+++ b/lis/surfacemodels/land/awral.6.0.0/AWRAL600_writerst.F90
@@ -87,7 +87,7 @@ subroutine AWRAL600_writerst(n)
             elseif(wformat .eq. "netcdf") then
 #if (defined USE_NETCDF3 .OR. defined USE_NETCDF4)
                 status = nf90_close(ftn)
-                call LIS_verify(status, "[ERR] Error in nf90_close in AWRAL600_writerst")
+                call LIS_verify(status, "Error in nf90_close in AWRAL600_writerst")
 #endif
             endif
             write(LIS_logunit, *) "[INFO] AWRAL600 archive restart written: ", filen


### PR DESCRIPTION
The recent AWRA-L additions included several `[ERR]` statements in strings passed to `LIS_verify` calls. These are not necessary because `LIS_verify` prepends `[ERR]` to the error messages. This PR cleans up those strings.