### PR TITLE
Update configure defaults for 557WW

### DIFF
--- a/ldt/arch/Config.pl
+++ b/ldt/arch/Config.pl
@@ -111,11 +111,11 @@ elsif($opt_lev == 3) {
    $sys_opt = "-O3 ";
    $sys_c_opt = "";
 }
-print "Assume little/big_endian data format (1-little, 2-big, default=1): ";
+print "Assume little/big_endian data format (1-little, 2-big, default=2): ";
 $use_endian=<stdin>;
 chomp($use_endian);
 if($use_endian eq "") {
-    $use_endian=1;
+    $use_endian=2; # For many LDT input datasets
 }
 
 

--- a/ldt/arch/Config.pl
+++ b/ldt/arch/Config.pl
@@ -111,11 +111,11 @@ elsif($opt_lev == 3) {
    $sys_opt = "-O3 ";
    $sys_c_opt = "";
 }
-print "Assume little/big_endian data format (1-little, 2-big, default=2): ";
+print "Assume little/big_endian data format (1-little, 2-big, default=1): ";
 $use_endian=<stdin>;
 chomp($use_endian);
 if($use_endian eq "") {
-   $use_endian=2
+    $use_endian=1;
 }
 
 
@@ -134,11 +134,11 @@ else{
 }
 
 
-print "Use GRIBAPI/ECCODES? (0-neither, 1-gribapi, 2-eccodes, default=1): ";
+print "Use GRIBAPI/ECCODES? (0-neither, 1-gribapi, 2-eccodes, default=2): ";
 $use_gribapi=<stdin>;
 chomp($use_gribapi);
 if($use_gribapi eq ""){
-   $use_gribapi=1;
+    $use_gribapi=2;
 }
 
 if($use_gribapi == 1) {
@@ -296,10 +296,10 @@ if($use_netcdf == 1) {
    if($netcdf_deflate eq "\n"){
       $netcdf_deflate=1;
    }
-   print "NETCDF use deflate level? (1 to 9-yes, 0-no, default = 9): ";
+   print "NETCDF use deflate level? (1 to 9-yes, 0-no, default = 1): ";
    $netcdf_deflate_level=<stdin>;
    if($netcdf_deflate_level eq "\n"){
-      $netcdf_deflate_level=9;
+      $netcdf_deflate_level=1;
    }
 }
 

--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -257,11 +257,11 @@ elsif($opt_lev == 3) {
 }
 
 
-print "Assume little/big_endian data format (1-little, 2-big, default=2): ";
+print "Assume little/big_endian data format (1-little, 2-big, default=1): ";
 $use_endian=<stdin>;
 chomp($use_endian);
 if($use_endian eq "") {
-   $use_endian=2
+    $use_endian=1;
 }
 
 my $end_table = ();
@@ -298,11 +298,11 @@ else{
 }
 
 
-print "Use GRIBAPI/ECCODES? (0-neither, 1-gribapi, 2-eccodes, default=1): ";
+print "Use GRIBAPI/ECCODES? (0-neither, 1-gribapi, 2-eccodes, default=2): ";
 $use_gribapi=<stdin>;
 chomp($use_gribapi);
 if($use_gribapi eq ""){
-   $use_gribapi=1;
+   $use_gribapi=2;
 }
 
 if($use_gribapi == 1) {
@@ -447,11 +447,11 @@ else {
 }
 
 
-print "Enable AFWA-specific grib configuration settings? (1-yes, 0-no, default=0): ";
+print "Enable AFWA-specific grib configuration settings? (1-yes, 0-no, default=1): ";
 $use_afwagrib=<stdin>;
 chomp($use_afwagrib);
 if($use_afwagrib eq ""){
-   $use_afwagrib=0;
+   $use_afwagrib=1;
 }
 
 
@@ -499,11 +499,11 @@ if($use_netcdf == 1) {
       $netcdf_deflate=1;
    }
 
-   print "NETCDF use deflate level? (1 to 9-yes, 0-no, default = 9): ";
+   print "NETCDF use deflate level? (1 to 9-yes, 0-no, default = 1): ";
    $netcdf_deflate_level=<stdin>;
    chomp($netcdf_deflate_level);
    if($netcdf_deflate_level eq ""){
-      $netcdf_deflate_level=9;
+      $netcdf_deflate_level=1;
    }
 }
 

--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -261,7 +261,7 @@ print "Assume little/big_endian data format (1-little, 2-big, default=1): ";
 $use_endian=<stdin>;
 chomp($use_endian);
 if($use_endian eq "") {
-    $use_endian=1;
+    $use_endian=1; # For AGRMET
 }
 
 my $end_table = ();

--- a/lvt/arch/Config.pl
+++ b/lvt/arch/Config.pl
@@ -148,10 +148,10 @@ elsif($opt_lev == 3) {
    $sys_opt = "-O3 ";
    $sys_c_opt = "";
 }
-print "Assume little/big_endian data format (1-little, 2-big, default=2): ";
+print "Assume little/big_endian data format (1-little, 2-big, default=1): ";
 $use_endian=<stdin>;
 if($use_endian eq "\n") {
-   $use_endian=2
+    $use_endian=1;
 }
 
 
@@ -169,11 +169,11 @@ else{
    exit 1;
 }
 
-print "Use GRIBAPI/ECCODES? (1-gribapi, 2-eccodes, default=1): ";
+print "Use GRIBAPI/ECCODES? (1-gribapi, 2-eccodes, default=2): ";
 $use_gribapi=<stdin>;
 chomp($use_gribapi);
 if($use_gribapi eq ""){
-   $use_gribapi=1;
+   $use_gribapi=2;
 }
 
 if($use_gribapi == 1) {
@@ -328,10 +328,10 @@ if($use_netcdf == 1) {
    if($netcdf_deflate eq "\n"){
       $netcdf_deflate=1;
    }
-   print "NETCDF use deflate level? (1 to 9-yes, 0-no, default = 9): ";
+   print "NETCDF use deflate level? (1 to 9-yes, 0-no, default = 1): ";
    $netcdf_deflate_level=<stdin>;
    if($netcdf_deflate_level eq "\n"){
-      $netcdf_deflate_level=9;
+      $netcdf_deflate_level=1;
    }
 }
 
@@ -416,10 +416,10 @@ if($use_hdfeos == 1) {
    }
 }
 
-print "Enable AFWA-specific grib configuration settings? (1-yes, 0-no, default=0): ";
+print "Enable AFWA-specific grib configuration settings? (1-yes, 0-no, default=1): ";
 $use_afwagrib=<stdin>;
 if($use_afwagrib eq "\n"){
-   $use_afwagrib=0;
+   $use_afwagrib=1;
 }
 
 print "Enable GeoTIFF support? (1-yes, 0-no, default=1): ";

--- a/lvt/arch/Config.pl
+++ b/lvt/arch/Config.pl
@@ -148,10 +148,10 @@ elsif($opt_lev == 3) {
    $sys_opt = "-O3 ";
    $sys_c_opt = "";
 }
-print "Assume little/big_endian data format (1-little, 2-big, default=1): ";
+print "Assume little/big_endian data format (1-little, 2-big, default=2): ";
 $use_endian=<stdin>;
 if($use_endian eq "\n") {
-    $use_endian=1;
+    $use_endian=2;
 }
 
 


### PR DESCRIPTION
IMPORTANT:  DO NOT MERGE THIS UNTIL PR 201 HAS BEEN BACKPORTED TO support/lisf-557ww-7.3!

Among the changes in this pull request is configuring LDT/LIS/LVT to compile in little-endian.  This will not work unless PR201 is backported first (LDT needs to use big-endian for certain inputs, and PR201 addresses this.)