### PR TITLE
Fix AWRAL compile and run errors w/ GNU4 compiler

### DIFF
--- a/lis/metforcing/AWRAL/read_AWRAL.F90
+++ b/lis/metforcing/AWRAL/read_AWRAL.F90
@@ -114,7 +114,7 @@ subroutine read_AWRAL( order, n, findex, year, doy, ferror_AWRAL )
   timestep = doy
 
 !-- Check forcing is on the same grid as the model --!
-  if((AWRAL_struc(n)%ncol .neqv. LIS_rc%gnr(n)) .or. (AWRAL_struc(n)%ncol .neqv. LIS_rc%gnc(n))) then
+  if((AWRAL_struc(n)%nrow .ne. LIS_rc%gnr(n)) .or. (AWRAL_struc(n)%ncol .ne. LIS_rc%gnc(n))) then
      if(LIS_masterproc) then
           write(LIS_logunit,*)'[ERR] Problem using AWRAL forcing: Forcing must be on the same grid as the model'
           write(LIS_logunit,*)'[ERR] Remapping not implemented. Stopping...'

--- a/lis/metforcing/AWRAL/read_AWRAL.F90
+++ b/lis/metforcing/AWRAL/read_AWRAL.F90
@@ -65,12 +65,12 @@ subroutine read_AWRAL( order, n, findex, year, doy, ferror_AWRAL )
   integer            :: ftn, ndata, index1,v
   integer, parameter :: N_AF = 6 ! # of AWRAL forcing variables
   character(10), dimension(N_AF), parameter :: awral_fv = (/  &
-       'tat',    &
-       'avpt',    &
-       'rgt',    &
-       'radcskyt',    &
-       'u2t',    &
-       'pt'     /)
+       'tat       ',    &
+       'avpt      ',    &
+       'rgt       ',    &
+       'radcskyt  ',    &
+       'u2t       ',    &
+       'pt        '     /)
 
 
   character*255 :: var_fname

--- a/lis/surfacemodels/land/awral.6.0.0/AWRAL600_finalize.F90
+++ b/lis/surfacemodels/land/awral.6.0.0/AWRAL600_finalize.F90
@@ -66,16 +66,16 @@ subroutine AWRAL600_finalize(n)
         deallocate(AWRAL600_struc(n)%wslimu)
 
         ! free momory for initial state variable
-        if ( ASSOCIATED(AWRAL600_struc(n)%init_s0)) then        
+        if ( allocated(AWRAL600_struc(n)%init_s0)) then
           deallocate(AWRAL600_struc(n)%init_s0)
         end if
-        if ( ASSOCIATED(AWRAL600_struc(n)%init_ss)) then
+        if ( allocated(AWRAL600_struc(n)%init_ss)) then
           deallocate(AWRAL600_struc(n)%init_ss)
         end if
-        if ( ASSOCIATED(AWRAL600_struc(n)%init_s0)) then
+        if ( allocated(AWRAL600_struc(n)%init_s0)) then
           deallocate(AWRAL600_struc(n)%init_sd)
         end if
-        if ( ASSOCIATED(AWRAL600_struc(n)%init_s0)) then
+        if ( allocated(AWRAL600_struc(n)%init_s0)) then
           deallocate(AWRAL600_struc(n)%init_mleaf)
         end if
     end do ! nest loop

--- a/lis/surfacemodels/land/awral.6.0.0/AWRAL600_lsmMod.F90
+++ b/lis/surfacemodels/land/awral.6.0.0/AWRAL600_lsmMod.F90
@@ -167,10 +167,10 @@ module AWRAL600_lsmMod
         !-------------------------------------------------------------------------
         real               :: init_sr
         real               :: init_sg
-        real, pointer      :: init_s0(:)
-        real, pointer      :: init_ss(:)
-        real, pointer      :: init_sd(:)
-        real, pointer      :: init_mleaf(:)
+        real, allocatable  :: init_s0(:)
+        real, allocatable  :: init_ss(:)
+        real, allocatable  :: init_sd(:)
+        real, allocatable  :: init_mleaf(:)
         !-------------------------------------------------------------------------
         ! Constant Parameter
         !-------------------------------------------------------------------------
@@ -179,31 +179,31 @@ module AWRAL600_lsmMod
         real               :: kr_coeff
         integer            :: nhru
         integer            :: nhypsbins
-        real, pointer      :: hypsperc(:)
-        real, pointer      :: alb_dry(:)
-        real, pointer      :: alb_wet(:)
-        real, pointer      :: cgsmax(:)
-        real, pointer      :: er_frac_ref(:)
-        real, pointer      :: fsoilemax(:)
-        real, pointer      :: lairef(:)
-        real, pointer      :: rd(:)
-        real, pointer      :: s_sls(:)
-        real, pointer      :: sla(:)
-        real, pointer      :: tgrow(:)
-        real, pointer      :: tsenc(:)
-        real, pointer      :: ud0(:)
-        real, pointer      :: us0(:)
-        real, pointer      :: vc(:)
-        real, pointer      :: w0lime(:)
-        real, pointer      :: w0ref_alb(:)
-        real, pointer      :: wdlimu(:)
-        real, pointer      :: wslimu(:)
-        real, pointer      :: hy
+        real, allocatable  :: hypsperc(:)
+        real, allocatable  :: alb_dry(:)
+        real, allocatable  :: alb_wet(:)
+        real, allocatable  :: cgsmax(:)
+        real, allocatable  :: er_frac_ref(:)
+        real, allocatable  :: fsoilemax(:)
+        real, allocatable  :: lairef(:)
+        real, allocatable  :: rd(:)
+        real, allocatable  :: s_sls(:)
+        real, allocatable  :: sla(:)
+        real, allocatable  :: tgrow(:)
+        real, allocatable  :: tsenc(:)
+        real, allocatable  :: ud0(:)
+        real, allocatable  :: us0(:)
+        real, allocatable  :: vc(:)
+        real, allocatable  :: w0lime(:)
+        real, allocatable  :: w0ref_alb(:)
+        real, allocatable  :: wdlimu(:)
+        real, allocatable  :: wslimu(:)
+        real, allocatable  :: hy
         integer            :: timesteps
-        type(AWRAL600dec), pointer :: awral600(:)
+        type(AWRAL600dec), allocatable :: awral600(:)
     end type AWRAL600_type_dec
 
-    type(AWRAL600_type_dec), pointer :: AWRAL600_struc(:)
+    type(AWRAL600_type_dec), allocatable :: AWRAL600_struc(:)
  
 contains 
 

--- a/lis/surfacemodels/land/awral.6.0.0/AWRAL600_module.F90
+++ b/lis/surfacemodels/land/awral.6.0.0/AWRAL600_module.F90
@@ -189,19 +189,19 @@ module AWRAL600_module
         !-------------------------------------------------------------------------
         ! multilevel spatial parameter
         !-------------------------------------------------------------------------
-        real, pointer      :: height(:)
-        real, pointer      :: fhru(:)
-        real, pointer      :: hveg(:)
-        real, pointer      :: laimax(:)
+        real, allocatable      :: height(:)
+        real, allocatable      :: fhru(:)
+        real, allocatable      :: hveg(:)
+        real, allocatable      :: laimax(:)
         !-------------------------------------------------------------------------
         ! state
         !-------------------------------------------------------------------------
-        real               :: sr
-        real               :: sg
-        real, pointer      :: s0(:)
-        real, pointer      :: ss(:)
-        real, pointer      :: sd(:)
-        real, pointer      :: mleaf(:)
+        real                   :: sr
+        real                   :: sg
+        real, allocatable      :: s0(:)
+        real, allocatable      :: ss(:)
+        real, allocatable      :: sd(:)
+        real, allocatable      :: mleaf(:)
         !-------------------------------------------------------------------------
         ! output
         !-------------------------------------------------------------------------

--- a/lis/surfacemodels/land/awral.6.0.0/AWRAL600_readrst.F90
+++ b/lis/surfacemodels/land/awral.6.0.0/AWRAL600_readrst.F90
@@ -24,7 +24,7 @@ subroutine AWRAL600_readrst()
                                LIS_verify                
     use AWRAL600_lsmMod
 
-#if (defined USE_NETCDF3 .OR. defined USE_NETCDF4)
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
     use netcdf
 #endif
 
@@ -98,7 +98,7 @@ subroutine AWRAL600_readrst()
                     call LIS_endrun
                 endif
             elseif(wformat .eq. "netcdf") then
-#if (defined USE_NETCDF3 .OR. defined USE_NETCDF4)
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
                 status = nf90_open(path=AWRAL600_struc(n)%rfile, &
                                    mode=NF90_NOWRITE, ncid=ftn)
                 call LIS_verify(status, "[ERR] Error opening file "//AWRAL600_struc(n)%rfile)
@@ -153,7 +153,7 @@ subroutine AWRAL600_readrst()
             if(wformat .eq. "binary") then
                 call LIS_releaseUnitNumber(ftn)
             elseif(wformat .eq. "netcdf") then
-#if (defined USE_NETCDF3 .OR. defined USE_NETCDF4)
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
                 status = nf90_close(ftn)
                 call LIS_verify(status, "Error in nf90_close in AWRAL600_readrst")
 #endif            

--- a/lis/surfacemodels/land/awral.6.0.0/AWRAL600_setup.F90
+++ b/lis/surfacemodels/land/awral.6.0.0/AWRAL600_setup.F90
@@ -279,7 +279,7 @@ subroutine AWRAL600_read_MULTILEVEL_param(n, ncvar_name, level, placeholder)
     integer       :: ios, nid, param_ID, nc_ID, nr_ID, dimids(3)
     integer       :: nc, nr, t, k
     integer       :: nlevel
-    real, pointer :: level_data(:, :, :)
+    real, allocatable :: level_data(:, :, :)
     logical       :: file_exists
 
     inquire(file=LIS_rc%paramfile(n), exist=file_exists)

--- a/lis/surfacemodels/land/awral.6.0.0/AWRAL600_writerst.F90
+++ b/lis/surfacemodels/land/awral.6.0.0/AWRAL600_writerst.F90
@@ -24,7 +24,7 @@ subroutine AWRAL600_writerst(n)
                                LIS_create_restart_filename
     use AWRAL600_lsmMod
 
-#if (defined USE_NETCDF3 .OR. defined USE_NETCDF4)
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
     use netcdf
 #endif
 
@@ -85,7 +85,7 @@ subroutine AWRAL600_writerst(n)
             if(wformat .eq. "binary") then
                 call LIS_releaseUnitNumber(ftn)
             elseif(wformat .eq. "netcdf") then
-#if (defined USE_NETCDF3 .OR. defined USE_NETCDF4)
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
                 status = nf90_close(ftn)
                 call LIS_verify(status, "Error in nf90_close in AWRAL600_writerst")
 #endif


### PR DESCRIPTION
This pull request fixes compile and runtime errors in the AWRAL600 code that are thrown on SLES11 with the GNU4 compiler.

**GNU compile errors fixed:**
* In `read_AWRAL.F90`: pad character variables with whitespace on initialization to fix a `Different CHARACTER lengths` error. These variables are always `trim`med before use.
* In `AWRAL600_readrst.F90`/`AWRAL600_writerst.F90`: convert logical operators in preprocessor directives from `.OR.` to `||` to fix an `error: token "." is not valid in preprocessor expressions` error. This solution is consistent with preprocessor directives elsewhere in LIS.

**Runtime errors fixed:**
When using a GNU4-based executable, LIS would seg fault with an "invalid memory reference" error in the finalize routine when attempting to deallocate uninitalized pointers.
* In `AWRAL_lsmMod.F90` and `AWRAL_module.F90`: initializations changed from pointers to allocatables
* `if (ASSOCIATED...` checks changed to `if (allocated...` checks in the finalize routine

While fixing the above I noticed that in `read_AWRAL.F90`, a grid check incorrectly compared `AWRAL_struc%ncol` to `LIS_rc%gnr`. The check would therefore evaluate to false and end the run when the forcing grid was the same as the model (error only thrown with GNU4-based executable?). I also had to convert the logical operator ".neqv" to ".ne" as the former requires both operands to be of type LOGICAL while the operands here are INTEGER(4). (This fixes a `Operands of logical operator '.neqv.' at (1) are INTEGER(4)/INTEGER(4)` compiler error.)

These fixes have been tested with GNU4, Intel18, and Intel19 compilers. ✔️ 

**Testcase files are staged here:** /discover/nobackup/projects/lis/PR_TESTCASES/370/awral600_testcase