### PR TITLE
Fix full name of SMAP_filelist for SPL3SMP

### DIFF
--- a/lvt/datastreams/SMAPsm/readSMAPsmobs.F90
+++ b/lvt/datastreams/SMAPsm/readSMAPsmobs.F90
@@ -187,7 +187,7 @@ subroutine readSMAPsmobs(source)
          
          call system(trim(list_files))
          ftn = LVT_getNextUnitNumber()
-         open (ftn, file="./SMAP_filelist.dat", &
+         open (ftn, file="./SMAPsm/SMAP_filelist.dat", &
                status='old', iostat=ierr)
 
 ! if multiple files for the same time and orbits are present, the latest


### PR DESCRIPTION
The SMAP_filelist file for the "SMAP_L3_SM_P" files in the SPL3SMP section
of readSMAPsmobs.F90 was incorrectly specified.  When LVT tried to read
the SMAP_filelist at line 190, it did not exist, and thus no observations
were read.