### PR TITLE
Add floating point optimization flag to configure script

### DIFF
--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -256,6 +256,10 @@ elsif($opt_lev == 3) {
    $sys_c_opt = "";
 }
 
+if(($sys_arch eq "linux_ifc") && ($opt_lev gt 0)) {
+   $sys_opt .= " -fp-model precise";
+   $sys_c_opt .= "-fp-model precise";
+}
 
 print "Assume little/big_endian data format (1-little, 2-big, default=2): ";
 $use_endian=<stdin>;


### PR DESCRIPTION
Adds the `-fp-model precise` flag for positive optimization levels when using Intel compilers to the Configure.pl script.

Resolves #626 