### PR TITLE
Fix HYMAP2 2-way coupling in parallel mode

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -10227,6 +10227,18 @@ of how to specify a time interval.
 `HYMAP2 routing model restart file:` specifies the HyMAP2 router
 active restart file.
 
+`HYMAP2 enable 2-way coupling:` specifies whether to enable 2-way coupling.
+
+|====
+|Value | Description
+
+|0     | Do not use
+|1     | Use
+|====
+
+`HYMAP2 2-way coupling flooded fraction threshold:` specifies the flooded fraction
+threshold used in the 2-way coupling mode.
+
 .Example _lis.config_ entry
 ....
 HYMAP2 routing model time step: "30mn"
@@ -10248,6 +10260,8 @@ HYMAP2 routing model dwi flag: 0
 HYMAP2 routing model start mode: "coldstart"
 HYMAP2 routing model restart interval: "1mo"
 HYMAP2 routing model restart file: "./OL/ROUTING/197901/LIS_RST_HYMAP2_router_197901030000.d01.nc
+HYMAP2 enable 2-way coupling: 0
+HYMAP2 2-way coupling flooded fraction threshold: 2.0
 ....
 
 

--- a/lis/plugins/LIS_lsmrouting_pluginMod.F90
+++ b/lis/plugins/LIS_lsmrouting_pluginMod.F90
@@ -67,6 +67,8 @@ subroutine LIS_lsmrouting_plugin
 #if ( defined SM_NOAH_3_6 )
    external noah36_getrunoffs
    external noah36_getrunoffs_mm
+   external noah36_getrunoffs_hymap2
+   external noah36_getsws_hymap2
 #endif
 
 #if ( defined SM_NOAH_3_9 )
@@ -84,6 +86,8 @@ subroutine LIS_lsmrouting_plugin
 #if ( defined SM_NOAHMP_4_0_1 )
    external noahmp401_getrunoffs
    external noahmp401_getrunoffs_mm
+   external noahmp401_getrunoffs_hymap2
+   external noahmp401_getsws_hymap2
 #endif
 
 #if ( defined SM_RUC_3_7 )
@@ -95,6 +99,7 @@ subroutine LIS_lsmrouting_plugin
    external clsmf25_getrunoffs
    external clsmf25_getrunoffs_mm
    external clsmf25_getrunoffs_hymap2
+   external clsmf25_getsws_hymap2
 #endif
 
 #if ( defined SM_VIC_4_1_2 )
@@ -121,96 +126,96 @@ subroutine LIS_lsmrouting_plugin
 #if ( defined ROUTE_HYMAP_ROUTER )
 #if ( defined SM_LSM_TEMPLATE )
    call registerlsmroutinggetrunoff(trim(LIS_templateLSMId)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    template_getrunoffs)
+        trim(LIS_HYMAProuterId)//char(0), &
+        template_getrunoffs)
 #endif
 #if ( defined SM_NOAH_2_7_1 )
    call registerlsmroutinggetrunoff(trim(LIS_noah271Id)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    noah271_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        noah271_getrunoffs_mm)
 #endif
 
 
 #if ( defined SM_NOAH_3_2 )
    call registerlsmroutinggetrunoff(trim(LIS_noah32Id)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    noah32_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        noah32_getrunoffs_mm)
 #endif
 
 #if ( defined SM_NOAH_3_3 )
    call registerlsmroutinggetrunoff(trim(LIS_noah33Id)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    noah33_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        noah33_getrunoffs_mm)
 #endif
 
 #if ( defined SM_NOAH_3_6 )
    call registerlsmroutinggetrunoff(trim(LIS_noah36Id)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    noah36_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        noah36_getrunoffs_mm)
 #endif
 
 #if ( defined SM_NOAH_3_9 )
    call registerlsmroutinggetrunoff(trim(LIS_noah39Id)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    noah39_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        noah39_getrunoffs_mm)
 #endif
 
 #if ( defined SM_NOAHMP_3_6 )
    call registerlsmroutinggetrunoff(trim(LIS_noahmp36Id)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    noahmp36_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        noahmp36_getrunoffs_mm)
    call registerlsmroutinggetsws(trim(LIS_noahmp36Id)//"+"//&
-                                    trim(LIS_HYMAP2routerId)//char(0), &
-                                    noahmp36_getsws_hymap2)
+        trim(LIS_HYMAP2routerId)//char(0), &
+        noahmp36_getsws_hymap2)
 #endif
 
 #if ( defined SM_NOAHMP_4_0_1 )
    call registerlsmroutinggetrunoff(trim(LIS_noahmp401Id)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    noahmp401_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        noahmp401_getrunoffs_mm)
 #endif
 
 #if ( defined SM_RUC_3_7 )
    call registerlsmroutinggetrunoff(trim(LIS_ruc37Id)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    ruc37_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        ruc37_getrunoffs_mm)
 #endif
 
 
 #if ( defined SM_CLSM_F2_5 )
    call registerlsmroutinggetrunoff(trim(LIS_clsmf25Id)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    clsmf25_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        clsmf25_getrunoffs_mm)
 #endif
 
 #if ( defined SM_VIC_4_1_2 )
    call registerlsmroutinggetrunoff(trim(LIS_vic412Id)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    vic412_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        vic412_getrunoffs_mm)
 #endif
 
 #if ( defined SM_JULES_5_0 )
    call registerlsmroutinggetrunoff(trim(LIS_jules50Id)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    jules50_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        jules50_getrunoffs_mm)
 #endif
 
 #if ( defined SM_JULES_5_2 )
    call registerlsmroutinggetrunoff(trim(LIS_jules52Id)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    jules52_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        jules52_getrunoffs_mm)
 #endif
 
 #if ( defined SM_JULES_5_3 )
    call registerlsmroutinggetrunoff(trim(LIS_jules53Id)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    jules53_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        jules53_getrunoffs_mm)
 #endif
 
 #if ( defined SM_JULES_5_X )
    call registerlsmroutinggetrunoff(trim(LIS_jules5xId)//"+"//&
-                                    trim(LIS_HYMAProuterId)//char(0), &
-                                    jules5x_getrunoffs_mm)
+        trim(LIS_HYMAProuterId)//char(0), &
+        jules5x_getrunoffs_mm)
 #endif
 
 #endif
@@ -218,131 +223,141 @@ subroutine LIS_lsmrouting_plugin
 #if ( defined ROUTE_HYMAP2_ROUTER )
 #if ( defined SM_LSM_TEMPLATE )
    call registerlsmroutinggetrunoff(trim(LIS_templateLSMId)//"+"//&
-                                    trim(LIS_HYMAP2routerId)//char(0), &
-                                    template_getrunoffs)
+        trim(LIS_HYMAP2routerId)//char(0), &
+        template_getrunoffs)
 #endif
 
 #if ( defined SM_NOAH_3_2 )
    call registerlsmroutinggetrunoff(trim(LIS_noah32Id)//"+"//&
-                                    trim(LIS_HYMAP2routerId)//char(0), &
-                                    noah32_getrunoffs_mm)
+        trim(LIS_HYMAP2routerId)//char(0), &
+        noah32_getrunoffs_mm)
 #endif
 
 #if ( defined SM_NOAH_3_3 )
    call registerlsmroutinggetrunoff(trim(LIS_noah33Id)//"+"//&
-                                    trim(LIS_HYMAP2routerId)//char(0), &
-                                    noah33_getrunoffs_et)
+        trim(LIS_HYMAP2routerId)//char(0), &
+        noah33_getrunoffs_et)
 #endif
 
 #if ( defined SM_NOAH_3_6 )
    call registerlsmroutinggetrunoff(trim(LIS_noah36Id)//"+"//&
-                                    trim(LIS_HYMAP2routerId)//char(0), &
-                                    noah36_getrunoffs_mm)
+        trim(LIS_HYMAP2routerId)//char(0), &
+        noah36_getrunoffs_hymap2)
+   call registerlsmroutinggetsws(trim(LIS_noah36Id)//"+"//&
+        trim(LIS_HYMAP2routerId)//char(0), &
+        noah36_getsws_hymap2) 
 #endif
 
 #if ( defined SM_NOAH_3_9 )
    call registerlsmroutinggetrunoff(trim(LIS_noah39Id)//"+"//&
-                                    trim(LIS_HYMAP2routerId)//char(0), &
-                                    noah39_getrunoffs_mm)
+        trim(LIS_HYMAP2routerId)//char(0), &
+        noah39_getrunoffs_mm)
 #endif
 
 #if ( defined SM_NOAHMP_3_6 )
    call registerlsmroutinggetrunoff(trim(LIS_noahmp36Id)//"+"//&
-                                    trim(LIS_HYMAP2routerId)//char(0), &
-                                    noahmp36_getrunoffs_hymap2)
+        trim(LIS_HYMAP2routerId)//char(0), &
+        noahmp36_getrunoffs_hymap2)
    call registerlsmroutinggetsws(trim(LIS_noahmp36Id)//"+"//&
-                                    trim(LIS_HYMAP2routerId)//char(0), &
-                                    noahmp36_getsws_hymap2)
+        trim(LIS_HYMAP2routerId)//char(0), &
+        noahmp36_getsws_hymap2)
 #endif
 
 #if ( defined SM_NOAHMP_4_0_1 )
    call registerlsmroutinggetrunoff(trim(LIS_noahmp401Id)//"+"//&
-                                    trim(LIS_HYMAP2routerId)//char(0), &
-                                    noahmp401_getrunoffs_mm)
+        trim(LIS_HYMAP2routerId)//char(0), &
+        noahmp401_getrunoffs_hymap2)
+   call registerlsmroutinggetsws(trim(LIS_noahmp401Id)//"+"//&
+        trim(LIS_HYMAP2routerId)//char(0), &
+        noahmp401_getsws_hymap2)
+
 #endif
 
 #if ( defined SM_RUC_3_7 )
    call registerlsmroutinggetrunoff(trim(LIS_ruc37Id)//"+"//&
-                                    trim(LIS_HYMAP2routerId)//char(0), &
-                                    ruc37_getrunoffs_mm)
+        trim(LIS_HYMAP2routerId)//char(0), &
+        ruc37_getrunoffs_mm)
 #endif
-
+   
 
 #if ( defined SM_CLSM_F2_5 )
    call registerlsmroutinggetrunoff(trim(LIS_clsmf25Id)//"+"//&
         trim(LIS_HYMAP2routerId)//char(0), &
         clsmf25_getrunoffs_hymap2)
+   call registerlsmroutinggetsws(trim(LIS_clsmf25Id)//"+"//&
+        trim(LIS_HYMAP2routerId)//char(0), &
+        clsmf25_getsws_hymap2)
 #endif
 
 #if ( defined SM_VIC_4_1_2 )
    call registerlsmroutinggetrunoff(trim(LIS_vic412Id)//"+"//&
-                                    trim(LIS_HYMAP2routerId)//char(0), &
-                                    vic412_getrunoffs_mm)
+        trim(LIS_HYMAP2routerId)//char(0), &
+        vic412_getrunoffs_mm)
 #endif
 #endif
 
 #if ( defined ROUTE_NLDAS_ROUTER )
 #if ( defined SM_NOAH_2_7_1 )
    call registerlsmroutinggetrunoff(trim(LIS_noah271Id)//"+"//&
-                                    trim(LIS_NLDASrouterId)//char(0), &
-                                    noah271_getrunoffs)
+        trim(LIS_NLDASrouterId)//char(0), &
+        noah271_getrunoffs)
 #endif
-
+   
 #if ( defined SM_NOAH_3_2 )
    call registerlsmroutinggetrunoff(trim(LIS_noah32Id)//"+"//&
-                                    trim(LIS_NLDASrouterId)//char(0), &
-                                    noah32_getrunoffs)
+        trim(LIS_NLDASrouterId)//char(0), &
+        noah32_getrunoffs)
 #endif
-
+   
 #if ( defined SM_NOAH_3_3 )
    call registerlsmroutinggetrunoff(trim(LIS_noah33Id)//"+"//&
-                                    trim(LIS_NLDASrouterId)//char(0), &
-                                    noah33_getrunoffs)
+        trim(LIS_NLDASrouterId)//char(0), &
+        noah33_getrunoffs)
 #endif
-
+   
 #if ( defined SM_NOAH_3_6 )
    call registerlsmroutinggetrunoff(trim(LIS_noah36Id)//"+"//&
-                                    trim(LIS_NLDASrouterId)//char(0), &
-                                    noah36_getrunoffs)
+        trim(LIS_NLDASrouterId)//char(0), &
+        noah36_getrunoffs)
 #endif
 
 #if ( defined SM_NOAH_3_9 )
    call registerlsmroutinggetrunoff(trim(LIS_noah39Id)//"+"//&
-                                    trim(LIS_NLDASrouterId)//char(0), &
-                                    noah39_getrunoffs)
+        trim(LIS_NLDASrouterId)//char(0), &
+        noah39_getrunoffs)
 #endif
 
 #if ( defined SM_NOAHMP_3_6 )
    call registerlsmroutinggetrunoff(trim(LIS_noahmp36Id)//"+"//&
-                                    trim(LIS_NLDASrouterId)//char(0), &
-                                    noahmp36_getrunoffs)
+        trim(LIS_NLDASrouterId)//char(0), &
+        noahmp36_getrunoffs)
 #endif
 
 #if ( defined SM_NOAHMP_4_0_1 )
    call registerlsmroutinggetrunoff(trim(LIS_noahmp401Id)//"+"//&
-                                    trim(LIS_NLDASrouterId)//char(0), &
-                                    noahmp401_getrunoffs)
+        trim(LIS_NLDASrouterId)//char(0), &
+        noahmp401_getrunoffs)
 #endif
-
+   
 #if ( defined SM_RUC_3_7 )
    call registerlsmroutinggetrunoff(trim(LIS_ruc37Id)//"+"//&
-                                    trim(LIS_NLDASrouterId)//char(0), &
-                                    ruc37_getrunoffs)
+        trim(LIS_NLDASrouterId)//char(0), &
+        ruc37_getrunoffs)
 #endif
-
+   
 #if ( defined SM_CLSM_F2_5 )
    call registerlsmroutinggetrunoff(trim(LIS_clsmf25Id)//"+"//&
-                                    trim(LIS_NLDASrouterId)//char(0), &
-                                    clsmf25_getrunoffs)
+        trim(LIS_NLDASrouterId)//char(0), &
+        clsmf25_getrunoffs)
 #endif
-
+   
 #if ( defined SM_VIC_4_1_2 )
    call registerlsmroutinggetrunoff(trim(LIS_vic412Id)//"+"//&
-                                    trim(LIS_NLDASrouterId)//char(0), &
-                                    vic412_getrunoffs)
+        trim(LIS_NLDASrouterId)//char(0), &
+        vic412_getrunoffs)
 #endif
 #endif
 #endif
-
+   
 end subroutine LIS_lsmrouting_plugin
 end module LIS_lsmrouting_pluginMod

--- a/lis/surfacemodels/land/clsm.f2.5/routing/clsmf25_getsws_hymap2.F90
+++ b/lis/surfacemodels/land/clsm.f2.5/routing/clsmf25_getsws_hymap2.F90
@@ -38,9 +38,4 @@ subroutine clsmf25_getsws_hymap2(n)
   
   enable2waycpl = 0 
 
-  if(enable2waycpl==1) then 
-     write(LIS_logunit,*) '[ERR] The clsmf25_getsws_hymap2 is not implemented'
-     call LIS_endrun()
-  endif
-
 end subroutine clsmf25_getsws_hymap2

--- a/lis/surfacemodels/land/clsm.f2.5/routing/clsmf25_getsws_hymap2.F90
+++ b/lis/surfacemodels/land/clsm.f2.5/routing/clsmf25_getsws_hymap2.F90
@@ -36,7 +36,6 @@ subroutine clsmf25_getsws_hymap2(n)
   integer                :: status
   integer                :: enable2waycpl
   
-  enable2waycpl = 0
   if(enable2waycpl==1) then
      write(LIS_logunit,*) '[ERR] Two-way coupling between CLSM and HYMAP2'
      write(LIS_logunit,*) '[ERR] is not currently supported'

--- a/lis/surfacemodels/land/clsm.f2.5/routing/clsmf25_getsws_hymap2.F90
+++ b/lis/surfacemodels/land/clsm.f2.5/routing/clsmf25_getsws_hymap2.F90
@@ -27,7 +27,7 @@ subroutine clsmf25_getsws_hymap2(n)
   integer,  intent(in)   :: n 
 !
 ! !DESCRIPTION:
-!   This routine defines the surface water storage variables in NoahMP
+!   This routine defines the surface water storage variables in the LSM
 !   to be updated based on feedback from HYMAP2
 !  
 !EOP
@@ -38,7 +38,7 @@ subroutine clsmf25_getsws_hymap2(n)
   
   enable2waycpl = 0
   if(enable2waycpl==1) then
-     write(LIS_logunit,*) '[ERR] Two-way coupling between Noah36 and HYMAP2'
+     write(LIS_logunit,*) '[ERR] Two-way coupling between CLSM and HYMAP2'
      write(LIS_logunit,*) '[ERR] is not currently supported'
      call LIS_endrun()
   endif

--- a/lis/surfacemodels/land/clsm.f2.5/routing/clsmf25_getsws_hymap2.F90
+++ b/lis/surfacemodels/land/clsm.f2.5/routing/clsmf25_getsws_hymap2.F90
@@ -36,6 +36,11 @@ subroutine clsmf25_getsws_hymap2(n)
   integer                :: status
   integer                :: enable2waycpl
   
-  enable2waycpl = 0 
+  enable2waycpl = 0
+  if(enable2waycpl==1) then
+     write(LIS_logunit,*) '[ERR] Two-way coupling between Noah36 and HYMAP2'
+     write(LIS_logunit,*) '[ERR] is not currently supported'
+     call LIS_endrun()
+  endif
 
 end subroutine clsmf25_getsws_hymap2

--- a/lis/surfacemodels/land/clsm.f2.5/routing/clsmf25_getsws_hymap2.F90
+++ b/lis/surfacemodels/land/clsm.f2.5/routing/clsmf25_getsws_hymap2.F90
@@ -36,6 +36,10 @@ subroutine clsmf25_getsws_hymap2(n)
   integer                :: status
   integer                :: enable2waycpl
   
+  call ESMF_AttributeGet(LIS_runoff_state(n),"2 way coupling",&
+       enable2waycpl, rc=status)
+  call LIS_verify(status)
+  
   if(enable2waycpl==1) then
      write(LIS_logunit,*) '[ERR] Two-way coupling between CLSM and HYMAP2'
      write(LIS_logunit,*) '[ERR] is not currently supported'

--- a/lis/surfacemodels/land/clsm.f2.5/routing/clsmf25_getsws_hymap2.F90
+++ b/lis/surfacemodels/land/clsm.f2.5/routing/clsmf25_getsws_hymap2.F90
@@ -1,0 +1,46 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
+!
+! Copyright (c) 2015 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: clsmf25_getsws_hymap2
+!  \label{clsmf25_getsws_hymap2}
+!
+! !REVISION HISTORY:
+! 12 Sep 2019: Augusto Getirana; implementation of two-way coupling
+!
+! !INTERFACE:
+subroutine clsmf25_getsws_hymap2(n)
+! !USES:
+  use ESMF
+  use LIS_coreMod, only : LIS_rc, LIS_masterproc
+  use LIS_routingMod, only : LIS_runoff_state
+  use LIS_logMod
+  use LIS_historyMod
+  use clsmf25_lsmMod, only : clsmf25_struc
+
+  implicit none
+! !ARGUMENTS: 
+  integer,  intent(in)   :: n 
+!
+! !DESCRIPTION:
+!   This routine defines the surface water storage variables in NoahMP
+!   to be updated based on feedback from HYMAP2
+!  
+!EOP
+  integer                :: t
+  integer                :: c,r
+  integer                :: status
+  integer                :: enable2waycpl
+  
+  enable2waycpl = 0 
+
+  if(enable2waycpl==1) then 
+     write(LIS_logunit,*) '[ERR] The clsmf25_getsws_hymap2 is not implemented'
+     call LIS_endrun()
+  endif
+
+end subroutine clsmf25_getsws_hymap2

--- a/lis/surfacemodels/land/noah.3.6/routing/noah36_getrunoffs_hymap2.F90
+++ b/lis/surfacemodels/land/noah.3.6/routing/noah36_getrunoffs_hymap2.F90
@@ -1,0 +1,95 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
+!
+! Copyright (c) 2015 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: noah36_getrunoffs_hymap2
+!  \label{noah36_getrunoffs_hymap2}
+!
+! !REVISION HISTORY:
+!  6 May 2011: Sujay Kumar; Initial Specification
+! 31 Oct 2014: David Mocko, added Noah-3.6 into LIS-7
+!
+! !INTERFACE:
+subroutine noah36_getrunoffs_hymap2(n)
+! !USES:
+  use ESMF
+  use LIS_coreMod, only : LIS_rc, LIS_masterproc
+  use LIS_routingMod, only : LIS_runoff_state
+  use LIS_logMod,     only : LIS_verify
+  use LIS_constantsMod
+  use LIS_historyMod
+  use noah36_lsmMod, only : noah36_struc
+
+  implicit none
+! !ARGUMENTS: 
+  integer,  intent(in)   :: n 
+!
+! !DESCRIPTION:
+!  
+!
+! 
+!EOP
+  type(ESMF_Field)       :: sfrunoff_field
+  type(ESMF_Field)       :: baseflow_field
+  real, pointer          :: sfrunoff(:)
+  real, pointer          :: baseflow(:)
+  real, allocatable          :: gvar1(:)
+  real, allocatable          :: gvar2(:)
+  real, allocatable          :: runoff1(:)
+  real, allocatable          :: runoff2(:)
+  real, allocatable          :: runoff1_t(:)
+  real, allocatable          :: runoff2_t(:)
+  integer                :: t
+  integer                :: c,r
+  integer                :: status
+
+  allocate(runoff1(LIS_rc%npatch(n,LIS_rc%lsm_index)))
+  allocate(runoff2(LIS_rc%npatch(n,LIS_rc%lsm_index)))
+  allocate(runoff1_t(LIS_rc%ntiles(n)))
+  allocate(runoff2_t(LIS_rc%ntiles(n)))
+
+  runoff1_t = -9999.0
+  runoff2_t = -9999.0
+
+  call ESMF_StateGet(LIS_runoff_state(n),"Surface Runoff",&
+       sfrunoff_field,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for Surface Runoff')
+  
+  call ESMF_StateGet(LIS_runoff_state(n),"Subsurface Runoff",&
+       baseflow_field,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for Subsurface Runoff')
+  
+  call ESMF_FieldGet(sfrunoff_field,localDE=0,farrayPtr=sfrunoff,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for Surface Runoff')
+  
+  call ESMF_FieldGet(baseflow_field,localDE=0,farrayPtr=baseflow,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for Subsurface Runoff')
+
+  do t=1, LIS_rc%npatch(n,LIS_rc%lsm_index)  
+     runoff1(t) = noah36_struc(n)%noah(t)%runoff1*LIS_CONST_RHOFW
+     runoff2(t) = noah36_struc(n)%noah(t)%runoff2*LIS_CONST_RHOFW 
+  enddo
+
+  call LIS_patch2tile(n,1,runoff1_t, runoff1)
+  call LIS_patch2tile(n,1,runoff2_t, runoff2)
+
+  runoff1_t = LIS_rc%udef
+  runoff2_t = LIS_rc%udef
+  
+  call LIS_patch2tile(n,1,runoff1_t, runoff1)
+  call LIS_patch2tile(n,1,runoff2_t, runoff2)
+
+
+  sfrunoff = runoff1_t
+  baseflow = runoff2_t
+
+  deallocate(runoff1)
+  deallocate(runoff2)
+  deallocate(runoff1_t)
+  deallocate(runoff2_t)
+ 
+end subroutine noah36_getrunoffs_hymap2

--- a/lis/surfacemodels/land/noah.3.6/routing/noah36_getsws_hymap2.F90
+++ b/lis/surfacemodels/land/noah.3.6/routing/noah36_getsws_hymap2.F90
@@ -1,0 +1,48 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
+!
+! Copyright (c) 2015 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: noah36_getsws_hymap2
+!  \label{noah36_getsws_hymap2}
+!
+! !REVISION HISTORY:
+! 12 Sep 2019: Augusto Getirana; implementation of two-way coupling
+!
+! !INTERFACE:
+subroutine noah36_getsws_hymap2(n)
+! !USES:
+  use ESMF
+  use LIS_coreMod, only : LIS_rc, LIS_masterproc
+  use LIS_routingMod, only : LIS_runoff_state
+  use LIS_logMod
+  use LIS_historyMod
+  use noahmp36_lsmMod, only : noahmp36_struc
+
+  implicit none
+! !ARGUMENTS: 
+  integer,  intent(in)   :: n 
+!
+! !DESCRIPTION:
+!   This routine defines the surface water storage variables in NoahMP
+!   to be updated based on feedback from HYMAP2
+!  
+!EOP
+  integer                :: status
+  integer                :: enable2waycpl
+  
+  call ESMF_AttributeGet(LIS_runoff_state(n),"2 way coupling",&
+       enable2waycpl, rc=status)
+  call LIS_verify(status)
+
+  if(enable2waycpl==1) then 
+
+     write(LIS_logunit,*) '[ERR] Two-way coupling between Noah36 and HYMAP2'
+     write(LIS_logunit,*) '[ERR] is not currently supported'
+     call LIS_endrun()
+  endif  
+
+end subroutine noah36_getsws_hymap2

--- a/lis/surfacemodels/land/noahmp.4.0.1/routing/noahmp401_getsws_hymap2.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/routing/noahmp401_getsws_hymap2.F90
@@ -1,0 +1,85 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
+!
+! Copyright (c) 2015 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: noahmp401_getsws_hymap2
+!  \label{noahmp401_getsws_hymap2}
+!
+! !REVISION HISTORY:
+! 12 Sep 2019: Augusto Getirana; implementation of two-way coupling
+!
+! !INTERFACE:
+subroutine noahmp401_getsws_hymap2(n)
+! !USES:
+  use ESMF
+  use LIS_coreMod, only : LIS_rc, LIS_masterproc
+  use LIS_routingMod, only : LIS_runoff_state
+  use LIS_logMod
+  use LIS_historyMod
+  use noahmp401_lsmMod, only : noahmp401_struc
+
+  implicit none
+! !ARGUMENTS: 
+  integer,  intent(in)   :: n 
+!
+! !DESCRIPTION:
+!   This routine defines the surface water storage variables in NoahMP
+!   to be updated based on feedback from HYMAP2
+!  
+!EOP
+  type(ESMF_Field)       :: rivsto_field
+  type(ESMF_Field)       :: fldsto_field
+  type(ESMF_Field)       :: fldfrc_field
+  real, pointer          :: rivstotmp(:)
+  real, pointer          :: fldstotmp(:)
+  real, pointer          :: fldfrctmp(:)
+  integer                :: t
+  integer                :: c,r
+  integer                :: status
+  integer                :: enable2waycpl
+  
+  enable2waycpl = 0 
+
+  if(enable2waycpl==1) then 
+     print*, 'The noahmp401_getsws_hymap2 is not implemented'
+     stop
+  endif
+#if 0 
+  call ESMF_AttributeGet(LIS_runoff_state(n),"2 way coupling",&
+       enable2waycpl, rc=status)
+  call LIS_verify(status)
+
+  if(enable2waycpl==1) then 
+     ! River Storage
+     call ESMF_StateGet(LIS_runoff_state(n),"River Storage",rivsto_field,rc=status)
+     call LIS_verify(status,'ESMF_StateGet failed for River Storage')
+     
+     call ESMF_FieldGet(rivsto_field,localDE=0,farrayPtr=rivstotmp,rc=status)
+     call LIS_verify(status,'ESMF_FieldGet failed for River Storage')
+     where(rivstotmp/=LIS_rc%udef) &
+          NOAHMP401_struc(n)%noahmp401(:)%rivsto=rivstotmp/NOAHMP401_struc(n)%dt
+
+     ! Flood Storage
+     call ESMF_StateGet(LIS_runoff_state(n),"Flood Storage",fldsto_field,rc=status)
+     call LIS_verify(status,'ESMF_StateGet failed for Flood Storage')
+     
+     call ESMF_FieldGet(fldsto_field,localDE=0,farrayPtr=fldstotmp,rc=status)
+     call LIS_verify(status,'ESMF_FieldGet failed for Flood Storage')
+     where(fldstotmp/=LIS_rc%udef)&
+          NOAHMP401_struc(n)%noahmp401(:)%fldsto=fldstotmp/NOAHMP401_struc(n)%dt
+
+     ! Flooded Fraction Flag
+     call ESMF_StateGet(LIS_runoff_state(n),"Flooded Fraction",fldfrc_field,rc=status)
+     call LIS_verify(status,'ESMF_StateGet failed for Flooded Fraction')
+     
+     call ESMF_FieldGet(fldfrc_field,localDE=0,farrayPtr=fldfrctmp,rc=status)
+     call LIS_verify(status,'ESMF_FieldGet failed for Flooded Fraction')
+     NOAHMP401_struc(n)%noahmp401(:)%fldfrc=fldfrctmp
+  endif  
+#endif
+
+end subroutine noahmp401_getsws_hymap2

--- a/lis/surfacemodels/land/noahmp.4.0.1/routing/noahmp401_getsws_hymap2.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/routing/noahmp401_getsws_hymap2.F90
@@ -44,10 +44,6 @@ subroutine noahmp401_getsws_hymap2(n)
   
   enable2waycpl = 0 
 
-  if(enable2waycpl==1) then 
-     print*, 'The noahmp401_getsws_hymap2 is not implemented'
-     stop
-  endif
 #if 0 
   call ESMF_AttributeGet(LIS_runoff_state(n),"2 way coupling",&
        enable2waycpl, rc=status)

--- a/lis/surfacemodels/land/noahmp.4.0.1/routing/noahmp401_getsws_hymap2.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/routing/noahmp401_getsws_hymap2.F90
@@ -43,7 +43,12 @@ subroutine noahmp401_getsws_hymap2(n)
   integer                :: enable2waycpl
   
   enable2waycpl = 0 
+  if(enable2waycpl==1) then 
 
+     write(LIS_logunit,*) '[ERR] Two-way coupling between NoahMP401 and HYMAP2'
+     write(LIS_logunit,*) '[ERR] is not currently supported'
+     call LIS_endrun()
+  endif
 #if 0 
   call ESMF_AttributeGet(LIS_runoff_state(n),"2 way coupling",&
        enable2waycpl, rc=status)

--- a/lis/surfacemodels/land/noahmp.4.0.1/routing/noahmp401_getsws_hymap2.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/routing/noahmp401_getsws_hymap2.F90
@@ -42,7 +42,6 @@ subroutine noahmp401_getsws_hymap2(n)
   integer                :: status
   integer                :: enable2waycpl
   
-  enable2waycpl = 0 
   if(enable2waycpl==1) then 
 
      write(LIS_logunit,*) '[ERR] Two-way coupling between NoahMP401 and HYMAP2'

--- a/lis/surfacemodels/land/noahmp.4.0.1/routing/noahmp401_getsws_hymap2.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/routing/noahmp401_getsws_hymap2.F90
@@ -42,17 +42,18 @@ subroutine noahmp401_getsws_hymap2(n)
   integer                :: status
   integer                :: enable2waycpl
   
+  call ESMF_AttributeGet(LIS_runoff_state(n),"2 way coupling",&
+       enable2waycpl, rc=status)
+  call LIS_verify(status)
+  
   if(enable2waycpl==1) then 
 
      write(LIS_logunit,*) '[ERR] Two-way coupling between NoahMP401 and HYMAP2'
      write(LIS_logunit,*) '[ERR] is not currently supported'
      call LIS_endrun()
   endif
+  
 #if 0 
-  call ESMF_AttributeGet(LIS_runoff_state(n),"2 way coupling",&
-       enable2waycpl, rc=status)
-  call LIS_verify(status)
-
   if(enable2waycpl==1) then 
      ! River Storage
      call ESMF_StateGet(LIS_runoff_state(n),"River Storage",rivsto_field,rc=status)


### PR DESCRIPTION
HYMAP2 2-way coupling was not working properly when run in
parallel. This fix adds dummy subroutines to the land-surface
models which allow the 2-way coupling options to work properly.
A more robust fix might be added in the future.

Resolves: #605