### PR TITLE
Make JULES snow depth and SWE available to AGRMET Ops code

### DIFF
--- a/lis/surfacemodels/land/jules.5.0/da_snodep/jules50_setsnodepvars.F90
+++ b/lis/surfacemodels/land/jules.5.0/da_snodep/jules50_setsnodepvars.F90
@@ -76,42 +76,22 @@ subroutine jules50_setsnodepvars(n, LSM_State)
      LIS_snow_struc(n)%snowdepth = 0.0 ! Mean snow depth by grid id
      LIS_snow_struc(n)%sneqv = 0.0     ! SWE by tile
 
-     ! Logic below follows jules50_main
-     do m = 1, LIS_rc%nensem(n)
-        k = 1
-        do
-           if ( k > LIS_rc%npatch(n, LIS_rc%lsm_index) ) then
-              exit
-           end if
+     ! Store SWE by tile
+     do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+        tid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%tile_id
+        LIS_snow_struc(n)%sneqv(tid) = LIS_snow_struc(n)%sneqv(tid) + &
+             jules50_struc(n)%jules50(t)%snow_mass_ij
+     end do
 
-           ! Find all tiles in current grid
-           gid = LIS_surface(n, LIS_rc%lsm_index)%tile(k)%index
-           start_k = k
-           end_k = jules50_struc(n)%jules50(start_k)%end_k
-           k = end_k + 1
-
-           do t = start_k, end_k
-              if ( LIS_surface(n, LIS_rc%lsm_index)%tile(t)%ensem == m ) then
-
-                 ! Store mean snow depth per grid box
-                 pft = jules50_struc(n)%jules50(t)%pft
-                 LIS_snow_struc(n)%snowdepth(gid) = &
-                      LIS_snow_struc(n)%snowdepth(gid) + &
-                      jules50_struc(n)%jules50(t)%snowdepth(pft)
-                 ncount(gid) = ncount(gid) + 1
-
-                 ! Store SWE by tile
-                 tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id
-                 LIS_snow_struc(n)%sneqv(tid) = &
-                      LIS_snow_struc(n)%sneqv(tid) + &
-                      jules50_struc(n)%jules50(t)%snow_mass_ij
-
-              end if
-           end do ! k
-        end do ! Open do loop
-     end do ! m
-
-     ! Normalize the snow depth
+     ! Store mean snow depth per grid box
+     do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+        pft = jules50_struc(n)%jules50(t)%pft
+        gid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%index
+        LIS_snow_struc(n)%snowdepth(gid) = &
+             LIS_snow_struc(n)%snowdepth(gid) + &
+             jules50_struc(n)%jules50(t)%snowdepth(pft)
+        ncount(gid) = ncount(gid) + 1
+     end do
      do t = 1, LIS_rc%ngrid(n)
         if (ncount(t) .gt. 0) then
            LIS_snow_struc(n)%snowdepth(t) = &
@@ -120,6 +100,52 @@ subroutine jules50_setsnodepvars(n, LSM_State)
            LIS_snow_struc(n)%snowdepth(t) = 0.0
         endif
      end do
+
+     ! ! Logic below follows jules50_main
+     ! do m = 1, LIS_rc%nensem(n)
+     !    k = 1
+     !    do
+     !       if ( k > LIS_rc%npatch(n, LIS_rc%lsm_index) ) then
+     !          exit
+     !       end if
+
+     !       ! Find all tiles in current grid
+     !       gid = LIS_surface(n, LIS_rc%lsm_index)%tile(k)%index
+     !       start_k = k
+     !       end_k = jules50_struc(n)%jules50(start_k)%end_k
+     !       k = end_k + 1
+
+     !       do t = start_k, end_k
+     !          if ( LIS_surface(n, LIS_rc%lsm_index)%tile(t)%ensem == m ) then
+
+     !             ! Store mean snow depth per grid box
+     !             pft = jules50_struc(n)%jules50(t)%pft
+     !             LIS_snow_struc(n)%snowdepth(gid) = &
+     !                  LIS_snow_struc(n)%snowdepth(gid) + &
+     !                  jules50_struc(n)%jules50(t)%snowdepth(pft)
+     !             ncount(gid) = ncount(gid) + 1
+
+     !             ! Store SWE by tile
+     !             tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id
+     !             LIS_snow_struc(n)%sneqv(tid) = &
+     !                  LIS_snow_struc(n)%sneqv(tid) + &
+     !                  jules50_struc(n)%jules50(t)%snow_mass_ij
+
+     !          end if
+     !       end do ! k
+     !    end do ! Open do loop
+     ! end do ! m
+
+     ! ! Normalize the snow depth
+     ! do t = 1, LIS_rc%ngrid(n)
+     !    if (ncount(t) .gt. 0) then
+     !       LIS_snow_struc(n)%snowdepth(t) = &
+     !            LIS_snow_struc(n)%snowdepth(t) / ncount(t)
+     !    else
+     !       LIS_snow_struc(n)%snowdepth(t) = 0.0
+     !    endif
+     ! end do
+
   end if
 
 end subroutine jules50_setsnodepvars

--- a/lis/surfacemodels/land/jules.5.0/da_snodep/jules50_setsnodepvars.F90
+++ b/lis/surfacemodels/land/jules.5.0/da_snodep/jules50_setsnodepvars.F90
@@ -101,51 +101,6 @@ subroutine jules50_setsnodepvars(n, LSM_State)
         endif
      end do
 
-     ! ! Logic below follows jules50_main
-     ! do m = 1, LIS_rc%nensem(n)
-     !    k = 1
-     !    do
-     !       if ( k > LIS_rc%npatch(n, LIS_rc%lsm_index) ) then
-     !          exit
-     !       end if
-
-     !       ! Find all tiles in current grid
-     !       gid = LIS_surface(n, LIS_rc%lsm_index)%tile(k)%index
-     !       start_k = k
-     !       end_k = jules50_struc(n)%jules50(start_k)%end_k
-     !       k = end_k + 1
-
-     !       do t = start_k, end_k
-     !          if ( LIS_surface(n, LIS_rc%lsm_index)%tile(t)%ensem == m ) then
-
-     !             ! Store mean snow depth per grid box
-     !             pft = jules50_struc(n)%jules50(t)%pft
-     !             LIS_snow_struc(n)%snowdepth(gid) = &
-     !                  LIS_snow_struc(n)%snowdepth(gid) + &
-     !                  jules50_struc(n)%jules50(t)%snowdepth(pft)
-     !             ncount(gid) = ncount(gid) + 1
-
-     !             ! Store SWE by tile
-     !             tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id
-     !             LIS_snow_struc(n)%sneqv(tid) = &
-     !                  LIS_snow_struc(n)%sneqv(tid) + &
-     !                  jules50_struc(n)%jules50(t)%snow_mass_ij
-
-     !          end if
-     !       end do ! k
-     !    end do ! Open do loop
-     ! end do ! m
-
-     ! ! Normalize the snow depth
-     ! do t = 1, LIS_rc%ngrid(n)
-     !    if (ncount(t) .gt. 0) then
-     !       LIS_snow_struc(n)%snowdepth(t) = &
-     !            LIS_snow_struc(n)%snowdepth(t) / ncount(t)
-     !    else
-     !       LIS_snow_struc(n)%snowdepth(t) = 0.0
-     !    endif
-     ! end do
-
   end if
 
 end subroutine jules50_setsnodepvars

--- a/lis/surfacemodels/land/jules.5.0/da_snodep/jules50_setsnodepvars.F90
+++ b/lis/surfacemodels/land/jules.5.0/da_snodep/jules50_setsnodepvars.F90
@@ -15,25 +15,27 @@
 ! 02 Mar 2010: Sujay Kumar; Modified for Noah 3.1
 ! 21 Jul 2011: James Geiger; Modified for Noah 3.2
 ! 05 Nov 2018: Yeosang Yoon; Modified for Jules 5.0
+! 10 Nov 2020: Eric Kemp; Added support for LIS_snow_struc
 !
 ! !INTERFACE:
 subroutine jules50_setsnodepvars(n, LSM_State)
 ! !USES:
   use ESMF
+  use jules50_lsmMod
   use LIS_coreMod, only : LIS_rc, LIS_domain,LIS_surface
   use LIS_snowMod, only : LIS_snow_struc
   use LIS_logMod, only : LIS_logunit, LIS_verify, LIS_endrun
-  use jules50_lsmMod
+
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in)    :: n
-! 
+!
 ! !DESCRIPTION:
-! 
-!  This routine assigns the snow progognostic variables to noah's
-!  model space. 
-! 
+!
+!  This routine assigns the snow progognostic variables to JULES
+!  model space.
+!
 !EOP
   type(ESMF_State)       :: LSM_State
   type(ESMF_Field)       :: sweField
@@ -43,6 +45,9 @@ subroutine jules50_setsnodepvars(n, LSM_State)
   real                   :: dsneqv,dsnowh
   integer                :: t, pft
   integer                :: status
+  real                   :: ncount(LIS_rc%ngrid(n))
+  integer                :: tid, gid
+  integer                :: m, k, start_k, end_k
 
   call ESMF_StateGet(LSM_State,"SWE",sweField,rc=status)
   call LIS_verify(status)
@@ -65,6 +70,57 @@ subroutine jules50_setsnodepvars(n, LSM_State)
      call jules50_snodep_update(n, t, dsneqv, dsnowh)
 
   enddo
-  
+
+  if (LIS_rc%snowsrc(n) .gt. 0) then
+     ncount = 0 ! Tiles per grid id (land only)
+     LIS_snow_struc(n)%snowdepth = 0.0 ! Mean snow depth by grid id
+     LIS_snow_struc(n)%sneqv = 0.0     ! SWE by tile
+
+     ! Logic below follows jules50_main
+     do m = 1, LIS_rc%nensem(n)
+        k = 1
+        do
+           if ( k > LIS_rc%npatch(n, LIS_rc%lsm_index) ) then
+              exit
+           end if
+
+           ! Find all tiles in current grid
+           gid = LIS_surface(n, LIS_rc%lsm_index)%tile(k)%index
+           start_k = k
+           end_k = jules50_struc(n)%jules50(start_k)%end_k
+           k = end_k + 1
+
+           do t = start_k, end_k
+              if ( LIS_surface(n, LIS_rc%lsm_index)%tile(t)%ensem == m ) then
+
+                 ! Store mean snow depth per grid box
+                 pft = jules50_struc(n)%jules50(t)%pft
+                 LIS_snow_struc(n)%snowdepth(gid) = &
+                      LIS_snow_struc(n)%snowdepth(gid) + &
+                      jules50_struc(n)%jules50(t)%snowdepth(pft)
+                 ncount(gid) = ncount(gid) + 1
+
+                 ! Store SWE by tile
+                 tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id
+                 LIS_snow_struc(n)%sneqv(tid) = &
+                      LIS_snow_struc(n)%sneqv(tid) + &
+                      jules50_struc(n)%jules50(t)%snow_mass_ij
+
+              end if
+           end do ! k
+        end do ! Open do loop
+     end do ! m
+
+     ! Normalize the snow depth
+     do t = 1, LIS_rc%ngrid(n)
+        if (ncount(t) .gt. 0) then
+           LIS_snow_struc(n)%snowdepth(t) = &
+                LIS_snow_struc(n)%snowdepth(t) / ncount(t)
+        else
+           LIS_snow_struc(n)%snowdepth(t) = 0.0
+        endif
+     end do
+  end if
+
 end subroutine jules50_setsnodepvars
 

--- a/lis/surfacemodels/land/jules.5.0/da_usafsi/jules50_setusafsivars.F90
+++ b/lis/surfacemodels/land/jules.5.0/da_usafsi/jules50_setusafsivars.F90
@@ -17,25 +17,27 @@
 ! 05 Nov 2018: Yeosang Yoon; Modified for Jules 5.0 and SNODEP data
 ! 08 Jul 2019: Yeosang Yoon; Modified for Jules.5.0 and LDT-SI data
 ! 13 Dec 2019: Eric Kemp; Replaced LDTSI with USAFSI.
+! 11 Nov 2020: Eric Kemp; Updated LIS_snow_struc
 !
 ! !INTERFACE:
 subroutine jules50_setusafsivars(n, LSM_State)
 ! !USES:
   use ESMF
+  use jules50_lsmMod
   use LIS_coreMod, only : LIS_rc, LIS_domain,LIS_surface
   use LIS_snowMod, only : LIS_snow_struc
   use LIS_logMod,  only : LIS_logunit, LIS_verify, LIS_endrun
-  use jules50_lsmMod
+
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in)    :: n
-! 
+!
 ! !DESCRIPTION:
-! 
-!  This routine assigns the snow progognostic variables to noah's
-!  model space. 
-! 
+!
+!  This routine assigns the snow progognostic variables to JULES
+!  model space.
+!
 !EOP
   type(ESMF_State)       :: LSM_State
   type(ESMF_Field)       :: sweField
@@ -45,6 +47,9 @@ subroutine jules50_setusafsivars(n, LSM_State)
   real                   :: dsneqv,dsnowh
   integer                :: t, pft
   integer                :: status
+  real                   :: ncount(LIS_rc%ngrid(n))
+  integer                :: tid, gid
+  integer                :: m, k, start_k, end_k
 
   call ESMF_StateGet(LSM_State,"SWE",sweField,rc=status)
   call LIS_verify(status)
@@ -63,10 +68,61 @@ subroutine jules50_setusafsivars(n, LSM_State)
      dsneqv = swe(t) - jules50_struc(n)%jules50(t)%snow_mass_ij     ! unit: mm
      dsnowh = snod(t) - jules50_struc(n)%jules50(t)%snowdepth(pft)  ! unit: m
 
-     ! update snow prognostic variables using jules's snow physics 
+     ! update snow prognostic variables using jules's snow physics
      call jules50_usafsi_update(n, t, dsneqv, dsnowh)
 
   enddo
-  
+
+    if (LIS_rc%snowsrc(n) .gt. 0) then
+     ncount = 0 ! Tiles per grid id (land only)
+     LIS_snow_struc(n)%snowdepth = 0.0 ! Mean snow depth by grid id
+     LIS_snow_struc(n)%sneqv = 0.0     ! SWE by tile
+
+     ! Logic below follows jules50_main
+     do m = 1, LIS_rc%nensem(n)
+        k = 1
+        do
+           if ( k > LIS_rc%npatch(n, LIS_rc%lsm_index) ) then
+              exit
+           end if
+
+           ! Find all tiles in current grid
+           gid = LIS_surface(n, LIS_rc%lsm_index)%tile(k)%index
+           start_k = k
+           end_k = jules50_struc(n)%jules50(start_k)%end_k
+           k = end_k + 1
+
+           do t = start_k, end_k
+              if ( LIS_surface(n, LIS_rc%lsm_index)%tile(t)%ensem == m ) then
+
+                 ! Store mean snow depth per grid box
+                 pft = jules50_struc(n)%jules50(t)%pft
+                 LIS_snow_struc(n)%snowdepth(gid) = &
+                      LIS_snow_struc(n)%snowdepth(gid) + &
+                      jules50_struc(n)%jules50(t)%snowdepth(pft)
+                 ncount(gid) = ncount(gid) + 1
+
+                 ! Store SWE by tile
+                 tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id
+                 LIS_snow_struc(n)%sneqv(tid) = &
+                      LIS_snow_struc(n)%sneqv(tid) + &
+                      jules50_struc(n)%jules50(t)%snow_mass_ij
+
+              end if
+           end do ! k
+        end do ! Open do loop
+     end do ! m
+
+     ! Normalize the snow depth
+     do t = 1, LIS_rc%ngrid(n)
+        if (ncount(t) .gt. 0) then
+           LIS_snow_struc(n)%snowdepth(t) = &
+                LIS_snow_struc(n)%snowdepth(t) / ncount(t)
+        else
+          LIS_snow_struc(n)%snowdepth(t) = 0.0
+        endif
+     end do
+  end if
+
 end subroutine jules50_setusafsivars
 

--- a/lis/surfacemodels/land/jules.5.0/da_usafsi/jules50_setusafsivars.F90
+++ b/lis/surfacemodels/land/jules.5.0/da_usafsi/jules50_setusafsivars.F90
@@ -103,51 +103,6 @@ subroutine jules50_setusafsivars(n, LSM_State)
         endif
      end do
 
-     ! ! Logic below follows jules50_main
-     ! do m = 1, LIS_rc%nensem(n)
-     !    k = 1
-     !    do
-     !       if ( k > LIS_rc%npatch(n, LIS_rc%lsm_index) ) then
-     !          exit
-     !       end if
-
-     !       ! Find all tiles in current grid
-     !       gid = LIS_surface(n, LIS_rc%lsm_index)%tile(k)%index
-     !       start_k = k
-     !       end_k = jules50_struc(n)%jules50(start_k)%end_k
-     !       k = end_k + 1
-
-     !       do t = start_k, end_k
-     !          if ( LIS_surface(n, LIS_rc%lsm_index)%tile(t)%ensem == m ) then
-
-     !             ! Store mean snow depth per grid box
-     !             pft = jules50_struc(n)%jules50(t)%pft
-     !             LIS_snow_struc(n)%snowdepth(gid) = &
-     !                  LIS_snow_struc(n)%snowdepth(gid) + &
-     !                  jules50_struc(n)%jules50(t)%snowdepth(pft)
-     !             ncount(gid) = ncount(gid) + 1
-
-     !             ! Store SWE by tile
-     !             tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id
-     !             LIS_snow_struc(n)%sneqv(tid) = &
-     !                  LIS_snow_struc(n)%sneqv(tid) + &
-     !                  jules50_struc(n)%jules50(t)%snow_mass_ij
-
-     !          end if
-     !       end do ! k
-     !    end do ! Open do loop
-     ! end do ! m
-
-     ! ! Normalize the snow depth
-     ! do t = 1, LIS_rc%ngrid(n)
-     !    if (ncount(t) .gt. 0) then
-     !       LIS_snow_struc(n)%snowdepth(t) = &
-     !            LIS_snow_struc(n)%snowdepth(t) / ncount(t)
-     !    else
-     !      LIS_snow_struc(n)%snowdepth(t) = 0.0
-     !    endif
-     ! end do
-
   end if
 
 end subroutine jules50_setusafsivars

--- a/lis/surfacemodels/land/jules.5.0/da_usafsi/jules50_setusafsivars.F90
+++ b/lis/surfacemodels/land/jules.5.0/da_usafsi/jules50_setusafsivars.F90
@@ -73,55 +73,81 @@ subroutine jules50_setusafsivars(n, LSM_State)
 
   enddo
 
-    if (LIS_rc%snowsrc(n) .gt. 0) then
+  if (LIS_rc%snowsrc(n) .gt. 0) then
      ncount = 0 ! Tiles per grid id (land only)
      LIS_snow_struc(n)%snowdepth = 0.0 ! Mean snow depth by grid id
      LIS_snow_struc(n)%sneqv = 0.0     ! SWE by tile
 
-     ! Logic below follows jules50_main
-     do m = 1, LIS_rc%nensem(n)
-        k = 1
-        do
-           if ( k > LIS_rc%npatch(n, LIS_rc%lsm_index) ) then
-              exit
-           end if
+     ! Store SWE by tile
+     do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+        tid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%tile_id
+        LIS_snow_struc(n)%sneqv(tid) = LIS_snow_struc(n)%sneqv(tid) + &
+             jules50_struc(n)%jules50(t)%snow_mass_ij
+     end do
 
-           ! Find all tiles in current grid
-           gid = LIS_surface(n, LIS_rc%lsm_index)%tile(k)%index
-           start_k = k
-           end_k = jules50_struc(n)%jules50(start_k)%end_k
-           k = end_k + 1
-
-           do t = start_k, end_k
-              if ( LIS_surface(n, LIS_rc%lsm_index)%tile(t)%ensem == m ) then
-
-                 ! Store mean snow depth per grid box
-                 pft = jules50_struc(n)%jules50(t)%pft
-                 LIS_snow_struc(n)%snowdepth(gid) = &
-                      LIS_snow_struc(n)%snowdepth(gid) + &
-                      jules50_struc(n)%jules50(t)%snowdepth(pft)
-                 ncount(gid) = ncount(gid) + 1
-
-                 ! Store SWE by tile
-                 tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id
-                 LIS_snow_struc(n)%sneqv(tid) = &
-                      LIS_snow_struc(n)%sneqv(tid) + &
-                      jules50_struc(n)%jules50(t)%snow_mass_ij
-
-              end if
-           end do ! k
-        end do ! Open do loop
-     end do ! m
-
-     ! Normalize the snow depth
+     ! Store mean snow depth per grid box
+     do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+        pft = jules50_struc(n)%jules50(t)%pft
+        gid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%index
+        LIS_snow_struc(n)%snowdepth(gid) = &
+             LIS_snow_struc(n)%snowdepth(gid) + &
+             jules50_struc(n)%jules50(t)%snowdepth(pft)
+        ncount(gid) = ncount(gid) + 1
+     end do
      do t = 1, LIS_rc%ngrid(n)
         if (ncount(t) .gt. 0) then
            LIS_snow_struc(n)%snowdepth(t) = &
                 LIS_snow_struc(n)%snowdepth(t) / ncount(t)
         else
-          LIS_snow_struc(n)%snowdepth(t) = 0.0
+           LIS_snow_struc(n)%snowdepth(t) = 0.0
         endif
      end do
+
+     ! ! Logic below follows jules50_main
+     ! do m = 1, LIS_rc%nensem(n)
+     !    k = 1
+     !    do
+     !       if ( k > LIS_rc%npatch(n, LIS_rc%lsm_index) ) then
+     !          exit
+     !       end if
+
+     !       ! Find all tiles in current grid
+     !       gid = LIS_surface(n, LIS_rc%lsm_index)%tile(k)%index
+     !       start_k = k
+     !       end_k = jules50_struc(n)%jules50(start_k)%end_k
+     !       k = end_k + 1
+
+     !       do t = start_k, end_k
+     !          if ( LIS_surface(n, LIS_rc%lsm_index)%tile(t)%ensem == m ) then
+
+     !             ! Store mean snow depth per grid box
+     !             pft = jules50_struc(n)%jules50(t)%pft
+     !             LIS_snow_struc(n)%snowdepth(gid) = &
+     !                  LIS_snow_struc(n)%snowdepth(gid) + &
+     !                  jules50_struc(n)%jules50(t)%snowdepth(pft)
+     !             ncount(gid) = ncount(gid) + 1
+
+     !             ! Store SWE by tile
+     !             tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id
+     !             LIS_snow_struc(n)%sneqv(tid) = &
+     !                  LIS_snow_struc(n)%sneqv(tid) + &
+     !                  jules50_struc(n)%jules50(t)%snow_mass_ij
+
+     !          end if
+     !       end do ! k
+     !    end do ! Open do loop
+     ! end do ! m
+
+     ! ! Normalize the snow depth
+     ! do t = 1, LIS_rc%ngrid(n)
+     !    if (ncount(t) .gt. 0) then
+     !       LIS_snow_struc(n)%snowdepth(t) = &
+     !            LIS_snow_struc(n)%snowdepth(t) / ncount(t)
+     !    else
+     !      LIS_snow_struc(n)%snowdepth(t) = 0.0
+     !    endif
+     ! end do
+
   end if
 
 end subroutine jules50_setusafsivars

--- a/lis/surfacemodels/land/jules.5.0/jules50_dynsetup.F90
+++ b/lis/surfacemodels/land/jules.5.0/jules50_dynsetup.F90
@@ -46,42 +46,22 @@ subroutine jules50_dynsetup(n)
      LIS_snow_struc(n)%snowdepth = 0.0 ! Snow depth by grid id
      LIS_snow_struc(n)%sneqv     = 0.0 ! SWE by tile
 
-     ! Logic below follows jules50_main
-     do m = 1, LIS_rc%nensem(n)
-        k = 1
-        do
-           if ( k > LIS_rc%npatch(n, LIS_rc%lsm_index) ) then
-              exit
-           end if
+     ! Store SWE by tile
+     do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+        tid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%tile_id
+        LIS_snow_struc(n)%sneqv(tid) = LIS_snow_struc(n)%sneqv(tid) + &
+             jules50_struc(n)%jules50(t)%snow_mass_ij
+     end do
 
-           ! Find all tiles in current grid
-           gid = LIS_surface(n, LIS_rc%lsm_index)%tile(k)%index
-           start_k = k
-           end_k = jules50_struc(n)%jules50(start_k)%end_k
-           k = end_k + 1
-
-           do t = start_k, end_k
-              if ( LIS_surface(n, LIS_rc%lsm_index)%tile(t)%ensem == m ) then
-
-                 ! Store mean snow depth per grid box
-                 pft = jules50_struc(n)%jules50(t)%pft
-                 LIS_snow_struc(n)%snowdepth(gid) = &
-                      LIS_snow_struc(n)%snowdepth(gid) + &
-                      jules50_struc(n)%jules50(t)%snowdepth(pft)
-                 ncount(gid) = ncount(gid) + 1
-
-                 ! Store SWE by tile
-                 tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id
-                 LIS_snow_struc(n)%sneqv(tid) = &
-                      LIS_snow_struc(n)%sneqv(tid) + &
-                      jules50_struc(n)%jules50(t)%snow_mass_ij
-
-              end if
-           end do ! k
-        end do ! Open do loop
-     end do ! m
-
-     ! Normalize the snow depth
+     ! Store mean snow depth per grid box
+     do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+        pft = jules50_struc(n)%jules50(t)%pft
+        gid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%index
+        LIS_snow_struc(n)%snowdepth(gid) = &
+             LIS_snow_struc(n)%snowdepth(gid) + &
+             jules50_struc(n)%jules50(t)%snowdepth(pft)
+        ncount(gid) = ncount(gid) + 1
+     end do
      do t = 1, LIS_rc%ngrid(n)
         if (ncount(t) .gt. 0) then
            LIS_snow_struc(n)%snowdepth(t) = &
@@ -90,6 +70,51 @@ subroutine jules50_dynsetup(n)
            LIS_snow_struc(n)%snowdepth(t) = 0.0
         endif
      end do
+
+     ! ! Logic below follows jules50_main
+     ! do m = 1, LIS_rc%nensem(n)
+     !    k = 1
+     !    do
+     !       if ( k > LIS_rc%npatch(n, LIS_rc%lsm_index) ) then
+     !          exit
+     !       end if
+
+     !       ! Find all tiles in current grid
+     !       gid = LIS_surface(n, LIS_rc%lsm_index)%tile(k)%index
+     !       start_k = k
+     !       end_k = jules50_struc(n)%jules50(start_k)%end_k
+     !       k = end_k + 1
+
+     !       do t = start_k, end_k
+     !          if ( LIS_surface(n, LIS_rc%lsm_index)%tile(t)%ensem == m ) then
+
+     !             ! Store mean snow depth per grid box
+     !             pft = jules50_struc(n)%jules50(t)%pft
+     !             LIS_snow_struc(n)%snowdepth(gid) = &
+     !                  LIS_snow_struc(n)%snowdepth(gid) + &
+     !                  jules50_struc(n)%jules50(t)%snowdepth(pft)
+     !             ncount(gid) = ncount(gid) + 1
+
+     !             ! Store SWE by tile
+     !             tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id
+     !             LIS_snow_struc(n)%sneqv(tid) = &
+     !                  LIS_snow_struc(n)%sneqv(tid) + &
+     !                  jules50_struc(n)%jules50(t)%snow_mass_ij
+
+     !          end if
+     !       end do ! k
+     !    end do ! Open do loop
+     ! end do ! m
+
+     ! ! Normalize the snow depth
+     ! do t = 1, LIS_rc%ngrid(n)
+     !    if (ncount(t) .gt. 0) then
+     !       LIS_snow_struc(n)%snowdepth(t) = &
+     !            LIS_snow_struc(n)%snowdepth(t) / ncount(t)
+     !    else
+     !       LIS_snow_struc(n)%snowdepth(t) = 0.0
+     !    endif
+     ! end do
 
   end if
 

--- a/lis/surfacemodels/land/jules.5.0/jules50_dynsetup.F90
+++ b/lis/surfacemodels/land/jules.5.0/jules50_dynsetup.F90
@@ -71,51 +71,6 @@ subroutine jules50_dynsetup(n)
         endif
      end do
 
-     ! ! Logic below follows jules50_main
-     ! do m = 1, LIS_rc%nensem(n)
-     !    k = 1
-     !    do
-     !       if ( k > LIS_rc%npatch(n, LIS_rc%lsm_index) ) then
-     !          exit
-     !       end if
-
-     !       ! Find all tiles in current grid
-     !       gid = LIS_surface(n, LIS_rc%lsm_index)%tile(k)%index
-     !       start_k = k
-     !       end_k = jules50_struc(n)%jules50(start_k)%end_k
-     !       k = end_k + 1
-
-     !       do t = start_k, end_k
-     !          if ( LIS_surface(n, LIS_rc%lsm_index)%tile(t)%ensem == m ) then
-
-     !             ! Store mean snow depth per grid box
-     !             pft = jules50_struc(n)%jules50(t)%pft
-     !             LIS_snow_struc(n)%snowdepth(gid) = &
-     !                  LIS_snow_struc(n)%snowdepth(gid) + &
-     !                  jules50_struc(n)%jules50(t)%snowdepth(pft)
-     !             ncount(gid) = ncount(gid) + 1
-
-     !             ! Store SWE by tile
-     !             tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id
-     !             LIS_snow_struc(n)%sneqv(tid) = &
-     !                  LIS_snow_struc(n)%sneqv(tid) + &
-     !                  jules50_struc(n)%jules50(t)%snow_mass_ij
-
-     !          end if
-     !       end do ! k
-     !    end do ! Open do loop
-     ! end do ! m
-
-     ! ! Normalize the snow depth
-     ! do t = 1, LIS_rc%ngrid(n)
-     !    if (ncount(t) .gt. 0) then
-     !       LIS_snow_struc(n)%snowdepth(t) = &
-     !            LIS_snow_struc(n)%snowdepth(t) / ncount(t)
-     !    else
-     !       LIS_snow_struc(n)%snowdepth(t) = 0.0
-     !    endif
-     ! end do
-
   end if
 
 end subroutine jules50_dynsetup


### PR DESCRIPTION
The AGRMET code retrieves snow depth and SWE stored in LIS_snow_struc (defined in lis/core/LIS_snowMod.F90).  However, this data was not actually copied into the structure by the JULES 5.0 interface (unlike Noah 3.9).  This patch set fixes that oversight.

LIS-JULES functional tests have been performed in AGRMET Ops mode w/o DA, w/ SNODEP DA, and w/ USAFSI DA.  Log output showed the snowDepthQC test in the precipitation analysis was seeing positive snow depth.  An additional hack (not included in this patch set) was to copy the LIS_snow_struc snow depth into the precipitation analysis array for output.  Visualization showed the snow depth values to be in the correct geographic locations, and to show expected variations between the no DA, SNODEP DA, and USAFSI DA cases.

Simulations were also performed with the code compiled with strict checks (-2).  No runtime errors were detected.

TODO:  Similar changes for NoahMP 4.0.1.  That will be a separate pull request.