### PR TITLE
Make NoahMP 4.0.1 snow depth and SWE available to AGRMET

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_dynsetup.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_dynsetup.F90
@@ -11,16 +11,18 @@
 !  by Shugong Wang for the NASA Land Information System Version 7. The initial 
 !  specification of the subroutine is defined by Sujay Kumar. 
 !   10/25/18: Shugong Wang, Zhuo Wang; initial implementation for LIS 7 and NoahMP401
+!   11 Nov 2020: Eric Kemp, added updates to LIS_snow_struc
 !
 ! !INTERFACE:
 subroutine NoahMP401_dynsetup(n)
 ! !USES:
-    use LIS_logMod, only     : LIS_logunit
     use LIS_coreMod, only    : LIS_rc, LIS_domain, LIS_surface
-    use LIS_timeMgrMod, only : LIS_date2time, LIS_tick
     use LIS_fileIOMod, only  : LIS_read_param
+    use LIS_logMod, only     : LIS_logunit
+    use LIS_snowMod, only    : LIS_snow_struc
+    use LIS_timeMgrMod, only : LIS_date2time, LIS_tick
     use NoahMP401_lsmMod, only : NOAHMP401_struc
-   !use any other modules 
+
 !
 ! !DESCRIPTION:
 !  This routine sets up the time-dependent variables in NoahMP401
@@ -28,7 +30,7 @@ subroutine NoahMP401_dynsetup(n)
 !EOP
     implicit none
     integer, intent(in) :: n
-    
+
     integer   :: tid
     integer   :: t, gid, change, local_hour
     integer   :: locdoy, locyr, locmo, locda, lochr, locmn, locss
@@ -36,8 +38,39 @@ subroutine NoahMP401_dynsetup(n)
     real      :: interp_fraction
     real      :: locgmt
     integer   :: col, row, ncount(LIS_rc%npatch(n, LIS_rc%lsm_index))
- 
+
+    if (LIS_rc%snowsrc(n) .gt. 0) then
+
+       ncount = 0 ! Number of tiles per grid id (over land)
+       LIS_snow_struc(n)%snowdepth = 0 ! At grid points
+       LIS_snow_struc(n)%sneqv = 0     ! At tiles
+
+       ! Collect SWE at tiles
+       do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+          tid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%tile_id
+          LIS_snow_struc(n)%sneqv(tid) = LIS_snow_struc(n)%sneqv(tid) + &
+               noahmp401_struc(n)%noahmp401(t)%sneqv
+       end do
+
+       ! Collect mean snow depth at grid points
+       do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+          gid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%index
+          LIS_snow_struc(n)%snowdepth(gid) = &
+               LIS_snow_struc(n)%snowdepth(gid) + &
+                noahmp401_struc(n)%noahmp401(t)%snowh
+          ncount(gid) = ncount(gid) + 1
+       end do
+       do t = 1, LIS_rc%ngrid(n)
+          if (ncount(t).gt.0) then
+             LIS_snow_struc(n)%snowdepth(t) = &
+                  LIS_snow_struc(n)%snowdepth(t) / ncount(t)
+          else
+             LIS_snow_struc(n)%snowdepth(t) = 0.0
+          endif
+       end do
+    end if
+
     !TODO: add code here if needed.
 end subroutine NoahMP401_dynsetup
- 
-! generate date/time string for reading time-dependent variables 
+
+! generate date/time string for reading time-dependent variables

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_dynsetup.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_dynsetup.F90
@@ -37,7 +37,7 @@ subroutine NoahMP401_dynsetup(n)
     real*8    :: loctime
     real      :: interp_fraction
     real      :: locgmt
-    integer   :: col, row, ncount(LIS_rc%npatch(n, LIS_rc%lsm_index))
+    integer   :: col, row, ncount(LIS_rc%grid(n))
 
     if (LIS_rc%snowsrc(n) .gt. 0) then
 

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_dynsetup.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_dynsetup.F90
@@ -37,7 +37,7 @@ subroutine NoahMP401_dynsetup(n)
     real*8    :: loctime
     real      :: interp_fraction
     real      :: locgmt
-    integer   :: col, row, ncount(LIS_rc%grid(n))
+    integer   :: col, row, ncount(LIS_rc%ngrid(n))
 
     if (LIS_rc%snowsrc(n) .gt. 0) then
 

--- a/lis/surfacemodels/land/noahmp.4.0.1/da_snodep/noahmp401_setsnodepvars.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/da_snodep/noahmp401_setsnodepvars.F90
@@ -19,28 +19,29 @@
 ! 21 Jul 2011: James Geiger; Modified for Noah 3.2
 ! 03 Oct 2018: Yeosang Yoon; Modified for NoahMP 3.6
 ! 14 Dec 2018: Yeosang Yoon; Modified for NoahMP 4.0.1
+! 10 Nov 2020: Eric Kemp; Added update to LIS_snow_struc
 !
 ! !INTERFACE:
 subroutine noahmp401_setsnodepvars(n, LSM_State)
 ! !USES:
   use ESMF
   use LIS_coreMod, only : LIS_rc, LIS_domain, LIS_surface
-  use LIS_snowMod, only : LIS_snow_struc
   use LIS_logMod, only : LIS_logunit, LIS_verify
+  use LIS_snowMod, only : LIS_snow_struc
   use noahmp401_lsmMod
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in)    :: n
   type(ESMF_State)       :: LSM_State
-! 
+!
 ! !DESCRIPTION:
-! 
+!
 !  This routine assigns the snow progognostic variables to noah's
-!  model space. The state vector consists of total SWE and snow depth. 
+!  model space. The state vector consists of total SWE and snow depth.
 !  This routine also updates other model prognostics (snice, snliq,
-!  snow thickness, snow temperature) based on the update. 
-! 
+!  snow thickness, snow temperature) based on the update.
+!
 !EOP
   type(ESMF_Field)       :: sweField
   type(ESMF_Field)       :: snodField
@@ -49,7 +50,9 @@ subroutine noahmp401_setsnodepvars(n, LSM_State)
   real                   :: dsneqv,dsnowh
   integer                :: t
   integer                :: status
-  
+  integer                :: ncount(LIS_rc%ngrid(n))
+  integer                :: tid, gid
+
   call ESMF_StateGet(LSM_State,"SWE",sweField,rc=status)
   call LIS_verify(status)
   call ESMF_StateGet(LSM_State,"Snowdepth",snodField,rc=status)
@@ -69,6 +72,38 @@ subroutine noahmp401_setsnodepvars(n, LSM_State)
      call noahmp401_snodep_update(n, t, dsneqv, dsnowh)
 
   enddo
+
+  if (LIS_rc%snowsrc(n) .gt. 0) then
+
+     ncount = 0 ! Number of tiles per grid id (over land)
+     LIS_snow_struc(n)%snowdepth = 0 ! At grid points
+     LIS_snow_struc(n)%sneqv = 0     ! At tiles
+
+     ! Collect SWE at tiles
+     do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+        tid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%tile_id
+        LIS_snow_struc(n)%sneqv(tid) = LIS_snow_struc(n)%sneqv(tid) + &
+             noahmp401_struc(n)%noahmp401(t)%sneqv
+     end do
+
+     ! Collect mean snow depth at grid points
+     do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+        gid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%index
+        LIS_snow_struc(n)%snowdepth(gid) = &
+             LIS_snow_struc(n)%snowdepth(gid) + &
+             noahmp401_struc(n)%noahmp401(t)%snowh
+        ncount(gid) = ncount(gid) + 1
+     end do
+     do t = 1, LIS_rc%ngrid(n)
+        if (ncount(t).gt.0) then
+           LIS_snow_struc(n)%snowdepth(t) = &
+                LIS_snow_struc(n)%snowdepth(t) / ncount(t)
+        else
+           LIS_snow_struc(n)%snowdepth(t) = 0.0
+        endif
+     end do
+  end if
+
 end subroutine noahmp401_setsnodepvars
 
 


### PR DESCRIPTION
The AGRMET code retrieves snow depth and SWE stored in LIS_snow_struc (defined in lis/core/LIS_snowMod.F90). However, this data was not actually copied into the structure by the NoahMP 4.0.1 interface (unlike Noah 3.9). This patch set fixes that oversight.

LIS-NoahMP functional tests have been performed in AGRMET Ops mode w/o DA, w/ SNODEP DA, and w/ USAFSI DA. Log output showed the snowDepthQC test in the precipitation analysis was seeing positive snow depth. An additional hack (not included in this patch set) was to copy the LIS_snow_struc snow depth into the precipitation analysis array for output. Visualization showed the snow depth values to be in the correct geographic locations, and to show expected variations between the no DA, SNODEP DA, and USAFSI DA cases.

Simulations were also performed with the code compiled with strict checks (-2). No runtime errors were detected.