### PR TITLE
Bug fix to snow depth/SWE copying to AGRMET from Noah 3.9 snow DA

### DIFF
--- a/lis/surfacemodels/land/noah.3.9/da_snodep/noah39_setsnodepvars.F90
+++ b/lis/surfacemodels/land/noah.3.9/da_snodep/noah39_setsnodepvars.F90
@@ -15,7 +15,7 @@
 !  02 Mar 2010: Sujay Kumar; Modified for Noah 3.1
 !  21 Jul 2011: James Geiger; Modified for Noah 3.2
 !  16 Apr 2019: Eric Kemp; Modified for Noah 3.9
-!
+!  16 Nov 2020: Eric Kemp; Added check for LIS_rc%snowsrc(n), and reformatted.
 ! !INTERFACE:
 subroutine noah39_setsnodepvars(n, LSM_State)
 ! !USES:
@@ -26,14 +26,14 @@ subroutine noah39_setsnodepvars(n, LSM_State)
   use noah39_lsmMod
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in)    :: n
-! 
+!
 ! !DESCRIPTION:
-! 
+!
 !  This routine assigns the snow progognostic variables to noah's
-!  model space. 
-! 
+!  model space.
+!
 !EOP
   type(ESMF_State)       :: LSM_State
   type(ESMF_Field)       :: sweField
@@ -41,57 +41,58 @@ subroutine noah39_setsnodepvars(n, LSM_State)
   real, pointer          :: swe(:)
   real, pointer          :: snod(:)
   real                   :: npts(LIS_rc%ngrid(n))
-  integer                :: t,tid,gid
-  integer                :: status 
+  integer                :: t, tid, gid
+  integer                :: status
 
-  call ESMF_StateGet(LSM_State,"SWE",sweField,rc=status)
+  call ESMF_StateGet(LSM_State, "SWE", sweField, rc=status)
   call LIS_verify(status)
-  call ESMF_StateGet(LSM_State,"Snowdepth",snodField,rc=status)
-  call LIS_verify(status)
-
-  call ESMF_FieldGet(sweField,localDE=0,farrayPtr=swe,rc=status)
-  call LIS_verify(status)
-  call ESMF_FieldGet(snodField,localDE=0,farrayPtr=snod,rc=status)
+  call ESMF_StateGet(LSM_State, "Snowdepth", snodField, rc=status)
   call LIS_verify(status)
 
-  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+  call ESMF_FieldGet(sweField, localDE=0, farrayPtr=swe, rc=status)
+  call LIS_verify(status)
+  call ESMF_FieldGet(snodField, localDE=0, farrayPtr=snod, rc=status)
+  call LIS_verify(status)
+
+  do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
     if (noah39_struc(n)%noah(t)%t1 >= 273.15+2.0) then    ! Yeosang Yoon
-       if(snod(t) <= 1.e-6 .or. swe(t) <= 1.E-3) THEN
+       if (snod(t) <= 1.e-6 .or. swe(t) <= 1.E-3) THEN
           snod(t) = 0.0
           swe(t) = 0.0
        end if
-    endif
-  enddo
+    end if
+  end do
 
-  LIS_snow_struc(n)%sneqv = 0.0
-  LIS_snow_struc(n)%snowdepth = 0.0
-  npts = 0 
+  if (LIS_rc%snowsrc(n) .gt. 0) then
+     LIS_snow_struc(n)%sneqv = 0.0
+     LIS_snow_struc(n)%snowdepth = 0.0
+     npts = 0
 
-  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
-     !transform t to the patch
-     tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id 
-     noah39_struc(n)%noah(t)%sneqv = swe(t)
-     
-     LIS_snow_struc(n)%sneqv(tid) = LIS_snow_struc(n)%sneqv(tid) + swe(t)
-  enddo
-  npts = 0 
-  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
-     !transform t to the patch
-     tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id 
-     gid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%index
-     noah39_struc(n)%noah(t)%snowh = snod(t)
-     npts(gid) = npts(gid) + 1
-     LIS_snow_struc(n)%snowdepth(gid) = &
-          LIS_snow_struc(n)%snowdepth(gid)+snod(t)
-  enddo
+     do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+        !transform t to the patch
+        tid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%tile_id
+        noah39_struc(n)%noah(t)%sneqv = swe(t)
+        LIS_snow_struc(n)%sneqv(tid) = LIS_snow_struc(n)%sneqv(tid) + swe(t)
+     end do
+     npts = 0
+     do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+        !transform t to the patch
+        tid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%tile_id
+        gid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%index
+        noah39_struc(n)%noah(t)%snowh = snod(t)
+        npts(gid) = npts(gid) + 1
+        LIS_snow_struc(n)%snowdepth(gid) = &
+             LIS_snow_struc(n)%snowdepth(gid)+snod(t)
+     end do
 
-  do t=1,LIS_rc%ngrid(n)
-     if(npts(t).gt.0) then 
-        LIS_snow_struc(n)%snowdepth(t) = LIS_snow_struc(n)%snowdepth(t)/npts(t)
-     else
-        LIS_snow_struc(n)%snowdepth(t) = 0.0
-     endif
-  enddo
-  
+     do t = 1, LIS_rc%ngrid(n)
+        if (npts(t) .gt. 0) then
+           LIS_snow_struc(n)%snowdepth(t) = &
+                LIS_snow_struc(n)%snowdepth(t) / npts(t)
+        else
+           LIS_snow_struc(n)%snowdepth(t) = 0.0
+        end if
+     end do
+  end if
 end subroutine noah39_setsnodepvars
 

--- a/lis/surfacemodels/land/noah.3.9/da_usafsi/noah39_setusafsivars.F90
+++ b/lis/surfacemodels/land/noah.3.9/da_usafsi/noah39_setusafsivars.F90
@@ -16,26 +16,26 @@
 !  21 Jul 2011: James Geiger; Modified for Noah 3.2
 !  09 Apr 2019: Eric Kemp; Modified for Noah 3.9 and LDT-SI
 !  13 Dec 2019: Eric Kemp; Replaced LDTSI with USAFSI
-
+!  16 Nov 2020: Eric Kemp; Added check to LIS_rc%snowsrc(n), and reformatted
 !
 ! !INTERFACE:
 subroutine noah39_setusafsivars(n, LSM_State)
 ! !USES:
   use ESMF
   use LIS_coreMod, only : LIS_rc, LIS_surface
-  use LIS_snowMod, only : LIS_snow_struc
   use LIS_logMod, only : LIS_verify
+  use LIS_snowMod, only : LIS_snow_struc
   use noah39_lsmMod
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in)    :: n
-! 
+!
 ! !DESCRIPTION:
-! 
+!
 !  This routine assigns the snow progognostic variables to noah's
-!  model space. 
-! 
+!  model space.
+!
 !EOP
   type(ESMF_State)       :: LSM_State
   type(ESMF_Field)       :: sweField
@@ -43,59 +43,58 @@ subroutine noah39_setusafsivars(n, LSM_State)
   real, pointer          :: swe(:)
   real, pointer          :: snod(:)
   real                   :: npts(LIS_rc%ngrid(n))
-  integer                :: t,tid,gid
-  integer                :: status 
+  integer                :: t, tid, gid
+  integer                :: status
 
-  call ESMF_StateGet(LSM_State,"SWE",sweField,rc=status)
+  call ESMF_StateGet(LSM_State, "SWE", sweField, rc=status)
   call LIS_verify(status)
-  call ESMF_StateGet(LSM_State,"Snowdepth",snodField,rc=status)
-  call LIS_verify(status)
-
-  call ESMF_FieldGet(sweField,localDE=0,farrayPtr=swe,rc=status)
-  call LIS_verify(status)
-  call ESMF_FieldGet(snodField,localDE=0,farrayPtr=snod,rc=status)
+  call ESMF_StateGet(LSM_State, "Snowdepth", snodField, rc=status)
   call LIS_verify(status)
 
-  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
-    if (noah39_struc(n)%noah(t)%t1>=273.15+2.0) then    ! Yeosang Yoon
-       if(snod(t) <= 1.e-6 .or. swe(t) <= 1.E-3) THEN
+  call ESMF_FieldGet(sweField, localDE=0, farrayPtr=swe, rc=status)
+  call LIS_verify(status)
+  call ESMF_FieldGet(snodField, localDE=0, farrayPtr=snod, rc=status)
+  call LIS_verify(status)
+
+  do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+    if (noah39_struc(n)%noah(t)%t1 >= 273.15+2.0) then    ! Yeosang Yoon
+       if (snod(t) <= 1.e-6 .or. swe(t) <= 1.E-3) THEN
           snod(t) = 0.0
           swe(t) = 0.0
        end if
-    endif
-  enddo
+    end if
+  end do
 
-  LIS_snow_struc(n)%sneqv = 0.0
-  LIS_snow_struc(n)%snowdepth = 0.0
-  npts = 0 
+  if (LIS_rc%snowsrc(n) .gt. 0) then
+     LIS_snow_struc(n)%sneqv = 0.0
+     LIS_snow_struc(n)%snowdepth = 0.0
+     npts = 0
 
-  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
-     !transform t to the patch
-     tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id 
-     noah39_struc(n)%noah(t)%sneqv = swe(t)
-     
-     LIS_snow_struc(n)%sneqv(tid)   = LIS_snow_struc(n)%sneqv(tid)+swe(t)
-  enddo
-  npts = 0 
-  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
-     !transform t to the patch
-     tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id 
-     gid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%index
-     noah39_struc(n)%noah(t)%snowh = snod(t)
-     npts(gid) = npts(gid) + 1
-     LIS_snow_struc(n)%snowdepth(gid) = &
-          LIS_snow_struc(n)%snowdepth(gid)+snod(t)
+     do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+        !transform t to the patch
+        tid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%tile_id
+        noah39_struc(n)%noah(t)%sneqv = swe(t)
+        LIS_snow_struc(n)%sneqv(tid) = LIS_snow_struc(n)%sneqv(tid) + swe(t)
+     end do
+     npts = 0
+     do t = 1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+        !transform t to the patch
+        tid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%tile_id
+        gid = LIS_surface(n, LIS_rc%lsm_index)%tile(t)%index
+        noah39_struc(n)%noah(t)%snowh = snod(t)
+        npts(gid) = npts(gid) + 1
+        LIS_snow_struc(n)%snowdepth(gid) = &
+             LIS_snow_struc(n)%snowdepth(gid) + snod(t)
+     end do
 
-  enddo
-
-  do t=1,LIS_rc%ngrid(n)
-     if(npts(t).gt.0) then 
-        LIS_snow_struc(n)%snowdepth(t) = LIS_snow_struc(n)%snowdepth(t)/npts(t)
-     else
-        LIS_snow_struc(n)%snowdepth(t) = 0.0
-     endif
-
-  enddo
-  
+     do t = 1, LIS_rc%ngrid(n)
+        if (npts(t) .gt. 0) then
+           LIS_snow_struc(n)%snowdepth(t) = &
+                LIS_snow_struc(n)%snowdepth(t) / npts(t)
+        else
+           LIS_snow_struc(n)%snowdepth(t) = 0.0
+        end if
+     end do
+  end if
 end subroutine noah39_setusafsivars
 


### PR DESCRIPTION
The AGRMET code retrieves snow depth and SWE stored in LIS_snow_struc (defined in lis/core/LIS_snowMod.F90). While the data are copied by the existing Noah 3.9 interface, the relevant code in da_snodep and da_usafsi do not check if the arrays are allocated. This pull request fixes the error.

NOTE:  Similar bugs exist with earlier Noah versions, but I will handle this in a separate pull request that (probably) targets the master branch, rather than support/lisf-557ww-7.3.
