### PR TITLE
Add public testcase URL to LIS User's Guide.

### DIFF
--- a/docs/LIS_users_guide/LIS_usersguide.adoc
+++ b/docs/LIS_users_guide/LIS_usersguide.adoc
@@ -11,6 +11,7 @@
 :devonly!:
 :lisrevision: 7.3
 :lisurl: http://lis.gsfc.nasa.gov
+:listesturl: https://lis.gsfc.nasa.gov/tests/lis
 :svnurl: http://subversion.apache.org
 :nasalisf: https://github.com/NASA-LIS/LISF
 :githuburl: https://github.com


### PR DESCRIPTION
Fixes a broken link in section 7.1.

The URL was added in #203, but disappeared a few commits afterwards and the commits that added/removed it do not appear in the file's [revision history](https://github.com/NASA-LIS/LISF/commits/a217196430b1b472ba0e5d918597543b7574a1c0/docs/LIS_users_guide/LIS_usersguide.adoc).