### PR TITLE
Added ability to read WWMCA GRIB1 files instead of binary

### DIFF
--- a/lis/configs/557WW-7.3-FOC/for_discover/lis.config.global.jules50.discover
+++ b/lis/configs/557WW-7.3-FOC/for_discover/lis.config.global.jules50.discover
@@ -327,6 +327,8 @@ AGRMET GFS SPD10M station observation error variance:                2.48
 # 20071101 to 2012032700, use NONE from 2012032700 to 2012040912,
 # use WWMCA beginning 2012040912.
 AGRMET cloud data directory:               WWMCA           # WWMCA_LE, NONE, or WWMCA
+# Use WWMCA GRIB1 files beginning 12Z 4 Jul 2020
+AGRMET WWMCA GRIB1 read option: 1
 AGRMET snow distribution shape parameter:  2.6
 
 # Legacy AGRMET settings.  Eventually these will be removed,

--- a/lis/configs/557WW-7.3-FOC/for_discover/lis.config.global.noah39.discover
+++ b/lis/configs/557WW-7.3-FOC/for_discover/lis.config.global.noah39.discover
@@ -327,6 +327,8 @@ AGRMET GFS SPD10M station observation error variance:                2.48
 # 20071101 to 2012032700, use NONE from 2012032700 to 2012040912,
 # use WWMCA beginning 2012040912.
 AGRMET cloud data directory:               WWMCA           # WWMCA_LE, NONE, or WWMCA
+# Use WWMCA GRIB1 files beginning 12Z 4 Jul 2020
+AGRMET WWMCA GRIB1 read option: 1
 AGRMET snow distribution shape parameter:  2.6
 
 # Legacy AGRMET settings.  Eventually these will be removed,

--- a/lis/configs/557WW-7.3-FOC/for_discover/lis.config.global.noahmp401.discover
+++ b/lis/configs/557WW-7.3-FOC/for_discover/lis.config.global.noahmp401.discover
@@ -327,6 +327,8 @@ AGRMET GFS SPD10M station observation error variance:                2.48
 # 20071101 to 2012032700, use NONE from 2012032700 to 2012040912,
 # use WWMCA beginning 2012040912.
 AGRMET cloud data directory:               WWMCA           # WWMCA_LE, NONE, or WWMCA
+# Use WWMCA GRIB1 files beginning 12Z 4 Jul 2020
+AGRMET WWMCA GRIB1 read option: 1
 AGRMET snow distribution shape parameter:  2.6
 
 # Legacy AGRMET settings.  Eventually these will be removed,

--- a/lis/configs/557WW-7.3-FOC/lis.config.global.jules50.ops
+++ b/lis/configs/557WW-7.3-FOC/lis.config.global.jules50.ops
@@ -330,6 +330,8 @@ AGRMET GFS SPD10M station observation error variance:                2.48
 # 20071101 to 2012032700, use NONE from 2012032700 to 2012040912,
 # use WWMCA beginning 2012040912.
 AGRMET cloud data directory:               WWMCA           # WWMCA_LE, NONE, or WWMCA
+# Use WWMCA GRIB1 files beginning 12Z 4 Jul 2020
+AGRMET WWMCA GRIB1 read option: 1
 AGRMET snow distribution shape parameter:  2.6
 
 # Legacy AGRMET settings.  Eventually these will be removed,

--- a/lis/configs/557WW-7.3-FOC/lis.config.global.jules50.ops.galwem10
+++ b/lis/configs/557WW-7.3-FOC/lis.config.global.jules50.ops.galwem10
@@ -330,7 +330,10 @@ AGRMET GFS SPD10M station observation error variance:                2.48
 # 20071101 to 2012032700, use NONE from 2012032700 to 2012040912,
 # use WWMCA beginning 2012040912.
 AGRMET cloud data directory:               WWMCA           # WWMCA_LE, NONE, or WWMCA
+# Use WWMCA GRIB1 files beginning 12Z 4 Jul 2020
+AGRMET WWMCA GRIB1 read option: 1
 AGRMET snow distribution shape parameter:  2.6
+
 
 # Legacy AGRMET settings.  Eventually these will be removed,
 # but for now keep these settings.

--- a/lis/configs/557WW-7.3-FOC/lis.config.global.jules50.retrospective
+++ b/lis/configs/557WW-7.3-FOC/lis.config.global.jules50.retrospective
@@ -327,6 +327,8 @@ AGRMET GFS SPD10M station observation error variance:                2.48
 # 20071101 to 2012032700, use NONE from 2012032700 to 2012040912,
 # use WWMCA beginning 2012040912.
 AGRMET cloud data directory:               WWMCA           # WWMCA_LE, NONE, or WWMCA
+# Use WWMCA GRIB1 files beginning 12Z 4 Jul 2020
+AGRMET WWMCA GRIB1 read option: 1
 AGRMET snow distribution shape parameter:  2.6
 
 # Legacy AGRMET settings.  Eventually these will be removed,

--- a/lis/configs/557WW-7.3-FOC/lis.config.global.noah39.ops
+++ b/lis/configs/557WW-7.3-FOC/lis.config.global.noah39.ops
@@ -330,6 +330,8 @@ AGRMET GFS SPD10M station observation error variance:                2.48
 # 20071101 to 2012032700, use NONE from 2012032700 to 2012040912,
 # use WWMCA beginning 2012040912.
 AGRMET cloud data directory:               WWMCA           # WWMCA_LE, NONE, or WWMCA
+# Use WWMCA GRIB1 files beginning 12Z 4 Jul 2020
+AGRMET WWMCA GRIB1 read option: 1
 AGRMET snow distribution shape parameter:  2.6
 
 # Legacy AGRMET settings.  Eventually these will be removed,

--- a/lis/configs/557WW-7.3-FOC/lis.config.global.noah39.ops.galwem10
+++ b/lis/configs/557WW-7.3-FOC/lis.config.global.noah39.ops.galwem10
@@ -330,6 +330,8 @@ AGRMET GFS SPD10M station observation error variance:                2.48
 # 20071101 to 2012032700, use NONE from 2012032700 to 2012040912,
 # use WWMCA beginning 2012040912.
 AGRMET cloud data directory:               WWMCA           # WWMCA_LE, NONE, or WWMCA
+# Use WWMCA GRIB1 files beginning 12Z 4 Jul 2020
+AGRMET WWMCA GRIB1 read option: 1
 AGRMET snow distribution shape parameter:  2.6
 
 # Legacy AGRMET settings.  Eventually these will be removed,

--- a/lis/configs/557WW-7.3-FOC/lis.config.global.noah39.retrospective
+++ b/lis/configs/557WW-7.3-FOC/lis.config.global.noah39.retrospective
@@ -327,6 +327,8 @@ AGRMET GFS SPD10M station observation error variance:                2.48
 # 20071101 to 2012032700, use NONE from 2012032700 to 2012040912,
 # use WWMCA beginning 2012040912.
 AGRMET cloud data directory:               WWMCA           # WWMCA_LE, NONE, or WWMCA
+# Use WWMCA GRIB1 files beginning 12Z 4 Jul 2020
+AGRMET WWMCA GRIB1 read option: 1
 AGRMET snow distribution shape parameter:  2.6
 
 # Legacy AGRMET settings.  Eventually these will be removed,

--- a/lis/configs/557WW-7.3-FOC/lis.config.global.noahmp401.ops
+++ b/lis/configs/557WW-7.3-FOC/lis.config.global.noahmp401.ops
@@ -330,6 +330,8 @@ AGRMET GFS SPD10M station observation error variance:                2.48
 # 20071101 to 2012032700, use NONE from 2012032700 to 2012040912,
 # use WWMCA beginning 2012040912.
 AGRMET cloud data directory:               WWMCA           # WWMCA_LE, NONE, or WWMCA
+# Use WWMCA GRIB1 files beginning 12Z 4 Jul 2020
+AGRMET WWMCA GRIB1 read option: 1
 AGRMET snow distribution shape parameter:  2.6
 
 # Legacy AGRMET settings.  Eventually these will be removed,

--- a/lis/configs/557WW-7.3-FOC/lis.config.global.noahmp401.ops.galwem10
+++ b/lis/configs/557WW-7.3-FOC/lis.config.global.noahmp401.ops.galwem10
@@ -330,6 +330,8 @@ AGRMET GFS SPD10M station observation error variance:                2.48
 # 20071101 to 2012032700, use NONE from 2012032700 to 2012040912,
 # use WWMCA beginning 2012040912.
 AGRMET cloud data directory:               WWMCA           # WWMCA_LE, NONE, or WWMCA
+# Use WWMCA GRIB1 files beginning 12Z 4 Jul 2020
+AGRMET WWMCA GRIB1 read option: 1
 AGRMET snow distribution shape parameter:  2.6
 
 # Legacy AGRMET settings.  Eventually these will be removed,

--- a/lis/configs/557WW-7.3-FOC/lis.config.global.noahmp401.retrospective
+++ b/lis/configs/557WW-7.3-FOC/lis.config.global.noahmp401.retrospective
@@ -327,6 +327,8 @@ AGRMET GFS SPD10M station observation error variance:                2.48
 # 20071101 to 2012032700, use NONE from 2012032700 to 2012040912,
 # use WWMCA beginning 2012040912.
 AGRMET cloud data directory:               WWMCA           # WWMCA_LE, NONE, or WWMCA
+# Use WWMCA GRIB1 files beginning 12Z 4 Jul 2020
+AGRMET WWMCA GRIB1 read option: 1
 AGRMET snow distribution shape parameter:  2.6
 
 # Legacy AGRMET settings.  Eventually these will be removed,

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -4923,6 +4923,11 @@ processed precip obs (__presav_*__).
 `AGRMET cloud data directory:` specifies the location of the
 WWMCA data (_WWMCA*_).
 
+`AGRMET WWMCA GRIB1 read option:` specifies whether to try reading
+WWMCA GRIB1 files, or try directly to read binary. (_0 = binary, 1 = GRIB1_).
+Note that if GRIB1 files cannot be found, the code will search for binary
+as a backup.
+
 `AGRMET GFS data directory:` specifies the location of the
 GFS data (_MT.avn*_).
 
@@ -5325,6 +5330,7 @@ AGRMET analysis directory:              ./Analysis
 AGRMET surface fields directory:        SFCALC
 AGRMET merged precip directory:         PRECIP
 AGRMET cloud data directory:            WWMCA
+AGRMET WWMCA GRIB1 read option:         0
 AGRMET GFS data directory:              GFS
 AGRMET GALWEM data directory:           GALWEM
 AGRMET SSMI data directory:             SSMI

--- a/lis/metforcing/usaf/AGRMET_forcingMod.F90
+++ b/lis/metforcing/usaf/AGRMET_forcingMod.F90
@@ -704,6 +704,10 @@ integer, allocatable   :: n112_sh4(:)
      integer :: oba_switch
      integer :: skip_backqc
      integer :: skip_superstatqc
+
+     ! EMK Add WWMCA GRIB1 option
+     integer :: read_wwmca_grib1
+     
   end type agrmet_type_dec
 
   type(agrmet_type_dec), allocatable :: agrmet_struc(:)

--- a/lis/metforcing/usaf/USAF_WWMCA_grib1Mod.F90
+++ b/lis/metforcing/usaf/USAF_WWMCA_grib1Mod.F90
@@ -1,0 +1,652 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center Land Information System (LIS) v7.0
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+
+#include "LIS_misc.h"
+
+!
+! MODULE: USAF_WWMCA_grib1Mod
+!
+! DESCRIPTION:
+! This module contains code for reading WWMCA cloud amounts, types, tops,
+! and time information from Air Force GRIB1 files, with data projected
+! on 16th mesh polar stereographic grids.
+!
+! REVISION HISTORY:
+! 23 Nov 2020: Eric Kemp, Initial specification.
+!
+
+module USAF_WWMCA_grib1Mod
+
+  ! Defaults
+  implicit none
+  private
+
+  ! Create structure to share internal routines
+  type :: wwmca_grib1_t
+     private
+     character(len=255) :: full_grib_path
+     integer :: nx
+     integer :: ny
+     integer :: nk
+     real, allocatable :: cldamt(:,:,:)
+     real, allocatable :: cldtyp(:,:,:)
+     real, allocatable :: cldtop(:,:,:)
+     real, allocatable :: pixtim(:,:)
+   contains
+     procedure :: new
+     procedure :: destroy
+     procedure :: read_grib
+     procedure :: return_binary_fields
+  end type wwmca_grib1_t
+
+  type(wwmca_grib1_t), public, protected :: wwmca_grib1
+
+  public :: USAF_wwmca_grib1_filename
+
+  ! Local constants for the 16th mesh WWMCA data
+  integer, parameter :: NX = 1024
+  integer, parameter :: NY = 1024
+  integer, parameter :: NZ = 4
+
+contains
+
+  ! Constructor
+  subroutine new(this, full_grib_path)
+
+    ! Defaults
+    implicit none
+
+    ! Arguments
+    class(wwmca_grib1_t), intent(inout) :: this
+    character(*), intent(in) :: full_grib_path
+
+    this%full_grib_path = trim(full_grib_path)
+    this%nx = NX
+    this%ny = NY
+    this%nk = NZ
+
+    allocate(this%cldamt(NX, NY, NZ))
+    this%cldamt = -9999
+
+    allocate(this%cldtyp(NX, NY, NZ))
+    this%cldtyp = -9999
+
+    allocate(this%cldtop(NX, NY, NZ))
+    this%cldtop = -9999
+
+    allocate(this%pixtim(NX, NY))
+    this%pixtim = -9999
+
+  end subroutine new
+
+  ! Destructor
+  subroutine destroy(this)
+    implicit none
+    class(wwmca_grib1_t), intent(inout) :: this
+    this%full_grib_path = "NULL"
+    deallocate(this%cldamt)
+    deallocate(this%cldtyp)
+    deallocate(this%cldtop)
+    deallocate(this%pixtim)
+  end subroutine destroy
+
+  ! Read the data from the GRIB file
+  subroutine read_grib(this, year, month, day, hour, rc)
+
+    ! Imports
+#if (defined USE_GRIBAPI)
+    use grib_api
+#endif
+    use LIS_logMod, only: LIS_logunit
+
+    ! Defaults
+    implicit none
+
+    ! Arguments
+    class(wwmca_grib1_t), intent(inout) :: this
+    integer, intent(in) :: year
+    integer, intent(in) :: month
+    integer, intent(in) :: day
+    integer, intent(in) :: hour
+    integer, intent(inout) :: rc
+
+    ! Locals
+    logical :: file_exists
+    integer :: ftn
+    integer :: nmsgs
+    real, allocatable :: dum1d(:)
+    integer :: counter
+    integer :: k
+    integer :: igrib
+    integer :: edition
+    integer :: grid
+    integer :: inx
+    integer :: iny
+    integer :: firstlat
+    integer :: firstlon
+    integer :: orient
+    integer :: dx
+    integer :: dy
+    integer :: res_component_flags
+    integer :: datadate
+    integer :: datatime
+    integer :: param
+    integer :: leveltype
+    integer :: level
+
+    ! See if file exists
+    inquire(file=trim(this%full_grib_path), exist=file_exists)
+    if (.not. file_exists) then
+       write(LIS_logunit)'[WARN] ', trim(this%full_grib_path), &
+            ' does not exist!'
+       rc = 1
+       return
+    end if
+
+#if (defined USE_GRIBAPI)
+
+    ! Open the file through GRIB_API
+    call grib_open_file(ftn, trim(this%full_grib_path), 'r', rc)
+    if (rc .ne. 0) then
+       write(LIS_logunit)'[WARN] Cannot open ', trim(this%full_grib_path)
+       rc = 1
+       return
+    end if
+
+    ! Check total number of messages in this file.
+    call grib_count_in_file(ftn, nmsgs, rc)
+    if (rc .ne. 0) then
+       write(LIS_logunit)'[WARN] Cannot count messages in ', &
+            trim(this%full_grib_path)
+       call grib_close_file(ftn)
+       rc = 1
+       return
+    end if
+
+    allocate(dum1d(NX*NY))
+    counter = 0
+
+    ! Loop through the GRIB file until all fields are found, or we reach
+    ! end of file
+    do k = 1, nmsgs
+
+       ! Find next message
+       call grib_new_from_file(ftn, igrib, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit)'[WARN] Cannot read from ', &
+               trim(this%full_grib_path)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+
+       ! Check edition number of this message
+       call grib_get(igrib, 'editionNumber', edition, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit)'[WARN] Cannot read editionNumber from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+       if (edition .ne. 1) then
+          write(LIS_logunit)'[WARN] Did not find GRIB1 message in ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          cycle
+       end if
+
+       ! Check the grid definition -- should be 16th mesh, either northern
+       ! or southern hemisphere
+       call grib_get(igrib, 'gridDefinition', grid, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit)'[WARN] Cannot read gridDefinition from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+       if (grid .ne. 212 .and. grid .ne. 213) then
+          write(LIS_logunit)'[WARN] Did not find 16th mesh data from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          cycle
+       end if
+
+       ! Check the nx dimension
+       call grib_get(igrib, 'Nx', inx, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit)'[WARN] Cannot read Nx from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+       if (inx .ne. NX) then
+          write(LIS_logunit)'[WARN] Found wrong Nx dimension in ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          cycle
+       end if
+
+       ! Check the ny dimension
+       call grib_get(igrib, 'Ny', iny, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit)'[WARN] Cannot read Ny from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+       if (iny .ne. NY) then
+          write(LIS_logunit)'[WARN] Found wrong Ny dimension in ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          cycle
+       end if
+
+       ! Check the first latitude
+       call grib_get(igrib, 'latitudeOfFirstGridPoint', firstlat, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit) &
+               '[WARN] Cannot read latitudeOfFirstGridPoint from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+       if (.not. (grid .eq. 212 .and. firstlat .eq. -20826) .and. &
+            .not. (grid .eq. 213 .and. firstlat .eq. 20826)) then
+          write(LIS_logunit) &
+               '[WARN] Found wrong latitudeOfFirstGridPoint in ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          cycle
+       end if
+
+       ! Check the first longitude
+       call grib_get(igrib, 'longitudeOfFirstGridPoint', firstlon, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit) &
+               '[WARN] Cannot read longitudeOfFirstGridPoint from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+       if (.not. (grid .eq. 212 .and. firstlon .eq. 145000) .and. &
+            .not. (grid .eq. 213 .and. firstlon .eq. -125000)) then
+          write(LIS_logunit) &
+               '[WARN] Found wrong longitudeOfFirstGridPoint in ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          cycle
+       end if
+
+       ! Check the grid orientation
+       call grib_get(igrib, 'orientationOfTheGrid', orient, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit) &
+               '[WARN] Cannot read orientationOfTheGrid from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+       if (orient .ne. 100000) then
+          write(LIS_logunit) &
+               '[WARN] Found wrong orientationOfTheGrid in ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          cycle
+       end if
+
+       ! Check the grid resolution
+       call grib_get(igrib, 'DxInMetres', dx, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit) &
+               '[WARN] Cannot read DxInMetres from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+       if (dx .ne. 23813) then
+          write(LIS_logunit) &
+               '[WARN] Found wrong DxInMetres in ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          cycle
+       end if
+
+       ! Check the grid resolution
+       call grib_get(igrib, 'DyInMetres', dy, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit) &
+               '[WARN] Cannot read DyInMetres from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+       if (dy .ne. 23813) then
+          write(LIS_logunit) &
+               '[WARN] Found wrong DyInMetres in ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          cycle
+       end if
+
+       ! Check the resolution and component flags
+       call grib_get(igrib, 'resolutionAndComponentFlags', &
+            res_component_flags, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit) &
+               '[WARN] Cannot read resolutionAndComponentFlags from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+       if (res_component_flags .ne. 128) then
+          write(LIS_logunit) &
+               '[WARN] Found wrong resolutionAndComponentFlags in ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          cycle
+       end if
+
+       ! Check the valid date
+       call grib_get(igrib, 'dataDate', datadate, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit) &
+               '[WARN] Cannot read dataDate from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+       if ((year*10000 + month*100 + day) .ne. datadate) then
+          write(LIS_logunit) &
+               '[WARN] Found wrong datadate in ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          cycle
+       end if
+
+       ! Check the valid time
+       call grib_get(igrib, 'dataTime', datatime, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit) &
+               '[WARN] Cannot read dataTime from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+       if ((hour*100) .ne. datatime) then
+          write(LIS_logunit) &
+               '[WARN] Found wrong datatime in ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          cycle
+       end if
+
+       ! At this point we are ready to check the parameter and level
+       ! information.
+       call grib_get(igrib, 'indicatorOfParameter', param, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit) &
+               '[WARN] Cannot read indicatorOfParameter from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+
+       call grib_get(igrib, 'indicatorOfTypeOfLevel', leveltype, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit) &
+               '[WARN] Cannot read indicatorOfTypeOfLevel from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+
+       call grib_get(igrib, 'level', level, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit) &
+               '[WARN] Cannot read level from ', &
+               trim(this%full_grib_path)
+          call grib_release(igrib, rc)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+
+       ! See if this field is desired
+       rc = 0
+       if (param .eq. 163 .and. leveltype .eq. 109 .and. &
+            level .gt. 0 .and. level .lt. 5) then
+          ! Cloud amount (%)
+          call fetch_values(this%full_grib_path, igrib, inx, iny, dum1d, &
+               this%cldamt(:, :, level), counter, rc)
+       else if (param .eq. 164 .and. leveltype .eq. 109 .and. &
+            level .gt. 0 .and. level .lt. 5) then
+          ! Cloud type [code]
+          call fetch_values(this%full_grib_path, igrib, inx, iny, dum1d, &
+               this%cldtyp(:, :, level), counter, rc)
+       else if (param .eq. 228 .and. leveltype .eq. 109 .and. &
+            level .gt. 0 .and. level .lt. 5) then
+          ! Cloud top (m)
+          call fetch_values(this%full_grib_path, igrib, inx, iny, dum1d, &
+               this%cldtop(:, :, level), counter, rc)
+       else if (param .eq. 183 .and. leveltype .eq. 200 .and. &
+            level .eq. 0) then
+          ! Time of last update from base time (min)
+          call fetch_values(this%full_grib_path, igrib, inx, iny, dum1d, &
+               this%pixtim, counter, rc)
+       end if
+
+       if (rc .ne. 0) then
+          write(LIS_logunit)'[WARN] Problem reading values in ', &
+               trim(this%full_grib_path)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+
+       ! Close the GRIB message
+       call grib_release(igrib, rc)
+       if (rc .ne. 0) then
+          write(LIS_logunit)'[WARN] Problem releasing message in ', &
+               trim(this%full_grib_path)
+          call grib_close_file(ftn)
+          deallocate(dum1d)
+          rc = 1
+          return
+       end if
+
+       ! We can stop reading if we found all the variables we need.
+       if (counter .gt. (3*NZ + 1)) exit
+
+    end do ! k
+
+    call grib_close_file(ftn)
+#endif
+
+    ! Print warning message if we found less than what we wanted.
+    if (counter .ne. (3*NZ + 1)) then
+       write(LIS_logunit) 'Missing WWMCA data in ', &
+            trim(this%full_grib_path)
+    end if
+
+    ! Clean up
+    deallocate(dum1d)
+
+  contains
+
+    ! Internal routine. Fetches value field from GRIB message.
+    subroutine fetch_values(full_grib_path, igrib, inx, iny, data1d, data2d, &
+         counter, rc)
+
+      ! Imports
+#if (defined USE_GRIBAPI)
+      use grib_api
+#endif
+      use LIS_logMod, only: LIS_logunit
+
+      ! Defaults
+      implicit none
+
+      ! Arguments
+      character(*), intent(in) :: full_grib_path
+      integer, intent(in) :: igrib
+      integer, intent(in) :: inx
+      integer, intent(in) :: iny
+      real, intent(inout) :: data1d(inx*iny)
+      real, intent(inout) :: data2d(inx, iny)
+      integer, intent(inout) :: counter
+      integer, intent(inout) :: rc
+
+      ! Locals
+      integer :: i
+      integer :: j
+
+#if (defined USE_GRIBAPI)
+
+      call grib_get(igrib, 'values', data1d, rc)
+      if (rc .ne. 0) then
+         write(LIS_logunit)'[WARN] Failed to read values from ', &
+              trim(full_grib_path)
+         rc = 1
+         return
+      end if
+
+      do j = 1, iny
+         do i = 1, inx
+            data2d(i, j) = data1d(1 + (j-1)*inx)
+         end do ! i
+      end do ! j
+
+      counter = counter + 1
+      rc = 0
+
+#endif
+    end subroutine fetch_values
+
+  end subroutine read_grib
+
+  ! Copy the WWMCA GRIB1 data into the legacy binary arrays.
+  subroutine return_binary_fields(this, amounts, types, tops, times)
+
+    ! Defaults
+    implicit none
+
+    ! Arguments
+    class(wwmca_grib1_t), intent(in) :: this
+    byte, intent(inout) :: amounts(4, 1024, 1024)
+    byte, intent(inout) :: types(4, 1024, 1024)
+    integer*2, intent(inout) :: tops(4, 1024, 1024)
+    integer*4, intent(inout) :: times(1024, 1024)
+
+    ! Locals
+    integer :: i, j, k
+
+    do k = 1, 4
+       do j = 1, 1024
+          do i = 1, 1024
+             amounts(k, i, j) = this%cldamt(i, j, k)
+          end do ! i
+       end do ! j
+    end do ! k
+
+    do k = 1, 4
+       do j = 1, 1024
+          do i = 1, 1024
+             types(k, i, j) = this%cldtyp(i, j, k)
+          end do ! i
+       end do ! j
+    end do ! k
+
+    do k = 1, 4
+       do j = 1, 1024
+          do i = 1, 1024
+             tops(k, i, j) = this%cldtop(i, j, k)
+          end do ! i
+       end do ! j
+    end do ! k
+
+    do j = 1, 1024
+       do i = 1, 1024
+          times(i, j) = this%pixtim(i, j)
+       end do ! j
+    end do ! i
+
+  end subroutine return_binary_fields
+
+  ! Constructs WWMCA GRIB1 filename, which contains all WWMCA fields.
+  subroutine USAF_wwmca_grib1_filename(fname, rootdir, dir, &
+       use_timestamp, hemi, yr, mo, da, hr)
+
+    ! Defaults
+    implicit none
+
+    ! Arguments
+    character(*), intent(inout) :: fname
+    character(*), intent(in) :: rootdir
+    character(*), intent(in) :: dir
+    integer, intent(in) :: use_timestamp
+    integer, intent(in) :: hemi
+    integer, intent(in) :: yr, mo, da, hr
+
+    ! Locals
+    character(2), parameter :: FHEMI(2) = (/'N_', 'S_'/)
+    character(10) :: ftime1, ftime2
+
+    write(unit=ftime2, fmt='(i4, i2.2, i2.2, i2.2)') yr, mo, da, hr
+
+    if (use_timestamp .eq. 1) then
+       write(unit=ftime1, fmt='(a1, i4, i2.2, i2.2, a1)') '/', yr, mo, da, '/'
+       fname = trim(rootdir) // ftime1 // trim(dir) // 'WWMCA_' // &
+            ftime2 // '_' // fhemi(hemi) // '_16_M.GR1'
+    else
+       fname = trim(rootdir) // trim(dir) // 'WWMCA_' // &
+            ftime2 // '_' // fhemi(hemi) // '_16_M.GR1'
+    end if
+  end subroutine USAF_wwmca_grib1_filename
+
+end module USAF_WWMCA_grib1Mod

--- a/lis/metforcing/usaf/compute_type_based_clouds.F90
+++ b/lis/metforcing/usaf/compute_type_based_clouds.F90
@@ -96,9 +96,9 @@ subroutine compute_type_based_clouds(n, cldamt_nh, cldamt_sh, cldamt, &
             call wwmca_grib1%destroy()
             try = 1
             do while (try .lt. 10)
-               write(LIS_logunit) &
+               write(LIS_logunit,*) &
                     '[WARN] Problem reading ', trim(filename)
-               write(LIS_logunit)'[WARN] shifting to previous hour'
+               write(LIS_logunit,*)'[WARN] shifting to previous hour'
                ts1 = -60*60
                call LIS_tick(backtime1, doy1, gmt1, yr1, mo1, da1, &
                     hr1, mn1, ss1, ts1)
@@ -124,8 +124,9 @@ subroutine compute_type_based_clouds(n, cldamt_nh, cldamt_sh, cldamt, &
             end do ! try loop
 
             if (try .ge. 10) then
-               write(LIS_logunit)'[WARN] Missing WWMCA GRIB1 file'
-               write(LIS_logunit)'[WARN] Will fall back on WWMCA binary files.'
+               write(LIS_logunit,*)'[WARN] Missing WWMCA GRIB1 file'
+               write(LIS_logunit,*) &
+                    '[WARN] Will fall back on WWMCA binary files.'
                exit
             end if
          end if
@@ -146,17 +147,36 @@ subroutine compute_type_based_clouds(n, cldamt_nh, cldamt_sh, cldamt, &
          ! Populate the legacy binary arrays.
          call wwmca_grib1%return_binary_fields(amounts, types, tops, times)
 
+         write(LIS_logunit,*)'EMK: maxval(amounts) = ', &
+              maxval(amounts)
+         write(LIS_logunit,*)'EMK: minval(amounts) = ', &
+              minval(amounts)
+         
          if (hemi .eq. 1) then
             call AGRMET_loadcloud(hemi, agrmet_struc(n)%land(:,:,hemi), &
                  thres, times, amounts, tops, types,   &
                  cldtyp_nh, cldamt_nh, fog_nh,                &
                  julhr, agrmet_struc(n)%imax, agrmet_struc(n)%jmax)
+
+            write(LIS_logunit,*)'EMK: maxval(cldamt_nh) = ', &
+                 maxval(cldamt_nh)
+            write(LIS_logunit,*)'EMK: minval(cldamt_nh) = ', &
+                 minval(cldamt_nh)
+
          else
             call AGRMET_loadcloud(hemi, agrmet_struc(n)%land(:,:,hemi), &
                  thres, times, amounts, tops, types,   &
                  cldtyp_sh, cldamt_sh, fog_sh,                &
                  julhr, agrmet_struc(n)%imax, agrmet_struc(n)%jmax)
+
+            write(LIS_logunit,*)'EMK: maxval(cldamt_sh) = ', &
+                 maxval(cldamt_sh)
+            write(LIS_logunit,*)'EMK: minval(cldamt_sh) = ', &
+                 minval(cldamt_sh)
+
          end if
+
+         call wwmca_grib1%destroy()
 
       end do ! hemi
 
@@ -416,6 +436,11 @@ subroutine compute_type_based_clouds(n, cldamt_nh, cldamt_sh, cldamt, &
    cldamt3(1,:,:) = real(cldamt_nh(3,:,:))
    cldamt3(2,:,:) = real(cldamt_sh(3,:,:))
 
+   write(LIS_logunit,*)'EMK: maxval(cldamt1(1,:,:)) = ', &
+        maxval(cldamt1(1,:,:))
+   write(LIS_logunit,*)'EMK: minval(cldamt1(1,:,:)) = ', &
+        minval(cldamt1(1,:,:))
+
    ip =1
    udef = -1.0
 
@@ -434,5 +459,7 @@ subroutine compute_type_based_clouds(n, cldamt_nh, cldamt_sh, cldamt, &
    deallocate(cldamt1)
    deallocate(cldamt2)
    deallocate(cldamt3)
+
+   call wwmca_grib1%destroy()
 
 end subroutine compute_type_based_clouds

--- a/lis/metforcing/usaf/compute_type_based_clouds.F90
+++ b/lis/metforcing/usaf/compute_type_based_clouds.F90
@@ -8,6 +8,7 @@
 !
 ! !REVISION HISTORY:
 ! 20 Apr 2016; James Geiger, Initial specification
+! 23 Nov 2020; Eric Kemp, added support for WWMCA GRIB1 files
 !
 ! !INTERFACE:
 subroutine compute_type_based_clouds(n, cldamt_nh, cldamt_sh, cldamt, &
@@ -17,6 +18,7 @@ subroutine compute_type_based_clouds(n, cldamt_nh, cldamt_sh, cldamt, &
    use LIS_logMod,        only : LIS_logunit
    use LIS_timeMgrMod,    only : LIS_get_julhr,LIS_tick,LIS_time2date
    use AGRMET_forcingMod, only : agrmet_struc
+   use USAF_WWMCA_grib1Mod, only: wwmca_grib1, usaf_wwmca_grib1_filename
 
    implicit none
 !  !ARGUMENTS:
@@ -49,7 +51,8 @@ subroutine compute_type_based_clouds(n, cldamt_nh, cldamt_sh, cldamt, &
    real,allocatable      :: cldamt1(:,:,:)
    real,allocatable      :: cldamt2(:,:,:)
    real,allocatable      :: cldamt3(:,:,:)
-
+   integer :: rc
+   
    data THRES /12600, 12300, 12000, 11700, 11400/
 
    allocate(amounts(4,1024,1024))
@@ -61,238 +64,350 @@ subroutine compute_type_based_clouds(n, cldamt_nh, cldamt_sh, cldamt, &
    allocate(cldamt2(2,agrmet_struc(n)%imax,agrmet_struc(n)%jmax))
    allocate(cldamt3(2,agrmet_struc(n)%imax,agrmet_struc(n)%jmax))
 
-   do hemi = 1,2
-      types   = 25
-      amounts = 0
-      tops    = 0
-      times   = 0
+   if (agrmet_struc(n)%read_wwmca_grib1 .eq. 1) then
+      do hemi = 1, 2
 
-      yr1 = LIS_rc%yr
-      mo1 = LIS_rc%mo
-      da1 = LIS_rc%da
-      hr1 = LIS_rc%hr
-      mn1 = LIS_rc%mn
-      ss1 = LIS_rc%ss
+         try = 0
 
-      call agrmet_cdfs_type_filename(filename,                      &
-                                     agrmet_struc(n)%agrmetdir,     &
-                                     agrmet_struc(n)%clouddir,      &
-                                     agrmet_struc(n)%use_timestamp, &
-                                     hemi, yr1, mo1, da1, hr1)
+         types   = 25
+         amounts = 0
+         tops    = 0
+         times   = 0
 
-      inquire (file=trim(filename), exist=file_exists)
-      if(file_exists) then
-         write(LIS_logunit,*)'[INFO] OPENING CDFS II DATA ', trim(filename)
-         open(8, file=trim(filename), access='direct', recl=1024*1024*4, &
-              status='old', iostat=istat)
-         read(8, rec=1, iostat=istat) types
-         close(8)
-      else !rolling back 1 hour at a time
-         try  = 1
-         do while(try.lt.10)
-            write(LIS_logunit,*) &
-               '[WARN] File missing, shifting to previous hour'
-            ts1 = -60*60
-            call LIS_tick(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
-            call LIS_time2date(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1)
-            call agrmet_cdfs_type_filename(filename,                      &
-                                           agrmet_struc(n)%agrmetdir,     &
-                                           agrmet_struc(n)%clouddir,      &
-                                           agrmet_struc(n)%use_timestamp, &
-                                           hemi, yr1, mo1, da1, hr1)
-            inquire (file=trim(filename), exist=file_exists)
-            if(file_exists) then
-               write(LIS_logunit,*)'[INFO] OPENING CDFS II DATA ',trim(filename)
-               open(8, file=trim(filename), access='direct', recl=1024*1024*4, &
-                    status='old', iostat=istat)
-               read(8, rec=1, iostat=istat) types
-               close(8)
-               exit;
-            else
-               try = try+1
+         yr1 = LIS_rc%yr
+         mo1 = LIS_rc%mo
+         da1 = LIS_rc%da
+         hr1 = LIS_rc%hr
+         mn1 = LIS_rc%mn
+         ss1 = LIS_rc%ss
+
+         call USAF_wwmca_grib1_filename(filename, &
+              agrmet_struc(n)%agrmetdir, &
+              agrmet_struc(n)%clouddir,  &
+              agrmet_struc(n)%use_timestamp, &
+              hemi, yr1, mo1, da1, hr1)
+
+         call wwmca_grib1%new(filename)
+
+         call wwmca_grib1%read_grib(yr1, mo1, da1, hr1, rc)
+
+         if (rc .ne. 0) then
+            ! Rolling back 1 hour at a time
+            call wwmca_grib1%destroy()
+            try = 1
+            do while (try .lt. 10)
+               write(LIS_logunit) &
+                    '[WARN] Problem reading ', trim(filename)
+               write(LIS_logunit)'[WARN] shifting to previous hour'
+               ts1 = -60*60
+               call LIS_tick(backtime1, doy1, gmt1, yr1, mo1, da1, &
+                    hr1, mn1, ss1, ts1)
+               call LIS_time2date(backtime1, doy1, gmt1, yr1, mo1, da1, &
+                    hr1, mn1)
+
+               call USAF_wwmca_grib1_filename(filename, &
+                    agrmet_struc(n)%agrmetdir, &
+                    agrmet_struc(n)%clouddir,  &
+                    agrmet_struc(n)%use_timestamp, &
+                    hemi, yr1, mo1, da1, hr1)
+
+               call wwmca_grib1%new(filename)
+
+               call wwmca_grib1%read_grib(yr1, mo1, da1, hr1, rc)
+
+               if (rc .eq. 0) then
+                  exit
+               else
+                  call wwmca_grib1%destroy()
+                  try = try + 1
+               end if
+            end do ! try loop
+
+            if (try .ge. 10) then
+               write(LIS_logunit)'[WARN] Missing WWMCA GRIB1 file'
+               write(LIS_logunit)'[WARN] Will fall back on WWMCA binary files.'
+               exit
+            end if
+         end if
+
+         ! We have the WWMCA data from the GRIB file.
+         yr1 = LIS_rc%yr
+         mo1 = LIS_rc%mo
+         da1 = LIS_rc%da
+         hr1 = LIS_rc%hr
+         mn1 = LIS_rc%mn
+         ss1 = LIS_rc%ss
+
+         times = times / 60
+
+         call LIS_get_julhr(yr1, mo1, da1, hr1, &
+              0, 0, julhr)
+
+         ! Populate the legacy binary arrays.
+         call wwmca_grib1%return_binary_fields(amounts, types, tops, times)
+
+         if (hemi .eq. 1) then
+            call AGRMET_loadcloud(hemi, agrmet_struc(n)%land(:,:,hemi), &
+                 thres, times, amounts, tops, types,   &
+                 cldtyp_nh, cldamt_nh, fog_nh,                &
+                 julhr, agrmet_struc(n)%imax, agrmet_struc(n)%jmax)
+         else
+            call AGRMET_loadcloud(hemi, agrmet_struc(n)%land(:,:,hemi), &
+                 thres, times, amounts, tops, types,   &
+                 cldtyp_sh, cldamt_sh, fog_sh,                &
+                 julhr, agrmet_struc(n)%imax, agrmet_struc(n)%jmax)
+         end if
+
+      end do ! hemi
+
+   end if ! WWMCA GRIB1 option
+
+   ! Handle legacy binary files
+   if (agrmet_struc(n)%read_wwmca_grib1 .ne. 1 .or. &
+        try .ge. 10) then
+
+      do hemi = 1,2
+         types   = 25
+         amounts = 0
+         tops    = 0
+         times   = 0
+
+         yr1 = LIS_rc%yr
+         mo1 = LIS_rc%mo
+         da1 = LIS_rc%da
+         hr1 = LIS_rc%hr
+         mn1 = LIS_rc%mn
+         ss1 = LIS_rc%ss
+
+         call agrmet_cdfs_type_filename(filename, &
+              agrmet_struc(n)%agrmetdir,     &
+              agrmet_struc(n)%clouddir,      &
+              agrmet_struc(n)%use_timestamp, &
+              hemi, yr1, mo1, da1, hr1)
+
+         inquire (file=trim(filename), exist=file_exists)
+         if(file_exists) then
+            write(LIS_logunit,*)'[INFO] OPENING CDFS II DATA ', trim(filename)
+            open(8, file=trim(filename), access='direct', recl=1024*1024*4, &
+                 status='old', iostat=istat)
+            read(8, rec=1, iostat=istat) types
+            close(8)
+         else !rolling back 1 hour at a time
+            try  = 1
+            do while(try.lt.10)
+               write(LIS_logunit,*) &
+                    '[WARN] File missing, shifting to previous hour'
+               ts1 = -60*60
+               call LIS_tick(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+               call LIS_time2date(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1)
+               call agrmet_cdfs_type_filename(filename,                      &
+                    agrmet_struc(n)%agrmetdir,     &
+                    agrmet_struc(n)%clouddir,      &
+                    agrmet_struc(n)%use_timestamp, &
+                    hemi, yr1, mo1, da1, hr1)
+               inquire (file=trim(filename), exist=file_exists)
+               if(file_exists) then
+                  write(LIS_logunit,*) &
+                       '[INFO] OPENING CDFS II DATA ',trim(filename)
+                  open(8, file=trim(filename), access='direct', &
+                       recl=1024*1024*4, &
+                       status='old', iostat=istat)
+                  read(8, rec=1, iostat=istat) types
+                  close(8)
+                  exit;
+               else
+                  try = try+1
+               endif
+            enddo
+            if(try.ge.10) then
+               write(LIS_logunit,*) '[WARN] Missing file ',trim(filename)
+               write(LIS_logunit,*) '[WARN] Leaving types set to zero...'
             endif
-         enddo
-         if(try.ge.10) then
-            write(LIS_logunit,*) '[WARN] Missing file ',trim(filename)
-            write(LIS_logunit,*) '[WARN] Leaving types set to zero...'
          endif
-      endif
 
-      yr1 = LIS_rc%yr
-      mo1 = LIS_rc%mo
-      da1 = LIS_rc%da
-      hr1 = LIS_rc%hr
-      mn1 = LIS_rc%mn
-      ss1 = LIS_rc%ss
+         yr1 = LIS_rc%yr
+         mo1 = LIS_rc%mo
+         da1 = LIS_rc%da
+         hr1 = LIS_rc%hr
+         mn1 = LIS_rc%mn
+         ss1 = LIS_rc%ss
 
-      call agrmet_cdfs_pcts_filename(filename,                      &
-                                     agrmet_struc(n)%agrmetdir,     &
-                                     agrmet_struc(n)%clouddir,      &
-                                     agrmet_struc(n)%use_timestamp, &
-                                     hemi, yr1, mo1, da1, hr1)
+         call agrmet_cdfs_pcts_filename(filename,                      &
+              agrmet_struc(n)%agrmetdir,     &
+              agrmet_struc(n)%clouddir,      &
+              agrmet_struc(n)%use_timestamp, &
+              hemi, yr1, mo1, da1, hr1)
 
-      inquire (file=trim(filename), exist=file_exists)
-      if(file_exists) then
-         write(LIS_logunit,*)'[INFO] OPENING CDFS II DATA ', trim(filename)
-         open(8, file=trim(filename), access='direct', recl=1024*1024*4, &
-              status='old', iostat=istat)
-         read(8, rec=1, iostat=istat) amounts
-         close(8)
-      else !rolling back 1 hour at a time
-         try  = 1
-         do while(try.lt.10)
-            write(LIS_logunit,*) &
-               '[WARN] File missing, shifting to previous hour'
-            ts1 = -60*60
-            call LIS_tick(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
-            call LIS_time2date(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1)
-            call agrmet_cdfs_pcts_filename(filename,                      &
-                                           agrmet_struc(n)%agrmetdir,     &
-                                           agrmet_struc(n)%clouddir,      &
-                                           agrmet_struc(n)%use_timestamp, &
-                                           hemi, yr1, mo1, da1, hr1)
-            inquire (file=trim(filename), exist=file_exists)
-            if(file_exists) then
-               write(LIS_logunit,*)'[INFO] OPENING CDFS II DATA ',trim(filename)
-               open(8, file=trim(filename), access='direct', recl=1024*1024*4, &
-                    status='old', iostat=istat)
-               read(8, rec=1, iostat=istat) amounts
-               close(8)
-               exit;
-            else
-               try = try+1
+         inquire (file=trim(filename), exist=file_exists)
+         if(file_exists) then
+            write(LIS_logunit,*)'[INFO] OPENING CDFS II DATA ', trim(filename)
+            open(8, file=trim(filename), access='direct', recl=1024*1024*4, &
+                 status='old', iostat=istat)
+            read(8, rec=1, iostat=istat) amounts
+            close(8)
+         else !rolling back 1 hour at a time
+            try  = 1
+            do while(try.lt.10)
+               write(LIS_logunit,*) &
+                    '[WARN] File missing, shifting to previous hour'
+               ts1 = -60*60
+               call LIS_tick(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+               call LIS_time2date(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1)
+               call agrmet_cdfs_pcts_filename(filename,                      &
+                    agrmet_struc(n)%agrmetdir,     &
+                    agrmet_struc(n)%clouddir,      &
+                    agrmet_struc(n)%use_timestamp, &
+                    hemi, yr1, mo1, da1, hr1)
+               inquire (file=trim(filename), exist=file_exists)
+               if(file_exists) then
+                  write(LIS_logunit,*)'[INFO] OPENING CDFS II DATA ', &
+                       trim(filename)
+                  open(8, file=trim(filename), access='direct', &
+                       recl=1024*1024*4, &
+                       status='old', iostat=istat)
+                  read(8, rec=1, iostat=istat) amounts
+                  close(8)
+                  exit;
+               else
+                  try = try+1
+               endif
+            enddo
+            if(try.ge.10) then
+               write(LIS_logunit,*) '[WARN] Missing file ',trim(filename)
+               write(LIS_logunit,*) '[WARN] Leaving amounts set to zero...'
             endif
-         enddo
-         if(try.ge.10) then
-            write(LIS_logunit,*) '[WARN] Missing file ',trim(filename)
-            write(LIS_logunit,*) '[WARN] Leaving amounts set to zero...'
          endif
-      endif
 
-      yr1 = LIS_rc%yr
-      mo1 = LIS_rc%mo
-      da1 = LIS_rc%da
-      hr1 = LIS_rc%hr
-      mn1 = LIS_rc%mn
-      ss1 = LIS_rc%ss
+         yr1 = LIS_rc%yr
+         mo1 = LIS_rc%mo
+         da1 = LIS_rc%da
+         hr1 = LIS_rc%hr
+         mn1 = LIS_rc%mn
+         ss1 = LIS_rc%ss
 
-      call agrmet_cdfs_hgts_filename(filename,                      &
-                                     agrmet_struc(n)%agrmetdir,     &
-                                     agrmet_struc(n)%clouddir,      &
-                                     agrmet_struc(n)%use_timestamp, &
-                                     hemi, yr1, mo1, da1, hr1)
+         call agrmet_cdfs_hgts_filename(filename,                      &
+              agrmet_struc(n)%agrmetdir,     &
+              agrmet_struc(n)%clouddir,      &
+              agrmet_struc(n)%use_timestamp, &
+              hemi, yr1, mo1, da1, hr1)
 
-      inquire (file=trim(filename), exist=file_exists)
-      if(file_exists) then
-         write(LIS_logunit,*)'[INFO] OPENING CDFS II DATA ', trim(filename)
-         open(8, file=trim(filename), access='direct', recl=1024*1024*8, &
-              status='old', iostat=istat)
-         read(8, rec=1, iostat=istat) tops
-         close(8)
-      else !rolling back 1 hour at a time
-         try  = 1
-         do while(try.lt.10)
-            write(LIS_logunit,*) &
-               '[WARN] File missing, shifting to previous hour'
-            ts1 = -60*60
-            call LIS_tick(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
-            call LIS_time2date(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1)
-            call agrmet_cdfs_hgts_filename(filename,                      &
-                                           agrmet_struc(n)%agrmetdir,     &
-                                           agrmet_struc(n)%clouddir,      &
-                                           agrmet_struc(n)%use_timestamp, &
-                                           hemi, yr1, mo1, da1, hr1)
-            inquire (file=trim(filename), exist=file_exists)
-            if(file_exists) then
-               write(LIS_logunit,*)'[INFO] OPENING CDFS II DATA ',trim(filename)
-               open(8, file=trim(filename), access='direct', recl=1024*1024*8, &
-                    status='old', iostat=istat)
-               read(8, rec=1, iostat=istat) tops
-               close(8)
-               exit;
-            else
-               try = try+1
+         inquire (file=trim(filename), exist=file_exists)
+         if(file_exists) then
+            write(LIS_logunit,*)'[INFO] OPENING CDFS II DATA ', trim(filename)
+            open(8, file=trim(filename), access='direct', recl=1024*1024*8, &
+                 status='old', iostat=istat)
+            read(8, rec=1, iostat=istat) tops
+            close(8)
+         else !rolling back 1 hour at a time
+            try  = 1
+            do while(try.lt.10)
+               write(LIS_logunit,*) &
+                    '[WARN] File missing, shifting to previous hour'
+               ts1 = -60*60
+               call LIS_tick(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+               call LIS_time2date(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1)
+               call agrmet_cdfs_hgts_filename(filename,                      &
+                    agrmet_struc(n)%agrmetdir,     &
+                    agrmet_struc(n)%clouddir,      &
+                    agrmet_struc(n)%use_timestamp, &
+                    hemi, yr1, mo1, da1, hr1)
+               inquire (file=trim(filename), exist=file_exists)
+               if(file_exists) then
+                  write(LIS_logunit,*) &
+                       '[INFO] OPENING CDFS II DATA ',trim(filename)
+                  open(8, file=trim(filename), access='direct', &
+                       recl=1024*1024*8, &
+                       status='old', iostat=istat)
+                  read(8, rec=1, iostat=istat) tops
+                  close(8)
+                  exit;
+               else
+                  try = try+1
+               endif
+            enddo
+            if(try.ge.10) then
+               write(LIS_logunit,*) '[WARN] Missing file ',trim(filename)
+               write(LIS_logunit,*) '[WARN] Leaving tops set to zero...'
             endif
-         enddo
-         if(try.ge.10) then
-            write(LIS_logunit,*) '[WARN] Missing file ',trim(filename)
-            write(LIS_logunit,*) '[WARN] Leaving tops set to zero...'
          endif
-      endif
 
-      yr1 = LIS_rc%yr
-      mo1 = LIS_rc%mo
-      da1 = LIS_rc%da
-      hr1 = LIS_rc%hr
-      mn1 = LIS_rc%mn
-      ss1 = LIS_rc%ss
+         yr1 = LIS_rc%yr
+         mo1 = LIS_rc%mo
+         da1 = LIS_rc%da
+         hr1 = LIS_rc%hr
+         mn1 = LIS_rc%mn
+         ss1 = LIS_rc%ss
 
-      call agrmet_cdfs_pixltime_filename(filename,                      &
-                                         agrmet_struc(n)%agrmetdir,     &
-                                         agrmet_struc(n)%clouddir,      &
-                                         agrmet_struc(n)%use_timestamp, &
-                                         hemi, yr1, mo1, da1, hr1)
-      inquire (file=trim(filename), exist=file_exists)
-      if(file_exists) then
-         write(LIS_logunit,*) '[INFO] READING CDFS II DATA ',trim(filename)
-         open(8, file=trim(filename), access='direct', recl=1024*1024*4, &
-              status='old', iostat=istat)
-         read(8, rec=1, iostat=istat) times
-         close(8)
-      else !rolling back 1 hour at a time
-         try  = 1
-         do while(try.lt.10)
-            write(LIS_logunit,*) &
-               '[WARN] File missing, shifting to previous hour'
-            ts1 = -60*60
-            call LIS_tick(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
-            call LIS_time2date(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1)
-            call agrmet_cdfs_pixltime_filename(filename,                      &
-                                               agrmet_struc(n)%agrmetdir,     &
-                                               agrmet_struc(n)%clouddir,      &
-                                               agrmet_struc(n)%use_timestamp, &
-                                               hemi, yr1, mo1, da1, hr1)
-            inquire (file=trim(filename), exist=file_exists)
-            if(file_exists) then
-               write(LIS_logunit,*)'[INFO] OPENING CDFS II DATA ',trim(filename)
-               open(8, file=trim(filename), access='direct', recl=1024*1024*4, &
-                    status='old', iostat=istat)
-               read(8, rec=1, iostat=istat) times
-               close(8)
-               exit;
-            else
-               try = try+1
+         call agrmet_cdfs_pixltime_filename(filename,                      &
+              agrmet_struc(n)%agrmetdir,     &
+              agrmet_struc(n)%clouddir,      &
+              agrmet_struc(n)%use_timestamp, &
+              hemi, yr1, mo1, da1, hr1)
+         inquire (file=trim(filename), exist=file_exists)
+         if(file_exists) then
+            write(LIS_logunit,*) '[INFO] READING CDFS II DATA ',trim(filename)
+            open(8, file=trim(filename), access='direct', recl=1024*1024*4, &
+                 status='old', iostat=istat)
+            read(8, rec=1, iostat=istat) times
+            close(8)
+         else !rolling back 1 hour at a time
+            try  = 1
+            do while(try.lt.10)
+               write(LIS_logunit,*) &
+                    '[WARN] File missing, shifting to previous hour'
+               ts1 = -60*60
+               call LIS_tick(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+               call LIS_time2date(backtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1)
+               call agrmet_cdfs_pixltime_filename(filename,               &
+                    agrmet_struc(n)%agrmetdir,     &
+                    agrmet_struc(n)%clouddir,      &
+                    agrmet_struc(n)%use_timestamp, &
+                    hemi, yr1, mo1, da1, hr1)
+               inquire (file=trim(filename), exist=file_exists)
+               if(file_exists) then
+                  write(LIS_logunit,*)'[INFO] OPENING CDFS II DATA ', &
+                       trim(filename)
+                  open(8, file=trim(filename), access='direct', &
+                       recl=1024*1024*4, &
+                       status='old', iostat=istat)
+                  read(8, rec=1, iostat=istat) times
+                  close(8)
+                  exit;
+               else
+                  try = try+1
+               endif
+            enddo
+            if(try.ge.10) then
+               write(LIS_logunit,*) '[WARN] Missing file ',trim(filename)
+               write(LIS_logunit,*) '[WARN] Leaving times set to zero...'
             endif
-         enddo
-         if(try.ge.10) then
-            write(LIS_logunit,*) '[WARN] Missing file ',trim(filename)
-            write(LIS_logunit,*) '[WARN] Leaving times set to zero...'
          endif
-      endif
 
-      yr1 = LIS_rc%yr
-      mo1 = LIS_rc%mo
-      da1 = LIS_rc%da
-      hr1 = LIS_rc%hr
-      mn1 = LIS_rc%mn
-      ss1 = LIS_rc%ss
+         yr1 = LIS_rc%yr
+         mo1 = LIS_rc%mo
+         da1 = LIS_rc%da
+         hr1 = LIS_rc%hr
+         mn1 = LIS_rc%mn
+         ss1 = LIS_rc%ss
 
-      times = times/60
+         times = times/60
 
-      call LIS_get_julhr(yr1, mo1, da1, hr1, &
-         0, 0,julhr)
-      if(hemi.eq.1) then
-         call AGRMET_loadcloud(hemi,agrmet_struc(n)%land(:,:,hemi),thres, &
-                               times,amounts,tops,types,                  &
-                               cldtyp_nh,cldamt_nh,fog_nh,                &
-                               julhr, agrmet_struc(n)%imax,agrmet_struc(n)%jmax)
-      else
-         call AGRMET_loadcloud(hemi,agrmet_struc(n)%land(:,:,hemi), &
-                               thres,times,amounts,tops,types,      &
-                               cldtyp_sh,cldamt_sh,fog_sh,          &
-                               julhr, agrmet_struc(n)%imax,agrmet_struc(n)%jmax)
-      endif
-   end do
+         call LIS_get_julhr(yr1, mo1, da1, hr1, &
+              0, 0,julhr)
+         if(hemi.eq.1) then
+            call AGRMET_loadcloud(hemi,agrmet_struc(n)%land(:,:,hemi),thres, &
+                 times,amounts,tops,types,                  &
+                 cldtyp_nh,cldamt_nh,fog_nh,                &
+                 julhr, agrmet_struc(n)%imax,agrmet_struc(n)%jmax)
+         else
+            call AGRMET_loadcloud(hemi,agrmet_struc(n)%land(:,:,hemi), &
+                 thres,times,amounts,tops,types,      &
+                 cldtyp_sh,cldamt_sh,fog_sh,          &
+                 julhr, agrmet_struc(n)%imax,agrmet_struc(n)%jmax)
+         endif
+      end do
+
+   end if ! Legacy binary files
 
    cldamt1(1,:,:) = real(cldamt_nh(1,:,:))
    cldamt1(2,:,:) = real(cldamt_sh(1,:,:))

--- a/lis/metforcing/usaf/readcrd_agrmet.F90
+++ b/lis/metforcing/usaf/readcrd_agrmet.F90
@@ -1064,14 +1064,14 @@ subroutine readcrd_agrmet()
 
   ! EMK Add WWMCA GRIB1 option
   call ESMF_ConfigFindLabel(LIS_config, &
-       "AGRMET WWMCA GRIB1 option:",rc=rc)
+       "AGRMET WWMCA GRIB1 read option:",rc=rc)
   call LIS_verify(rc, &
-       "[ERR] AGRMET WWMCA GRIB1 option: not specified in config file")
+       "[ERR] AGRMET WWMCA GRIB1 read option: not specified in config file")
   do n = 1, LIS_rc%nnest
      call ESMF_ConfigGetAttribute(LIS_config, &
           agrmet_struc(n)%read_wwmca_grib1, rc=rc)
      call LIS_verify(rc, &
-          "[ERR] AGRMET WWMCA GRIB1 option: not specified in config file")
+          "[ERR] AGRMET WWMCA GRIB1 read option: not specified in config file")
   enddo ! n
 
 

--- a/lis/metforcing/usaf/readcrd_agrmet.F90
+++ b/lis/metforcing/usaf/readcrd_agrmet.F90
@@ -1061,7 +1061,20 @@ subroutine readcrd_agrmet()
      call LIS_verify(rc, &
           "[ERR] AGRMET GFS filename version: not specified in config file")
   enddo ! n
-  
+
+  ! EMK Add WWMCA GRIB1 option
+  call ESMF_ConfigFindLabel(LIS_config, &
+       "AGRMET WWMCA GRIB1 option:",rc=rc)
+  call LIS_verify(rc, &
+       "[ERR] AGRMET WWMCA GRIB1 option: not specified in config file")
+  do n = 1, LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config, &
+          agrmet_struc(n)%read_wwmca_grib1, rc=rc)
+     call LIS_verify(rc, &
+          "[ERR] AGRMET WWMCA GRIB1 option: not specified in config file")
+  enddo ! n
+
+
   do n=1,LIS_rc%nnest
      agrmet_struc(n)%radProcessInterval = 1
      agrmet_struc(n)%radProcessAlarmTime = 0.0


### PR DESCRIPTION
This feature was requested by 557WW due to issues with transitioning to System 11 (apparently only WWMCA GRIB1 files will be available on that platform, instead of the legacy flat binary files currently used by LIS).  When turned on, the new functionality will search for WWMCA GRIB1 files first before falling back on binary files, if necessary.  When turned off, the existing behavior of searching for binary only is preserved.

The new lis.config entry (now required) is:

AGRMET WWMCA GRIB1 read option: 1 # 1 for searching for GRIB1, 0 for just searching for binary

and this entry has been added to the sample files in lis/configs/557WW-7.3-FOC.

Note 1:  WWMCA GRIB1 files only exist in the AGRMET archive beginning 12Z 4 Jul 2020.

Note 2:  This should be added to LISF 7.3 before being migrated to the master branch.