### PR TITLE
Fix garbage lislog output when writing model output

### DIFF
--- a/lis/core/LIS_RTMMod.F90
+++ b/lis/core/LIS_RTMMod.F90
@@ -357,16 +357,17 @@ contains
                 open_stats = .false.
                 if(LIS_masterproc) then 
                    call LIS_create_output_directory('RTM')
-                   call LIS_create_output_filename(n,outfile,&
-                        model_name = 'RTM',&
-                        writeint=LIS_rtm_struc(n)%rtmoutInterval)
-                   if(LIS_rtm_struc(n)%stats_file_open) then 
+                   if (LIS_rtm_struc(n)%stats_file_open) then
                       call LIS_create_stats_filename(n,statsfile,'RTM')
                       LIS_rtm_struc(n)%stats_file_open = .false.
-                      open_stats = .true. 
+                      open_stats = .true.
                    endif
                 endif
-                
+
+                call LIS_create_output_filename(n,outfile,&
+                     model_name = 'RTM',&
+                     writeint=LIS_rtm_struc(n)%rtmoutInterval)
+
                 call LIS_writeModelOutput(n,outfile,statsfile,open_stats, &
                      outInterval = LIS_rtm_struc(n)%rtmoutInterval,       &
                      nsoillayers = 1,                                     &

--- a/lis/core/LIS_irrigationMod.F90
+++ b/lis/core/LIS_irrigationMod.F90
@@ -244,14 +244,16 @@ contains
           if(LIS_rc%wopt.ne."none") then 
              if(LIS_masterproc) then 
                 call LIS_create_output_directory('IRRIGATION')
-                call LIS_create_output_filename(n,outfile,&
-                     model_name ="IRRIGATION")
-                if(LIS_irrig_struc(n)%stats_file_open) then 
+                if (LIS_irrig_struc(n)%stats_file_open) then
                    call LIS_create_stats_filename(n,statsfile,"IRRIGATION")
-                   LIS_irrig_struc(n)%stats_file_open = .false. 
-                   open_stats = .true. 
+                   LIS_irrig_struc(n)%stats_file_open = .false.
+                   open_stats = .true.
                 endif
              endif
+
+             call LIS_create_output_filename(n,outfile,&
+                  model_name ="IRRIGATION")
+
              call LIS_writeModelOutput(n,outfile,statsfile,              &
                   open_stats,outInterval=LIS_irrig_struc(n)%outInterval, &
                   nsoillayers=1, lyrthk = (/1.0/),                       &

--- a/lis/core/LIS_surfaceModelMod.F90
+++ b/lis/core/LIS_surfaceModelMod.F90
@@ -369,15 +369,17 @@ contains
              open_stats = .false.
              if(LIS_masterproc) then 
                 call LIS_create_output_directory('SURFACEMODEL')
-                call LIS_create_output_filename(n,outfile,&
-                     model_name = 'SURFACEMODEL',&
-                     writeint=LIS_sfmodel_struc(n)%outInterval)
-                if(LIS_sfmodel_struc(n)%stats_file_open) then 
+                if (LIS_sfmodel_struc(n)%stats_file_open) then
                    call LIS_create_stats_filename(n,statsfile,'SURFACEMODEL')
                    LIS_sfmodel_struc(n)%stats_file_open = .false.
-                   open_stats = .true. 
+                   open_stats = .true.
                 endif
              endif
+
+             call LIS_create_output_filename(n,outfile,&
+                  model_name = 'SURFACEMODEL',&
+                  writeint=LIS_sfmodel_struc(n)%outInterval)
+
              ! hkb-- added second set of soil layer thickness for CLSM
              if ( LIS_sfmodel_struc(n)%nsm_layers .eq.  &
                   LIS_sfmodel_struc(n)%nst_layers ) then   

--- a/lis/routing/HYMAP2_router/HYMAP2_routing_output.F90
+++ b/lis/routing/HYMAP2_router/HYMAP2_routing_output.F90
@@ -72,9 +72,6 @@ subroutine HYMAP2_routing_output(n)
            if(LIS_masterproc) then 
               HYMAP2_routing_struc(n)%numout=HYMAP2_routing_struc(n)%numout+1    
               call LIS_create_output_directory('ROUTING')
-              call LIS_create_output_filename(n, filename, &
-                   model_name='ROUTING', &
-                   writeint=HYMAP2_routing_struc(n)%outInterval)
 
 !-----------------------------------------------------------------------
 ! Open statistical output file
@@ -85,7 +82,11 @@ subroutine HYMAP2_routing_output(n)
                  open_stats = .true.
               endif
            endif
-     
+
+           call LIS_create_output_filename(n, filename, &
+                model_name='ROUTING', &
+                writeint=HYMAP2_routing_struc(n)%outInterval)
+
 !-----------------------------------------------------------------------
 ! Write Output 
 !-----------------------------------------------------------------------

--- a/lis/routing/HYMAP_router/HYMAP_routing_output.F90
+++ b/lis/routing/HYMAP_router/HYMAP_routing_output.F90
@@ -70,9 +70,6 @@ subroutine HYMAP_routing_output(n)
            if(LIS_masterproc) then 
               HYMAP_routing_struc(n)%numout=HYMAP_routing_struc(n)%numout+1    
               call LIS_create_output_directory('ROUTING')
-              call LIS_create_output_filename(n, filename, &
-                   model_name='ROUTING', &
-                   writeint=HYMAP_routing_struc(n)%outInterval)
 
 !-----------------------------------------------------------------------
 ! Open statistical output file
@@ -83,7 +80,11 @@ subroutine HYMAP_routing_output(n)
                  open_stats = .true.
               endif
            endif
-     
+
+           call LIS_create_output_filename(n, filename, &
+                model_name='ROUTING', &
+                writeint=HYMAP_routing_struc(n)%outInterval)
+
 !-----------------------------------------------------------------------
 ! Write Output 
 !-----------------------------------------------------------------------

--- a/lis/routing/NLDAS_router/NLDAS_routing_output.F90
+++ b/lis/routing/NLDAS_router/NLDAS_routing_output.F90
@@ -70,9 +70,6 @@ subroutine NLDAS_routing_output(n)
            if(LIS_masterproc) then 
               NLDAS_routing_struc(n)%numout=NLDAS_routing_struc(n)%numout+1    
               call LIS_create_output_directory('ROUTING')
-              call LIS_create_output_filename(n, filename, &
-                   model_name='ROUTING', &
-                   writeint=NLDAS_routing_struc(n)%outInterval)
 
 !-----------------------------------------------------------------------
 ! Open statistical output file
@@ -83,7 +80,11 @@ subroutine NLDAS_routing_output(n)
                  open_stats = .true.
               endif
            endif
-     
+
+           call LIS_create_output_filename(n, filename, &
+                model_name='ROUTING', &
+                writeint=NLDAS_routing_struc(n)%outInterval)
+
 !-----------------------------------------------------------------------
 ! Write Output 
 !-----------------------------------------------------------------------


### PR DESCRIPTION
This commit fixes garbage lislog output for non-masterproc
log files when writing a log message about writing model
output.  These garbage log messages occur for surface, RTMs,
irrigation, and routing models.  This fix ensures that the
filename is written correctly before the log messages are
written.

Resolves: #409