### PR TITLE
Update use of LIS and LISF in Users' Guides for LISF 7.3 release

### DIFF
--- a/docs/LDT_users_guide/LDT_usersguide.adoc
+++ b/docs/LDT_users_guide/LDT_usersguide.adoc
@@ -1,4 +1,4 @@
-= Land Data Toolkit (LDT): LDT {lisrevision} Users' Guide
+= Land Data Toolkit (LDT): LDT {lisfrevision} Users' Guide
 :revnumber: 1.9
 :revdate: 24 Aug 2020
 :doctype: book
@@ -10,8 +10,8 @@
 :stem: latexmath
 :data-uri:
 :devonly:
-:lisrevision: 7.3
-:lisurl: http://lis.gsfc.nasa.gov/LDT
+:lisfrevision: 7.3
+:lisfurl: http://lis.gsfc.nasa.gov
 :svnurl: http://subversion.apache.org
 :nasalisf: https://github.com/NASA-LIS/LISF
 :githuburl: https://github.com

--- a/docs/LDT_users_guide/obtain-source.adoc
+++ b/docs/LDT_users_guide/obtain-source.adoc
@@ -6,11 +6,11 @@ This section describes how to obtain the source code needed to build the LDT exe
 
 Beginning with Land Information System Framework (LISF) public release 7.3, the LDT source code is available as open source under the Apache License, version 2.0.  Please see {apachelicense}[Apache`'s web-site] for a copy of the license.
 
-From LDT public release 7.1rp1 through 7.2, the LDT source code is available as open source under the NASA Open Source Agreement (NOSA).  Please see {lisurl}[LIS`' web-site] for a copy of the NOSA.
+From LDT public release 7.1rp1 through 7.2, the LDT source code is available as open source under the NASA Open Source Agreement (NOSA).  Please see {lisfurl}[LISF`'s web-site] for a copy of the NOSA.
 
-Due to the history of LDT`'s development, versions of the LDT source code prior to 7.1rp1 may not be freely distributed.  Older source code is available only to U.S. government agencies or entities with a U.S. government grant/contract.  {lisurl}[LIS`' web-site] explains how qualified persons may request a copy of older source code.
+Due to the history of LDT`'s development, versions of the LDT source code prior to 7.1rp1 may not be freely distributed.  Older source code is available only to U.S. government agencies or entities with a U.S. government grant/contract.  {lisfurl}[LISF`'s web-site] explains how qualified persons may request a copy of older source code.
 
-NOTE: All users are encouraged to go to {lisurl}[LIS`' web-site] to fill in the Registration Form and join the mailing list.
+NOTE: All users are encouraged to go to {lisfurl}[LISF`'s web-site] to fill in the Registration Form and join the mailing list.
 
 [[sec-important_note_fs]]
 === Important Note Regarding File Systems
@@ -20,7 +20,7 @@ LDT is developed on Linux/Unix platforms.  Its build process expects a case sens
 [[sec_publicrelease,Public Release Source Code]]
 === Public Release Source Code
 
-The LDT public release {lisrevision} source code is available both on {lisurl}[LIS`' web-site] under the "`Source`" menu and on GitHub under the NASA-LIS organization at {nasalisf} under the "`Releases`" link.
+The LDT public release {lisfrevision} source code is available both on {lisfurl}[LISF`'s web-site] under the "`Source`" menu and on GitHub under the NASA-LIS organization at {nasalisf} under the "`Releases`" link.
 
 After downloading the LISF tar-file:
 
@@ -99,5 +99,5 @@ NOTE: The directory containing the LDT source code, _LISF/ldt_, will be referred
 
 === Documentation
 
-Processed documentation may be found on {lisurl}[LIS`' web-site] under the "`Docs`" menu.
+Processed documentation may be found on {lisfurl}[LISF`'s web-site] under the "`Docs`" menu.
 

--- a/docs/LIS_users_guide/LIS_usersguide.adoc
+++ b/docs/LIS_users_guide/LIS_usersguide.adoc
@@ -1,4 +1,4 @@
-= Land Information System (LIS): LIS {lisrevision} Users' Guide
+= Land Information System (LIS): LIS {lisfrevision} Users' Guide
 :revnumber: 1.12
 :revdate: 24 Aug 2020
 :doctype: book
@@ -9,8 +9,8 @@
 :imagesoutdir: images
 :stem: latexmath
 :devonly!:
-:lisrevision: 7.3
-:lisurl: http://lis.gsfc.nasa.gov
+:lisfrevision: 7.3
+:lisfurl: http://lis.gsfc.nasa.gov
 :listesturl: https://lis.gsfc.nasa.gov/tests/lis
 :svnurl: http://subversion.apache.org
 :nasalisf: https://github.com/NASA-LIS/LISF

--- a/docs/LIS_users_guide/intro.adoc
+++ b/docs/LIS_users_guide/intro.adoc
@@ -2,7 +2,7 @@
 [[sec_intro,Introduction]]
 == Introduction
 
-This is the Land Information System (LIS) User's Guide.  This document describes how to download and install the code and data needed to run the LIS executable for LIS revision {lisrevision}.  It describes how to build and run the code, and finally this document also describes how to download output data-sets to use for validation.
+This is the Land Information System (LIS) User's Guide.  This document describes how to download and install the code and data needed to run the LIS executable for LIS revision {lisfrevision}.  It describes how to build and run the code, and finally this document also describes how to download output data-sets to use for validation.
 
 This document consists of 12 sections, described as follows:
 

--- a/docs/LIS_users_guide/obtain-source.adoc
+++ b/docs/LIS_users_guide/obtain-source.adoc
@@ -6,11 +6,11 @@ This section describes how to obtain the source code needed to build the LIS exe
 
 Beginning with Land Information System Framework (LISF) public release 7.3, the LIS source code is available as open source under the Apache License, version 2.0.  Please see {apachelicense}[Apache`'s web-site] for a copy of the license.
 
-From LIS public release 7.1rp1 through 7.2, the LIS source code is available as open source under the NASA Open Source Agreement (NOSA).  Please see {lisurl}[LIS`' web-site] for a copy of the NOSA.
+From LIS public release 7.1rp1 through 7.2, the LIS source code is available as open source under the NASA Open Source Agreement (NOSA).  Please see {lisfurl}[LISF`'s web-site] for a copy of the NOSA.
 
-Due to the history of LIS`' development, versions of the LIS source code prior to 7.1rp1 may not be freely distributed.  Older source code is available only to U.S. government agencies or entities with a U.S. government grant/contract.  {lisurl}[LIS`' web-site] explains how qualified persons may request a copy of older source code.
+Due to the history of LIS`' development, versions of the LIS source code prior to 7.1rp1 may not be freely distributed.  Older source code is available only to U.S. government agencies or entities with a U.S. government grant/contract.  {lisfurl}[LISF`'s web-site] explains how qualified persons may request a copy of older source code.
 
-NOTE: All users are encouraged to go to {lisurl}[LIS`' web-site] to fill in the Registration Form and join the mailing list.
+NOTE: All users are encouraged to go to {lisfurl}[LISF`'s web-site] to fill in the Registration Form and join the mailing list.
 
 
 [[sec_important_note_fs,Important Note Regarding File Systems]]
@@ -22,7 +22,7 @@ LIS is developed on Linux/Unix platforms.  Its build process expects a case sens
 [[sec_publicrelease,Public Release Source Code]]
 === Public Release Source Code
 
-The LIS public release {lisrevision} source code is available both on {lisurl}[LIS`' web-site] under the "`Source`" menu and on GitHub under the NASA-LIS organization at {nasalisf} under the "`Releases`" link.
+The LIS public release {lisfrevision} source code is available both on {lisfurl}[LISF`'s web-site] under the "`Source`" menu and on GitHub under the NASA-LIS organization at {nasalisf} under the "`Releases`" link.
 
 After downloading the LISF tar-file:
 
@@ -1227,4 +1227,4 @@ Miscellaneous helpful utilities
 
 === Documentation
 
-Processed documentation may be found on {lisurl}[LIS`' web-site] under the "`Docs`" menu.
+Processed documentation may be found on {lisfurl}[LISF`'s web-site] under the "`Docs`" menu.

--- a/docs/LVT_users_guide/LVT_usersguide.adoc
+++ b/docs/LVT_users_guide/LVT_usersguide.adoc
@@ -1,4 +1,4 @@
-= Land surface Verification Toolkit (LVT): LVT {lisrevision} Users' Guide
+= Land surface Verification Toolkit (LVT): LVT {lisfrevision} Users' Guide
 :revnumber: 1.5
 :revdate: 24 Aug 2020
 :doctype: book
@@ -9,10 +9,9 @@
 :imagesoutdir: images
 :stem: latexmath
 :devonly:
-:lisrevision: 7.3
-:lisurl: http://lis.gsfc.nasa.gov
+:lisfrevision: 7.3
+:lisfurl: http://lis.gsfc.nasa.gov
 :svnurl: http://subversion.apache.org
-:lvturl: http://lis.gsfc.nasa.gov/LVT
 :nasalisf: https://github.com/NASA-LIS/LISF
 :githuburl: https://github.com
 :apachelicense: https://www.apache.org/licenses/LICENSE-2.0

--- a/docs/LVT_users_guide/obtain-source.adoc
+++ b/docs/LVT_users_guide/obtain-source.adoc
@@ -6,11 +6,11 @@ This section describes how to obtain the source code needed to build the LVT exe
 
 Beginning with Land Information System Framework (LISF) public release 7.3, the LVT source code is available as open source under the Apache License, version 2.0.  Please see {apachelicense}[Apache`'s web-site] for a copy of the license.
 
-From LVT public release 7.1rp1 through 7.2, the LVT source code is available as open source under the NASA Open Source Agreement (NOSA).  Please see {lisurl}[LIS`' web-site] for a copy of the NOSA.
+From LVT public release 7.1rp1 through 7.2, the LVT source code is available as open source under the NASA Open Source Agreement (NOSA).  Please see {lisfurl}[LISF`'s web-site] for a copy of the NOSA.
 
-Due to the history of LVT`'s development, versions of the LVT source code prior to 7.1rp1 may not be freely distributed.  Older source code is available only to U.S. government agencies or entities with a U.S. government grant/contract.  {lisurl}[LIS`' web-site] explains how qualified persons may request a copy of older source code.
+Due to the history of LVT`'s development, versions of the LVT source code prior to 7.1rp1 may not be freely distributed.  Older source code is available only to U.S. government agencies or entities with a U.S. government grant/contract.  {lisfurl}[LISF`'s web-site] explains how qualified persons may request a copy of older source code.
 
-NOTE: All users are encouraged to go to {lisurl}[LIS`' web-site] to fill in the Registration Form and join the mailing list.
+NOTE: All users are encouraged to go to {lisfurl}[LISF`'s web-site] to fill in the Registration Form and join the mailing list.
 
 [[sec-important_note_fs]]
 === Important Note Regarding File Systems
@@ -20,7 +20,7 @@ LVT is developed on Linux/Unix platforms.  Its build process expects a case sens
 [[sec_publicrelease,Public Release Source Code]]
 === Public Release Source Code
 
-The LVT public release {lisrevision} source code is available both on {lisurl}[LIS`' web-site] under the "`Source`" menu and on GitHub under the NASA-LIS organization at {nasalisf} under the "`Releases`" link.
+The LVT public release {lisfrevision} source code is available both on {lisfurl}[LISF`'s web-site] under the "`Source`" menu and on GitHub under the NASA-LIS organization at {nasalisf} under the "`Releases`" link.
 
 After downloading the LISF tar-file:
 
@@ -99,5 +99,5 @@ NOTE: The directory containing the LVT source code, _LISF/lvt_, will be referred
 
 === Documentation
 
-Processed documentation may be found on {lisurl}[LIS`' web-site] under the "`Docs`" menu.
+Processed documentation may be found on {lisfurl}[LISF`'s web-site] under the "`Docs`" menu.
 

--- a/ldt/configs/ldt.config.adoc
+++ b/ldt/configs/ldt.config.adoc
@@ -754,9 +754,9 @@ endif::devonly[]
 |AVHRR |Univ. of Maryland 1992-93 AVHRR landcover map.  Please see: http://glcf.umd.edu/data/landcover/
 |AVHRR_GFS |Similar to "`AVHRR`" option above but on a GFS grid.
 |MODIS_Native |Terra-MODIS sensor-based IGBP land classification map, modified by NCEP. For more info, please see: http://www.ral.ucar.edu/research/land/technology/noahmp_lsm.php
-|MODIS_LIS |Similar dataset as "`MODIS_Native`" above but processed by LIS-team.
+|MODIS_LIS |Similar dataset as "`MODIS_Native`" above but processed by LISF-team.
 |USGS_Native |The 24-category USGS native landcover map. See: http://www.ral.ucar.edu/research/land/technology/noahmp_lsm.php
-|USGS_LIS |Similar dataset as "`USGS_Native`" but processed by LIS-team.
+|USGS_LIS |Similar dataset as "`USGS_Native`" but processed by LISF-team.
 |ALMIPII |AMMA/ALMIP Phase-2 landcover input option. For more info: http://www.cnrm.meteo.fr/amma-moana/amma_surf/almip2/input.html
 |CLSMF2.5 |CLSM Fortuna 2.5 landcover dataset.
 |VIC412 |Variable Infiltration Capacity model, v4.1.2, UMD land cover.
@@ -1349,7 +1349,7 @@ endif::devonly[]
 |===
 |Value |Description
 
-|FAO |LIS-team produced soil porosity data source.
+|FAO |LISF-team produced soil porosity data source.
 |CLSMF2.5 |Similar to the above option but for CLSM F2.5 model.
 |CONSTANT |User can select a constant value.
 |===
@@ -1403,7 +1403,7 @@ endif::devonly[]
 
 |none |No soil fraction data source
 |FAO |FAO soil fraction percentage fields
-|STATSGO_LIS |LIS-team derived STATSGO v1 soil fraction fields
+|STATSGO_LIS |LISF-team derived STATSGO v1 soil fraction fields
 |ALMIPII |ALMIP II soil fraction percentage fields
 |CONSTANT |If user wants to set a constant soil fraction values
 |===
@@ -1544,7 +1544,7 @@ Permeability data source:   none
 |Value |Description
 
 |STATSGOFAO_Native |The blended STATSGOv1 and FAO soil texture map. See: http://www.ral.ucar.edu/research/land/technology/lsm.php
-|STATSGOFAO_LIS |Similar dataset as to the above one but processed by LIS-team.
+|STATSGOFAO_LIS |Similar dataset as to the above one but processed by LISF-team.
 |FAO |FAO or Reynolds et al. (1999) soil texture map.
 |ISRIC |ISRIC soil texture data source.
 |ZOBLER_GFS |Similar to above but on a GFS run domain.
@@ -1668,12 +1668,12 @@ Current options include:
 |Value |Description
 
 |GTOPO30_Native |The GTOPO30 elevation map native source. See: http://edcftp.cr.usgs.gov/pub/data/gtopo30/global
-|GTOPO30_LIS |Similar dataset as to the above one but processed by LIS-team.
+|GTOPO30_LIS |Similar dataset as to the above one but processed by LISF-team.
 |GTOPO30_GFS |Similar dataset as to the above but on GFS grid.
 |SRTM_Native |The SRTM elevation map native source. See: http://dds.cr.usgs.gov/srtm/version2_1/SRTM30
-|SRTM_LIS |Similar dataset as to the above one but processed by LIS-team.
+|SRTM_LIS |Similar dataset as to the above one but processed by LISF-team.
 |CONSTANT |User can set a constant elevation, slope or aspect class.
-|MERIT_1K |The MERIT elevation map, but processed by LIS-team to have a resolution '`0.008333`'. See: http://hydro.iis.u-tokyo.ac.jp/~yamadai/MERIT_DEM/index.html
+|MERIT_1K |The MERIT elevation map, but processed by LISF-team to have a resolution '`0.008333`'. See: http://hydro.iis.u-tokyo.ac.jp/~yamadai/MERIT_DEM/index.html
 |===
 
 .Example _ldt.config_ entry
@@ -1827,7 +1827,7 @@ Albedo maps
 |Value |Description
 
 |NCEP_Native |Native monthly NCEP albedo files.
-|NCEP_LIS |Similar to the above option but LIS-team processed.
+|NCEP_LIS |Similar to the above option but LISF-team processed.
 |CONSTANT |User can select a constant value.
 |===
 
@@ -1921,7 +1921,7 @@ Albedo resolution (dy):       0.2500
 |Value |Description
 
 |NCEP_Native |Native NCEP maximum snow albedo source.
-|NCEP_LIS |Similar to the above option but LIS-team processed.
+|NCEP_LIS |Similar to the above option but LISF-team processed.
 |NCEP_GFS |Similar to the above option but on GFS grid.
 |SACHTET.3.5.6 |Max snow albedo specific to the SAC-HTET model.
 |CONSTANT |User can select a constant value.
@@ -1996,7 +1996,7 @@ Greenness vegetation fraction is considered the horizontal greenness fraction re
 |Value |Description
 
 |NCEP_Native |Native NCEP monthly greenness climatology source.
-|NCEP_LIS |Similar to the above option but LIS-team processed.
+|NCEP_LIS |Similar to the above option but LISF-team processed.
 |CLSMF2.5 |Similar to the above option but for CLSM F2.5 model.
 |SACHTET.3.5.6 |Similar to the above option but for SAC-HTET model.
 |CONSTANT |User can select a constant value.
@@ -2096,7 +2096,7 @@ LAI/SAI maps Leaf area index and stem area index maps are used to describe the v
 |===
 |Value |Description
 
-|AVHRR |LIS-team produced monthly LAI climatology source.
+|AVHRR |LISF-team produced monthly LAI climatology source.
 |CLSMF2.5 |Similar to the above option but for CLSM F2.5 model.
 |CONSTANT |User can select a constant value.
 |===
@@ -2107,7 +2107,7 @@ LAI/SAI maps Leaf area index and stem area index maps are used to describe the v
 |===
 |Value |Description
 
-|AVHRR |LIS-team produced monthly SAI climatology source.
+|AVHRR |LISF-team produced monthly SAI climatology source.
 |CONSTANT |User can select a constant value.
 |===
 
@@ -2206,7 +2206,7 @@ LAI/SAI resolution (dy):       0.2500
 |Value |Description
 
 |NCEP_Native |Native NCEP slope type derived map source.
-|NCEP_LIS |Similar to the above option but LIS-team processed.
+|NCEP_LIS |Similar to the above option but LISF-team processed.
 |NCEP_GFS |Similar to the above option but on a GFS grid type.
 |CONSTANT |User can select a constant value.
 |===
@@ -2274,7 +2274,7 @@ Slope type resolution (dy):       0.2500
 |Value |Description
 
 |ISLSCP1 |Native (NCEP) ISLSCP1 temperature derived map.
-|NCEP_LIS |Similar to the above option but LIS-team processed.
+|NCEP_LIS |Similar to the above option but LISF-team processed.
 |NCEP_GFS |Similar to the above option but on a GFS grid type.
 |CONSTANT |User can select a constant value.
 |===

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5628,7 +5628,7 @@ Please note that MERRA2 forcing data are available via
 NASA`'s Goddard Earth Sciences Data and Information Services
 Center (GES DISC; https://disc.gsfc.nasa.gov/). Also, 
 topographic or elevation correction option is now supported
-with the latest LIS-7 MERRA-2 reader.  Please also see the
+with the latest LIS MERRA-2 reader.  Please also see the
 latest LDT notes for updates on how to use this option.
 
 `MERRA2 use lowest model level forcing:` specifies whether
@@ -6641,7 +6641,7 @@ RDHM constant wind speed:              4.0
 `Generated metforcing directory:` specifies the location of the
 LDT generated meteorological forcing files.  Files generated in LDT
 are in netCDF format, and they are automatically loaded and handled
-by the LIS-7 reader.
+by the LIS reader.
 
 .Example _lis.config_ entry
 ....


### PR DESCRIPTION
Use LISF for the whole project (LDT, LIS, and LVT) and LIS for the component.