### PR TITLE
Fixed type declaration for variable found_inq.

### DIFF
--- a/ldt/USAFSI/USAFSI_galwemMod.F90
+++ b/ldt/USAFSI/USAFSI_galwemMod.F90
@@ -67,7 +67,7 @@ contains
     integer :: dataTime
     integer :: ifguess
     integer :: jfguess
-    integer :: found_inq
+    logical :: found_inq
     integer :: k
     integer :: prod_def_tmpl_num
     integer :: param_disc_val


### PR DESCRIPTION
This bug was found by Brendan McAndrew while using the GNU compiler.

This bug fix will need to be migrated to master after merging into support/lisf-557ww-7.3.