### PR TITLE
Update devonly guards in Users' Guides for LISF 7.3 release

### DIFF
--- a/docs/LIS_users_guide/LIS_usersguide.adoc
+++ b/docs/LIS_users_guide/LIS_usersguide.adoc
@@ -8,7 +8,7 @@
 :mathematical-format: svg
 :imagesoutdir: images
 :stem: latexmath
-:devonly!:
+:devonly:
 :lisfrevision: 7.3
 :lisfurl: http://lis.gsfc.nasa.gov
 :listesturl: https://lis.gsfc.nasa.gov/tests/lis

--- a/docs/LIS_users_guide/obtain-source.adoc
+++ b/docs/LIS_users_guide/obtain-source.adoc
@@ -111,13 +111,11 @@ The structure of _LISF/lis_ is as follows:
 Directory the NASA Open Source license for LIS along with the licenses of other
 included components
 
-ifdef::devonly[]
-* _RESTRICTED_ footnote:disclaimer[{lispublicna}]
-endif::devonly[]
+* _RESTRICTED_
 
-ifdef::devonly[]
-* _apps_ footnote:disclaimer[]
-endif::devonly[]
+* _apps_
++
+Directory containing applications built on LIS
 
 * _arch_
 +
@@ -175,11 +173,9 @@ NASA GMAO`'s dynamic bias estimation algorithm
 +
 Directory containing the following observation handlers for data assimilation:
 
-ifdef::devonly[]
-*** _AMRE_swe_ footnote:disclaimer[]
+*** _AMRE_swe_
 +
 AMSRE snow water equivalent retrievals in HDF4/HDFEOS format
-endif::devonly[]
 
 *** _ANSA_SCF_
 +
@@ -189,15 +185,13 @@ Blended snow cover fraction from the AFWA NASA snow algorithm
 +
 Snow depth retrievals from the AFWA NASA snow algorithm
 
-ifdef::devonly[]
-*** _ANSA_SWE_ footnote:disclaimer[]
+*** _ANSA_SWE_
 +
 Snow water equivalent retrievals from the AFWA NASA snow algorithm
 
-*** _ASCAT_TUW_ footnote:disclaimer[]
+*** _ASCAT_TUW_
 +
 ASCAT (TU Wein) soil moisture
-endif::devonly[]
 
 *** _ASO_SWE_
 +
@@ -227,15 +221,13 @@ AMSR2 soil moisture retrievals
 +
 GRACE soil moisture
 
-ifdef::devonly[]
-*** _IMS_sca_ footnote:disclaimer[]
+*** _IMS_sca_
 +
 IMS snow cover area
 
-*** _ISCCP_Tskin_ footnote:disclaimer[]
+*** _ISCCP_Tskin_
 +
 ISCCP skin temperature product in binary format
-endif::devonly[]
 
 *** _LPRM_AMSREsm_
 +
@@ -297,31 +289,25 @@ SMOS L2 soil moisture
 +
 SMOS NESDIS soil moisture retrievals
 
-ifdef::devonly[]
-*** _SNODEP_ footnote:disclaimer[]
+*** _SNODEP_
 +
 AFWA snowdepth data in Grib1 format
-endif::devonly[]
 
 *** _SSMI_SNWD_
 +
 SSMI snow depth
 
-ifdef::devonly[]
-*** _SYN_LBAND_TB_ footnote:disclaimer[]
+*** _SYN_LBAND_TB_
 +
 Synthetic L-band brightness temperature
-endif::devonly[]
 
 *** _USAFSI_
 +
-[red]##specifies what?##
+USAF Snow and Ice Analysis
 
-ifdef::devonly[]
-*** _WindSat_Cband_sm_ footnote:disclaimer[]
+*** _WindSat_Cband_sm_
 +
 C-band soil moisture retrievals from WindSat
-endif::devonly[]
 
 *** _WindSat_sm_
 +
@@ -331,48 +317,43 @@ X-band soil moisture retrievals from WindSat
 +
 PILDAS soil moisture observations (such as one generated from a previous LIS LSM run)
 
-ifdef::devonly[]
-*** _simGRACE_JPL_ footnote:disclaimer[]
+*** _simGRACE_JPL_
 +
 Synthetic soil moisture retrievals from GRACE
-endif::devonly[]
-
-ifdef::devonly[]
 
 *** This directory also includes the following synthetic data handler examples:
 
-*** _multisynsmobs_ footnote:disclaimer[]
+*** _multisynsmobs_
 +
 synthetic soil moisture data with multiple observation types
 
-*** _syntheticSnowTb_ footnote:disclaimer[]
+*** _syntheticSnowTb_
 +
 [red]##specifies what?##
 
-*** _syntheticlst_ footnote:disclaimer[]
+*** _syntheticlst_
 +
 synthetic land surface temperature data handler
 
-*** _syntheticsf_ footnote:disclaimer[]
+*** _syntheticsf_
 +
 synthetic streamflow data handler
 
-*** _syntheticsm_ footnote:disclaimer[]
+*** _syntheticsm_
 +
 synthetic soil moisture data handler (produced from a LIS LSM run)
 
-*** _syntheticsnd_ footnote:disclaimer[]
+*** _syntheticsnd_
 +
 synthetic snow depth data handler
 
-*** _syntheticswe_ footnote:disclaimer[]
+*** _syntheticswe_
 +
 synthetic snow water equivalent data handler
 
-*** _syntheticwl_ footnote:disclaimer[]
+*** _syntheticwl_
 +
 [red]##specifies what?##
-endif::devonly[]
 
 ** _perturb_
 +
@@ -394,11 +375,9 @@ Supports forecast capabilities
 +
 Directory containing the following forecasting algorithm implementations
 
-ifdef::devonly[]
-*** ESPboot footnote:disclaimer[]
+*** ESPboot
 +
 Boot ensemble streamflow prediction
-endif::devonly[]
 
 *** ESPconv
 +
@@ -456,11 +435,9 @@ Routines for handling the TRMM 3B42V6 precipitation product
 +
 Routines for handling the TRMM 3B42V7 precipitation product
 
-ifdef::devonly[]
-** _ALMIPII_ footnote:disclaimer[]
+** _ALMIPII_
 +
 Routines for handling the AMMA land surface model intercomparision project phase 2
-endif::devonly[]
 
 ** _AWAP_
 +
@@ -474,14 +451,12 @@ Routines for handling the AWAP precipitation product
 +
 Routines for handling the Bondville forcing products
 
-ifdef::devonly[]
-** _CaPA_ footnote:disclaimer[]
+** _CaPA_
 +
 Canadian Precipitation analysis
-endif::devonly[]
 
 ifdef::devonly[]
-** _FASSTsingle_ footnote:disclaimer[]
+** _FASSTsingle_ footnote:disclaimer[{lispublicna}]
 +
 Routines for handling the single-point FASST product
 endif::devonly[]
@@ -522,11 +497,9 @@ Routines for handling the AGRMET radiation product
 +
 Routines for handling the AGRMET radiation product (polar stereographic prjection)
 
-ifdef::devonly[]
-** _arms_ footnote:disclaimer[]
+** _arms_
 +
 Routines for handling the Walnut Gulch meteorological station data
-endif::devonly[]
 
 ** _ceop_
 +
@@ -568,11 +541,9 @@ ECMWF reanalysis meteorological forcing data based on <<berg_etal_jgr_2003>>.
 +
 NCEP GDAS meteorological forcing data
 
-ifdef::devonly[]
-** _gdas3d_ footnote:disclaimer[]
+** _gdas3d_
 +
 Routines for handling the GDAS 3d (including the atmospheric profile) data
-endif::devonly[]
 
 ** _gdasLSWG_
 +
@@ -719,11 +690,9 @@ differential evolution monte carlo algorithm
 +
 differential evolution monte carlo Z algorithm
 
-ifdef::devonly[]
-*** _ES_ footnote:disclaimer[]
+*** _ES_
 +
 enumerated search
-endif::devonly[]
 
 *** _GA_
 +
@@ -741,11 +710,9 @@ monte carlo simple propagation scheme
 +
 Random walk Markov chain monte carlo algorithm
 
-ifdef::devonly[]
-*** _SCE-UA_ footnote:disclaimer[]
+*** _SCE-UA_
 +
 Shuffled Complex Evolutionary Algorithm
-endif::devonly[]
 
 ** _type_
 
@@ -763,11 +730,9 @@ Directory containing the following objective function evaluation methods
 +
 maximum likelihood
 
-ifdef::devonly[]
-***** _LM_ footnote:disclaimer[]
+***** _LM_
 +
 objective function definition for LM algorithm
-endif::devonly[]
 
 ***** _LS_
 +
@@ -783,41 +748,35 @@ Directory containing the following observation handlers for parameter estimation
 
 ***** _AMSRE_SR_
 
-ifdef::devonly[]
-***** _ARM_ footnote:disclaimer[]
+***** _ARM_
 +
 [red]##specifies what?##
-endif::devonly[]
 
 ***** _ARSsm_
 +
 [red]##specifies what?##
 
-ifdef::devonly[]
-***** _Ameriflux_ footnote:disclaimer[]
+***** _Ameriflux_
 +
 In-situ observations from Ameriflux
 
-***** _CNRS_ footnote:disclaimer[]
+***** _CNRS_
 +
 [red]##specifies what?##
-endif::devonly[]
 
 ***** _EmptyObs_
 
-ifdef::devonly[]
-***** _FLUXNET_ footnote:disclaimer[]
+***** _FLUXNET_
 +
 [red]##specifies what?##
 
-***** _Global_LS_data_ footnote:disclaimer[]
+***** _Global_LS_data_
 +
 Global landslide observational data
 
-***** _ISCCP_Tskin_ footnote:disclaimer[]
+***** _ISCCP_Tskin_
 +
 ISCCP land surface temperature observations
-endif::devonly[]
 
 ***** _ISMNsm_
 +
@@ -827,11 +786,9 @@ endif::devonly[]
 +
 Soil moisture retrievals from AMSRE derived using the land parameter retrieval model (LPRM) from University of Amsterdam
 
-ifdef::devonly[]
-***** _Macon_LS_data_ footnote:disclaimer[]
+***** _Macon_LS_data_
 +
 Macon County North Carolina landslide observational data
-endif::devonly[]
 
 ***** _SMAPsm_
 +
@@ -841,37 +798,31 @@ endif::devonly[]
 +
 [red]##specifies what?##
 
-ifdef::devonly[]
-***** _USDA_ARSsm_ footnote:disclaimer[]
+***** _USDA_ARSsm_
 +
 USDA Agricultural Research Service soil mositure retrievals
 
-***** _pesynsm1_ footnote:disclaimer[]
+***** _pesynsm1_
 +
 synthetic soil moisture observations
-endif::devonly[]
 
 ***** _template_
 
-ifdef::devonly[]
-***** _wgPBMRsm_ footnote:disclaimer[]
+***** _wgPBMRsm_
 +
 PBMR soil moisture data for the Walnut Gulch watershed
-endif::devonly[]
 
 * _params_
 +
 Directory containing implementations of the following land surface model parameters
 
-ifdef::devonly[]
-** _albedo_ footnote:disclaimer[]
+** _albedo_
 +
 Routines for handling albedo data products
 
-** _emissivity_ footnote:disclaimer[]
+** _emissivity_
 +
 Routines for handling emissivity data products
-endif::devonly[]
 
 ** _gfrac_
 +
@@ -881,11 +832,9 @@ Routines for handling green vegetation fraction data products
 +
 Routines for handling Leaf/Stem area index data products
 
-ifdef::devonly[]
-** _roughness_ footnote:disclaimer[]
+** _roughness_
 +
 Routines for handling roughness data products
-endif::devonly[]
 
 * _plugins_
 +
@@ -929,29 +878,25 @@ Routines to handle coupling to the Tau Omega Radiative Transfer Model
 +
 Directory containing the following running modes in LIS
 
-ifdef::devonly[]
-** _RTMforward_ footnote:disclaimer[]
+** _RTMforward_
 +
 Routines to manage the program flow when a forward model integration using a radiative transfer model is employed
 
-** _agrmetmode_ footnote:disclaimer[]
+** _agrmetmode_
 +
 Routines to manage the program flow in the AFWA operational mode
-endif::devonly[]
 
 ** _forecast_
 +
 Routines to manage the forecast simulation mode
 
-ifdef::devonly[]
-** _gce_cpl_mode_ footnote:disclaimer[]
+** _gce_cpl_mode_
 +
 Routines to manage the program flow in the coupled LIS-GCE mode
 
-** _landslide_optUE_ footnote:disclaimer[]
+** _landslide_optUE_
 +
 Routines to manage the program flow in combined use of landslide modelling simulations and optimization
-endif::devonly[]
 
 ** _paramEstimation_
 +
@@ -985,8 +930,7 @@ Directory containing implementations of the following glacier surface models
 +
 An empty template for glacire surface model implementations
 
-ifdef::devonly[]
-** _lake_ footnote:disclaimer[]
+** _lake_
 +
 Directory containing implementations of the following lake surface models
 
@@ -995,7 +939,6 @@ Directory containing implementations of the following lake surface models
 FLake, version 1.0
 +
 #internal use only!#
-endif::devonly[]
 
 ** _land_
 +
@@ -1138,11 +1081,9 @@ Routines for coupling Noah with WRF without ESMF
 //Noah routines related to the assimilation of snow cover
 //fraction observations
 
-ifdef::devonly[]
-**** _da_snodep_ footnote:disclaimer[]
+**** _da_snodep_
 +
 Noah routines related to the assimilation of AFWA SNODEP observations
-endif::devonly[]
 
 **** _da_snow_
 +

--- a/ldt/configs/ldt.config.adoc
+++ b/ldt/configs/ldt.config.adoc
@@ -60,9 +60,7 @@ Number of surface model types:   1
 |Value |Description
 
 |LSM |Land surface model type
-ifdef::devonly[]
 |Lake |Lake model type
-endif::devonly[]
 |Openwater |Openwater surface type
 |===
 
@@ -96,13 +94,13 @@ Surface model types:  "LSM"
 |SNOW17 |Snow17
 |RDHM.3.5.6 |Sacramento+snow17
 |GeoWRSI.2 |GeoWRSI, v2.0
-ifdef::devonly[]
 |SiB2 |SiB v2
+ifdef::devonly[]
 |FASST |FASST
 |CABLE |CABLE
 |HTESSEL |HTESSEL
-|JULES.4.3 |JULES.4.3
 endif::devonly[]
+|JULES.5.0 |JULES.5.0
 |===
 
 .Example _ldt.config_ entry
@@ -149,8 +147,8 @@ For more information about LIS`'s meteorological forcing data reader options, pl
 |"`NONE`" |none
 ifdef::devonly[]
 |"`AGRMET`" |AGRMET (AFWA-0.25 deg)
-|"`AGRMET radiation (polar stereographic)`" |AGRMET radiation fields
 endif::devonly[]
+|"`AGRMET radiation (polar stereographic)`" |AGRMET radiation fields
 |"`CMAP`" |CMAP precipitation fields
 |"`CPC CMORPH`" |CMORPH precipitation fields
 |"`ECMWF`" |ECMWF near-realtime analysis
@@ -921,7 +919,6 @@ Landmask resolution (dx):        0.01
 Landmask resolution (dy):        0.01
 ....
 
-ifdef::devonly[]
 `Lakecover data source:` specifies the data source for lake depth and/or fraction for lake models, like FLake.
 
 .Example _ldt.config_ entry
@@ -1016,7 +1013,6 @@ Inland waterbody type map:  ./inlandwater_parms/GLWD/rastert_glwd_31.flt
 ....
 Inland waterbody spatial transform:    tile
 ....
-endif::devonly[]
 
 `Regional mask data source:` specifies a regional land mask dataset source to be read in. Should either match grid domain or be smaller to the LIS run domain.
 
@@ -1339,9 +1335,7 @@ Soils maps
 
 `Silt fraction map:` specifies the silt map file.
 
-ifdef::devonly[]
 `Gravel fraction map:` specifies the gravel map file.
-endif::devonly[]
 
 `Porosity data source:` specifies the soil porosity dataset source to be read in. Current source options include:
 
@@ -1382,9 +1376,7 @@ endif::devonly[]
 Sand fraction map:        ../input/25KM/sand_FAO.1gd4r
 Clay fraction map:        ../input/25KM/clay_FAO.1gd4r
 Silt fraction map:        ../input/25KM/silt_FAO.1gd4r
-ifdef::devonly[]
 Gravel fraction map:      ../input/25KM/gravel_Special.1gd4r
-endif::devonly[]
 Porosity data source:        none
 Porosity map:                  
 Saturated matric potential map:       
@@ -2753,7 +2745,6 @@ SNOW17 parameter fill value:
 SNOW17 map projection:               hrap
 ....
 
-ifdef::devonly[]
 `SiB2 static parameter directory:` specifies the location of Simple Biospheric v2 (SiB2) Model parameter files. These files contain vegetation- and soil-based parameter information that can be used in the SiB2 model run.
 
 `SiB2 parameter spatial transform:` specifies the general grid spatial transform option for SiB2. Only current option for now is "`none`".
@@ -2779,7 +2770,6 @@ SiB2 upper right lon:             -67.025
 SiB2 resolution (dx):               0.05
 SiB2 resolution (dy):               0.05
 ....
-endif::devonly[]
 
 ==== WRSI model parameter files
 
@@ -2844,7 +2834,6 @@ PPT climatology maps:  ../LS_PARAMETERS/climate_maps/ppt_1981_2010
 PPT climatology interval:     monthly
 ....
 
-ifdef::devonly[]
 `TMIN climatology maps:` specifies the source of the climatology based minimum temperature files.
 
 `TMAX climatology maps:` specifies the source of the climatology based maximum temperature files.
@@ -2854,7 +2843,6 @@ ifdef::devonly[]
 TMIN climatology maps:
 TMAX climatology maps:
 ....
-endif::devonly[]
 
 `Climate params spatial transform:` indicates which spatial transform (i.e., upscale or downscale) type is to be applied to climate parameters. Only "`average`" spatial transform works currently for the "`WORLDCLIM`" climatology files. Options include:
 

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -51,13 +51,11 @@ Acceptable values are:
 |Value                    | Description
 
 |"`retrospective`"        | Retrospective mode
-ifdef::devonly[]
 |"`RTM forward`"          | RTM forward mode
 |"`AGRMET ops`"           | AFWA AGRMET mode
-endif::devonly[]
 |"`WRF coupling`"         | Coupled WRF mode
-ifdef::devonly[]
 |"`GCE coupling`"         | Coupled GCE mode
+ifdef::devonly[]
 |"`GFS coupling`"         | Coupled GFS mode
 endif::devonly[]
 |"`parameter estimation`" | Parameter estimation mode
@@ -174,9 +172,7 @@ Acceptable values are:
 |Mosaic      | Mosaic
 |HySSiB      | Hy-SSiB
 |GeoWRSI.2   | GeoWRSI version 2.0
-ifdef::devonly[]
-|JULES.4.3   | JULES version 4.3
-endif::devonly[]
+|JULES.5.0   | JULES version 5.0
 |CABLE.1.4b  | CABLE version 1.4b
 ifdef::devonly[]
 |FASST       | FASST
@@ -192,8 +188,6 @@ Land surface model: Noah.2.7.1
 ....
 
 
-ifdef::devonly[]
-
 `Lake model:` specifies the lake model to run.
 Acceptable values are:
 
@@ -207,7 +201,6 @@ Acceptable values are:
 ....
 Lake model:
 ....
-endif::devonly[]
 
 
 `Open water model:` specifies the open water model to run.
@@ -225,8 +218,6 @@ Open water model:
 ....
 
 
-ifdef::devonly[]
-
 `land slide model:` specifies the land slide model to run.
 Acceptable values are:
 
@@ -241,7 +232,6 @@ Acceptable values are:
 ....
 land slide model:
 ....
-endif::devonly[]
 
 
 `Number of met forcing sources:` specifies the
@@ -313,9 +303,7 @@ Acceptable values for the sources are:
 |"`GSWP1`"                     | GSWP1
 |"`GSWP2`"                     | GSWP2
 |"`ECMWF reanalysis`"          | ECMWF Reanalysis
-ifdef::devonly[]
 |"`AGRMET`"                    | AGRMET
-endif::devonly[]
 |"`PRINCETON`"                 | Princeton
 |"`NLDAS1`"                    | NLDAS1
 |"`NLDAS2`"                    | NLDAS2
@@ -336,19 +324,15 @@ endif::devonly[]
 |"`RFE2(daily)`"               | Daily rainfall estimator
 |"`RFE2(GDAS bias-corrected)`" | RFE2 data bias corrected to GDAS
 |"`CHIRPS2`"                   | UCSB CHIRPS v2.0 precipitation dataset
-ifdef::devonly[]
 |"`ALMIPII`"                   | ALMIPII
-endif::devonly[]
 |"`CEOP`"                      | CEOP
 |"`SCAN`"                      | SCAN
-ifdef::devonly[]
 |"`ARMS`"                      | ARMS
-endif::devonly[]
 |"`GDAS(LSWG)`"                | GDAS data for LSWG project
 ifdef::devonly[]
 |"`D2PCPOKL`"                  | D2PCPOKL
-|"`GDAS(3d)`"                  | GDAS 3d data
 endif::devonly[]
+|"`GDAS(3d)`"                  | GDAS 3d data
 |"`AGRMET radiation`"          | AGRMET radiation
 |"`Bondville`"                 | Bondville site data
 ifdef::devonly[]
@@ -1146,36 +1130,28 @@ Acceptable values are:
 |Value                          | Description
 
 |"`none`"                       | none
-ifdef::devonly[]
 |"`Synthetic SM`"               | Synthetic soil moisture
 |"`Synthetic SWE`"              | Synthetic SWE
 |"`Synthetic LST`"              | Synthetic LST
 |"`Synthetic(Multilayer) sm`"   | Synthetic multi-soil moisture observation types
 |"`Synthetic L-band Tb`"        | Synthetic L-band brightness temperature observations
 |"`ISCCP LST`"                  | ISCCP LST
-endif::devonly[]
 |"`AMSR-E(NASA) soil moisture`" | AMSRE L3 soil moisture daily gridded data (HDF format)
 |"`AMSR-E(LPRM) soil moisture`" | AMSRE L3 soil moisture daily gridded data (HDF format)
 |"`ESA CCI soil moisture`"      | ESA CCI soil moisture
 |"`Windsat`"                    | Windsat
-ifdef::devonly[]
 |"`Windsat C-band`"             | Windsat C-band
 |"`ANSA SWE`"                   | ANSA SWE
-endif::devonly[]
 |"`ANSA SCF`"                   | ANSA SCF
 |"`ANSA snow depth`"            | ANSA snow depth
 |"`SMMR snow depth`"            | SMMR snow depth
 |"`SMMI snow depth`"            | SMMI snow depth
-ifdef::devonly[]
 |"`AMSR-E SWE`"                 | AMSR-E SWE
-endif::devonly[]
 |"`PMW snow`"                   | PMW-based SWE or snow depth
 |"`MODIS SCF`"                  | MODIS SCF
 |"`GRACE TWS`"                  | GRACE TWS
 |"`SMOPS-ASCAT soil moisture`"  | SMOPS-ASCAT soil moisture
-ifdef::devonly[]
 |"`ASCAT (TUW) soil moisture`"  | ASCAT (TUW) soil moisture
-endif::devonly[]
 |"`GCOMW AMSR2 L3 snow depth`"  | AMSR2 (GCOMW) L3 snow depth
 |"`GCOMW AMSR2 L3 soil moisture`" | AMSR2 (GCOMW) soil moisture
 |"`SMAP(NASA) soil moisture`"   | NASA SMAP soil moisture
@@ -1706,7 +1682,6 @@ Observation perturbation attributes file: none
 IMS data directory:
 ....
 
-ifdef::devonly[]
 
 [[sssec_syntheticsm,Synthetic Soil Moisture Assimilation]]
 ==== Synthetic Soil Moisture Assimilation
@@ -1731,7 +1706,6 @@ Synthetic soil moisture model CDF file:       lsm.cdf.nc
 Synthetic soil moisture observation CDF file: obs_cdf.nc
 Synthetic soil moisture number of bins in the CDF:
 ....
-endif::devonly[]
 
 
 [[sssec_pildassm,PILDAS Soil Moisture Assimilation]]
@@ -1764,7 +1738,6 @@ PILDAS soil moisture number of bins in the CDF:
 ....
 
 
-ifdef::devonly[]
 
 [[sssec_syntheticmultism,Synthetic Soil Moisture (multiple observation types) Assimilation]]
 ==== Synthetic Soil Moisture (multiple observation types) Assimilation
@@ -1777,10 +1750,7 @@ directory for the synthetic soil moisture data (multi-levels).
 ....
 Synthetic multi-sm data directory: ./input/dainput/SynSM/
 ....
-endif::devonly[]
 
-
-ifdef::devonly[]
 
 [[sssec_syntheticswe,Synthetic SWE Assimilation]]
 ==== Synthetic SWE Assimilation
@@ -1792,10 +1762,7 @@ for the synthetic snow water equivalent data.
 ....
 Synthetic SWE data directory:           ./input/dainput/SynSWE/
 ....
-endif::devonly[]
 
-
-ifdef::devonly[]
 
 [[sssec_syntheticlst,Synthetic LST Assimilation]]
 ==== Synthetic LST Assimilation
@@ -1807,10 +1774,7 @@ for the synthetic land surface temperature data
 ....
 Synthetic LST data directory:           ./input/dainput/SynLST/
 ....
-endif::devonly[]
 
-
-ifdef::devonly[]
 
 [[sssec_syntheticlbandtb,Synthetic L-band Tb Assimilation]]
 ==== Synthetic L-band Tb Assimilation
@@ -1822,10 +1786,7 @@ for the synthetic brightness temperature data
 ....
 Synthetic L-band Tb data directory:           ./input/dainput/SynTb/
 ....
-endif::devonly[]
 
-
-ifdef::devonly[]
 
 [[sssec_syntheticsndda,Synthetic SND Assimilation]]
 ==== Synthetic SND Assimilation
@@ -1837,10 +1798,7 @@ for the synthetic snow depth data.
 ....
 Synthetic SND data directory:
 ....
-endif::devonly[]
 
-
-ifdef::devonly[]
 
 [[sssec_isccptskinda,ISCCP Tskin Assimilation]]
 ==== ISCCP Tskin Assimilation
@@ -1873,7 +1831,6 @@ ISCCP Tskin model std data file: ../SND_Input/noah_std
 ISCCP Tskin obs mean data file: ../SND_Input/isccp_obs_mean
 ISCCP Tskin obs std data file: ../SND_Input/isccp_obs_std
 ....
-endif::devonly[]
 
 
 [[sssec_nasaamsreda,AMSR-E (NASA) soil moisture assimilation]]
@@ -1969,8 +1926,6 @@ WindSat number of bins in the CDF:           100
 ....
 
 
-ifdef::devonly[]
-
 [[sssec_windsatcbandsmda,WindSat C-band soil moisture assimilation]]
 ==== WindSat C-band soil moisture assimilation
 
@@ -1998,7 +1953,6 @@ WindSat C-band model CDF file:                      lsm_cdf.nc
 WindSat C-band observation CDF file:                obs_cdf.nc
 WindSat C-band number of bins in the CDF: 100
 ....
-endif::devonly[]
 
 
 [[sssec_snodepda,SNODEP Assimilation]]
@@ -2045,8 +1999,6 @@ USAFSI data directory:                  ./FORCING/USAFSI
 USAFSI netcdf filename prefix:         usafsi
 ....
 
-ifdef::devonly[]
-
 [[sssec_ansasweda,ANSA SWE Assimilation]]
 ==== ANSA SWE Assimilation
 
@@ -2081,7 +2033,6 @@ ANSA SWE upper right lon:                 179.875
 ANSA SWE resolution (dx):                  0.25
 ANSA SWE resolution (dy):                  0.25
 ....
-endif::devonly[]
 
 
 [[sssec_ansascfda,ANSA Snow Covered Fraction (SCF) Assimilation]]
@@ -2321,8 +2272,6 @@ SSMI snow depth MOD10C1 data directory:
 ....
 
 
-ifdef::devonly[]
-
 [[sssec_amsresweda,AMSR-E SWE Assimilation]]
 ==== AMSR-E SWE Assimilation
 
@@ -2333,7 +2282,6 @@ SSMI snow depth data.
 ....
 AMSR-E SWE data directory:                  ./AMSRE_SWE
 ....
-endif::devonly[]
 
 
 [[sssec_modisscfda,MODIS snow cover fraction assimilation]]
@@ -2743,8 +2691,6 @@ SMOS L2 soil moisture number of bins in the CDF:
 ....
 
 
-ifdef::devonly[]
-
 [[sssec_ascattuwsmda,ASCAT (TU Wein) soil moisture assimilation]]
 ==== ASCAT (TU Wein) soil moisture assimilation
 
@@ -2773,7 +2719,6 @@ ASCAT (TUW) model CDF file:                      lsm_cdf.nc
 ASCAT (TUW) observation CDF file:                obs_cdf.nc
 ASCAT (TUW) soil moisture number of bins in the CDF: 100
 ....
-endif::devonly[]
 
 
 [[sssec_simgraceda,Simulated GRACE]]
@@ -2813,8 +2758,6 @@ Simulated GRACE use reported measurement error values:
 ....
 
 
-ifdef::devonly[]
-
 [[sssec_synsfda,Synthetic Streamflow]]
 ==== Synthetic Streamflow
 
@@ -2825,7 +2768,6 @@ of the synthetic streamflow data.
 ....
 Synthetic streamflow data directory:
 ....
-endif::devonly[]
 
 
 [[sssec_esaccismda,ESA CCI soil moisture data assimilation]]
@@ -3434,14 +3376,10 @@ Acceptable values are:
 |Value                                     | Description
 
 |"`none`"                                  | no optimization
-ifdef::devonly[]
 |"`Enumerated search`"                     | enumerated search
-endif::devonly[]
 |"`Levenberg marquardt`"                   | Levenberg-Marquardt
 |"`Genetic algorithm`"                     | Genetic Algorithm
-ifdef::devonly[]
 |"`Shuffled complex evolution`"            | SCE-UA Algorithm
-endif::devonly[]
 |"`Monte carlo sampling`"                  | MCSIM Algorithm
 |"`Random walk markov chain monte carlo`"  | MCMC Algorithm
 |"`Differential evolution markov chain`"   | DEMC Algorithm
@@ -3459,16 +3397,18 @@ Acceptable values are:
 
 |"`NONE`"                 | template observations
 |"`No obs`"               | no observations
-ifdef::devonly[]
 |"`WG PBMR sm`"           | PBMR soil moisture data for Walnut Gulch
 |"`Synthetic sm1`"        | synthetic soil moisture data
+ifdef::devonly[]
 |"`Synthetic sm2`"        | synthetic soil moisture data
+endif::devonly[]
 |"`Ameriflux obs`"        | flux data from the Ameriflux data network
 |"`ARM obs`"              | fluxes, soil moisture, and soil temperature
                             data from the ARM network
 |"`Macon landslide obs`"  | Macon County landslide observation data
 |"`Global landslide obs`" | Global landslide observation data
 |"`CNRS`"                 | CNRS
+ifdef::devonly[]
 |"`CNRS MPDI`"            | CNRS MPDI
 endif::devonly[]
 |"`AMSRE SR`"             | AMSR-E (Colorado State Univ.)
@@ -3477,10 +3417,8 @@ ifdef::devonly[]
                             Index (Colorado State Univ.)
 endif::devonly[]
 |"`AMSR-E(LPRM) pe soil moisture`" | AMSR-E LPRM soil moisture
-ifdef::devonly[]
 |"`Gridded FLUXNET`"      | FLUXNET
 |"`USDA ARSsm`"           | USDA ARS soil moisture
-endif::devonly[]
 |====
 
 `Objective Function Method:` specifies the objective function
@@ -3490,9 +3428,7 @@ Acceptable values are:
 |====
 |Value             | Description
 
-ifdef::devonly[]
 |"`LM`"            | Least squares (Levenberg-Marquardt)
-endif::devonly[]
 |"`Least squares`" | Least squares
 |"`Likelihood`"    | Maximum likelihood
 |"`Probability`"   | Maximize probability
@@ -3607,8 +3543,6 @@ instance.  There are no additional specifications needed.  Unlike the Probabilit
 objective function, Likelihood does not factor in prior probability.
 
 
-ifdef::devonly[]
-
 [[ssec_es,Enumerated search]]
 ==== Enumerated search
 
@@ -3619,7 +3553,6 @@ attributes file.
 ....
 ES decision space attributes file:
 ....
-endif::devonly[]
 
 
 [[ssec_lm,Levenberg Marquardt]]
@@ -3740,7 +3673,6 @@ GA start mode:                                 coldstart
 ....
 
 
-ifdef::devonly[]
 [[ssec_sceua,Shuffled complex evolution]]
 ==== Shuffled complex evolution
 
@@ -3792,7 +3724,6 @@ SCEUA Number of Points in a Subcomplex:
 SCEUA Num. of Evolution Steps before Shuffle for a Complex:
 SCEUA Whether Include Initial Point in Population:
 ....
-endif::devonly[]
 
 
 [[ssec_rwmcmc,Random walk markov chain monte carlo]]
@@ -3965,8 +3896,6 @@ MCSIM restart file:                 none
 This section of the config file includes the observation specifications
 for parameter estimation.
 
-ifdef::devonly[]
-
 [[sssec_wgpbmrsm,Walnut Gulch PBMR soil moisture data]]
 ==== Walnut Gulch PBMR soil moisture data
 
@@ -3985,10 +3914,6 @@ WG PBMR soil moisture data directory:   ../WG_domain/PBMR/
 WG PBMR observations attributes file:   ./wgPBMRsm_attribs.txt
 WG PBMR site index:                     5
 ....
-endif::devonly[]
-
-
-ifdef::devonly[]
 
 [[sssec_pesynsm1,Synthetic soil moisture1]]
 ==== Synthetic soil moisture1
@@ -4008,10 +3933,7 @@ Syn SM data directory:
 Syn SM observations attributes file:
 Syn SM number of observation types:
 ....
-endif::devonly[]
 
-
-ifdef::devonly[]
 
 [[sssec_ameriflux,Ameriflux network observations]]
 ==== Ameriflux network observations
@@ -4028,9 +3950,6 @@ Ameriflux data directory:
 Ameriflux station list file:
 Ameriflux observations attributes file:
 ....
-endif::devonly[]
-
-ifdef::devonly[]
 
 [[sssec_armobs,ARM network observations]]
 ==== ARM network observations
@@ -4053,10 +3972,7 @@ ARM station list file:
 ARM objective space attributes file:
 ARM number of observation types:
 ....
-endif::devonly[]
 
-
-ifdef::devonly[]
 
 [[sssec_mcland,Macon County landslide observation data]]
 ==== Macon County landslide observation data
@@ -4072,9 +3988,7 @@ Macon County landslide observation attributes file.
 Macon County Landslide Obs data directory:
 Macon County Landslide observations attributes file:
 ....
-endif::devonly[]
 
-ifdef::devonly[]
 
 [[sssec_glbland,Global landslide observation data]]
 ==== Global landslide observation data
@@ -4090,10 +4004,7 @@ landslide observations attributes file.
 Global Landslide Obs data directory:
 Global Landslide observations attributes file:
 ....
-endif::devonly[]
 
-
-ifdef::devonly[]
 
 [[sssec_cnrs,CNRS]]
 ==== CNRS
@@ -4131,7 +4042,6 @@ Mask hr descending lower:
 Mask hr descending upper:
 Mask cloud threshold:
 ....
-endif::devonly[]
 
 
 [[sssec_amsresremobs,AMSRE_SR Emissivity]]
@@ -4186,8 +4096,6 @@ LPRM AMSRE soil moisture observations attributes file: './LPRM_attribs.txt'
 ....
 
 
-ifdef::devonly[]
-
 [[sssec_usdaarssm,USDA ARS soil moisture]]
 ==== USDA ARS soil moisture
 
@@ -4205,10 +4113,7 @@ USDA ARS Soilmoisture Obs data directory:
 USDA ARS Soilmoisture observations attributes file:
 USDA ARS number of observations threshold:
 ....
-endif::devonly[]
 
-
-ifdef::devonly[]
 
 [[sssec_fluxnet,FLUXNET]]
 ==== FLUXNET
@@ -4225,7 +4130,6 @@ FLUXNET data directory:
 FLUXNET objective space attributes file:
 FLUXNET number of observation types:
 ....
-endif::devonly[]
 
 
 //ifdef::devonly[]
@@ -4644,7 +4548,6 @@ TBOT skin temperature lag days:          0
 ....
 
 
-ifdef::devonly[]
 [[sssec_almipiirtalb,ALMIPII real-time albedo]]
 ==== ALMIPII real-time albedo
 
@@ -4655,7 +4558,6 @@ ALMIPII real-time albedo data.
 ....
 ALMIPII albedo data directory:
 ....
-endif::devonly[]
 
 
 //[[sssec_modisclimolai,MODIS monthly climatology LAI]]
@@ -4682,7 +4584,6 @@ MODIS RT LAI data directory:
 ....
 
 
-ifdef::devonly[]
 [[sssec_almipiirtlai,ALMIPII real-time LAI]]
 ==== ALMIPII real-time LAI
 
@@ -4693,7 +4594,6 @@ ALMIPII real-time LAI files.
 ....
 ALMIPII LAI data directory:
 ....
-endif::devonly[]
 
 
 [[sssec_nesdisgreenness,NESDIS weekly greenness fraction]]
@@ -4818,7 +4718,6 @@ VIIRS GVF resolution (dy):         0.036
 ....
 
 
-ifdef::devonly[]
 [[sssec_almipiirtgreenness,ALMIPII real-time greenness fraction]]
 ==== ALMIPII real-time greenness fraction
 
@@ -4829,10 +4728,8 @@ real-time greenness data.
 ....
 ALMIPII greenness data directory:
 ....
-endif::devonly[]
 
 
-ifdef::devonly[]
 [[sssec_almipiirtemiss,ALMIPII real-time emissivity]]
 ==== ALMIPII real-time emissivity
 
@@ -4843,10 +4740,8 @@ real-time emissivity data.
 ....
 ALMIPII emissivity data directory:
 ....
-endif::devonly[]
 
 
-ifdef::devonly[]
 [[sssec_almipiirtrough,ALMIPII real-time roughness]]
 ==== ALMIPII real-time roughness
 
@@ -4857,7 +4752,6 @@ real-time roughness data.
 ....
 ALMIPII roughness data directory:
 ....
-endif::devonly[]
 
 
 [[ssec_forcings,Forcings]]
@@ -4925,8 +4819,6 @@ ECMWF Reanalysis domain x-dimension size:     720
 ECMWF Reanalysis domain y-dimension size:     360
 ....
 
-
-ifdef::devonly[]
 
 [[sssec_forcings_afwa,AFWA/AGRMET]]
 ==== AFWA/AGRMET
@@ -5457,7 +5349,6 @@ AGRMET use GFS precip:     1
 AGRMET use GALWEM precip:  0
 AGRMET radiation derived from: 'cloud types'
 ....
-endif::devonly[]
 
 
 [[sssec_forcings_princeton,PRINCETON]]
@@ -5730,8 +5621,6 @@ AGRRADPS forcing directory:             ./input/FORCING/AGRRADPS
 ....
 
 
-ifdef::devonly[]
-
 [[sssec_supp_capa,CaPA]]
 ==== CaPA
 
@@ -5742,7 +5631,6 @@ CAPA precipitation data.
 ....
 CAPA forcing directory:             ./input/FORCING/CAPA
 ....
-endif::devonly[]
 
 
 [[sssec_supp_cmap,CMAP precipitation]]
@@ -6093,8 +5981,6 @@ NARR domain z-dimension size:      30
 ....
 
 
-ifdef::devonly[]
-
 [[sssec_supp_gdas3d,GDAS3D]]
 ==== GDAS3D
 
@@ -6120,10 +6006,7 @@ GDAS3D domain x-dimension size:      768
 GDAS3D domain y-dimension size:      386
 GDAS3D domain z-dimension size:      64
 ....
-endif::devonly[]
 
-
-ifdef::devonly[]
 
 [[sssec_supp_arms,ARMS]]
 ==== ARMS
@@ -6143,7 +6026,6 @@ ARMS forcing file:        ../WG_domain/1990_forc.txt
 ARMS precip forcing file: ../WG_domain/WGbrk_19900723-19900815.out
 ARMS station metadata file: ../WG_domain/WGbrk_stnlocs_1990.dat
 ....
-endif::devonly[]
 
 
 [[sssec_supp_rfe2daily,RFE2Daily]]
@@ -6184,8 +6066,6 @@ CHIRPS2.0 forcing resolution:     0.05
 ....
 
 
-ifdef::devonly[]
-
 [[sssec_supp_almipii,ALMIPII]]
 ==== ALMIPII
 
@@ -6200,7 +6080,6 @@ of the ALMIPII forcing data.  The prefix is based on the site name.
 ALMIPII forcing directory:
 ALMIPII filename prefix:
 ....
-endif::devonly[]
 
 
 [[sssec_supp_petusgs,PET_USGS]]
@@ -8823,41 +8702,30 @@ VIC412 convert units:              1
 ....
 
 
-ifdef::devonly[]
+[[sssec_lsm_jules43,JULES 5.0]]
+==== JULES 5.0
 
-[[sssec_lsm_jules43,JULES 4.3]]
-==== JULES 4.3
+`JULES.5.0 model timestep:` specifies the timestep for the run.
 
-`JULES.4.3 model timestep:` specifies the timestep for the run.
+`JULES.5.0 restart file:` specifies the JULES.5.0 active restart file.
 
-`JULES.4.3 restart file:` specifies the JULES.4.3 active restart file.
+`JULES.5.0 namelist directory:` directory containing JULES.5.0 configuration name lists
 
-`JULES.4.3 namelist directory:` directory containing JULES.4.3 configuration name lists
+`JULES.5.0 restart output interval:` JULES.5.0 restart time interval
 
-`JULES.4.3 using 360-day calender:` `.true.` or `.false.` for using 360-day calender
+`JULES.5.0 reference height for forcing T and q:` reference height for air temperature and humidity
 
-`JULES.4.3 using aggregated surface scheme:` `.true.` or `.false.` for using aggregated land surface scheme
-
-`JULES.4.3 restart output interval:` JULES.4.3 restart time interval
-
-`JULES.4.3 reference height for forcing T and q:` reference height for air temperature and humidity
-
-`JULES.4.3 reference height for forcing u and v:` reference height for wind speed
-
-//`JULES.4.3 soil moisture CDF file:` specifies the JULES.4.3 soil moisture CDF file.
+`JULES.5.0 reference height for forcing u and v:` reference height for wind speed
 
 .Example _lis.config_ entry
 ....
-JULES.4.3 model timestep:                  15mn
-JULES.4.3 restart file:
-JULES.4.3 namelist directory:              ./
-JULES.4.3 using 360-day calender:          .false.
-JULES.4.3 using aggregated surface scheme: .false.
-JULES.4.3 restart output interval:         1mo
-JULES.4.3 reference height for forcing T and q: 2
-JULES.4.3 reference height for forcing u and v: 10
+JULES.5.0 model timestep:                  15mn
+JULES.5.0 restart file:
+JULES.5.0 namelist directory:              ./
+JULES.5.0 restart output interval:         1mo
+JULES.5.0 reference height for forcing T and q: 2
+JULES.5.0 reference height for forcing u and v: 10
 ....
-endif::devonly[]
 
 
 [[sssec_lsm_mosaic,Mosaic]]
@@ -9712,8 +9580,6 @@ AWRAL600 initial sd: 0.5 0.5
 AWRAL600 initial mleaf: 0.67 0.2
 ....
 
-ifdef::devonly[]
-
 [[ssec_lakes,Lake models]]
 === Lake models
 
@@ -9813,7 +9679,6 @@ FLAKE1 initial water surface albedo with respect to solar radiation:
 FLAKE1 initial ice surface albedo with respect to the solar radiation:
 FLAKE1 initial snow surface albedo with respect to the solar radiation:
 ....
-endif::devonly[]
 
 
 [[ssec_openwater,Open water models]]
@@ -9833,8 +9698,6 @@ of how to specify a time interval.
 Template open water timestep:
 ....
 
-
-ifdef::devonly[]
 
 [[ssec_landslides,Land slide models]]
 === Land slide models
@@ -9902,7 +9765,6 @@ TRIGRS initialization file:
 TRIGRS app timestep:
 TRIGRS rain input source style:
 ....
-endif::devonly[]
 
 
 [[ssec_irrigation,Irrigation]]


### PR DESCRIPTION
Update components of LISF that should be hidden within a development-only guard

This aspect of the Users' Guides should be removed, but a thorough code
review is required first.