### PR TITLE
Prevent divide-by-zero in Noah-MP with frozen soils

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/phys/module_sf_noahmplsm_401.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/phys/module_sf_noahmplsm_401.F90
@@ -7747,7 +7747,10 @@ ENDIF   ! CROPTYPE == 0
          END DO
 
          DO IZ = 1, NSOIL           ! Removing subsurface runoff
-         MLIQ(IZ) = MLIQ(IZ) - QDIS*DT*HK(IZ)*DZMM(IZ)/WTSUB
+! Prevent divide-by-zero when soils are frozen. - DMM
+            if (WTSUB.ne.0.0) then
+               MLIQ(IZ) = MLIQ(IZ) - QDIS*DT*HK(IZ)*DZMM(IZ)/WTSUB
+            endif
          END DO
       END IF
 


### PR DESCRIPTION
This pull request will prevent a divide-by-zero in the
Noah-MP-4.0.1 physics when removing sub-surface runoff.
This divide-by-zero is very rare, but can occur when
the soils are totally frozen.  The sub-surface runoff
will be zero as well as the hydraulic conductivity.
A simple check of the hydraulic conductivity was added
to prevent the divide-by-zero.