### PR TITLE
Fix allocation in LIS_DAobservationsMod

### DIFF
--- a/lis/core/LIS_DAobservationsMod.F90
+++ b/lis/core/LIS_DAobservationsMod.F90
@@ -360,7 +360,7 @@ contains
 #endif
        do k=1,LIS_rc%ndas
 
-          allocate(deblklist(2,2,LIS_npes))
+          allocate(deblklist(1,2,LIS_npes))
           do i=0,LIS_npes-1
              stid = LIS_ooffsets(k,i)+1
              enid = stid + LIS_obs_ngrids(k,i)-1


### PR DESCRIPTION
This pull request fixes an allocation in LIS_DAobservationsMod.

This fix was previously made in commit 58c6ddd in the master
branch, but is also needed to assist with debugging in the
support/lisf-557ww-7.3 branch.