### PR TITLE
Correct typo of HYMAP2 option in lis.config.adoc

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -9970,7 +9970,7 @@ Acceptable values are:
 
 |kinematic          | use kinematic method
 |diffusive          | use diffusive method
-|"`local intertia`" | use local intertia method
+|"`local inertia`"  | use local inertia method
 |hybrid             | use hybrid method (requires a river flow map from LDT)
 |====
 


### PR DESCRIPTION
Corrected a typo in the lis.config.adoc file for the config option "HYMAP2 routing method:".

One of the options should be "local inertia", which is what is also shown in the HYMAP2 routing code.

This should be migrated into master as well.