### PR TITLE
[LDT] Add revised 10-km snow climatology for USAF-SI analysis

### DIFF
--- a/ldt/USAFSI/LDT_usafsiMod.F90
+++ b/ldt/USAFSI/LDT_usafsiMod.F90
@@ -83,6 +83,9 @@ module LDT_usafsiMod
      ! Output file name (prefix)
      character*20 :: netcdf_prefix
 
+     ! option for snow climatology
+     integer       :: climo_option
+
   end type usafsi_t
   type(usafsi_t), public :: usafsi_settings
 
@@ -195,6 +198,14 @@ contains
             rc=rc)
        call LDT_verify(rc, trim(cfg_entry)//" not specified")
     end if
+
+    ! get option for snow climatology
+    cfg_entry = "USAFSI Snow Climatology:"
+    call ESMF_ConfigFindLabel(LDT_config, trim(cfg_entry), rc=rc)
+    call LDT_verify(rc, trim(cfg_entry)//" not specified")
+    call ESMF_ConfigGetAttribute(LDT_config, usafsi_settings%climo_option,&
+         rc=rc)
+    call LDT_verify(rc, trim(cfg_entry)//" not specified")
 
     ! *** Get former namelist variables ***
 

--- a/ldt/USAFSI/ldt.config.sample
+++ b/ldt/USAFSI/ldt.config.sample
@@ -42,6 +42,9 @@ USAFSI SSMIS snow depth retrieval algorithm option:   3
 # Forest fraction only for algorithm 3
 USAFSI SSMIS forest fraction file:         ./USAFSIIN/ForestFraction_0p25deg.nc
 
+# *** Snow climatology
+USAFSI Snow Climatology:                              1  # 1: legacy 2: updated 10-km climo
+
 # *** Former Namelist Variables ***
 USAFSI decimal fraction adjustment of snow depth towards climo: 0.1
 USAFSI default snow depth (m) when actual depth unknown: 0.1

--- a/ldt/configs/ldt.config.adoc
+++ b/ldt/configs/ldt.config.adoc
@@ -4225,6 +4225,21 @@ USAFSI SSMIS snow depth retrieval algorithm option:   3
 USAFSI SSMIS forest fraction file:     ./SNODEPIN/ForestFraction_0p25deg.nc
 ....
 
+`USAFSI Snow Climatology:` specifies snow climatology data. Acceptable values are:
+
+  [cols="<,<",]
+ |===
+ |Value |Description
+
+ |1 |legacy
+ |2 |updated 10-km climo
+ |===
+
+  .Example _ldt.config_ entry
+ ....
+ USAFSI Snow Climatology:    1
+ ....
+
 `USAFSI decimal fraction adjustment of snow depth towards climo):` controls drift to climo in data void region
 
 `USAFSI default snow depth (m) when actual depth unknown:` bogus value for when snow detected but depth unknown


### PR DESCRIPTION
Updated snow climatology for USAF-SI analysis using relationship between SNODEP and USAFI-SI.

Updated snow climatology (NetCDF) are in here:
/discover/nobackup/projects/lis/MET_FORCING/USAF_FORCING/Inputs_for_USAFSI/static/snoclimo_10km

Needed below new line in ldt.config to run
USAFSI Snow Climatology:                              1  # 1: legacy 2: updated 10-km climo.

Testcase:
/discover/nobackup/yyoon4/lis7/Testcase/ldt_usafsi_climo

 

