### PR TITLE
Fix LVT Max and Min metric time series output

### DIFF
--- a/lvt/core/LVT_statsDataMod.F90
+++ b/lvt/core/LVT_statsDataMod.F90
@@ -40,6 +40,7 @@ module LVT_statsDataMod
 !
 ! !REVISION HISTORY:
 !  02 Oct 2008: Sujay Kumar; Initial version
+!  05 Feb 2021: David Mocko; Fixed Max and Min metric time series output
 ! 
 !EOP
 
@@ -47,40 +48,54 @@ module LVT_statsDataMod
 
   type min_metric_spec 
      real,    allocatable :: model_value_total(:,:,:)     
+     integer, allocatable :: count_model_value_total(:,:,:)     
      real,    allocatable :: model_value_ci(:,:)
      real,    allocatable :: model_value_ts(:,:,:)        
+     integer, allocatable :: count_model_value_ts(:,:,:)        
      real,    allocatable :: tavg_model_value_ts(:,:,:)        
+     integer, allocatable :: tavg_count_model_value_ts(:,:,:)        
      real,    allocatable :: model_value_asc(:,:,:)
+     integer, allocatable :: count_model_value_asc(:,:,:)
      real,    allocatable :: model_value_adc(:,:,:)
+     integer, allocatable :: count_model_value_adc(:,:,:)
 
      real,    allocatable :: obs_value_total(:,:,:)     
+     integer, allocatable :: count_obs_value_total(:,:,:)     
      real,    allocatable :: obs_value_ci(:,:)
      real,    allocatable :: obs_value_ts(:,:,:)        
+     integer, allocatable :: count_obs_value_ts(:,:,:)        
      real,    allocatable :: tavg_obs_value_ts(:,:,:)        
+     integer, allocatable :: tavg_count_obs_value_ts(:,:,:)        
      real,    allocatable :: obs_value_asc(:,:,:)
+     integer, allocatable :: count_obs_value_asc(:,:,:)
      real,    allocatable :: obs_value_adc(:,:,:)
-
-     integer, allocatable :: tavg_count_model_value_ts(:,:,:)
-     integer, allocatable :: tavg_count_obs_value_ts(:,:,:)
+     integer, allocatable :: count_obs_value_adc(:,:,:)
   end type min_metric_spec
 
   type max_metric_spec
      real,    allocatable :: model_value_total(:,:,:)     
+     integer, allocatable :: count_model_value_total(:,:,:)     
      real,    allocatable :: model_value_ci(:,:)
      real,    allocatable :: model_value_ts(:,:,:)        
+     integer, allocatable :: count_model_value_ts(:,:,:)        
      real,    allocatable :: tavg_model_value_ts(:,:,:)        
+     integer, allocatable :: tavg_count_model_value_ts(:,:,:)        
      real,    allocatable :: model_value_asc(:,:,:)
+     integer, allocatable :: count_model_value_asc(:,:,:)
      real,    allocatable :: model_value_adc(:,:,:)
+     integer, allocatable :: count_model_value_adc(:,:,:)
 
      real,    allocatable :: obs_value_total(:,:,:)     
+     integer, allocatable :: count_obs_value_total(:,:,:)     
      real,    allocatable :: obs_value_ci(:,:)
      real,    allocatable :: obs_value_ts(:,:,:)        
+     integer, allocatable :: count_obs_value_ts(:,:,:)        
      real,    allocatable :: tavg_obs_value_ts(:,:,:)        
+     integer, allocatable :: tavg_count_obs_value_ts(:,:,:)        
      real,    allocatable :: obs_value_asc(:,:,:)
+     integer, allocatable :: count_obs_value_asc(:,:,:)
      real,    allocatable :: obs_value_adc(:,:,:)
-
-     integer, allocatable :: tavg_count_model_value_ts(:,:,:)
-     integer, allocatable :: tavg_count_obs_value_ts(:,:,:)
+     integer, allocatable :: count_obs_value_adc(:,:,:)
   end type max_metric_spec
 
   type mintime_metric_spec

--- a/lvt/metrics/LVT_MEANMod.F90
+++ b/lvt/metrics/LVT_MEANMod.F90
@@ -9,14 +9,14 @@
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
 !
 !BOP
-! 
+!
 ! !MODULE: LVT_MEANMod
 ! \label(LVT_MEANMod)
 !
 ! !INTERFACE:
 module LVT_MEANMod
-! 
-! !USES:   
+!
+! !USES:
   use LVT_coreMod
   use LVT_histDataMod
   use LVT_statsDataMod
@@ -28,19 +28,20 @@ module LVT_MEANMod
   implicit none
 
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This module handles the computations required to compute mean values
-!  of desired variables from the LIS output
-! 
+!  of desired variables from the datastreams.
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
+! !REVISION HISTORY:
 !  2 Oct 2008    Sujay Kumar  Initial Specification
-! 
+!  5 Feb 2021    David Mocko  Code clean-up (not output changes)
+!
 !EOP
 !BOP
 !-----------------------------------------------------------------------------
@@ -54,116 +55,140 @@ module LVT_MEANMod
   public :: LVT_writerestart_MEAN
   public :: LVT_readrestart_MEAN
 !EOP
-  
+
   private
 
 contains
   subroutine LVT_initMEAN(selectNlevs, stats,metric)
-! !ARGUMENTS: 
+! !ARGUMENTS:
     integer                 :: selectNlevs(LVT_rc%nDataStreams)
     type(LVT_statsEntry)    :: stats
     type(LVT_metricEntry)   :: metric
 !
-! !DESCRIPTION: 
-! 
+! !DESCRIPTION:
+!
+!  This routine initializes the datastructures required to support
+!  the Mean computations.
+!
 !EOP
     integer                 :: m
 
     allocate(stats%mean(LVT_rc%nensem))
 
     do m=1,LVT_rc%nensem
-       if(metric%selectOpt.eq.1) then 
-          allocate(stats%mean(m)%model_value_total(LVT_rc%ngrid, selectNlevs(1), &
+       if(metric%selectOpt.eq.1) then
+          allocate(stats%mean(m)%model_value_total(LVT_rc%ngrid, &
+               selectNlevs(1), &
                LVT_rc%strat_nlevels))
           stats%mean(m)%model_value_total = 0.0
-          allocate(stats%mean(m)%count_model_value_total(LVT_rc%ngrid, selectNlevs(1), &
+          allocate(stats%mean(m)%count_model_value_total(LVT_rc%ngrid, &
+               selectNlevs(1), &
                LVT_rc%strat_nlevels))
           stats%mean(m)%count_model_value_total = 0
-          allocate(stats%mean(m)%model_value_ci(selectNlevs(1),LVT_rc%strat_nlevels))
+          allocate(stats%mean(m)%model_value_ci(selectNlevs(1),&
+               LVT_rc%strat_nlevels))
           stats%mean(m)%model_value_ci = LVT_rc%udef
-          
-          if(metric%computeSC.eq.1) then 
-             allocate(stats%mean(m)%model_value_asc(LVT_rc%ngrid, selectNlevs(1),&
+
+          if(metric%computeSC.eq.1) then
+             allocate(stats%mean(m)%model_value_asc(LVT_rc%ngrid, &
+                  selectNlevs(1), &
                   LVT_rc%nasc))
              stats%mean(m)%model_value_asc = 0.0
-             allocate(stats%mean(m)%count_model_value_asc(LVT_rc%ngrid, selectNlevs(1),&
+             allocate(stats%mean(m)%count_model_value_asc(LVT_rc%ngrid, &
+                  selectNlevs(1), &
                   LVT_rc%nasc))
              stats%mean(m)%count_model_value_asc = 0
           endif
-          if(metric%computeADC.eq.1) then 
-             allocate(stats%mean(m)%model_value_adc(LVT_rc%ngrid, selectNlevs(2),&
+          if(metric%computeADC.eq.1) then
+             allocate(stats%mean(m)%model_value_adc(LVT_rc%ngrid, &
+                  selectNlevs(2), &
                   LVT_rc%nadc))
              stats%mean(m)%model_value_adc = 0.0
-             allocate(stats%mean(m)%count_model_value_adc(LVT_rc%ngrid, selectNlevs(2),&
+             allocate(stats%mean(m)%count_model_value_adc(LVT_rc%ngrid, &
+                  selectNlevs(2), &
                   LVT_rc%nadc))
              stats%mean(m)%count_model_value_adc = 0
           endif
 
-          if(LVT_rc%obssource(2).ne."none") then 
-             if(selectNlevs(2).ge.1) then 
-                allocate(stats%mean(m)%obs_value_total(LVT_rc%ngrid, selectNlevs(2), &
+          if(LVT_rc%obssource(2).ne."none") then
+             if(selectNlevs(2).ge.1) then
+                allocate(stats%mean(m)%obs_value_total(LVT_rc%ngrid, &
+                     selectNlevs(2), &
                      LVT_rc%strat_nlevels))
                 stats%mean(m)%obs_value_total = 0.0
-                allocate(stats%mean(m)%count_obs_value_total(LVT_rc%ngrid, selectNlevs(2), &
+                allocate(stats%mean(m)%count_obs_value_total(LVT_rc%ngrid, &
+                     selectNlevs(2), &
                      LVT_rc%strat_nlevels))
                 stats%mean(m)%count_obs_value_total = 0
-                allocate(stats%mean(m)%obs_value_ci(selectNlevs(2),LVT_rc%strat_nlevels))
+                allocate(stats%mean(m)%obs_value_ci(selectNlevs(2), &
+                     LVT_rc%strat_nlevels))
                 stats%mean(m)%obs_value_ci = LVT_rc%udef
 
-                if(metric%computeSC.eq.1) then 
-                   allocate(stats%mean(m)%obs_value_asc(LVT_rc%ngrid, selectNlevs(2),&
+                if(metric%computeSC.eq.1) then
+                   allocate(stats%mean(m)%obs_value_asc(LVT_rc%ngrid, &
+                        selectNlevs(2), &
                         LVT_rc%nasc))
                    stats%mean(m)%obs_value_asc = 0.0
-                   allocate(stats%mean(m)%count_obs_value_asc(LVT_rc%ngrid, selectNlevs(2),&
+                   allocate(stats%mean(m)%count_obs_value_asc(LVT_rc%ngrid, &
+                        selectNlevs(2), &
                         LVT_rc%nasc))
                    stats%mean(m)%count_obs_value_asc = 0
                 endif
-                if(metric%computeADC.eq.1) then 
-                   allocate(stats%mean(m)%obs_value_adc(LVT_rc%ngrid, selectNlevs(2),&
+                if(metric%computeADC.eq.1) then
+                   allocate(stats%mean(m)%obs_value_adc(LVT_rc%ngrid, &
+                        selectNlevs(2), &
                         LVT_rc%nadc))
                    stats%mean(m)%obs_value_adc = 0.0
-                   allocate(stats%mean(m)%count_obs_value_adc(LVT_rc%ngrid, selectNlevs(2),&
+                   allocate(stats%mean(m)%count_obs_value_adc(LVT_rc%ngrid, &
+                        selectNlevs(2), &
                         LVT_rc%nadc))
                    stats%mean(m)%count_obs_value_adc = 0
                 endif
              endif
           endif
        endif
-       if(metric%timeOpt.eq.1) then 
-          allocate(stats%mean(m)%model_value_ts(LVT_rc%ngrid, selectNlevs(1), &
+
+       if(metric%timeOpt.eq.1) then
+          allocate(stats%mean(m)%model_value_ts(LVT_rc%ngrid, &
+               selectNlevs(1), &
                LVT_rc%strat_nlevels))
           stats%mean(m)%model_value_ts = 0.0
-          allocate(stats%mean(m)%count_model_value_ts(LVT_rc%ngrid, selectNlevs(1), &
+          allocate(stats%mean(m)%count_model_value_ts(LVT_rc%ngrid, &
+               selectNlevs(1), &
                LVT_rc%strat_nlevels))
           stats%mean(m)%count_model_value_ts = 0
 
-          allocate(stats%mean(m)%tavg_model_value_ts(LVT_rc%ngrid, selectNlevs(1), &
+          allocate(stats%mean(m)%tavg_model_value_ts(LVT_rc%ngrid, &
+               selectNlevs(1), &
                LVT_rc%strat_nlevels))
           stats%mean(m)%tavg_model_value_ts = 0.0
-          allocate(stats%mean(m)%tavg_count_model_value_ts(LVT_rc%ngrid, selectNlevs(1), &
+          allocate(stats%mean(m)%tavg_count_model_value_ts(LVT_rc%ngrid, &
+               selectNlevs(1), &
                LVT_rc%strat_nlevels))
           stats%mean(m)%tavg_count_model_value_ts = 0
 
-          if(LVT_rc%obssource(2).ne."none") then 
-             if(selectNlevs(2).ge.1) then 
-                allocate(stats%mean(m)%obs_value_ts(LVT_rc%ngrid, selectNlevs(2), &
+          if(LVT_rc%obssource(2).ne."none") then
+             if(selectNlevs(2).ge.1) then
+                allocate(stats%mean(m)%obs_value_ts(LVT_rc%ngrid, &
+                     selectNlevs(2), &
                      LVT_rc%strat_nlevels))
                 stats%mean(m)%obs_value_ts = 0.0
-                allocate(stats%mean(m)%count_obs_value_ts(LVT_rc%ngrid, selectNlevs(2), &
+                allocate(stats%mean(m)%count_obs_value_ts(LVT_rc%ngrid, &
+                     selectNlevs(2), &
                      LVT_rc%strat_nlevels))
                 stats%mean(m)%count_obs_value_ts = 0
 
-
-                allocate(stats%mean(m)%tavg_obs_value_ts(LVT_rc%ngrid, selectNlevs(2), &
+                allocate(stats%mean(m)%tavg_obs_value_ts(LVT_rc%ngrid, &
+                     selectNlevs(2), &
                      LVT_rc%strat_nlevels))
                 stats%mean(m)%tavg_obs_value_ts = 0.0
-                allocate(stats%mean(m)%tavg_count_obs_value_ts(LVT_rc%ngrid, selectNlevs(2), &
+                allocate(stats%mean(m)%tavg_count_obs_value_ts(LVT_rc%ngrid, &
+                     selectNlevs(2), &
                      LVT_rc%strat_nlevels))
                 stats%mean(m)%tavg_count_obs_value_ts = 0
-
-#if 0 
-! disabling this as it is rarely used. 
-                if(obs%stdev_flag) then 
+#if 0
+! disabling this as it is rarely used.
+                if(obs%stdev_flag) then
                    allocate(stats%mean(m)%obs_value_stdev_ts(LVT_rc%ngrid, selectNlevs(2), &
                         LVT_rc%strat_nlevels))
                    stats%mean(m)%obs_value_stdev_ts = 0.0
@@ -183,50 +208,50 @@ contains
           endif
        endif
     enddo
+
 !-------------------------------------------------------------------------
 ! Number of passes required to compute the metric
 !-------------------------------------------------------------------------
-
-    metric%npass = 1    
-    if(LVT_rc%obssource(2).ne."none") then 
-       metric%obsData = .true. 
+    metric%npass = 1
+    if(LVT_rc%obssource(2).ne."none") then
+       metric%obsData = .true.
     else
-       metric%obsData = .false. 
+       metric%obsData = .false.
     endif
-    metric%stdevFlag = .false. 
+    metric%stdevFlag = .false.
 
   end subroutine LVT_initMEAN
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_diagnoseMEAN
 ! \label{LVT_diagnoseMEAN}
 !
-! !INTERFACE: 
+! !INTERFACE:
   subroutine LVT_diagnoseMEAN(pass)
-! 
-! !USES:     
+!
+! !USES:
 
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-!   This subroutine issues the calls to update the computations for 
+! !DESCRIPTION:
+!   This subroutine issues the calls to update the computations for
 !   calculating the mean of desired variables.
 !
-!   The methods invoked are: 
+!   The methods invoked are:
 !   \begin{description}
 !    \item[diagnoseSingleModelMEAN](\ref{diagnoseSingleModelMEAN})
-!     updates the mean computation for a single variable 
+!     updates the mean computation for a single variable
 !   \end{description}
-! 
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 !BOP
     integer       :: pass
@@ -237,7 +262,7 @@ contains
 
     if(pass.eq.LVT_metrics%mean%npass) then
        if(LVT_metrics%mean%selectOpt.eq.1.or.&
-            LVT_metrics%mean%timeOpt.eq.1) then 
+            LVT_metrics%mean%timeOpt.eq.1) then
 
           call LVT_getDataStream1Ptr(model)
           call LVT_getDataStream2Ptr(obs)
@@ -255,54 +280,54 @@ contains
   end subroutine LVT_diagnoseMEAN
 
 !BOP
-! 
+!
 ! !ROUTINE: diagnoseSingleMEAN
 ! \label{diagnoseSingleMEAN}
 !
-! !INTERFACE: 
+! !INTERFACE:
   subroutine diagnoseSingleMEAN(model, obs, stats,metric)
-! 
-! !USES:   
+!
+! !USES:
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-!   This routine updates the mean computation of the 
-!   specified variable. 
+! !DESCRIPTION:
+!   This routine updates the mean computation of the
+!   specified variable.
 !
-!  The arguments are: 
+!  The arguments are:
 !
 !  \begin{description}
 !   \item[model] model variable object
 !   \item[stats] object to hold the updated statistics
 !  \end{description}
-! 
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 !BOP
-! !ARGUMENTS: 
+! !ARGUMENTS:
     type(LVT_metaDataEntry) :: model
     type(LVT_metadataEntry) :: obs
     type(LVT_statsEntry)    :: stats
     type(LVT_metricEntry)   :: metric
 !EOP
-    integer    :: t,k,n,m,m_k,o_k,tind
+    integer    :: t,k,m,m_k,o_k,tind
 
     if(stats%selectOpt.eq.1.and.&
-         model%selectNlevs.ge.1) then        
+         model%selectNlevs.ge.1) then
        do t=1,LVT_rc%ngrid
           do k=1,model%selectNlevs
              do m=1,LVT_rc%nensem
                 m_k = k+model%startNlevs -1
                 if(model%count(t,m,m_k).gt.0) then
-                   if(metric%selectOpt.eq.1) then 
-                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                   if(metric%selectOpt.eq.1) then
+                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                          stats%mean(m)%model_value_total(t,k,1) = &
                               stats%mean(m)%model_value_total(t,k,1) + &
                               model%value(t,m,m_k)
@@ -310,43 +335,42 @@ contains
                               stats%mean(m)%count_model_value_total(t,k,1) + 1
                       endif
                    endif
-                
-                   if(metric%timeOpt.eq.1) then 
-                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+
+                   if(metric%timeOpt.eq.1) then
+                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                          stats%mean(m)%model_value_ts(t,k,1) = &
-                              stats%mean(m)%model_value_ts(t,k,1)+&
+                              stats%mean(m)%model_value_ts(t,k,1) + &
                               model%value(t,m,m_k)
-                         stats%mean(m)%count_model_value_ts(t,k,1) = & 
-                              stats%mean(m)%count_model_value_ts(t,k,1)+1
-                         
+                         stats%mean(m)%count_model_value_ts(t,k,1) = &
+                              stats%mean(m)%count_model_value_ts(t,k,1) + 1
                       endif
                    endif
-                   if(metric%computeSC.eq.1) then 
-                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                   if(metric%computeSC.eq.1) then
+                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                          call LVT_getSeasonalCycleTimeIndex(LVT_rc%scInterval,&
                               tind)
                          stats%mean(m)%model_value_asc(t,k,tind) = &
-                              stats%mean(m)%model_value_asc(t,k,tind)+&
+                              stats%mean(m)%model_value_asc(t,k,tind) + &
                               model%value(t,m,m_k)
                          stats%mean(m)%count_model_value_asc(t,k,tind) = &
                               stats%mean(m)%count_model_value_asc(t,k,tind) + 1
                       endif
                    endif
-                   if(metric%computeADC.eq.1) then 
-                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                   if(metric%computeADC.eq.1) then
+                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                          call LVT_getADCTimeIndex(tind)
                          stats%mean(m)%model_value_adc(t,k,tind) = &
-                              stats%mean(m)%model_value_adc(t,k,tind)+&
+                              stats%mean(m)%model_value_adc(t,k,tind) + &
                               model%value(t,m,m_k)
                          stats%mean(m)%count_model_value_adc(t,k,tind) = &
                               stats%mean(m)%count_model_value_adc(t,k,tind) + 1
                       endif
                    endif
-                   if(LVT_rc%strat_nlevels.gt.1) then 
+                   if(LVT_rc%strat_nlevels.gt.1) then
                       if(LVT_stats%strat_var(t,m,k).gt.&
                            LVT_rc%strat_var_threshold) then
                          if(metric%selectOpt.eq.1) then
-                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then  
+                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                                stats%mean(m)%model_value_total(t,k,2) = &
                                     stats%mean(m)%model_value_total(t,k,2) + &
                                     model%value(t,m,m_k)
@@ -354,19 +378,19 @@ contains
                                     stats%mean(m)%count_model_value_total(t,k,2) + 1
                             endif
                          endif
-                         if(metric%timeOpt.eq.1) then 
-                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                         if(metric%timeOpt.eq.1) then
+                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                                stats%mean(m)%model_value_ts(t,k,2) = &
-                                    stats%mean(m)%model_value_ts(t,k,2)+&
+                                    stats%mean(m)%model_value_ts(t,k,2) + &
                                     model%value(t,m,m_k)
-                               stats%mean(m)%count_model_value_ts(t,k,2) = & 
-                                    stats%mean(m)%count_model_value_ts(t,k,2)+1
+                               stats%mean(m)%count_model_value_ts(t,k,2) = &
+                                    stats%mean(m)%count_model_value_ts(t,k,2) + 1
                             endif
                          endif
                       elseif(LVT_stats%strat_var(t,m,k).le.&
                            LVT_rc%strat_var_threshold) then
-                         if(metric%selectOpt.eq.1) then 
-                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                         if(metric%selectOpt.eq.1) then
+                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                                stats%mean(m)%model_value_total(t,k,3) = &
                                     stats%mean(m)%model_value_total(t,k,3) + &
                                     model%value(t,m,m_k)
@@ -374,28 +398,29 @@ contains
                                     stats%mean(m)%count_model_value_total(t,k,3) + 1
                             endif
                          endif
-                         if(metric%timeOpt.eq.1) then 
-                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                         if(metric%timeOpt.eq.1) then
+                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                                stats%mean(m)%model_value_ts(t,k,3) = &
-                                    stats%mean(m)%model_value_ts(t,k,3)+&
+                                    stats%mean(m)%model_value_ts(t,k,3) + &
                                     model%value(t,m,m_k)
-                               stats%mean(m)%count_model_value_ts(t,k,3) = & 
-                                    stats%mean(m)%count_model_value_ts(t,k,3)+1
+                               stats%mean(m)%count_model_value_ts(t,k,3) = &
+                                    stats%mean(m)%count_model_value_ts(t,k,3) + 1
                             endif
                          endif
                       endif
                    endif
                 endif
-             end do
+             enddo
           enddo
+
           do k=1,obs%selectNlevs
              do m=1,LVT_rc%nensem
                 o_k = k+obs%startNlevs -1
                 if(LVT_rc%obssource(2).ne."none") then
                    if(obs%selectNlevs.ge.1) then
-                      if(obs%count(t,m,o_k).gt.0) then 
+                      if(obs%count(t,m,o_k).gt.0) then
                          if(metric%selectOpt.eq.1.and.&
-                              obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                              obs%value(t,m,o_k).ne.LVT_rc%udef) then
                             stats%mean(m)%obs_value_total(t,k,1) = &
                                  stats%mean(m)%obs_value_total(t,k,1) + &
                                  obs%value(t,m,o_k)
@@ -403,41 +428,43 @@ contains
                                  stats%mean(m)%count_obs_value_total(t,k,1) + 1
                          endif
 
-                         if(metric%timeOpt.eq.1.and.obs%value(t,m,o_k).ne.LVT_rc%udef) then 
-
-                            stats%mean(m)%obs_value_ts(t,k,1) = stats%mean(m)%obs_value_ts(t,k,1)+&
+                         if(metric%timeOpt.eq.1.and.&
+                              obs%value(t,m,o_k).ne.LVT_rc%udef) then
+                            stats%mean(m)%obs_value_ts(t,k,1) = stats%mean(m)%obs_value_ts(t,k,1) + &
                                  obs%value(t,m,o_k)
-                            stats%mean(m)%count_obs_value_ts(t,k,1) = & 
-                                 stats%mean(m)%count_obs_value_ts(t,k,1)+1
-                            if(obs%stdev_flag) then 
+                            stats%mean(m)%count_obs_value_ts(t,k,1) = &
+                                 stats%mean(m)%count_obs_value_ts(t,k,1) + 1
+                            if(obs%stdev_flag) then
                                stats%mean(m)%obs_value_stdev_ts(t,k,1) = &
-                                    stats%mean(m)%obs_value_stdev_ts(t,k,1)+&
+                                    stats%mean(m)%obs_value_stdev_ts(t,k,1) + &
                                     obs%stdev(t,k)
-                               stats%mean(m)%count_obs_value_stdev_ts(t,k,1) = & 
-                                    stats%mean(m)%count_obs_value_stdev_ts(t,k,1)+1
+                               stats%mean(m)%count_obs_value_stdev_ts(t,k,1) = &
+                                    stats%mean(m)%count_obs_value_stdev_ts(t,k,1) + 1
                             endif
                          endif
-                         if(metric%computeSC.eq.1.and.obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                         if(metric%computeSC.eq.1.and.&
+                              obs%value(t,m,o_k).ne.LVT_rc%udef) then
                             call LVT_getSeasonalCycleTimeIndex(LVT_rc%scInterval,tind)
                             stats%mean(m)%obs_value_asc(t,k,tind) = &
-                                 stats%mean(m)%obs_value_asc(t,k,tind)+&
+                                 stats%mean(m)%obs_value_asc(t,k,tind) + &
                                  obs%value(t,m,o_k)
                             stats%mean(m)%count_obs_value_asc(t,k,tind) = &
                                  stats%mean(m)%count_obs_value_asc(t,k,tind) + 1
                          endif
-                         if(metric%computeADC.eq.1.and.obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                         if(metric%computeADC.eq.1.and.&
+                              obs%value(t,m,o_k).ne.LVT_rc%udef) then
                             call LVT_getADCTimeIndex(tind)
                             stats%mean(m)%obs_value_adc(t,k,tind) = &
-                                 stats%mean(m)%obs_value_adc(t,k,tind)+&
+                                 stats%mean(m)%obs_value_adc(t,k,tind) + &
                                  obs%value(t,m,o_k)
                             stats%mean(m)%count_obs_value_adc(t,k,tind) = &
                                  stats%mean(m)%count_obs_value_adc(t,k,tind) + 1
                          endif
-                         if(LVT_rc%strat_nlevels.gt.1) then 
+                         if(LVT_rc%strat_nlevels.gt.1) then
                             if(LVT_stats%strat_var(t,m,k).gt.&
                                  LVT_rc%strat_var_threshold) then
                                if(metric%selectOpt.eq.1 &
-                                    .and.obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                                    .and.obs%value(t,m,o_k).ne.LVT_rc%udef) then
                                   stats%mean(m)%obs_value_total(t,k,2) = &
                                        stats%mean(m)%obs_value_total(t,k,2) + &
                                        obs%value(t,m,o_k)
@@ -446,24 +473,24 @@ contains
                                endif
 
                                if(metric%timeOpt.eq.1.and.&
-                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then
                                   stats%mean(m)%obs_value_ts(t,k,2) = &
-                                       stats%mean(m)%obs_value_ts(t,k,2)+&
+                                       stats%mean(m)%obs_value_ts(t,k,2) + &
                                        obs%value(t,m,o_k)
-                                  stats%mean(m)%count_obs_value_ts(t,k,2) = & 
-                                       stats%mean(m)%count_obs_value_ts(t,k,2)+1
-                                  if(obs%stdev_flag) then 
+                                  stats%mean(m)%count_obs_value_ts(t,k,2) = &
+                                       stats%mean(m)%count_obs_value_ts(t,k,2) + 1
+                                  if(obs%stdev_flag) then
                                      stats%mean(m)%obs_value_stdev_ts(t,k,2) = &
-                                          stats%mean(m)%obs_value_stdev_ts(t,k,2)+&
+                                          stats%mean(m)%obs_value_stdev_ts(t,k,2) + &
                                           obs%stdev(t,k)
-                                     stats%mean(m)%count_obs_value_stdev_ts(t,k,2) = & 
-                                          stats%mean(m)%count_obs_value_stdev_ts(t,k,2)+1
+                                     stats%mean(m)%count_obs_value_stdev_ts(t,k,2) = &
+                                          stats%mean(m)%count_obs_value_stdev_ts(t,k,2) + 1
                                   endif
                                endif
                             elseif(LVT_stats%strat_var(t,m,k).le.&
                                  LVT_rc%strat_var_threshold) then
                                if(metric%selectOpt.eq.1.and.&
-                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then
                                   stats%mean(m)%obs_value_total(t,k,3) = &
                                        stats%mean(m)%obs_value_total(t,k,3) + &
                                        obs%value(t,m,o_k)
@@ -472,21 +499,20 @@ contains
                                endif
 
                                if(metric%timeOpt.eq.1.and.&
-                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then
                                   stats%mean(m)%obs_value_ts(t,k,3) = &
-                                       stats%mean(m)%obs_value_ts(t,k,3)+&
+                                       stats%mean(m)%obs_value_ts(t,k,3) + &
                                        obs%value(t,m,o_k)
-                                  stats%mean(m)%count_obs_value_ts(t,k,3) = & 
-                                       stats%mean(m)%count_obs_value_ts(t,k,3)+1
-                                  if(obs%stdev_flag) then 
+                                  stats%mean(m)%count_obs_value_ts(t,k,3) = &
+                                       stats%mean(m)%count_obs_value_ts(t,k,3) + 1
+                                  if(obs%stdev_flag) then
                                      stats%mean(m)%obs_value_stdev_ts(t,k,3) = &
-                                          stats%mean(m)%obs_value_stdev_ts(t,k,3)+&
+                                          stats%mean(m)%obs_value_stdev_ts(t,k,3) + &
                                           obs%stdev(t,k)
-                                     stats%mean(m)%count_obs_value_stdev_ts(t,k,3) = & 
-                                          stats%mean(m)%count_obs_value_stdev_ts(t,k,3)+1
+                                     stats%mean(m)%count_obs_value_stdev_ts(t,k,3) = &
+                                          stats%mean(m)%count_obs_value_stdev_ts(t,k,3) + 1
                                   endif
                                endif
-                            
                             endif
                          endif
                       endif
@@ -496,39 +522,38 @@ contains
           enddo
        enddo
     endif
-
   end subroutine diagnoseSingleMEAN
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_computeMEAN
 ! \label{LVT_computeMEAN}
 !
-! !INTERFACE: 
+! !INTERFACE:
   subroutine LVT_computeMEAN(pass,alarm)
-! 
-! !USES:   
+!
+! !USES:
 
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-!   This subroutine issues the calls to compute the mean values for 
+! !DESCRIPTION:
+!   This subroutine issues the calls to compute the mean values for
 !   desired variables.
 !
-!   The methods invoked are: 
+!   The methods invoked are:
 !   \begin{description}
 !    \item[computeSingleModelMEAN](\ref{computeSingleModelMEAN})
 !     computes the mean values for a single variable
 !   \end{description}
-! 
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 !BOP
     integer               :: pass
@@ -538,31 +563,31 @@ contains
     type(LVT_metadataEntry), pointer :: model
     type(LVT_metadataEntry), pointer :: obs
     type(LVT_statsEntry)   , pointer :: stats
-    
+
     if(pass.eq.LVT_metrics%mean%npass) then
        if(LVT_metrics%mean%selectOpt.eq.1.or.&
-            LVT_metrics%mean%timeOpt.eq.1) then 
-          if(alarm) then 
+            LVT_metrics%mean%timeOpt.eq.1) then
+          if(alarm) then
              if(LVT_metrics%mean%timeOpt.eq.1.and.&
-                  LVT_metrics%mean%extractTS.eq.1) then 
-                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then 
+                  LVT_metrics%mean%extractTS.eq.1) then
+                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then
                    do m=1,LVT_rc%nensem
                       do i=1,LVT_rc%ntslocs
                          write(LVT_metrics%mean%ftn_ts_loc(i,m),200,advance='no') &
                               LVT_rc%yr, '',LVT_rc%mo, '', LVT_rc%da, '', &
-                              LVT_rc%hr,'',LVT_rc%mn, '' 
+                              LVT_rc%hr,'',LVT_rc%mn, ''
                       enddo
                    enddo
                 else
                    do i=1,LVT_rc%ntslocs
                       write(LVT_metrics%mean%ftn_ts_loc(i,1),200,advance='no') &
                            LVT_rc%yr, '',LVT_rc%mo, '', LVT_rc%da, '', &
-                           LVT_rc%hr,'',LVT_rc%mn, '' 
+                           LVT_rc%hr,'',LVT_rc%mn, ''
                    enddo
                 endif
              endif
           endif
-             
+
 200       format(I4, a1, I2.2, a1, I2.2, a1, I2.2, a1, I2.2,a1)
 
           call LVT_getDataStream1Ptr(model)
@@ -570,19 +595,19 @@ contains
           call LVT_getstatsEntryPtr(stats)
 
           do while(associated(model))
-             
+
              call computeSingleMEAN(alarm,model,obs,stats,&
                   LVT_metrics%mean)
-             
+
              model => model%next
              obs => obs%next
              stats => stats%next
           enddo
-          
-          if(alarm) then 
+
+          if(alarm) then
              if(LVT_metrics%mean%timeOpt.eq.1.and.&
-                  LVT_metrics%mean%extractTS.eq.1) then 
-                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then 
+                  LVT_metrics%mean%extractTS.eq.1) then
+                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then
                    do m=1,LVT_rc%nensem
                       do i=1,LVT_rc%ntslocs
                          write(LVT_metrics%mean%ftn_ts_loc(i,m),fmt='(a1)') ''
@@ -598,40 +623,40 @@ contains
        endif
     endif
   end subroutine LVT_computeMEAN
-  
+
 
 !BOP
-! 
+!
 ! !ROUTINE: computeSingleMEAN
 ! \label{computeSingleMEAN}
 !
-! !INTERFACE: 
+! !INTERFACE:
   subroutine computeSingleMEAN(alarm,model,obs,stats,metric)
-! 
-! !USES:   
-        
+!
+! !USES:
+
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine computes the mean values
-!  The arguments are: 
+!  The arguments are:
 !
 !  \begin{description}
 !    \item[model] model variable object
 !    \item[stats] object to hold the updated statistics
 !  \end{description}
-! 
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 !BOP
-! !ARGUMENTS: 
+! !ARGUMENTS:
     logical                 :: alarm
     type(LVT_metaDataEntry) :: model
     type(LVT_metaDataEntry) :: obs
@@ -640,38 +665,39 @@ contains
 !EOP
 
     integer  :: t,l,k,m
+
     real,    allocatable :: tavg_model_value_ts(:,:,:)
     real,    allocatable :: tavg_obs_value_ts(:,:,:)
     real,    allocatable :: tavg_obs_value_stdev_ts(:,:,:)
-    
+
     real,    allocatable :: model_value_asc(:,:,:)
     integer, allocatable :: count_model_value_asc(:,:,:)
     real,    allocatable :: obs_value_asc(:,:,:)
 
     real,    allocatable :: model_value_adc(:,:,:)
     real,    allocatable :: obs_value_adc(:,:,:)
-    
-    real,    allocatable :: model_value_avg(:,:,:)
-    real,    allocatable :: obs_value_avg(:,:,:)   
 
-    if(metric%timeOpt.eq.1) then 
+    real,    allocatable :: model_value_avg(:,:,:)
+    real,    allocatable :: obs_value_avg(:,:,:)
+
+    if(metric%timeOpt.eq.1) then
        if(stats%selectOpt.eq.1.and.&
-            model%selectNlevs.ge.1) then 
+            model%selectNlevs.ge.1) then
           do t=1,LVT_rc%ngrid
              do m=1,LVT_rc%nensem
                 do k=1,model%selectNlevs
                    do l=1,LVT_rc%strat_nlevels
-                      if(stats%mean(m)%count_model_value_ts(t,k,l).gt.0) then 
-                         stats%mean(m)%model_value_ts(t,k,l) =&
-                              stats%mean(m)%model_value_ts(t,k,l)/&
-                              stats%mean(m)%count_model_value_ts(t,k,l)                   
-                         
+                      if(stats%mean(m)%count_model_value_ts(t,k,l).gt.0) then
+                         stats%mean(m)%model_value_ts(t,k,l) = &
+                              stats%mean(m)%model_value_ts(t,k,l) / &
+                              stats%mean(m)%count_model_value_ts(t,k,l)
+
                          stats%mean(m)%tavg_model_value_ts(t,k,l) = &
                               stats%mean(m)%tavg_model_value_ts(t,k,l) + &
                               stats%mean(m)%model_value_ts(t,k,l)
-                         stats%mean(m)%tavg_count_model_value_ts(t,k,l) = & 
+                         stats%mean(m)%tavg_count_model_value_ts(t,k,l) = &
                               stats%mean(m)%tavg_count_model_value_ts(t,k,l) + 1
-                         
+
                       else
                          stats%mean(m)%model_value_ts(t,k,l) = LVT_rc%udef
                       endif
@@ -679,30 +705,30 @@ contains
                 enddo
                 do k=1,obs%selectNlevs
                    do l=1,LVT_rc%strat_nlevels
-                      if(LVT_rc%obssource(2).ne."none") then 
-                         if(obs%selectNlevs.ge.1) then 
-                            if(stats%mean(m)%count_obs_value_ts(t,k,l).gt.0) then 
+                      if(LVT_rc%obssource(2).ne."none") then
+                         if(obs%selectNlevs.ge.1) then
+                            if(stats%mean(m)%count_obs_value_ts(t,k,l).gt.0) then
                                stats%mean(m)%obs_value_ts(t,k,l) = &
-                                    stats%mean(m)%obs_value_ts(t,k,l)/&
+                                    stats%mean(m)%obs_value_ts(t,k,l) / &
                                     stats%mean(m)%count_obs_value_ts(t,k,l)
 
                                stats%mean(m)%tavg_obs_value_ts(t,k,l) = &
-                                    stats%mean(m)%tavg_obs_value_ts(t,k,l) + & 
+                                    stats%mean(m)%tavg_obs_value_ts(t,k,l) + &
                                     stats%mean(m)%obs_value_ts(t,k,l)
                                stats%mean(m)%tavg_count_obs_value_ts(t,k,l) = &
-                                    stats%mean(m)%tavg_count_obs_value_ts(t,k,l) + 1 
+                                    stats%mean(m)%tavg_count_obs_value_ts(t,k,l) + 1
 
                             else
                                stats%mean(m)%obs_value_ts(t,k,l) = LVT_rc%udef
                             endif
-                            if(obs%stdev_flag) then 
-                               if(stats%mean(m)%count_obs_value_stdev_ts(t,k,l).gt.0) then 
+                            if(obs%stdev_flag) then
+                               if(stats%mean(m)%count_obs_value_stdev_ts(t,k,l).gt.0) then
                                   stats%mean(m)%obs_value_stdev_ts(t,k,l) = &
-                                       stats%mean(m)%obs_value_stdev_ts(t,k,l)/&
+                                       stats%mean(m)%obs_value_stdev_ts(t,k,l) / &
                                        stats%mean(m)%count_obs_value_stdev_ts(t,k,l)
 
                                   stats%mean(m)%tavg_obs_value_stdev_ts(t,k,l) = &
-                                       stats%mean(m)%tavg_obs_value_stdev_ts(t,k,l) + & 
+                                       stats%mean(m)%tavg_obs_value_stdev_ts(t,k,l) + &
                                        stats%mean(m)%obs_value_stdev_ts(t,k,l)
                                   stats%mean(m)%tavg_count_obs_value_stdev_ts(t,k,l) = &
                                        stats%mean(m)%tavg_count_obs_value_stdev_ts(t,k,l) + 1
@@ -716,36 +742,36 @@ contains
                 enddo
              enddo
           enddo
-                   
+
           if(alarm) then
              do t=1,LVT_rc%ngrid
                 do m=1,LVT_rc%nensem
                    do k=1,model%selectNlevs
                       do l=1,LVT_rc%strat_nlevels
-                         if(stats%mean(m)%tavg_count_model_value_ts(t,k,l).gt.0) then 
+                         if(stats%mean(m)%tavg_count_model_value_ts(t,k,l).gt.0) then
                             stats%mean(m)%tavg_model_value_ts(t,k,l) = &
-                                 stats%mean(m)%tavg_model_value_ts(t,k,l)/&
-                                 stats%mean(m)%tavg_count_model_value_ts(t,k,l)                   
+                                 stats%mean(m)%tavg_model_value_ts(t,k,l) / &
+                                 stats%mean(m)%tavg_count_model_value_ts(t,k,l)
                          else
                             stats%mean(m)%tavg_model_value_ts(t,k,l) = LVT_rc%udef
                          endif
                       enddo
                    enddo
                    do k=1,obs%selectNlevs
-                      do l=1,LVT_rc%strat_nlevels                
-                         if(LVT_rc%obssource(2).ne."none") then 
-                            if(obs%selectNlevs.ge.1) then 
-                               if(stats%mean(m)%tavg_count_obs_value_ts(t,k,l).gt.0) then 
+                      do l=1,LVT_rc%strat_nlevels
+                         if(LVT_rc%obssource(2).ne."none") then
+                            if(obs%selectNlevs.ge.1) then
+                               if(stats%mean(m)%tavg_count_obs_value_ts(t,k,l).gt.0) then
                                   stats%mean(m)%tavg_obs_value_ts(t,k,l) = &
-                                       stats%mean(m)%tavg_obs_value_ts(t,k,l)/&
+                                       stats%mean(m)%tavg_obs_value_ts(t,k,l) / &
                                        stats%mean(m)%tavg_count_obs_value_ts(t,k,l)
                                else
                                   stats%mean(m)%tavg_obs_value_ts(t,k,l) = LVT_rc%udef
                                endif
-                               if(obs%stdev_flag) then 
-                                  if(stats%mean(m)%tavg_count_obs_value_stdev_ts(t,k,l).gt.0) then 
+                               if(obs%stdev_flag) then
+                                  if(stats%mean(m)%tavg_count_obs_value_stdev_ts(t,k,l).gt.0) then
                                      stats%mean(m)%tavg_obs_value_stdev_ts(t,k,l) = &
-                                          stats%mean(m)%tavg_obs_value_stdev_ts(t,k,l)/&
+                                          stats%mean(m)%tavg_obs_value_stdev_ts(t,k,l) / &
                                           stats%mean(m)%tavg_count_obs_value_stdev_ts(t,k,l)
                                   else
                                      stats%mean(m)%tavg_obs_value_stdev_ts(t,k,l) = LVT_rc%udef
@@ -753,16 +779,17 @@ contains
                                endif
                             endif
                          endif
-                      end do
+                      enddo
                    enddo
                 enddo
              enddo
-             
-             if(metric%extractTS.eq.1) then 
-                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then 
+
+             if(metric%extractTS.eq.1) then
+                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then
                    do m=1,LVT_rc%nensem
-                      if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
-                         if(obs%stdev_flag) then 
+                      if(LVT_rc%obssource(2).ne."none".and. &
+                            obs%selectNlevs.ge.1) then
+                         if(obs%stdev_flag) then
                             call LVT_writeTSinfo(metric%ftn_ts_loc(:,m),&
                                  model,&
                                  LVT_rc%ngrid,&
@@ -797,7 +824,8 @@ contains
                         LVT_rc%strat_nlevels))
                    tavg_model_value_ts = 0.0
 
-                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                   if(LVT_rc%obssource(2).ne."none".and. &
+                         obs%selectNlevs.ge.1) then
 
                       allocate(tavg_obs_value_ts(LVT_rc%ngrid, &
                            obs%vlevels, &
@@ -805,12 +833,12 @@ contains
                       allocate(tavg_obs_value_stdev_ts(LVT_rc%ngrid, &
                            obs%vlevels, &
                            LVT_rc%strat_nlevels))
-                   
+
                       tavg_obs_value_ts = 0.0
                       tavg_obs_value_stdev_ts = 0.0
 
-                      if(obs%stdev_flag) then 
-                         
+                      if(obs%stdev_flag) then
+
                          do m=1,LVT_rc%nensem
                             do t=1,LVT_rc%ngrid
                                do k=1,model%selectNlevs
@@ -821,15 +849,15 @@ contains
                                      tavg_obs_value_ts(t,k,l) = &
                                           tavg_obs_value_ts(t,k,l) + &
                                           stats%mean(m)%tavg_obs_value_ts(t,k,l)
-                                     
-                                     tavg_obs_value_stdev_ts(t,k,l) = & 
-                                          tavg_obs_value_stdev_ts(t,k,l) + & 
+
+                                     tavg_obs_value_stdev_ts(t,k,l) = &
+                                          tavg_obs_value_stdev_ts(t,k,l) + &
                                           stats%mean(m)%tavg_obs_value_stdev_ts(t,k,l)
                                   enddo
                                enddo
                             enddo
                          enddo
-                         
+
                          do t=1,LVT_rc%ngrid
                             do k=1,model%selectNlevs
                                do l=1,LVT_rc%strat_nlevels
@@ -840,7 +868,7 @@ contains
                                enddo
                             enddo
                          enddo
-                         
+
                          call LVT_writeTSinfo(metric%ftn_ts_loc(:,1),&
                               model,&
                               LVT_rc%ngrid,&
@@ -852,7 +880,7 @@ contains
                               tavg_obs_value_stdev_ts, &
                               stats%mean(1)%tavg_count_obs_value_stdev_ts)
                       else
-                         
+
                          do m=1,LVT_rc%nensem
                             do t=1,LVT_rc%ngrid
                                do k=1,model%selectNlevs
@@ -867,7 +895,7 @@ contains
                                enddo
                             enddo
                          enddo
-                            
+
                          do t=1,LVT_rc%ngrid
                             do k=1,model%selectNlevs
                                do l=1,LVT_rc%strat_nlevels
@@ -878,7 +906,7 @@ contains
                                enddo
                             enddo
                          enddo
-                         
+
                          call LVT_writeTSinfo(metric%ftn_ts_loc(:,1),&
                               model,&
                               LVT_rc%ngrid,&
@@ -900,7 +928,7 @@ contains
                             enddo
                          enddo
                       enddo
-                      
+
                       do t=1,LVT_rc%ngrid
                          do k=1,model%selectNlevs
                             do l=1,LVT_rc%strat_nlevels
@@ -909,7 +937,7 @@ contains
                             enddo
                          enddo
                       enddo
-                      
+
                       call LVT_writeTSinfo(metric%ftn_ts_loc(:,1),&
                            model,&
                            LVT_rc%ngrid,&
@@ -917,7 +945,9 @@ contains
                            stats%mean(1)%tavg_count_model_value_ts)
                    endif
                    deallocate(tavg_model_value_ts)
-                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+
+                   if(LVT_rc%obssource(2).ne."none".and. &
+                         obs%selectNlevs.ge.1) then
                       deallocate(tavg_obs_value_ts)
                       deallocate(tavg_obs_value_stdev_ts)
                    endif
@@ -925,45 +955,44 @@ contains
              endif
           endif
        endif
-    end if
-       
-    if(LVT_rc%endtime.eq.1.and.metric%selectOpt.eq.1) then 
+    endif
+
+    if(LVT_rc%endtime.eq.1.and.metric%selectOpt.eq.1) then
        if(stats%selectOpt.eq.1.and.&
-            model%selectNlevs.ge.1) then 
+            model%selectNlevs.ge.1) then
           do t=1,LVT_rc%ngrid
              do m=1,LVT_rc%nensem
                 do k=1,model%selectNlevs
                    do l=1,LVT_rc%strat_nlevels
                       if(stats%mean(m)%count_model_value_total(t,k,l).gt.&
-                           LVT_rc%obsCountThreshold) then 
-                         
+                           LVT_rc%obsCountThreshold) then
                          stats%mean(m)%model_value_total(t,k,l) = &
-                              stats%mean(m)%model_value_total(t,k,l)/&
-                              stats%mean(m)%count_model_value_total(t,k,l)           
+                              stats%mean(m)%model_value_total(t,k,l) / &
+                              stats%mean(m)%count_model_value_total(t,k,l)
                       else
                          stats%mean(m)%model_value_total(t,k,l) = LVT_rc%udef
                       endif
                    enddo
-                   if(metric%computeSC.eq.1) then 
-                      do l=1, LVT_rc%nasc
+                   if(metric%computeSC.eq.1) then
+                      do l=1,LVT_rc%nasc
                          if(stats%mean(m)%count_model_value_asc(t,k,l).gt.&
-                              LVT_rc%SCCountThreshold) then 
+                              LVT_rc%SCCountThreshold) then
                             stats%mean(m)%model_value_asc(t,k,l) = &
-                                 stats%mean(m)%model_value_asc(t,k,l)/&
-                                 stats%mean(m)%count_model_value_asc(t,k,l)           
+                                 stats%mean(m)%model_value_asc(t,k,l) / &
+                                 stats%mean(m)%count_model_value_asc(t,k,l)
                          else
                             stats%mean(m)%model_value_asc(t,k,l) = LVT_rc%udef
                          endif
                       enddo
                    endif
 
-                   if(metric%computeADC.eq.1) then 
-                      do l=1, LVT_rc%nadc
+                   if(metric%computeADC.eq.1) then
+                      do l=1,LVT_rc%nadc
                          if(stats%mean(m)%count_model_value_adc(t,k,l).gt.&
-                              LVT_rc%ADCCountThreshold) then 
+                              LVT_rc%ADCCountThreshold) then
                             stats%mean(m)%model_value_adc(t,k,l) = &
-                                 stats%mean(m)%model_value_adc(t,k,l)/&
-                                 stats%mean(m)%count_model_value_adc(t,k,l)           
+                                 stats%mean(m)%model_value_adc(t,k,l) / &
+                                 stats%mean(m)%count_model_value_adc(t,k,l)
                          else
                             stats%mean(m)%model_value_adc(t,k,l) = LVT_rc%udef
                          endif
@@ -971,25 +1000,25 @@ contains
                    endif
                 enddo
                 do k=1,obs%selectNlevs
-                   if(LVT_rc%obssource(2).ne."none") then 
+                   if(LVT_rc%obssource(2).ne."none") then
                       if(obs%selectNlevs.ge.1) then
-                         do l=1,LVT_rc%strat_nlevels                      
+                         do l=1,LVT_rc%strat_nlevels
                             if(stats%mean(m)%count_obs_value_total(t,k,l).gt.&
-                                 LVT_rc%obsCountThreshold) then 
+                                 LVT_rc%obsCountThreshold) then
                                stats%mean(m)%obs_value_total(t,k,l) = &
-                                    stats%mean(m)%obs_value_total(t,k,l)/&
-                                    stats%mean(m)%count_obs_value_total(t,k,l)       
+                                    stats%mean(m)%obs_value_total(t,k,l) / &
+                                    stats%mean(m)%count_obs_value_total(t,k,l)
                             else
                                stats%mean(m)%obs_value_total(t,k,l) = LVT_rc%udef
                             endif
                          enddo
                          if(metric%computeSC.eq.1) then
-                            do l=1, LVT_rc%nasc 
+                            do l=1,LVT_rc%nasc
                                if(stats%mean(m)%count_obs_value_asc(t,k,l).gt.&
-                                    LVT_rc%SCCountThreshold) then 
+                                    LVT_rc%SCCountThreshold) then
                                   stats%mean(m)%obs_value_asc(t,k,l) = &
-                                       stats%mean(m)%obs_value_asc(t,k,l)/&
-                                       stats%mean(m)%count_obs_value_asc(t,k,l)           
+                                       stats%mean(m)%obs_value_asc(t,k,l) / &
+                                       stats%mean(m)%count_obs_value_asc(t,k,l)
                                else
                                   stats%mean(m)%obs_value_asc(t,k,l) = LVT_rc%udef
                                endif
@@ -997,12 +1026,12 @@ contains
                          endif
 
                          if(metric%computeADC.eq.1) then
-                            do l=1, LVT_rc%nadc  
+                            do l=1,LVT_rc%nadc
                                if(stats%mean(m)%count_obs_value_adc(t,k,l).gt.&
-                                    LVT_rc%ADCCountThreshold) then 
+                                    LVT_rc%ADCCountThreshold) then
                                   stats%mean(m)%obs_value_adc(t,k,l) = &
-                                       stats%mean(m)%obs_value_adc(t,k,l)/&
-                                       stats%mean(m)%count_obs_value_adc(t,k,l)           
+                                       stats%mean(m)%obs_value_adc(t,k,l) / &
+                                       stats%mean(m)%count_obs_value_adc(t,k,l)
                                else
                                   stats%mean(m)%obs_value_adc(t,k,l) = LVT_rc%udef
                                endif
@@ -1014,17 +1043,17 @@ contains
              enddo
           enddo
 
-          do m=1,LVT_rc%nensem          
-             do k=1,model%selectNlevs                
-                do l=1, LVT_rc%strat_nlevels
+          do m=1,LVT_rc%nensem
+             do k=1,model%selectNlevs
+                do l=1,LVT_rc%strat_nlevels
                    call LVT_computeCI(stats%mean(m)%model_value_total(:,k,l),&
                         LVT_rc%ngrid,&
                         LVT_rc%pval_CI,stats%mean(m)%model_value_ci(k,l))
                 enddo
              enddo
-             if(LVT_rc%obssource(2).ne."none") then 
+             if(LVT_rc%obssource(2).ne."none") then
                 do k=1,obs%selectNlevs
-                   do l=1, LVT_rc%strat_nlevels
+                   do l=1,LVT_rc%strat_nlevels
                       call LVT_computeCI(stats%mean(m)%obs_value_total(:,k,l),&
                            LVT_rc%ngrid,&
                            LVT_rc%pval_CI,stats%mean(m)%obs_value_ci(k,l))
@@ -1034,56 +1063,56 @@ contains
           enddo
 
 !----------------------------------------------------------------------
-!  External data based stratification 
+!  External data based stratification
 !----------------------------------------------------------------------
-          if(LVT_rc%data_based_strat.eq.1) then 
+          if(LVT_rc%data_based_strat.eq.1) then
 
              allocate(model_value_avg(LVT_rc%ngrid,&
                   model%vlevels,&
                   LVT_rc%strat_nlevels))
              model_value_avg = 0.0
 
-             do m=1,LVT_rc%nensem        
-                do t=1,LVT_rc%ngrid                      
-                   do k=1,model%selectNlevs                
-                      do l=1, LVT_rc%strat_nlevels
+             do m=1,LVT_rc%nensem
+                do t=1,LVT_rc%ngrid
+                   do k=1,model%selectNlevs
+                      do l=1,LVT_rc%strat_nlevels
                          model_value_avg(t,k,l) = &
-                              model_value_avg(t,k,l) + & 
+                              model_value_avg(t,k,l) + &
                               stats%mean(m)%model_value_total(t,k,l)
                       enddo
                    enddo
                 enddo
              enddo
-             
-             do t=1,LVT_rc%ngrid                      
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%strat_nlevels
+
+             do t=1,LVT_rc%ngrid
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%strat_nlevels
                       model_value_avg(t,k,l) = &
                            model_value_avg(t,k,l)/LVT_rc%nensem
                    enddo
                 enddo
              enddo
-             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
-                   
+             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
+
                 allocate(obs_value_avg(LVT_rc%ngrid,&
                      obs%vlevels,&
                      LVT_rc%strat_nlevels))
                 obs_value_avg = 0.0
 
-                do m=1,LVT_rc%nensem        
+                do m=1,LVT_rc%nensem
                    do t=1,LVT_rc%ngrid
-                      do k=1,obs%selectNlevs                
-                         do l=1, LVT_rc%strat_nlevels
+                      do k=1,obs%selectNlevs
+                         do l=1,LVT_rc%strat_nlevels
                             obs_value_avg(t,k,l) = &
-                                 obs_value_avg(t,k,l) + & 
+                                 obs_value_avg(t,k,l) + &
                                  stats%mean(m)%obs_value_total(t,k,l)
                          enddo
                       enddo
                    enddo
                 enddo
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%strat_nlevels                
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%strat_nlevels
                          obs_value_avg(t,k,l) = &
                               obs_value_avg(t,k,l)/LVT_rc%nensem
                       enddo
@@ -1092,13 +1121,13 @@ contains
                 call LVT_writeDataBasedStrat(model,obs,stats,metric,&
                      LVT_rc%ngrid, model_value_avg, &
                      LVT_rc%ngrid, obs_value_avg)
-                   
+
                 deallocate(obs_value_avg)
              else
-                   
+
                 call LVT_writeDataBasedStrat(model,obs,stats,metric,&
-                     LVT_rc%ngrid,model_value_avg)            
-                
+                     LVT_rc%ngrid,model_value_avg)
+
              endif
              deallocate(model_value_avg)
           endif
@@ -1110,18 +1139,19 @@ contains
              allocate(count_model_value_asc(LVT_rc%ngrid,&
                   model%vlevels,&
                   LVT_rc%nasc))
+
              model_value_asc = 0.0
-             count_model_value_asc = 0 
+             count_model_value_asc = 0
 
              do t=1,LVT_rc%ngrid
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%nasc
-                      do m=1,LVT_rc%nensem        
-                         if(stats%mean(m)%model_value_asc(t,k,l).ne.LVT_rc%udef) then 
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%nasc
+                      do m=1,LVT_rc%nensem
+                         if(stats%mean(m)%model_value_asc(t,k,l).ne.LVT_rc%udef) then
                             model_value_asc(t,k,l) = &
-                                 model_value_asc(t,k,l) + & 
+                                 model_value_asc(t,k,l) + &
                                  stats%mean(m)%model_value_asc(t,k,l)
-                            count_model_value_asc(t,k,l) = & 
+                            count_model_value_asc(t,k,l) = &
                                  count_model_value_asc(t,k,l) + 1
                          endif
                       enddo
@@ -1130,11 +1160,11 @@ contains
              enddo
 
              do t=1,LVT_rc%ngrid
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%nasc
-                      if(count_model_value_asc(t,k,l).gt.0) then 
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%nasc
+                      if(count_model_value_asc(t,k,l).gt.0) then
                          model_value_asc(t,k,l) = &
-                              model_value_asc(t,k,l)/&
+                              model_value_asc(t,k,l) / &
                               count_model_value_asc(t,k,l)
                       else
                          model_value_asc(t,k,l) = LVT_rc%udef
@@ -1143,42 +1173,42 @@ contains
                 enddo
              enddo
 
-             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                 allocate(obs_value_asc(LVT_rc%ngrid,&
                      obs%vlevels,&
                      LVT_rc%nasc))
-                
+
                 obs_value_asc = 0.0
 
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%nasc
-                         do m=1,LVT_rc%nensem          
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%nasc
+                         do m=1,LVT_rc%nensem
                             obs_value_asc(t,k,l) = &
-                                 obs_value_asc(t,k,l) + & 
+                                 obs_value_asc(t,k,l) + &
                                  stats%mean(m)%obs_value_asc(t,k,l)
                          enddo
                       enddo
                    enddo
                 enddo
-                
+
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%nasc
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%nasc
                          obs_value_asc(t,k,l) = &
                               obs_value_asc(t,k,l)/LVT_rc%nensem
                       enddo
                    enddo
                 enddo
-             
+
                 call LVT_writeSeasonalCycleInfo(model,obs,stats,metric,&
                      LVT_rc%ngrid,model_value_asc,&
                      stats%mean(1)%count_model_value_asc,&
                      LVT_rc%ngrid,obs_value_asc,&
-                     stats%mean(1)%count_obs_value_asc)   
+                     stats%mean(1)%count_obs_value_asc)
 
                 deallocate(obs_value_asc)
-       
+
              else
                 call LVT_writeSeasonalCycleInfo(model,obs,stats,metric,&
                      LVT_rc%ngrid,model_value_asc,&
@@ -1195,59 +1225,59 @@ contains
              model_value_adc = 0.0
 
              do t=1,LVT_rc%ngrid
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%nadc
-                      do m=1,LVT_rc%nensem          
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%nadc
+                      do m=1,LVT_rc%nensem
                          model_value_adc(t,k,l) = &
-                              model_value_adc(t,k,l) + & 
+                              model_value_adc(t,k,l) + &
                               stats%mean(m)%model_value_adc(t,k,l)
                       enddo
                    enddo
                 enddo
              enddo
-             
+
              do t=1,LVT_rc%ngrid
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%nadc
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%nadc
                       model_value_adc(t,k,l) = &
                            model_value_adc(t,k,l)/LVT_rc%nensem
                    enddo
                 enddo
              enddo
-             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                 allocate(obs_value_adc(LVT_rc%ngrid,&
                      obs%vlevels,&
                      LVT_rc%nadc))
-                
+
                 obs_value_adc = 0.0
 
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%nadc
-                         do m=1,LVT_rc%nensem          
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%nadc
+                         do m=1,LVT_rc%nensem
                             obs_value_adc(t,k,l) = &
-                                 obs_value_adc(t,k,l) + & 
+                                 obs_value_adc(t,k,l) + &
                                  stats%mean(m)%obs_value_adc(t,k,l)
                          enddo
                       enddo
                    enddo
                 enddo
-                
+
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%nadc
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%nadc
                          obs_value_adc(t,k,l) = &
                               obs_value_adc(t,k,l)/LVT_rc%nensem
                       enddo
                    enddo
                 enddo
-             
+
                 call LVT_writeAvgDiurnalCycleInfo(model,obs,stats,metric,&
                      LVT_rc%ngrid,model_value_adc,&
                      stats%mean(1)%count_model_value_adc,&
                      LVT_rc%ngrid,obs_value_adc,&
-                     stats%mean(1)%count_obs_value_adc)      
-                
+                     stats%mean(1)%count_obs_value_adc)
+
                 deallocate(obs_value_adc)
              else
                 call LVT_writeAvgDiurnalCycleInfo(model,obs,stats,metric,&
@@ -1262,28 +1292,27 @@ contains
   end subroutine computeSingleMEAN
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_writeMetric_MEAN
 ! \label(LVT_writeMetric_MEAN)
 !
 ! !INTERFACE:
   subroutine LVT_writeMetric_MEAN(pass,final,vlevels,stats,obs)
-! 
-! !USES:   
+!
+! !USES:
     use LVT_statsMod, only : LVT_writeSummaryStats
     use LVT_pluginIndices
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-! 
-! !FILES USED:
+! !DESCRIPTION:
+!   This routine writes the computed Mean values to an external file.
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 
     integer                 :: pass
@@ -1316,12 +1345,12 @@ contains
 
     if(pass.eq.LVT_metrics%mean%npass) then
        if(final.ne.1) then
-           if(stats%selectOpt.eq.1) then 
-              
+           if(stats%selectOpt.eq.1) then
+
               allocate(model_value_ts(LVT_rc%ngrid,LVT_rc%nensem))
               allocate(count_model_value_ts(LVT_rc%ngrid,LVT_rc%nensem))
 
-              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                  allocate(obs_value_ts(LVT_rc%ngrid,LVT_rc%nensem))
                  allocate(count_obs_value_ts(LVT_rc%ngrid,LVT_rc%nensem))
               endif
@@ -1331,27 +1360,27 @@ contains
                     do m=1,LVT_rc%nensem
                          model_value_ts(:,m) = &
                               stats%mean(m)%tavg_model_value_ts(:,k,l)
-                         count_model_value_ts(:,m) = & 
+                         count_model_value_ts(:,m) = &
                               stats%mean(m)%tavg_count_model_value_ts(:,k,l)
-                       if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                       if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                           obs_value_ts(:,m) = &
                                stats%mean(m)%tavg_obs_value_ts(:,k,l)
-                          count_obs_value_ts(:,m) = & 
+                          count_obs_value_ts(:,m) = &
                                stats%mean(m)%tavg_count_obs_value_ts(:,k,l)
                        endif
                     enddo
-                    if(LVT_metrics%mean%timeOpt.eq.1) then 
-                       
+                    if(LVT_metrics%mean%timeOpt.eq.1) then
+
                        call LVT_writevar_gridded(LVT_metrics%mean%ftn_ts, &
                             model_value_ts(:,:),&
                             stats%vid_ts(LVT_MEANid,1),k)
-                       
+
                        call LVT_writevar_gridded(LVT_metrics%mean%ftn_ts, &
                             real(count_model_value_ts(:,:)),&
                             stats%vid_count_ts(LVT_MEANid,1),k)
                     endif
-                    
-                    if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+
+                    if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                        call LVT_writevar_gridded(LVT_metrics%mean%ftn_ts, &
                             obs_value_ts(:,:),&
                             stats%vid_ts(LVT_MEANid,2),k)
@@ -1365,7 +1394,7 @@ contains
               deallocate(model_value_ts)
               deallocate(count_model_value_ts)
 
-              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                  deallocate(obs_value_ts)
                  deallocate(count_obs_value_ts)
               endif
@@ -1378,23 +1407,23 @@ contains
               allocate(count_model_value_total(LVT_rc%ngrid,LVT_rc%nensem))
               allocate(model_value_ci(LVT_rc%nensem))
 
-              if(LVT_metrics%mean%computeSC.eq.1) then 
+              if(LVT_metrics%mean%computeSC.eq.1) then
                  allocate(model_value_asc(LVT_rc%ngrid,&
                       LVT_rc%nensem,&
                       LVT_rc%nasc))
                  if(LVT_rc%obssource(2).ne."none".and.&
-                      obs%selectNlevs.ge.1) then 
+                      obs%selectNlevs.ge.1) then
                     allocate(obs_value_asc(LVT_rc%ngrid,&
                          LVT_rc%nensem,&
                          LVT_rc%nasc))
                  endif
               endif
-              if(LVT_metrics%mean%computeADC.eq.1) then 
+              if(LVT_metrics%mean%computeADC.eq.1) then
                  allocate(model_value_adc(LVT_rc%ngrid,&
                       LVT_rc%nensem,&
-                      LVT_rc%nadc))        
+                      LVT_rc%nadc))
                  if(LVT_rc%obssource(2).ne."none".and.&
-                      obs%selectNlevs.ge.1) then 
+                      obs%selectNlevs.ge.1) then
                     allocate(obs_value_adc(LVT_rc%ngrid,&
                          LVT_rc%nensem,&
                          LVT_rc%nadc))
@@ -1402,59 +1431,59 @@ contains
 
               endif
 
-              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                  allocate(obs_value_total(LVT_rc%ngrid,LVT_rc%nensem))
                  allocate(count_obs_value_total(LVT_rc%ngrid,LVT_rc%nensem))
                  allocate(obs_value_ci(LVT_rc%nensem))
-              endif                
+              endif
 
                 do k=1,vlevels
                    do l=1,LVT_rc%strat_nlevels
                       do m=1,LVT_rc%nensem
                          model_value_total(:,m) = &
                               stats%mean(m)%model_value_total(:,k,l)
-                         count_model_value_total(:,m) = & 
+                         count_model_value_total(:,m) = &
                               stats%mean(m)%count_model_value_total(:,k,l)
                          model_value_ci(m) = stats%mean(m)%model_value_ci(k,l)
-                         
-                         if(LVT_metrics%mean%computeSC.eq.1) then 
+
+                         if(LVT_metrics%mean%computeSC.eq.1) then
                             do tind = 1,LVT_rc%nasc
-                               model_value_asc(:,m,tind) = & 
+                               model_value_asc(:,m,tind) = &
                                     stats%mean(m)%model_value_asc(:,k,tind)
                             enddo
                          endif
 
-                         if(LVT_metrics%mean%computeADC.eq.1) then 
+                         if(LVT_metrics%mean%computeADC.eq.1) then
                             do tind = 1,LVT_rc%nadc
-                               model_value_adc(:,m,tind) = & 
+                               model_value_adc(:,m,tind) = &
                                     stats%mean(m)%model_value_adc(:,k,tind)
                             enddo
                          endif
 
                          if(LVT_rc%obssource(2).ne."none".and.&
-                              obs%selectNlevs.ge.1) then 
+                              obs%selectNlevs.ge.1) then
                             obs_value_total(:,m) = &
                                  stats%mean(m)%obs_value_total(:,k,l)
-                            count_obs_value_total(:,m) = & 
+                            count_obs_value_total(:,m) = &
                                  stats%mean(m)%count_obs_value_total(:,k,l)
                             obs_value_ci(m) = stats%mean(m)%obs_value_ci(k,l)
 
-                            if(LVT_metrics%mean%computeSC.eq.1) then 
+                            if(LVT_metrics%mean%computeSC.eq.1) then
                                do tind = 1,LVT_rc%nasc
-                                  obs_value_asc(:,m,tind) = & 
+                                  obs_value_asc(:,m,tind) = &
                                        stats%mean(m)%obs_value_asc(:,k,tind)
                                enddo
                             endif
-                            if(LVT_metrics%mean%computeADC.eq.1) then 
+                            if(LVT_metrics%mean%computeADC.eq.1) then
                                do tind = 1,LVT_rc%nadc
-                                  obs_value_adc(:,m,tind) = & 
+                                  obs_value_adc(:,m,tind) = &
                                        stats%mean(m)%obs_value_adc(:,k,tind)
                                enddo
                             endif
-                            
+
                          endif
                       enddo
-                      if(LVT_metrics%mean%selectOpt.eq.1) then 
+                      if(LVT_metrics%mean%selectOpt.eq.1) then
                          call LVT_writevar_gridded(LVT_metrics%mean%ftn_total, &
                               model_value_total(:,:),&
                               stats%vid_total(LVT_MEANid,1),k)
@@ -1463,7 +1492,7 @@ contains
                               stats%vid_count_total(LVT_MEANid,1),k)
 
                          if(LVT_rc%obssource(2).ne."none".and.&
-                              obs%selectNlevs.ge.1) then 
+                              obs%selectNlevs.ge.1) then
                             call LVT_writevar_gridded(LVT_metrics%mean%ftn_total, &
                                  obs_value_total(:,:),&
                                  stats%vid_total(LVT_MEANid,2),k)
@@ -1471,15 +1500,15 @@ contains
                                  real(count_obs_value_total(:,:)),&
                                  stats%vid_count_total(LVT_MEANid,2),k)
                          endif
-                         
-                         if(LVT_metrics%mean%computeSC.eq.1) then 
+
+                         if(LVT_metrics%mean%computeSC.eq.1) then
                             do tind = 1,LVT_rc%nasc
                                call LVT_writevar_gridded(&
                                     LVT_metrics%mean%ftn_total,&
                                     model_value_asc(:,:,tind),&
                                     stats%vid_sc_total(tind,LVT_MEANid,1),k)
                             enddo
-                            if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                            if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                                do tind = 1,LVT_rc%nasc
                                   call LVT_writevar_gridded(&
                                        LVT_metrics%mean%ftn_total,&
@@ -1488,14 +1517,14 @@ contains
                                enddo
                             endif
                          endif
-                         if(LVT_metrics%mean%computeADC.eq.1) then 
+                         if(LVT_metrics%mean%computeADC.eq.1) then
                             do tind = 1,LVT_rc%nadc
                                call LVT_writevar_gridded(&
                                     LVT_metrics%mean%ftn_total,&
                                     model_value_adc(:,:,tind),&
                                     stats%vid_adc_total(tind,LVT_MEANid,1),k)
                             enddo
-                            if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                            if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                                do tind = 1,LVT_rc%nadc
                                   call LVT_writevar_gridded(&
                                        LVT_metrics%mean%ftn_total,&
@@ -1513,7 +1542,7 @@ contains
                               count_model_value_total(:,:),&
                               stats%standard_name,&
                               model_value_ci(:))
-                         if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                         if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                             call LVT_writeSummaryStats(&
                                  LVT_metrics%mean%ftn_summ,&
                                  l,&
@@ -1532,20 +1561,20 @@ contains
                 deallocate(count_model_value_total)
                 deallocate(model_value_ci)
 
-                if(LVT_metrics%mean%computeSC.eq.1) then 
+                if(LVT_metrics%mean%computeSC.eq.1) then
                    deallocate(model_value_asc)
-                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                       deallocate(obs_value_asc)
                    endif
                 endif
-                if(LVT_metrics%mean%computeADC.eq.1) then 
+                if(LVT_metrics%mean%computeADC.eq.1) then
                    deallocate(model_value_adc)
-                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                       deallocate(obs_value_adc)
                    endif
                 endif
 
-                if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                    deallocate(obs_value_total)
                    deallocate(count_obs_value_total)
                    deallocate(obs_value_ci)
@@ -1558,26 +1587,26 @@ contains
   end subroutine LVT_writeMetric_MEAN
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_resetMetric_MEAN
 ! \label(LVT_resetMetric_MEAN)
 !
 ! !INTERFACE:
   subroutine LVT_resetMetric_MEAN(alarm)
-! 
-! !USES:   
 !
-! !INPUT PARAMETERS: 
+! !USES:
+!
+! !INPUT PARAMETERS:
     logical                :: alarm
-! 
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-! 
-! !FILES USED:
+! !DESCRIPTION:
+!  This routine resets required variables to support the
+!  temporal computation of Mean values.
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 
     integer                :: i,k,l,m
@@ -1590,49 +1619,48 @@ contains
     call LVT_getstatsEntryPtr(stats)
 
     do while(associated(model))
-       if(stats%selectOpt.eq.1) then 
+       if(stats%selectOpt.eq.1) then
           do m=1,LVT_rc%nensem
              do k=1,model%selectNlevs
-                if(LVT_metrics%mean%timeOpt.eq.1) then 
+                if(LVT_metrics%mean%timeOpt.eq.1) then
                    do l=1,LVT_rc%strat_nlevels
                       stats%mean(m)%model_value_ts(:,k,l) = 0.0
-                      stats%mean(m)%count_model_value_ts(:,k,l)=0 
-                      if(alarm) then 
+                      stats%mean(m)%count_model_value_ts(:,k,l) = 0
+                      if(alarm) then
                          stats%mean(m)%tavg_model_value_ts(:,k,l) = 0.0
-                         stats%mean(m)%tavg_count_model_value_ts(:,k,l)=0 
+                         stats%mean(m)%tavg_count_model_value_ts(:,k,l) = 0
                       endif
                    enddo
                 endif
              enddo
              do k=1,obs%selectNlevs
-                if(LVT_metrics%mean%timeOpt.eq.1) then 
+                if(LVT_metrics%mean%timeOpt.eq.1) then
                    if(LVT_rc%obssource(2).ne."none".and.&
-                        obs%selectNlevs.ge.1) then 
+                        obs%selectNlevs.ge.1) then
                       do l=1,LVT_rc%strat_nlevels
                          stats%mean(m)%obs_value_ts(:,k,l) = 0.0
-                         stats%mean(m)%count_obs_value_ts(:,k,l)=0 
-                         if(alarm) then 
+                         stats%mean(m)%count_obs_value_ts(:,k,l) = 0
+                         if(alarm) then
                             stats%mean(m)%tavg_obs_value_ts(:,k,l) = 0.0
-                            stats%mean(m)%tavg_count_obs_value_ts(:,k,l)=0 
+                            stats%mean(m)%tavg_count_obs_value_ts(:,k,l) = 0
                          endif
                       enddo
-                      if(obs%stdev_flag) then 
+                      if(obs%stdev_flag) then
                          do l=1,LVT_rc%strat_nlevels
                             stats%mean(m)%obs_value_stdev_ts(:,k,l) = 0.0
-                            stats%mean(m)%count_obs_value_stdev_ts(:,k,l)=0 
-                            if(alarm) then 
+                            stats%mean(m)%count_obs_value_stdev_ts(:,k,l) = 0
+                            if(alarm) then
                                stats%mean(m)%tavg_obs_value_stdev_ts(:,k,l) = 0.0
-                               stats%mean(m)%tavg_count_obs_value_stdev_ts(:,k,l)=0 
+                               stats%mean(m)%tavg_count_obs_value_stdev_ts(:,k,l) = 0
                             endif
                          enddo
-                         
                       endif
                    endif
                 endif
              enddo
           enddo
        endif
-       
+
        model => model%next
        obs => obs%next
        stats => stats%next
@@ -1641,26 +1669,26 @@ contains
   end subroutine LVT_resetMetric_MEAN
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_writerestart_MEAN
-! 
+!
 ! !INTERFACE:
   subroutine LVT_writerestart_MEAN(ftn,pass)
-! !USES: 
+! !USES:
 
-! 
-! !ARGUMENTS: 
+!
+! !ARGUMENTS:
     integer                 :: ftn
     integer                 :: pass
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine writes the restart file for MEAN metric computations
-! 
-!EOP
-    
 !
-! !DESCRIPTION: 
-! 
+!EOP
+
+!
+! !DESCRIPTION:
+!
 !EOP
     integer              :: k,l,m
     type(LVT_metaDataEntry), pointer :: model
@@ -1670,23 +1698,23 @@ contains
     call LVT_getDataStream1Ptr(model)
     call LVT_getDataStream2Ptr(obs)
     call LVT_getstatsEntryPtr(stats)
-    
+
     do while(associated(model))
-       if(LVT_metrics%mean%selectOpt.eq.1) then 
+       if(LVT_metrics%mean%selectOpt.eq.1) then
           if(stats%selectOpt.eq.1.and.&
-               model%selectNlevs.ge.1) then 
+               model%selectNlevs.ge.1) then
              do m=1,LVT_rc%nensem
                 do k=1,model%selectNlevs
-                   do l=1,LVT_rc%strat_nlevels         
+                   do l=1,LVT_rc%strat_nlevels
                       call LVT_writevar_restart(ftn,&
                            stats%mean(m)%model_value_total(:,k,l))
                       call LVT_writevar_restart(ftn,&
                            stats%mean(m)%count_model_value_total(:,k,l))
                    enddo
                 enddo
-                if(LVT_metrics%mean%computeSC.eq.1) then 
+                if(LVT_metrics%mean%computeSC.eq.1) then
                    do k=1,model%selectNlevs
-                      do l=1,LVT_rc%nasc         
+                      do l=1,LVT_rc%nasc
                          call LVT_writevar_restart(ftn,&
                               stats%mean(m)%model_value_asc(:,k,l))
                          call LVT_writevar_restart(ftn,&
@@ -1694,9 +1722,9 @@ contains
                       enddo
                    enddo
                 endif
-                if(LVT_metrics%mean%computeADC.eq.1) then 
+                if(LVT_metrics%mean%computeADC.eq.1) then
                    do k=1,model%selectNlevs
-                      do l=1,LVT_rc%nadc         
+                      do l=1,LVT_rc%nadc
                          call LVT_writevar_restart(ftn,&
                               stats%mean(m)%model_value_adc(:,k,l))
                          call LVT_writevar_restart(ftn,&
@@ -1704,9 +1732,9 @@ contains
                       enddo
                    enddo
                 endif
-                
-                if(LVT_rc%obssource(2).ne."none") then 
-                   if(obs%selectNlevs.ge.1) then 
+
+                if(LVT_rc%obssource(2).ne."none") then
+                   if(obs%selectNlevs.ge.1) then
                       do k=1,obs%selectNlevs
                          do l=1,LVT_rc%strat_nlevels
                             call LVT_writevar_restart(ftn,&
@@ -1715,8 +1743,8 @@ contains
                                  stats%mean(m)%count_obs_value_total(:,k,l))
                          enddo
                       enddo
-                   
-                      if(LVT_metrics%mean%computeSC.eq.1) then 
+
+                      if(LVT_metrics%mean%computeSC.eq.1) then
                          do k=1,obs%selectNlevs
                             do l=1,LVT_rc%nasc
                                call LVT_writevar_restart(ftn,&
@@ -1726,7 +1754,7 @@ contains
                             enddo
                          enddo
                       endif
-                      if(LVT_metrics%mean%computeADC.eq.1) then 
+                      if(LVT_metrics%mean%computeADC.eq.1) then
                          do k=1,obs%selectNlevs
                             do l=1,LVT_rc%nasc
                                call LVT_writevar_restart(ftn,&
@@ -1749,24 +1777,24 @@ contains
 
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_readrestart_MEAN
-! 
+!
 ! !INTERFACE:
   subroutine LVT_readrestart_MEAN(ftn)
-! !USES: 
-! 
-! !ARGUMENTS: 
+! !USES:
+!
+! !ARGUMENTS:
     integer                 :: ftn
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine reads the restart file for MEAN metric computations
-! 
-!EOP
-    
 !
-! !DESCRIPTION: 
-! 
+!EOP
+
+!
+! !DESCRIPTION:
+!
 !EOP
 
     integer              :: k,l,m,index
@@ -1777,23 +1805,23 @@ contains
     call LVT_getDataStream1Ptr(model)
     call LVT_getDataStream2Ptr(obs)
     call LVT_getstatsEntryPtr(stats)
-    
+
     do while(associated(model))
-       if(LVT_metrics%mean%selectOpt.eq.1) then 
+       if(LVT_metrics%mean%selectOpt.eq.1) then
           if(stats%selectOpt.eq.1.and.&
-               model%selectNlevs.ge.1) then 
+               model%selectNlevs.ge.1) then
              do m=1,LVT_rc%nensem
                 do k=1,model%selectNlevs
-                   do l=1,LVT_rc%strat_nlevels         
+                   do l=1,LVT_rc%strat_nlevels
                       call LVT_readvar_restart(ftn,&
                            stats%mean(m)%model_value_total(:,k,l))
                       call LVT_readvar_restart(ftn,&
                            stats%mean(m)%count_model_value_total(:,k,l))
                    enddo
                 enddo
-                if(LVT_metrics%mean%computeSC.eq.1) then 
+                if(LVT_metrics%mean%computeSC.eq.1) then
                    do k=1,model%selectNlevs
-                      do l=1,LVT_rc%nasc         
+                      do l=1,LVT_rc%nasc
                          call LVT_readvar_restart(ftn,&
                               stats%mean(m)%model_value_asc(:,k,l))
                          call LVT_readvar_restart(ftn,&
@@ -1801,9 +1829,9 @@ contains
                       enddo
                    enddo
                 endif
-                if(LVT_metrics%mean%computeADC.eq.1) then 
+                if(LVT_metrics%mean%computeADC.eq.1) then
                    do k=1,model%selectNlevs
-                      do l=1,LVT_rc%nadc         
+                      do l=1,LVT_rc%nadc
                          call LVT_readvar_restart(ftn,&
                               stats%mean(m)%model_value_adc(:,k,l))
                          call LVT_readvar_restart(ftn,&
@@ -1812,8 +1840,8 @@ contains
                    enddo
                 endif
 
-                if(LVT_rc%obssource(2).ne."none") then 
-                   if(obs%selectNlevs.ge.1) then 
+                if(LVT_rc%obssource(2).ne."none") then
+                   if(obs%selectNlevs.ge.1) then
                       do k=1,obs%selectNlevs
                          do l=1,LVT_rc%strat_nlevels
                             call LVT_readvar_restart(ftn,&
@@ -1823,7 +1851,7 @@ contains
                          enddo
                       enddo
 
-                      if(LVT_metrics%mean%computeSC.eq.1) then 
+                      if(LVT_metrics%mean%computeSC.eq.1) then
                          do k=1,obs%selectNlevs
                             do l=1,LVT_rc%nasc
                                call LVT_readvar_restart(ftn,&
@@ -1833,7 +1861,7 @@ contains
                             enddo
                          enddo
                       endif
-                      if(LVT_metrics%mean%computeADC.eq.1) then 
+                      if(LVT_metrics%mean%computeADC.eq.1) then
                          do k=1,obs%selectNlevs
                             do l=1,LVT_rc%nasc
                                call LVT_readvar_restart(ftn,&
@@ -1842,10 +1870,10 @@ contains
                                     stats%mean(m)%count_obs_value_adc(:,k,l))
                             enddo
                          enddo
-                      endif                      
+                      endif
                    endif
                 endif
-             end do
+             enddo
           endif
        endif
        model => model%next
@@ -1853,6 +1881,5 @@ contains
        stats => stats%next
     end do
   end subroutine LVT_readrestart_MEAN
-
 
 end module LVT_MEANMod

--- a/lvt/metrics/LVT_MaxMod.F90
+++ b/lvt/metrics/LVT_MaxMod.F90
@@ -9,14 +9,14 @@
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
 !
 !BOP
-! 
+!
 ! !MODULE: LVT_MaxMod
 ! \label(LVT_MaxMod)
 !
 ! !INTERFACE:
 module LVT_MaxMod
-! 
-! !USES:   
+!
+! !USES:
   use LVT_coreMod
   use LVT_histDataMod
   use LVT_statsDataMod
@@ -24,20 +24,24 @@ module LVT_MaxMod
   use LVT_TSMod
   use LVT_logMod
   use LVT_CIMod
+
+  implicit none
+
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This module handles the computations required to compute maximum values
-!  (temporally) of desired variables from rhe datastreams. 
-! 
+!  (temporally) of desired variables from the datastreams.
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
+! !REVISION HISTORY:
 !  2 Oct 2008    Sujay Kumar  Initial Specification
-! 
+!  5 Feb 2021    David Mocko  Fixed time series output and code clean-up
+!
 !EOP
 !BOP
 !-----------------------------------------------------------------------------
@@ -51,153 +55,185 @@ module LVT_MaxMod
   public :: LVT_writerestart_Max
   public :: LVT_readrestart_Max
 !EOP
-  
+
   private
 
 contains
   subroutine LVT_initMax(selectNlevs, stats,metric)
-! !ARGUMENTS: 
+! !ARGUMENTS:
     integer                 :: selectNlevs(LVT_rc%nDataStreams)
     type(LVT_statsEntry)    :: stats
     type(LVT_metricEntry)   :: metric
 !
-! !DESCRIPTION: 
-! 
+! !DESCRIPTION:
+!
 !  This routine initializes the datastructures required to support
-!  the Max computations. 
-
+!  the Max computations.
+!
 !EOP
+    integer                 :: m
 
-    integer                 :: m 
-    
     allocate(stats%max(LVT_rc%nensem))
 
     do m=1,LVT_rc%nensem
-       if(metric%selectOpt.eq.1) then 
+       if(metric%selectOpt.eq.1) then
           allocate(stats%max(m)%model_value_total(LVT_rc%ngrid, &
                selectNlevs(1), &
                LVT_rc%strat_nlevels))
           stats%max(m)%model_value_total = -1E10
-          allocate(stats%max(m)%model_value_ci(selectNlevs(1),&
+          allocate(stats%max(m)%count_model_value_total(LVT_rc%ngrid, &
+               selectNlevs(1), &
+               LVT_rc%strat_nlevels))
+          stats%max(m)%count_model_value_total = 0
+          allocate(stats%max(m)%model_value_ci(selectNlevs(1), &
                LVT_rc%strat_nlevels))
           stats%max(m)%model_value_ci = LVT_rc%udef
-          
-          if(metric%computeSC.eq.1) then 
+
+          if(metric%computeSC.eq.1) then
              allocate(stats%max(m)%model_value_asc(LVT_rc%ngrid, &
-                  selectNlevs(1),&
+                  selectNlevs(1), &
                   LVT_rc%nasc))
              stats%max(m)%model_value_asc = -1E10
+             allocate(stats%max(m)%count_model_value_asc(LVT_rc%ngrid, &
+                  selectNlevs(1), &
+                  LVT_rc%nasc))
+             stats%max(m)%count_model_value_asc = 0
           endif
-          if(metric%computeADC.eq.1) then 
+          if(metric%computeADC.eq.1) then
              allocate(stats%max(m)%model_value_adc(LVT_rc%ngrid, &
-                  selectNlevs(2),&
+                  selectNlevs(2), &
                   LVT_rc%nadc))
              stats%max(m)%model_value_adc = -1E10
+             allocate(stats%max(m)%count_model_value_adc(LVT_rc%ngrid, &
+                  selectNlevs(2), &
+                  LVT_rc%nadc))
+             stats%max(m)%count_model_value_adc = 0
           endif
-          
-          if(LVT_rc%obssource(2).ne."none") then 
-             if(selectNlevs(2).ge.1) then 
+
+          if(LVT_rc%obssource(2).ne."none") then
+             if(selectNlevs(2).ge.1) then
                 allocate(stats%max(m)%obs_value_total(LVT_rc%ngrid, &
                      selectNlevs(2), &
                      LVT_rc%strat_nlevels))
                 stats%max(m)%obs_value_total = -1E10
-                allocate(stats%max(m)%obs_value_ci(selectNlevs(2),&
+                allocate(stats%max(m)%count_obs_value_total(LVT_rc%ngrid, &
+                     selectNlevs(2), &
+                     LVT_rc%strat_nlevels))
+                stats%max(m)%count_obs_value_total = 0
+                allocate(stats%max(m)%obs_value_ci(selectNlevs(2), &
                      LVT_rc%strat_nlevels))
                 stats%max(m)%obs_value_ci = LVT_rc%udef
-                
-                if(metric%computeSC.eq.1) then 
+
+                if(metric%computeSC.eq.1) then
                    allocate(stats%max(m)%obs_value_asc(LVT_rc%ngrid, &
-                        selectNlevs(2),&
+                        selectNlevs(2), &
                         LVT_rc%nasc))
                    stats%max(m)%obs_value_asc = -1E10
+                   allocate(stats%max(m)%count_obs_value_asc(LVT_rc%ngrid, &
+                        selectNlevs(2), &
+                        LVT_rc%nasc))
+                   stats%max(m)%count_obs_value_asc = 0
                 endif
-                if(metric%computeADC.eq.1) then 
+                if(metric%computeADC.eq.1) then
                    allocate(stats%max(m)%obs_value_adc(LVT_rc%ngrid, &
-                        selectNlevs(2),&
+                        selectNlevs(2), &
                         LVT_rc%nadc))
                    stats%max(m)%obs_value_adc = -1E10
+                   allocate(stats%max(m)%count_obs_value_adc(LVT_rc%ngrid, &
+                        selectNlevs(2), &
+                        LVT_rc%nadc))
+                   stats%max(m)%count_obs_value_adc = 0
                 endif
              endif
           endif
        endif
-       if(metric%timeOpt.eq.1) then 
-          allocate(stats%max(m)%model_value_ts(LVT_rc%ngrid,&
+
+       if(metric%timeOpt.eq.1) then
+          allocate(stats%max(m)%model_value_ts(LVT_rc%ngrid, &
                selectNlevs(1), &
                LVT_rc%strat_nlevels))
           stats%max(m)%model_value_ts = -1E10
-          
+          allocate(stats%max(m)%count_model_value_ts(LVT_rc%ngrid, &
+               selectNlevs(1), &
+               LVT_rc%strat_nlevels))
+          stats%max(m)%count_model_value_ts = 0
+
           allocate(stats%max(m)%tavg_model_value_ts(LVT_rc%ngrid, &
                selectNlevs(1), &
                LVT_rc%strat_nlevels))
+          stats%max(m)%tavg_model_value_ts = -1E10
           allocate(stats%max(m)%tavg_count_model_value_ts(LVT_rc%ngrid, &
                selectNlevs(1), &
                LVT_rc%strat_nlevels))
-          stats%max(m)%tavg_model_value_ts = 0.0
-          stats%max(m)%tavg_count_model_value_ts = 0 
-          
-          if(LVT_rc%obssource(2).ne."none") then 
-             if(selectNlevs(2).ge.1) then 
-                allocate(stats%max(m)%obs_value_ts(LVT_rc%ngrid,&
-                     selectNlevs(1), &
+          stats%max(m)%tavg_count_model_value_ts = 0
+
+          if(LVT_rc%obssource(2).ne."none") then
+             if(selectNlevs(2).ge.1) then
+                allocate(stats%max(m)%obs_value_ts(LVT_rc%ngrid, &
+                     selectNlevs(2), &
                      LVT_rc%strat_nlevels))
                 stats%max(m)%obs_value_ts = -1E10
-                
+                allocate(stats%max(m)%count_obs_value_ts(LVT_rc%ngrid, &
+                     selectNlevs(2), &
+                     LVT_rc%strat_nlevels))
+                stats%max(m)%count_obs_value_ts = 0
+
                 allocate(stats%max(m)%tavg_obs_value_ts(LVT_rc%ngrid, &
                      selectNlevs(2), &
                      LVT_rc%strat_nlevels))
+                stats%max(m)%tavg_obs_value_ts = -1E10
                 allocate(stats%max(m)%tavg_count_obs_value_ts(LVT_rc%ngrid, &
                      selectNlevs(2), &
                      LVT_rc%strat_nlevels))
-                stats%max(m)%tavg_obs_value_ts = 0.0
-                stats%max(m)%tavg_count_obs_value_ts = 0 
+                stats%max(m)%tavg_count_obs_value_ts = 0
              endif
           endif
        endif
     enddo
+
 !-------------------------------------------------------------------------
 ! Number of passes required to compute the metric
 !-------------------------------------------------------------------------
-
-    metric%npass = 1    
-    if(LVT_rc%obssource(2).ne."none") then 
-       metric%obsData = .true. 
+    metric%npass = 1
+    if(LVT_rc%obssource(2).ne."none") then
+       metric%obsData = .true.
     else
-       metric%obsData = .false. 
+       metric%obsData = .false.
     endif
-    metric%stdevFlag = .false. 
+    metric%stdevFlag = .false.
 
   end subroutine LVT_initMax
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_diagnoseMax
 ! \label{LVT_diagnoseMax}
 !
-! !INTERFACE: 
+! !INTERFACE:
   subroutine LVT_diagnoseMax(pass)
-! 
-! !USES:     
+!
+! !USES:
 
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-!   This subroutine issues the calls to update the computations for 
+! !DESCRIPTION:
+!   This subroutine issues the calls to update the computations for
 !   calculating the max of desired variables.
 !
-!   The methods invoked are: 
+!   The methods invoked are:
 !   \begin{description}
 !    \item[diagnoseSingleModelMax](\ref{diagnoseSingleModelMax})
-!     updates the max computation for a single variable 
+!     updates the max computation for a single variable
 !   \end{description}
-! 
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 !BOP
     integer       :: pass
@@ -206,9 +242,9 @@ contains
     type(LVT_metadataEntry), pointer :: obs
     type(LVT_statsEntry)   , pointer :: stats
 
-    if(pass.eq.1) then 
+    if(pass.eq.LVT_metrics%max%npass) then
        if(LVT_metrics%max%selectOpt.eq.1.or.&
-            LVT_metrics%max%timeOpt.eq.1) then 
+            LVT_metrics%max%timeOpt.eq.1) then
 
           call LVT_getDataStream1Ptr(model)
           call LVT_getDataStream2Ptr(obs)
@@ -226,38 +262,38 @@ contains
   end subroutine LVT_diagnoseMax
 
 !BOP
-! 
+!
 ! !ROUTINE: diagnoseSingleMax
 ! \label{diagnoseSingleMax}
 !
-! !INTERFACE: 
+! !INTERFACE:
   subroutine diagnoseSingleMax(model, obs, stats,metric)
-! 
-! !USES:   
+!
+! !USES:
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-!   This routine updates the max computation of the 
-!   specified variable. 
+! !DESCRIPTION:
+!   This routine updates the max computation of the
+!   specified variable.
 !
-!  The arguments are: 
+!  The arguments are:
 !
 !  \begin{description}
 !   \item[model] model variable object
 !   \item[stats] object to hold the updated statistics
 !  \end{description}
-! 
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 !BOP
-! !ARGUMENTS: 
+! !ARGUMENTS:
     type(LVT_metaDataEntry) :: model
     type(LVT_metadataEntry) :: obs
     type(LVT_statsEntry)    :: stats
@@ -266,172 +302,207 @@ contains
     integer    :: t,k,m,m_k,o_k,tind
 
     if(stats%selectOpt.eq.1.and.&
-         model%selectNlevs.ge.1) then        
+         model%selectNlevs.ge.1) then
        do t=1,LVT_rc%ngrid
           do k=1,model%selectNlevs
-             do m =1, LVT_rc%nensem
+             do m=1,LVT_rc%nensem
                 m_k = k+model%startNlevs -1
-                o_k = k+obs%startNlevs -1
-
                 if(model%count(t,m,m_k).gt.0) then
-                   if(metric%selectOpt.eq.1) then 
-                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                   if(metric%selectOpt.eq.1) then
+                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                          if(model%value(t,m,m_k).gt.&
-                              stats%max(m)%model_value_total(t,k,1)) then 
+                              stats%max(m)%model_value_total(t,k,1)) then
                             stats%max(m)%model_value_total(t,k,1) = &
                                  model%value(t,m,m_k)
                          endif
+                         stats%max(m)%count_model_value_total(t,k,1) = &
+                              stats%max(m)%count_model_value_total(t,k,1) + 1
                       endif
                    endif
-                   
-                   if(metric%timeOpt.eq.1) then 
-                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+
+                   if(metric%timeOpt.eq.1) then
+                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                          if(model%value(t,m,m_k).gt.&
-                              stats%max(m)%model_value_ts(t,k,1)) then 
+                              stats%max(m)%model_value_ts(t,k,1)) then
                             stats%max(m)%model_value_ts(t,k,1) = &
                                  model%value(t,m,m_k)
                          endif
+                         stats%max(m)%count_model_value_ts(t,k,1) = &
+                              stats%max(m)%count_model_value_ts(t,k,1) + 1
                       endif
                    endif
-                   if(metric%computeSC.eq.1) then 
-                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                   if(metric%computeSC.eq.1) then
+                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                          call LVT_getSeasonalCycleTimeIndex(LVT_rc%scInterval,&
                               tind)
                          if(model%value(t,m,m_k).gt.&
-                              stats%max(m)%model_value_asc(t,k,tind)) then 
+                              stats%max(m)%model_value_asc(t,k,tind)) then
                             stats%max(m)%model_value_asc(t,k,tind) = &
                                  model%value(t,m,m_k)
                          endif
+                         stats%max(m)%count_model_value_asc(t,k,tind) = &
+                              stats%max(m)%count_model_value_asc(t,k,tind) + 1
                       endif
                    endif
-                   if(metric%computeADC.eq.1) then 
-                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                   if(metric%computeADC.eq.1) then
+                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                          call LVT_getADCTimeIndex(tind)
                          if(model%value(t,m,m_k).gt.&
-                              stats%max(m)%model_value_adc(t,k,tind)) then 
+                              stats%max(m)%model_value_adc(t,k,tind)) then
                             stats%max(m)%model_value_adc(t,k,tind) = &
                                  model%value(t,m,m_k)
                          endif
+                         stats%max(m)%count_model_value_adc(t,k,tind) = &
+                              stats%max(m)%count_model_value_adc(t,k,tind) + 1
                       endif
                    endif
-                   if(LVT_rc%strat_nlevels.gt.1) then 
+                   if(LVT_rc%strat_nlevels.gt.1) then
                       if(LVT_stats%strat_var(t,m,k).gt.&
                            LVT_rc%strat_var_threshold) then
                          if(metric%selectOpt.eq.1) then
-                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then  
+                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                                if(model%value(t,m,m_k).gt.&
-                                    stats%max(m)%model_value_total(t,k,2)) then 
+                                    stats%max(m)%model_value_total(t,k,2)) then
                                   stats%max(m)%model_value_total(t,k,2) = &
                                        model%value(t,m,m_k)
                                endif
+                               stats%max(m)%count_model_value_total(t,k,2) = &
+                                    stats%max(m)%count_model_value_total(t,k,2) + 1
                             endif
                          endif
-                         if(metric%timeOpt.eq.1) then 
-                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                         if(metric%timeOpt.eq.1) then
+                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                                if(model%value(t,m,m_k).gt.&
-                                    stats%max(m)%model_value_ts(t,k,2)) then 
+                                    stats%max(m)%model_value_ts(t,k,2)) then
                                   stats%max(m)%model_value_ts(t,k,2) = &
                                        model%value(t,m,m_k)
                                endif
+                               stats%max(m)%count_model_value_ts(t,k,2) = &
+                                    stats%max(m)%count_model_value_ts(t,k,2) + 1
                             endif
                          endif
                       elseif(LVT_stats%strat_var(t,m,k).le.&
                            LVT_rc%strat_var_threshold) then
-                         if(metric%selectOpt.eq.1) then 
-                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                         if(metric%selectOpt.eq.1) then
+                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                                if(model%value(t,m,m_k).gt.&
-                                    stats%max(m)%model_value_total(t,k,3)) then 
+                                    stats%max(m)%model_value_total(t,k,3)) then
                                   stats%max(m)%model_value_total(t,k,3) = &
                                        model%value(t,m,m_k)
                                endif
+                               stats%max(m)%count_model_value_total(t,k,3) = &
+                                    stats%max(m)%count_model_value_total(t,k,3) + 1
                             endif
                          endif
-                         if(metric%timeOpt.eq.1) then 
-                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                         if(metric%timeOpt.eq.1) then
+                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                                if(model%value(t,m,m_k).gt.&
-                                    stats%max(m)%model_value_ts(t,k,3)) then 
+                                    stats%max(m)%model_value_ts(t,k,3)) then
                                   stats%max(m)%model_value_ts(t,k,3) = &
                                        model%value(t,m,m_k)
                                endif
+                               stats%max(m)%count_model_value_ts(t,k,3) = &
+                                    stats%max(m)%count_model_value_ts(t,k,3) + 1
                             endif
                          endif
                       endif
                    endif
                 endif
-                
+             enddo
+          enddo
+
+          do k=1,obs%selectNlevs
+             do m=1,LVT_rc%nensem
+                o_k = k+obs%startNlevs -1
                 if(LVT_rc%obssource(2).ne."none") then
                    if(obs%selectNlevs.ge.1) then
-                      if(obs%count(t,m,o_k).gt.0) then 
+                      if(obs%count(t,m,o_k).gt.0) then
                          if(metric%selectOpt.eq.1.and.&
-                              obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                              obs%value(t,m,o_k).ne.LVT_rc%udef) then
                             if(obs%value(t,m,o_k).gt.&
-                                 stats%max(m)%obs_value_total(t,k,1)) then 
+                                 stats%max(m)%obs_value_total(t,k,1)) then
                                stats%max(m)%obs_value_total(t,k,1) = &
                                     obs%value(t,m,o_k)
                             endif
+                            stats%max(m)%count_obs_value_total(t,k,1) = &
+                                 stats%max(m)%count_obs_value_total(t,k,1) + 1
                          endif
-                         
+
                          if(metric%timeOpt.eq.1.and.&
-                              obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                              obs%value(t,m,o_k).ne.LVT_rc%udef) then
                             if(obs%value(t,m,o_k).gt.&
-                                 stats%max(m)%obs_value_ts(t,k,1)) then 
+                                 stats%max(m)%obs_value_ts(t,k,1)) then
                                stats%max(m)%obs_value_ts(t,k,1) = &
                                     obs%value(t,m,o_k)
                             endif
+                            stats%max(m)%count_obs_value_ts(t,k,1) = &
+                                 stats%max(m)%count_obs_value_ts(t,k,1) + 1
                          endif
                          if(metric%computeSC.eq.1.and.&
-                              obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                              obs%value(t,m,o_k).ne.LVT_rc%udef) then
                             call LVT_getSeasonalCycleTimeIndex(LVT_rc%scInterval,tind)
                             if(obs%value(t,m,o_k).gt.&
-                                 stats%max(m)%obs_value_asc(t,k,tind)) then 
+                                 stats%max(m)%obs_value_asc(t,k,tind)) then
                                stats%max(m)%obs_value_asc(t,k,tind) = &
                                     obs%value(t,m,o_k)
                             endif
+                            stats%max(m)%count_obs_value_asc(t,k,tind) = &
+                                 stats%max(m)%count_obs_value_asc(t,k,tind) + 1
                          endif
                          if(metric%computeADC.eq.1.and.&
-                              obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                              obs%value(t,m,o_k).ne.LVT_rc%udef) then
                             call LVT_getADCTimeIndex(tind)
                             if(obs%value(t,m,o_k).gt.&
-                                 stats%max(m)%obs_value_adc(t,k,tind)) then 
+                                 stats%max(m)%obs_value_adc(t,k,tind)) then
                                stats%max(m)%obs_value_adc(t,k,tind) = &
                                     obs%value(t,m,o_k)
                             endif
+                            stats%max(m)%count_obs_value_adc(t,k,tind) = &
+                                 stats%max(m)%count_obs_value_adc(t,k,tind) + 1
                          endif
-                         if(LVT_rc%strat_nlevels.gt.1) then 
+                         if(LVT_rc%strat_nlevels.gt.1) then
                             if(LVT_stats%strat_var(t,m,k).gt.&
                                  LVT_rc%strat_var_threshold) then
                                if(metric%selectOpt.eq.1 &
-                                    .and.obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                                    .and.obs%value(t,m,o_k).ne.LVT_rc%udef) then
                                   if(obs%value(t,m,o_k).gt.&
-                                       stats%max(m)%obs_value_total(t,k,2)) then 
+                                       stats%max(m)%obs_value_total(t,k,2)) then
                                      stats%max(m)%obs_value_total(t,k,2) = &
                                           obs%value(t,m,o_k)
                                   endif
+                                  stats%max(m)%count_obs_value_total(t,k,2) = &
+                                       stats%max(m)%count_obs_value_total(t,k,2) + 1
                                endif
-                               
+
                                if(metric%timeOpt.eq.1.and.&
-                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then 
-                                  if(obs%value(t,m,o_k).gt.stats%max(m)%obs_value_ts(t,k,2)) then 
+                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then
+                                  if(obs%value(t,m,o_k).gt.stats%max(m)%obs_value_ts(t,k,2)) then
                                      stats%max(m)%obs_value_ts(t,k,2) = &
                                           obs%value(t,m,o_k)
                                   endif
+                                  stats%max(m)%count_obs_value_ts(t,k,2) = &
+                                       stats%max(m)%count_obs_value_ts(t,k,2) + 1
                                endif
                             elseif(LVT_stats%strat_var(t,m,k).le.&
                                  LVT_rc%strat_var_threshold) then
                                if(metric%selectOpt.eq.1.and.&
-                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then 
-                                  if(obs%value(t,m,o_k).gt.stats%max(m)%obs_value_total(t,k,3)) then 
+                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then
+                                  if(obs%value(t,m,o_k).gt.stats%max(m)%obs_value_total(t,k,3)) then
                                      stats%max(m)%obs_value_total(t,k,3) = &
                                           obs%value(t,m,o_k)
                                   endif
+                                  stats%max(m)%count_obs_value_total(t,k,3) = &
+                                       stats%max(m)%count_obs_value_total(t,k,3) + 1
                                endif
-                               
+
                                if(metric%timeOpt.eq.1.and.&
-                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then 
-                                  if(obs%value(t,m,o_k).gt.stats%max(m)%obs_value_ts(t,k,3)) then 
+                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then
+                                  if(obs%value(t,m,o_k).gt.stats%max(m)%obs_value_ts(t,k,3)) then
                                      stats%max(m)%obs_value_ts(t,k,3) = &
                                           obs%value(t,m,o_k)
                                   endif
+                                  stats%max(m)%count_obs_value_ts(t,k,3) = &
+                                       stats%max(m)%count_obs_value_ts(t,k,3) + 1
                                endif
                             endif
                          endif
@@ -445,35 +516,35 @@ contains
   end subroutine diagnoseSingleMax
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_computeMax
 ! \label{LVT_computeMax}
 !
-! !INTERFACE: 
+! !INTERFACE:
   subroutine LVT_computeMax(pass,alarm)
-! 
-! !USES:   
+!
+! !USES:
 
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-!   This subroutine issues the calls to compute the max values for 
+! !DESCRIPTION:
+!   This subroutine issues the calls to compute the max values for
 !   desired variables.
 !
-!   The methods invoked are: 
+!   The methods invoked are:
 !   \begin{description}
 !    \item[computeSingleModelMax](\ref{computeSingleModelMax})
 !     computes the max values for a single variable
 !   \end{description}
-! 
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 !BOP
     integer               :: pass
@@ -483,30 +554,31 @@ contains
     type(LVT_metadataEntry), pointer :: model
     type(LVT_metadataEntry), pointer :: obs
     type(LVT_statsEntry)   , pointer :: stats
-    
-    if(pass.eq.1) then 
+
+    if(pass.eq.LVT_metrics%max%npass) then
        if(LVT_metrics%max%selectOpt.eq.1.or.&
-            LVT_metrics%max%timeOpt.eq.1) then 
-          if(alarm) then 
+            LVT_metrics%max%timeOpt.eq.1) then
+          if(alarm) then
              if(LVT_metrics%max%timeOpt.eq.1.and.&
-                  LVT_metrics%max%extractTS.eq.1) then 
-                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then 
+                  LVT_metrics%max%extractTS.eq.1) then
+                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then
                    do m=1,LVT_rc%nensem
                       do i=1,LVT_rc%ntslocs
                          write(LVT_metrics%max%ftn_ts_loc(i,m),200,advance='no') &
                               LVT_rc%yr, '',LVT_rc%mo, '', LVT_rc%da, '', &
-                              LVT_rc%hr,'',LVT_rc%mn, '' 
+                              LVT_rc%hr,'',LVT_rc%mn, ''
                       enddo
                    enddo
                 else
                    do i=1,LVT_rc%ntslocs
                       write(LVT_metrics%max%ftn_ts_loc(i,1),200,advance='no') &
                            LVT_rc%yr, '',LVT_rc%mo, '', LVT_rc%da, '', &
-                           LVT_rc%hr,'',LVT_rc%mn, '' 
+                           LVT_rc%hr,'',LVT_rc%mn, ''
                    enddo
                 endif
              endif
           endif
+
 200       format(I4, a1, I2.2, a1, I2.2, a1, I2.2, a1, I2.2,a1)
 
           call LVT_getDataStream1Ptr(model)
@@ -514,19 +586,19 @@ contains
           call LVT_getstatsEntryPtr(stats)
 
           do while(associated(model))
-             
+
              call computeSingleMax(alarm,model,obs,stats,&
                   LVT_metrics%max)
-             
+
              model => model%next
              obs => obs%next
              stats => stats%next
           enddo
-          
-          if(alarm) then 
+
+          if(alarm) then
              if(LVT_metrics%max%timeOpt.eq.1.and.&
                   LVT_metrics%max%extractTS.eq.1) then
-                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then 
+                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then
                    do m=1,LVT_rc%nensem
                       do i=1,LVT_rc%ntslocs
                          write(LVT_metrics%max%ftn_ts_loc(i,m),fmt='(a1)') ''
@@ -536,46 +608,46 @@ contains
                    do i=1,LVT_rc%ntslocs
                       write(LVT_metrics%max%ftn_ts_loc(i,1),fmt='(a1)') ''
                    enddo
-                endif 
+                endif
              endif
           endif
        endif
     endif
   end subroutine LVT_computeMax
-  
+
 
 !BOP
-! 
+!
 ! !ROUTINE: computeSingleMax
 ! \label{computeSingleMax}
 !
-! !INTERFACE: 
+! !INTERFACE:
   subroutine computeSingleMax(alarm,model,obs,stats,metric)
-! 
-! !USES:   
-        
+!
+! !USES:
+
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine computes the max values
-!  The arguments are: 
+!  The arguments are:
 !
 !  \begin{description}
 !    \item[model] model variable object
 !    \item[stats] object to hold the updated statistics
 !  \end{description}
-! 
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 !BOP
-! !ARGUMENTS: 
+! !ARGUMENTS:
     logical                 :: alarm
     type(LVT_metaDataEntry) :: model
     type(LVT_metaDataEntry) :: obs
@@ -584,11 +656,6 @@ contains
 !EOP
 
     integer  :: t,l,k,m
-    real     :: diff_field(LVT_rc%ngrid)
-    integer     :: count_model_asc(LVT_rc%ngrid,model%selectNlevs,LVT_rc%nasc)
-    integer     :: count_obs_asc(LVT_rc%ngrid,obs%selectNlevs,LVT_rc%nasc)
-    integer     :: count_model_adc(LVT_rc%ngrid,model%selectNlevs,LVT_rc%nadc)
-    integer     :: count_obs_adc(LVT_rc%ngrid,obs%selectNlevs,LVT_rc%nadc)
 
     real,    allocatable :: tavg_model_value_ts(:,:,:)
     real,    allocatable :: tavg_obs_value_ts(:,:,:)
@@ -599,43 +666,41 @@ contains
 
     real,    allocatable :: model_value_adc(:,:,:)
     real,    allocatable :: obs_value_adc(:,:,:)
-    
+
     real,    allocatable :: model_value_avg(:,:,:)
-    real,    allocatable :: obs_value_avg(:,:,:)   
+    real,    allocatable :: obs_value_avg(:,:,:)
 
-    count_model_asc = 1
-    count_model_adc = 1
-    count_obs_adc = 1
-
-    if(metric%timeOpt.eq.1) then 
+    if(metric%timeOpt.eq.1) then
        if(stats%selectOpt.eq.1.and.&
-            model%selectNlevs.ge.1) then 
+            model%selectNlevs.ge.1) then
           do t=1,LVT_rc%ngrid
              do m=1,LVT_rc%nensem
                 do k=1,model%selectNlevs
                    do l=1,LVT_rc%strat_nlevels
-                      if(stats%max(m)%model_value_ts(t,k,l).gt.-1E10) then 
-                         stats%max(m)%model_value_ts(t,k,l) = &
-                              stats%max(m)%model_value_ts(t,k,l)
-
-                         stats%max(m)%tavg_model_value_ts(t,k,l) = & 
-                              stats%max(m)%tavg_model_value_ts(t,k,l) + &
-                              stats%max(m)%model_value_ts(t,k,l)
-                         stats%max(m)%tavg_count_model_value_ts(t,k,l) = & 
+                      if(stats%max(m)%count_model_value_ts(t,k,l).gt.0) then
+                         if(stats%max(m)%model_value_ts(t,k,l).gt. &
+                            stats%max(m)%tavg_model_value_ts(t,k,l)) then
+                            stats%max(m)%tavg_model_value_ts(t,k,l) = &
+                                 stats%max(m)%model_value_ts(t,k,l)
+                         endif
+                         stats%max(m)%tavg_count_model_value_ts(t,k,l) = &
                               stats%max(m)%tavg_count_model_value_ts(t,k,l) + 1
                       else
                          stats%max(m)%model_value_ts(t,k,l) = LVT_rc%udef
                       endif
-                      if(LVT_rc%obssource(2).ne."none") then 
-                         if(obs%selectNlevs.ge.1) then 
-                            if(stats%max(m)%obs_value_ts(t,k,l).gt.-1E10) then 
-                               stats%max(m)%obs_value_ts(t,k,l) = &
-                                    stats%max(m)%obs_value_ts(t,k,l)
-                               
-                               stats%max(m)%tavg_obs_value_ts(t,k,l) = & 
-                                    stats%max(m)%tavg_obs_value_ts(t,k,l) + &
-                                    stats%max(m)%obs_value_ts(t,k,l)
-                               stats%max(m)%tavg_count_obs_value_ts(t,k,l) = & 
+                   enddo
+                enddo
+                do k=1,obs%selectNlevs
+                   do l=1,LVT_rc%strat_nlevels
+                      if(LVT_rc%obssource(2).ne."none") then
+                         if(obs%selectNlevs.ge.1) then
+                            if(stats%max(m)%count_obs_value_ts(t,k,l).gt.0) then
+                               if(stats%max(m)%obs_value_ts(t,k,l).gt. &
+                                  stats%max(m)%tavg_obs_value_ts(t,k,l)) then
+                                  stats%max(m)%tavg_obs_value_ts(t,k,l) = &
+                                       stats%max(m)%obs_value_ts(t,k,l)
+                               endif
+                               stats%max(m)%tavg_count_obs_value_ts(t,k,l) = &
                                     stats%max(m)%tavg_count_obs_value_ts(t,k,l) + 1
                             else
                                stats%max(m)%obs_value_ts(t,k,l) = LVT_rc%udef
@@ -647,25 +712,26 @@ contains
              enddo
           enddo
 
-          if(alarm) then 
-
+          if(alarm) then
              do t=1,LVT_rc%ngrid
                 do m=1,LVT_rc%nensem
                    do k=1,model%selectNlevs
                       do l=1,LVT_rc%strat_nlevels
-                         if(stats%max(m)%tavg_count_model_value_ts(t,k,l).gt.0) then 
-                            stats%max(m)%tavg_model_value_ts(t,k,l) = & 
-                                 stats%max(m)%tavg_model_value_ts(t,k,l) /&
-                                 stats%max(m)%tavg_count_model_value_ts(t,k,l) 
+                         if(stats%max(m)%tavg_count_model_value_ts(t,k,l).gt.0) then
+                            stats%max(m)%tavg_model_value_ts(t,k,l) = &
+                                 stats%max(m)%tavg_model_value_ts(t,k,l)
                          else
                             stats%max(m)%tavg_model_value_ts(t,k,l) = LVT_rc%udef
                          endif
-                         if(LVT_rc%obssource(2).ne."none") then 
-                            if(obs%selectNlevs.ge.1) then 
-                               if(stats%max(m)%tavg_count_obs_value_ts(t,k,l).gt.0) then 
-                                  stats%max(m)%tavg_obs_value_ts(t,k,l) = & 
-                                       stats%max(m)%tavg_obs_value_ts(t,k,l)/&
-                                       stats%max(m)%tavg_count_obs_value_ts(t,k,l)
+                      enddo
+                   enddo
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%strat_nlevels
+                         if(LVT_rc%obssource(2).ne."none") then
+                            if(obs%selectNlevs.ge.1) then
+                               if(stats%max(m)%tavg_count_obs_value_ts(t,k,l).gt.0) then
+                                  stats%max(m)%tavg_obs_value_ts(t,k,l) = &
+                                       stats%max(m)%tavg_obs_value_ts(t,k,l)
                                else
                                   stats%max(m)%tavg_obs_value_ts(t,k,l) = LVT_rc%udef
                                endif
@@ -676,12 +742,11 @@ contains
                 enddo
              enddo
 
-             if(metric%extractTS.eq.1) then 
-                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then 
+             if(metric%extractTS.eq.1) then
+                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then
                    do m=1,LVT_rc%nensem
-                      if(LVT_rc%obssource(2).ne."none"&
-                           .and.obs%selectNlevs.ge.1) then 
-
+                      if(LVT_rc%obssource(2).ne."none".and. &
+                            obs%selectNlevs.ge.1) then
                          call LVT_writeTSinfo(metric%ftn_ts_loc(:,m),&
                               model,&
                               LVT_rc%ngrid,&
@@ -695,23 +760,23 @@ contains
                               model,&
                               LVT_rc%ngrid,&
                               stats%max(m)%tavg_model_value_ts,&
-                              stats%max(m)%tavg_count_obs_value_ts)
+                              stats%max(m)%tavg_count_model_value_ts)
                       endif
                    enddo
                 else
-                   allocate(tavg_model_value_ts(LVT_rc%ngrid,&
-                        model%vlevels,&
+                   allocate(tavg_model_value_ts(LVT_rc%ngrid, &
+                        model%vlevels, &
                         LVT_rc%strat_nlevels))
                    tavg_model_value_ts = 0.0
 
-                   if(LVT_rc%obssource(2).ne."none".and.&
-                        obs%selectNlevs.ge.1) then 
+                   if(LVT_rc%obssource(2).ne."none".and. &
+                         obs%selectNlevs.ge.1) then
 
-                      allocate(tavg_obs_value_ts(LVT_rc%ngrid,&
-                           obs%vlevels,&
+                      allocate(tavg_obs_value_ts(LVT_rc%ngrid, &
+                           obs%vlevels, &
                            LVT_rc%strat_nlevels))
                       tavg_obs_value_ts = 0.0
-                      
+
                       do m=1,LVT_rc%nensem
                          do t=1,LVT_rc%ngrid
                             do k=1,model%selectNlevs
@@ -722,11 +787,11 @@ contains
                                   tavg_obs_value_ts(t,k,l) = &
                                        tavg_obs_value_ts(t,k,l) + &
                                        stats%max(m)%tavg_obs_value_ts(t,k,l)
-                                  
-                                  
+
+
                                enddo
                             enddo
-                         enddo                         
+                         enddo
                       enddo
 
                       do t=1,LVT_rc%ngrid
@@ -739,7 +804,7 @@ contains
                             enddo
                          enddo
                       enddo
-                      
+
                       call LVT_writeTSinfo(metric%ftn_ts_loc(:,1),&
                            model,&
                            LVT_rc%ngrid,&
@@ -747,7 +812,7 @@ contains
                            stats%max(1)%tavg_count_model_value_ts,&
                            LVT_rc%ngrid,&
                            tavg_obs_value_ts,&
-                           stats%max(m)%tavg_count_obs_value_ts)
+                           stats%max(1)%tavg_count_obs_value_ts)
                    else
                       do m=1,LVT_rc%nensem
                          do t=1,LVT_rc%ngrid
@@ -760,7 +825,7 @@ contains
                             enddo
                          enddo
                       enddo
-                      
+
                       do t=1,LVT_rc%ngrid
                          do k=1,model%selectNlevs
                             do l=1,LVT_rc%strat_nlevels
@@ -769,18 +834,17 @@ contains
                             enddo
                          enddo
                       enddo
-                      
+
                       call LVT_writeTSinfo(metric%ftn_ts_loc(:,1),&
                            model,&
                            LVT_rc%ngrid,&
                            tavg_model_value_ts,&
                            stats%max(1)%tavg_count_model_value_ts)
-
                    endif
                    deallocate(tavg_model_value_ts)
 
-                   if(LVT_rc%obssource(2).ne."none".and.&
-                        obs%selectNlevs.ge.1) then 
+                   if(LVT_rc%obssource(2).ne."none".and. &
+                         obs%selectNlevs.ge.1) then
                       deallocate(tavg_obs_value_ts)
                    endif
                 endif
@@ -789,35 +853,37 @@ contains
        endif
     endif
 
-       
-    if(LVT_rc%endtime.eq.1.and.metric%selectOpt.eq.1) then 
+    if(LVT_rc%endtime.eq.1.and.metric%selectOpt.eq.1) then
        if(stats%selectOpt.eq.1.and.&
-            model%selectNlevs.ge.1) then 
+            model%selectNlevs.ge.1) then
           do t=1,LVT_rc%ngrid
              do m=1,LVT_rc%nensem
                 do k=1,model%selectNlevs
                    do l=1,LVT_rc%strat_nlevels
-                      if(stats%max(m)%model_value_total(t,k,l).gt.-1E10) then 
+                      if(stats%max(m)%count_model_value_total(t,k,l).gt.&
+                           LVT_rc%obsCountThreshold) then
                          stats%max(m)%model_value_total(t,k,l) = &
                               stats%max(m)%model_value_total(t,k,l)
                       else
                          stats%max(m)%model_value_total(t,k,l) = LVT_rc%udef
                       endif
                    enddo
-                   if(metric%computeSC.eq.1) then 
-                      do l=1, LVT_rc%nasc
-                         if(stats%max(m)%model_value_asc(t,k,l).gt.-1E10) then 
+                   if(metric%computeSC.eq.1) then
+                      do l=1,LVT_rc%nasc
+                         if(stats%max(m)%count_model_value_asc(t,k,l).gt.&
+                              LVT_rc%SCCountThreshold) then
                             stats%max(m)%model_value_asc(t,k,l) = &
-                                 count_model_asc(t,1,l)           
+                                 stats%max(m)%count_model_value_asc(t,k,l)
                          else
                             stats%max(m)%model_value_asc(t,k,l) = LVT_rc%udef
                          endif
                       enddo
                    endif
-                   
-                   if(metric%computeADC.eq.1) then 
-                      do l=1, LVT_rc%nadc
-                         if(stats%max(m)%model_value_adc(t,k,l).gt.-1E10) then 
+
+                   if(metric%computeADC.eq.1) then
+                      do l=1,LVT_rc%nadc
+                         if(stats%max(m)%count_model_value_adc(t,k,l).gt.&
+                              LVT_rc%ADCCountThreshold) then
                             stats%max(m)%model_value_adc(t,k,l) = &
                                  stats%max(m)%model_value_adc(t,k,l)
                          else
@@ -825,10 +891,13 @@ contains
                          endif
                       enddo
                    endif
-                   if(LVT_rc%obssource(2).ne."none") then 
+                enddo
+                do k=1,obs%selectNlevs
+                   if(LVT_rc%obssource(2).ne."none") then
                       if(obs%selectNlevs.ge.1) then
-                         do l=1,LVT_rc%strat_nlevels                      
-                            if(stats%max(m)%obs_value_total(t,k,l).gt.-1E10) then 
+                         do l=1,LVT_rc%strat_nlevels
+                            if(stats%max(m)%count_obs_value_total(t,k,l).gt.&
+                                 LVT_rc%obsCountThreshold) then
                                stats%max(m)%obs_value_total(t,k,l) = &
                                     stats%max(m)%obs_value_total(t,k,l)
                             else
@@ -836,8 +905,9 @@ contains
                             endif
                          enddo
                          if(metric%computeSC.eq.1) then
-                            do l=1, LVT_rc%nasc 
-                               if(stats%max(m)%obs_value_asc(t,k,l).gt.-1E10) then 
+                            do l=1,LVT_rc%nasc
+                               if(stats%max(m)%count_obs_value_asc(t,k,l).gt.&
+                                    LVT_rc%SCCountThreshold) then
                                   stats%max(m)%obs_value_asc(t,k,l) = &
                                        stats%max(m)%obs_value_asc(t,k,l)
                                else
@@ -845,10 +915,11 @@ contains
                                endif
                             enddo
                          endif
-                         
+
                          if(metric%computeADC.eq.1) then
-                            do l=1, LVT_rc%nadc  
-                               if(stats%max(m)%obs_value_adc(t,k,l).gt.-1E10) then
+                            do l=1,LVT_rc%nadc
+                               if(stats%max(m)%count_obs_value_adc(t,k,l).gt.&
+                                    LVT_rc%ADCCountThreshold) then
                                   stats%max(m)%obs_value_adc(t,k,l) = &
                                        stats%max(m)%obs_value_adc(t,k,l)
                                else
@@ -861,17 +932,18 @@ contains
                 enddo
              enddo
           enddo
-          do m=1,LVT_rc%nensem          
+
+          do m=1,LVT_rc%nensem
              do k=1,model%selectNlevs
-                do l=1, LVT_rc%strat_nlevels
+                do l=1,LVT_rc%strat_nlevels
                    call LVT_computeCI(stats%max(m)%model_value_total(:,k,l),&
                         LVT_rc%ngrid,&
                         LVT_rc%pval_CI,stats%max(m)%model_value_ci(k,l))
                 enddo
              enddo
-             if(LVT_rc%obssource(2).ne."none") then 
+             if(LVT_rc%obssource(2).ne."none") then
                 do k=1,obs%selectNlevs
-                   do l=1, LVT_rc%strat_nlevels
+                   do l=1,LVT_rc%strat_nlevels
                       call LVT_computeCI(stats%max(m)%obs_value_total(:,k,l),&
                            LVT_rc%ngrid,&
                            LVT_rc%pval_CI,stats%max(m)%obs_value_ci(k,l))
@@ -879,57 +951,58 @@ contains
                 enddo
              endif
           enddo
+
 !----------------------------------------------------------------------
-!  External data based stratification 
+!  External data based stratification
 !----------------------------------------------------------------------
-          if(LVT_rc%data_based_strat.eq.1) then 
+          if(LVT_rc%data_based_strat.eq.1) then
 
              allocate(model_value_avg(LVT_rc%ngrid,&
                   model%vlevels,&
                   LVT_rc%strat_nlevels))
              model_value_avg = 0.0
-             
-             do m=1,LVT_rc%nensem        
-                do t=1,LVT_rc%ngrid                      
-                   do k=1,model%selectNlevs                
-                      do l=1, LVT_rc%strat_nlevels
+
+             do m=1,LVT_rc%nensem
+                do t=1,LVT_rc%ngrid
+                   do k=1,model%selectNlevs
+                      do l=1,LVT_rc%strat_nlevels
                          model_value_avg(t,k,l) = &
-                              model_value_avg(t,k,l) + & 
+                              model_value_avg(t,k,l) + &
                               stats%max(m)%model_value_total(t,k,l)
                       enddo
                    enddo
                 enddo
              enddo
-             
-             do t=1,LVT_rc%ngrid                      
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%strat_nlevels
+
+             do t=1,LVT_rc%ngrid
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%strat_nlevels
                       model_value_avg(t,k,l) = &
                            model_value_avg(t,k,l)/LVT_rc%nensem
                    enddo
                 enddo
              enddo
-             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
-                
+             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
+
                 allocate(obs_value_avg(LVT_rc%ngrid,&
                      obs%vlevels,&
                      LVT_rc%strat_nlevels))
                 obs_value_avg = 0.0
-                
-                do m=1,LVT_rc%nensem        
+
+                do m=1,LVT_rc%nensem
                    do t=1,LVT_rc%ngrid
-                      do k=1,obs%selectNlevs                
-                         do l=1, LVT_rc%strat_nlevels
+                      do k=1,obs%selectNlevs
+                         do l=1,LVT_rc%strat_nlevels
                             obs_value_avg(t,k,l) = &
-                                 obs_value_avg(t,k,l) + & 
+                                 obs_value_avg(t,k,l) + &
                                  stats%max(m)%obs_value_total(t,k,l)
                          enddo
                       enddo
                    enddo
                 enddo
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%strat_nlevels                
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%strat_nlevels
                          obs_value_avg(t,k,l) = &
                               obs_value_avg(t,k,l)/LVT_rc%nensem
                       enddo
@@ -938,18 +1011,17 @@ contains
                 call LVT_writeDataBasedStrat(model,obs,stats,metric,&
                      LVT_rc%ngrid, model_value_avg, &
                      LVT_rc%ngrid, obs_value_avg)
-                   
+
                 deallocate(obs_value_avg)
              else
-                   
+
                 call LVT_writeDataBasedStrat(model,obs,stats,metric,&
-                     LVT_rc%ngrid,model_value_avg)            
-                
+                     LVT_rc%ngrid,model_value_avg)
+
              endif
              deallocate(model_value_avg)
-                
           endif
-          
+
           if(metric%computeSC.eq.1) then
              allocate(model_value_asc(LVT_rc%ngrid,&
                   model%vlevels,&
@@ -959,17 +1031,17 @@ contains
                   LVT_rc%nasc))
 
              model_value_asc = 0.0
-             count_model_value_asc = 0 
+             count_model_value_asc = 0
 
              do t=1,LVT_rc%ngrid
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%nasc
-                      do m=1,LVT_rc%nensem        
-                         if(stats%max(m)%model_value_asc(t,k,l).ne.LVT_rc%udef) then 
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%nasc
+                      do m=1,LVT_rc%nensem
+                         if(stats%max(m)%model_value_asc(t,k,l).ne.LVT_rc%udef) then
                             model_value_asc(t,k,l) = &
-                                 model_value_asc(t,k,l) + & 
+                                 model_value_asc(t,k,l) + &
                                  stats%max(m)%model_value_asc(t,k,l)
-                            count_model_value_asc(t,k,l) = & 
+                            count_model_value_asc(t,k,l) = &
                                  count_model_value_asc(t,k,l) + 1
                          endif
                       enddo
@@ -978,11 +1050,11 @@ contains
              enddo
 
              do t=1,LVT_rc%ngrid
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%nasc
-                      if(count_model_value_asc(t,k,l).gt.0) then 
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%nasc
+                      if(count_model_value_asc(t,k,l).gt.0) then
                          model_value_asc(t,k,l) = &
-                              model_value_asc(t,k,l)/&
+                              model_value_asc(t,k,l) / &
                               count_model_value_asc(t,k,l)
                       else
                          model_value_asc(t,k,l) = LVT_rc%udef
@@ -991,46 +1063,46 @@ contains
                 enddo
              enddo
 
-             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                 allocate(obs_value_asc(LVT_rc%ngrid,&
                      obs%vlevels,&
                      LVT_rc%nasc))
-                
+
                 obs_value_asc = 0.0
 
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%nasc
-                         do m=1,LVT_rc%nensem          
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%nasc
+                         do m=1,LVT_rc%nensem
                             obs_value_asc(t,k,l) = &
-                                 obs_value_asc(t,k,l) + & 
+                                 obs_value_asc(t,k,l) + &
                                  stats%max(m)%obs_value_asc(t,k,l)
                          enddo
                       enddo
                    enddo
                 enddo
-                
+
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%nasc
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%nasc
                          obs_value_asc(t,k,l) = &
                               obs_value_asc(t,k,l)/LVT_rc%nensem
                       enddo
                    enddo
                 enddo
-             
+
                 call LVT_writeSeasonalCycleInfo(model,obs,stats,metric,&
                      LVT_rc%ngrid,model_value_asc,&
-                     count_model_asc,&
+                     stats%max(1)%count_model_value_asc,&
                      LVT_rc%ngrid,obs_value_asc,&
-                     count_obs_asc)   
+                     stats%max(1)%count_obs_value_asc)
 
                 deallocate(obs_value_asc)
-       
+
              else
                 call LVT_writeSeasonalCycleInfo(model,obs,stats,metric,&
                      LVT_rc%ngrid,model_value_asc,&
-                     count_model_asc)
+                     stats%max(1)%count_model_value_asc)
 
                 deallocate(model_value_asc)
              endif
@@ -1043,64 +1115,64 @@ contains
              model_value_adc = 0.0
 
              do t=1,LVT_rc%ngrid
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%nadc
-                      do m=1,LVT_rc%nensem          
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%nadc
+                      do m=1,LVT_rc%nensem
                          model_value_adc(t,k,l) = &
-                              model_value_adc(t,k,l) + & 
+                              model_value_adc(t,k,l) + &
                               stats%max(m)%model_value_adc(t,k,l)
                       enddo
                    enddo
                 enddo
              enddo
-             
+
              do t=1,LVT_rc%ngrid
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%nadc
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%nadc
                       model_value_adc(t,k,l) = &
                            model_value_adc(t,k,l)/LVT_rc%nensem
                    enddo
                 enddo
              enddo
-             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                 allocate(obs_value_adc(LVT_rc%ngrid,&
                      obs%vlevels,&
                      LVT_rc%nadc))
-                
+
                 obs_value_adc = 0.0
 
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%nadc
-                         do m=1,LVT_rc%nensem          
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%nadc
+                         do m=1,LVT_rc%nensem
                             obs_value_adc(t,k,l) = &
-                                 obs_value_adc(t,k,l) + & 
+                                 obs_value_adc(t,k,l) + &
                                  stats%max(m)%obs_value_adc(t,k,l)
                          enddo
                       enddo
                    enddo
                 enddo
-                
+
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%nadc
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%nadc
                          obs_value_adc(t,k,l) = &
                               obs_value_adc(t,k,l)/LVT_rc%nensem
                       enddo
                    enddo
                 enddo
-             
+
                 call LVT_writeAvgDiurnalCycleInfo(model,obs,stats,metric,&
                      LVT_rc%ngrid,model_value_adc,&
-                     count_model_adc,&
+                     stats%max(1)%count_model_value_adc,&
                      LVT_rc%ngrid,obs_value_adc,&
-                     count_obs_adc)      
-                
+                     stats%max(1)%count_obs_value_adc)
+
                 deallocate(obs_value_adc)
              else
                 call LVT_writeAvgDiurnalCycleInfo(model,obs,stats,metric,&
                      LVT_rc%ngrid,model_value_adc,&
-                     count_model_adc)
+                     stats%max(m)%count_model_value_adc)
 
                 deallocate(model_value_adc)
              endif
@@ -1110,31 +1182,28 @@ contains
   end subroutine computeSingleMax
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_writeMetric_Max
 ! \label(LVT_writeMetric_Max)
 !
 ! !INTERFACE:
   subroutine LVT_writeMetric_Max(pass,final,vlevels,stats,obs)
-! 
-! !USES:   
+!
+! !USES:
     use LVT_statsMod, only : LVT_writeSummaryStats
     use LVT_pluginIndices
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-! 
-!   This routine writes the computed Max values to 
-!   an external file. 
+! !DESCRIPTION:
+!   This routine writes the computed Max values to an external file.
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
-
 
     integer                 :: pass
     integer                 :: final
@@ -1166,12 +1235,12 @@ contains
 
     if(pass.eq.LVT_metrics%max%npass) then
        if(final.ne.1) then
-           if(stats%selectOpt.eq.1) then 
-              
+           if(stats%selectOpt.eq.1) then
+
               allocate(model_value_ts(LVT_rc%ngrid,LVT_rc%nensem))
               allocate(count_model_value_ts(LVT_rc%ngrid,LVT_rc%nensem))
 
-              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                  allocate(obs_value_ts(LVT_rc%ngrid,LVT_rc%nensem))
                  allocate(count_obs_value_ts(LVT_rc%ngrid,LVT_rc%nensem))
               endif
@@ -1181,27 +1250,27 @@ contains
                     do m=1,LVT_rc%nensem
                          model_value_ts(:,m) = &
                               stats%max(m)%tavg_model_value_ts(:,k,l)
-                         count_model_value_ts(:,m) = & 
+                         count_model_value_ts(:,m) = &
                               stats%max(m)%tavg_count_model_value_ts(:,k,l)
-                       if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                       if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                           obs_value_ts(:,m) = &
                                stats%max(m)%tavg_obs_value_ts(:,k,l)
-                          count_obs_value_ts(:,m) = & 
+                          count_obs_value_ts(:,m) = &
                                stats%max(m)%tavg_count_obs_value_ts(:,k,l)
                        endif
                     enddo
-                    if(LVT_metrics%max%timeOpt.eq.1) then 
-                       
+                    if(LVT_metrics%max%timeOpt.eq.1) then
+
                        call LVT_writevar_gridded(LVT_metrics%max%ftn_ts, &
                             model_value_ts(:,:),&
                             stats%vid_ts(LVT_MAXid,1),k)
-                       
+
                        call LVT_writevar_gridded(LVT_metrics%max%ftn_ts, &
                             real(count_model_value_ts(:,:)),&
                             stats%vid_count_ts(LVT_MAXid,1),k)
                     endif
-                    
-                    if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+
+                    if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                        call LVT_writevar_gridded(LVT_metrics%max%ftn_ts, &
                             obs_value_ts(:,:),&
                             stats%vid_ts(LVT_MAXid,2),k)
@@ -1215,7 +1284,7 @@ contains
               deallocate(model_value_ts)
               deallocate(count_model_value_ts)
 
-              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                  deallocate(obs_value_ts)
                  deallocate(count_obs_value_ts)
               endif
@@ -1227,26 +1296,24 @@ contains
               allocate(model_value_total(LVT_rc%ngrid,LVT_rc%nensem))
               allocate(count_model_value_total(LVT_rc%ngrid,LVT_rc%nensem))
               allocate(model_value_ci(LVT_rc%nensem))
-              
-              count_model_value_total = 1
 
-              if(LVT_metrics%max%computeSC.eq.1) then 
+              if(LVT_metrics%max%computeSC.eq.1) then
                  allocate(model_value_asc(LVT_rc%ngrid,&
                       LVT_rc%nensem,&
                       LVT_rc%nasc))
                  if(LVT_rc%obssource(2).ne."none".and.&
-                      obs%selectNlevs.ge.1) then 
+                      obs%selectNlevs.ge.1) then
                     allocate(obs_value_asc(LVT_rc%ngrid,&
                          LVT_rc%nensem,&
                          LVT_rc%nasc))
                  endif
               endif
-              if(LVT_metrics%max%computeADC.eq.1) then 
+              if(LVT_metrics%max%computeADC.eq.1) then
                  allocate(model_value_adc(LVT_rc%ngrid,&
                       LVT_rc%nensem,&
-                      LVT_rc%nadc))        
+                      LVT_rc%nadc))
                  if(LVT_rc%obssource(2).ne."none".and.&
-                      obs%selectNlevs.ge.1) then 
+                      obs%selectNlevs.ge.1) then
                     allocate(obs_value_adc(LVT_rc%ngrid,&
                          LVT_rc%nensem,&
                          LVT_rc%nadc))
@@ -1254,57 +1321,59 @@ contains
 
               endif
 
-              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                  allocate(obs_value_total(LVT_rc%ngrid,LVT_rc%nensem))
                  allocate(count_obs_value_total(LVT_rc%ngrid,LVT_rc%nensem))
                  allocate(obs_value_ci(LVT_rc%nensem))
-
-                 count_obs_value_total = 1
-              endif                
+              endif
 
                 do k=1,vlevels
                    do l=1,LVT_rc%strat_nlevels
                       do m=1,LVT_rc%nensem
                          model_value_total(:,m) = &
                               stats%max(m)%model_value_total(:,k,l)
+                         count_model_value_total(:,m) = &
+                              stats%max(m)%count_model_value_total(:,k,l)
                          model_value_ci(m) = stats%max(m)%model_value_ci(k,l)
-                         
-                         if(LVT_metrics%max%computeSC.eq.1) then 
+
+                         if(LVT_metrics%max%computeSC.eq.1) then
                             do tind = 1,LVT_rc%nasc
-                               model_value_asc(:,m,tind) = & 
+                               model_value_asc(:,m,tind) = &
                                     stats%max(m)%model_value_asc(:,k,tind)
                             enddo
                          endif
 
-                         if(LVT_metrics%max%computeADC.eq.1) then 
+                         if(LVT_metrics%max%computeADC.eq.1) then
                             do tind = 1,LVT_rc%nadc
-                               model_value_adc(:,m,tind) = & 
+                               model_value_adc(:,m,tind) = &
                                     stats%max(m)%model_value_adc(:,k,tind)
                             enddo
                          endif
 
                          if(LVT_rc%obssource(2).ne."none".and.&
-                              obs%selectNlevs.ge.1) then 
+                              obs%selectNlevs.ge.1) then
                             obs_value_total(:,m) = &
                                  stats%max(m)%obs_value_total(:,k,l)
+                            count_obs_value_total(:,m) = &
+                                 stats%max(m)%count_obs_value_total(:,k,l)
                             obs_value_ci(m) = stats%max(m)%obs_value_ci(k,l)
 
-                            if(LVT_metrics%max%computeSC.eq.1) then 
+                            if(LVT_metrics%max%computeSC.eq.1) then
                                do tind = 1,LVT_rc%nasc
-                                  obs_value_asc(:,m,tind) = & 
+                                  obs_value_asc(:,m,tind) = &
                                        stats%max(m)%obs_value_asc(:,k,tind)
                                enddo
                             endif
-                            if(LVT_metrics%max%computeADC.eq.1) then 
+                            if(LVT_metrics%max%computeADC.eq.1) then
                                do tind = 1,LVT_rc%nadc
-                                  obs_value_adc(:,m,tind) = & 
+                                  obs_value_adc(:,m,tind) = &
                                        stats%max(m)%obs_value_adc(:,k,tind)
                                enddo
                             endif
-                            
+
                          endif
                       enddo
-                      if(LVT_metrics%max%selectOpt.eq.1) then 
+                      if(LVT_metrics%max%selectOpt.eq.1) then
                          call LVT_writevar_gridded(LVT_metrics%max%ftn_total, &
                               model_value_total(:,:),&
                               stats%vid_total(LVT_MAXid,1),k)
@@ -1313,7 +1382,7 @@ contains
                               stats%vid_count_total(LVT_MAXid,1),k)
 
                          if(LVT_rc%obssource(2).ne."none".and.&
-                              obs%selectNlevs.ge.1) then 
+                              obs%selectNlevs.ge.1) then
                             call LVT_writevar_gridded(LVT_metrics%max%ftn_total, &
                                  obs_value_total(:,:),&
                                  stats%vid_total(LVT_MAXid,2),k)
@@ -1321,15 +1390,15 @@ contains
                                  real(count_obs_value_total(:,:)),&
                                  stats%vid_count_total(LVT_MAXid,2),k)
                          endif
-                         
-                         if(LVT_metrics%max%computeSC.eq.1) then 
+
+                         if(LVT_metrics%max%computeSC.eq.1) then
                             do tind = 1,LVT_rc%nasc
                                call LVT_writevar_gridded(&
                                     LVT_metrics%max%ftn_total,&
                                     model_value_asc(:,:,tind),&
                                     stats%vid_sc_total(tind,LVT_MAXid,1),k)
                             enddo
-                            if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                            if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                                do tind = 1,LVT_rc%nasc
                                   call LVT_writevar_gridded(&
                                        LVT_metrics%max%ftn_total,&
@@ -1338,14 +1407,14 @@ contains
                                enddo
                             endif
                          endif
-                         if(LVT_metrics%max%computeADC.eq.1) then 
+                         if(LVT_metrics%max%computeADC.eq.1) then
                             do tind = 1,LVT_rc%nadc
                                call LVT_writevar_gridded(&
                                     LVT_metrics%max%ftn_total,&
                                     model_value_adc(:,:,tind),&
                                     stats%vid_adc_total(tind,LVT_MAXid,1),k)
                             enddo
-                            if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                            if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                                do tind = 1,LVT_rc%nadc
                                   call LVT_writevar_gridded(&
                                        LVT_metrics%max%ftn_total,&
@@ -1363,7 +1432,7 @@ contains
                               count_model_value_total(:,:),&
                               stats%standard_name,&
                               model_value_ci(:))
-                         if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                         if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                             call LVT_writeSummaryStats(&
                                  LVT_metrics%max%ftn_summ,&
                                  l,&
@@ -1382,20 +1451,20 @@ contains
                 deallocate(count_model_value_total)
                 deallocate(model_value_ci)
 
-                if(LVT_metrics%max%computeSC.eq.1) then 
+                if(LVT_metrics%max%computeSC.eq.1) then
                    deallocate(model_value_asc)
-                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                       deallocate(obs_value_asc)
                    endif
                 endif
-                if(LVT_metrics%max%computeADC.eq.1) then 
+                if(LVT_metrics%max%computeADC.eq.1) then
                    deallocate(model_value_adc)
-                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                       deallocate(obs_value_adc)
                    endif
                 endif
 
-                if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                    deallocate(obs_value_total)
                    deallocate(count_obs_value_total)
                    deallocate(obs_value_ci)
@@ -1408,25 +1477,26 @@ contains
   end subroutine LVT_writeMetric_Max
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_resetMetric_Max
 ! \label(LVT_resetMetric_Max)
 !
 ! !INTERFACE:
   subroutine LVT_resetMetric_Max(alarm)
-! 
-! !INPUT PARAMETERS: 
-    logical         :: alarm
-! 
+!
+! !USES:
+!
+! !INPUT PARAMETERS:
+    logical                :: alarm
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-! 
+! !DESCRIPTION:
 !  This routine resets required variables to support the
-!  temporal computation of Max alues. 
+!  temporal computation of Max values.
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 
     integer                :: i,k,l,m
@@ -1434,30 +1504,35 @@ contains
     type(LVT_metadataEntry), pointer :: obs
     type(LVT_statsEntry)   , pointer :: stats
 
-
     call LVT_getDataStream1Ptr(model)
     call LVT_getDataStream1Ptr(obs)
     call LVT_getstatsEntryPtr(stats)
-    
+
     do while(associated(model))
-       if(stats%selectOpt.eq.1) then 
+       if(stats%selectOpt.eq.1) then
           do m=1,LVT_rc%nensem
              do k=1,model%selectNlevs
-                if(LVT_metrics%max%timeOpt.eq.1) then 
+                if(LVT_metrics%max%timeOpt.eq.1) then
                    do l=1,LVT_rc%strat_nlevels
                       stats%max(m)%model_value_ts(:,k,l) = -1E10
-                      if(alarm) then 
-                         stats%max(m)%tavg_model_value_ts(:,k,l) = 0.0
-                         stats%max(m)%tavg_count_model_value_ts(:,k,l) = 0.0
+                      stats%max(m)%count_model_value_ts(:,k,l) = 0
+                      if(alarm) then
+                         stats%max(m)%tavg_model_value_ts(:,k,l) = -1E10
+                         stats%max(m)%tavg_count_model_value_ts(:,k,l) = 0
                       endif
                    enddo
+                endif
+             enddo
+             do k=1,obs%selectNlevs
+                if(LVT_metrics%max%timeOpt.eq.1) then
                    if(LVT_rc%obssource(2).ne."none".and.&
-                        obs%selectNlevs.ge.1) then 
+                        obs%selectNlevs.ge.1) then
                       do l=1,LVT_rc%strat_nlevels
                          stats%max(m)%obs_value_ts(:,k,l) = -1E10
-                         if(alarm) then 
-                            stats%max(m)%tavg_obs_value_ts(:,k,l) = 0.0
-                            stats%max(m)%tavg_count_obs_value_ts(:,k,l) = 0.0
+                         stats%max(m)%count_obs_value_ts(:,k,l) = 0
+                         if(alarm) then
+                            stats%max(m)%tavg_obs_value_ts(:,k,l) = -1E10
+                            stats%max(m)%tavg_count_obs_value_ts(:,k,l) = 0
                          endif
                       enddo
                    endif
@@ -1465,7 +1540,7 @@ contains
              enddo
           enddo
        endif
-       
+
        model => model%next
        obs => obs%next
        stats => stats%next
@@ -1474,26 +1549,26 @@ contains
   end subroutine LVT_resetMetric_Max
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_writerestart_Max
-! 
+!
 ! !INTERFACE:
   subroutine LVT_writerestart_Max(ftn,pass)
-! !USES: 
+! !USES:
 
-! 
-! !ARGUMENTS: 
+!
+! !ARGUMENTS:
     integer                 :: ftn
     integer                 :: pass
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine writes the restart file for Max metric computations
-! 
-!EOP
-    
 !
-! !DESCRIPTION: 
-! 
+!EOP
+
+!
+! !DESCRIPTION:
+!
 !EOP
     integer              :: k,l,m
     type(LVT_metaDataEntry), pointer :: model
@@ -1503,57 +1578,69 @@ contains
     call LVT_getDataStream1Ptr(model)
     call LVT_getDataStream2Ptr(obs)
     call LVT_getstatsEntryPtr(stats)
-    
+
     do while(associated(model))
-       if(LVT_metrics%max%selectOpt.eq.1) then 
+       if(LVT_metrics%max%selectOpt.eq.1) then
           if(stats%selectOpt.eq.1.and.&
-               model%selectNlevs.ge.1) then 
+               model%selectNlevs.ge.1) then
              do m=1,LVT_rc%nensem
                 do k=1,model%selectNlevs
-                   do l=1,LVT_rc%strat_nlevels         
+                   do l=1,LVT_rc%strat_nlevels
                       call LVT_writevar_restart(ftn,&
                            stats%max(m)%model_value_total(:,k,l))
+                      call LVT_writevar_restart(ftn,&
+                           stats%max(m)%count_model_value_total(:,k,l))
                    enddo
                 enddo
-                if(LVT_metrics%max%computeSC.eq.1) then 
+                if(LVT_metrics%max%computeSC.eq.1) then
                    do k=1,model%selectNlevs
-                      do l=1,LVT_rc%nasc         
+                      do l=1,LVT_rc%nasc
                          call LVT_writevar_restart(ftn,&
                               stats%max(m)%model_value_asc(:,k,l))
+                         call LVT_writevar_restart(ftn,&
+                              stats%max(m)%count_model_value_asc(:,k,l))
                       enddo
                    enddo
                 endif
-                if(LVT_metrics%max%computeADC.eq.1) then 
+                if(LVT_metrics%max%computeADC.eq.1) then
                    do k=1,model%selectNlevs
-                      do l=1,LVT_rc%nadc         
+                      do l=1,LVT_rc%nadc
                          call LVT_writevar_restart(ftn,&
                               stats%max(m)%model_value_adc(:,k,l))
+                         call LVT_writevar_restart(ftn,&
+                              stats%max(m)%count_model_value_adc(:,k,l))
                       enddo
                    enddo
                 endif
-                
-                if(LVT_rc%obssource(2).ne."none") then 
-                   if(obs%selectNlevs.ge.1) then 
+
+                if(LVT_rc%obssource(2).ne."none") then
+                   if(obs%selectNlevs.ge.1) then
                       do k=1,obs%selectNlevs
                          do l=1,LVT_rc%strat_nlevels
                             call LVT_writevar_restart(ftn,&
                                  stats%max(m)%obs_value_total(:,k,l))
+                            call LVT_writevar_restart(ftn,&
+                                 stats%max(m)%count_obs_value_total(:,k,l))
                          enddo
                       enddo
-                      
-                      if(LVT_metrics%max%computeSC.eq.1) then 
+
+                      if(LVT_metrics%max%computeSC.eq.1) then
                          do k=1,obs%selectNlevs
                             do l=1,LVT_rc%nasc
                                call LVT_writevar_restart(ftn,&
                                     stats%max(m)%obs_value_asc(:,k,l))
+                               call LVT_writevar_restart(ftn,&
+                                    stats%max(m)%count_obs_value_asc(:,k,l))
                             enddo
                          enddo
                       endif
-                      if(LVT_metrics%max%computeADC.eq.1) then 
+                      if(LVT_metrics%max%computeADC.eq.1) then
                          do k=1,obs%selectNlevs
                             do l=1,LVT_rc%nasc
                                call LVT_writevar_restart(ftn,&
                                     stats%max(m)%obs_value_adc(:,k,l))
+                               call LVT_writevar_restart(ftn,&
+                                    stats%max(m)%count_obs_value_adc(:,k,l))
                             enddo
                          enddo
                       endif
@@ -1570,24 +1657,24 @@ contains
 
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_readrestart_Max
-! 
+!
 ! !INTERFACE:
   subroutine LVT_readrestart_Max(ftn)
-! !USES: 
-! 
-! !ARGUMENTS: 
+! !USES:
+!
+! !ARGUMENTS:
     integer                 :: ftn
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine reads the restart file for Max metric computations
-! 
-!EOP
-    
 !
-! !DESCRIPTION: 
-! 
+!EOP
+
+!
+! !DESCRIPTION:
+!
 !EOP
 
     integer              :: k,l,m,index
@@ -1598,57 +1685,69 @@ contains
     call LVT_getDataStream1Ptr(model)
     call LVT_getDataStream2Ptr(obs)
     call LVT_getstatsEntryPtr(stats)
-    
+
     do while(associated(model))
-       if(LVT_metrics%max%selectOpt.eq.1) then 
+       if(LVT_metrics%max%selectOpt.eq.1) then
           if(stats%selectOpt.eq.1.and.&
-               model%selectNlevs.ge.1) then 
+               model%selectNlevs.ge.1) then
              do m=1,LVT_rc%nensem
                 do k=1,model%selectNlevs
-                   do l=1,LVT_rc%strat_nlevels         
+                   do l=1,LVT_rc%strat_nlevels
                       call LVT_readvar_restart(ftn,&
                            stats%max(m)%model_value_total(:,k,l))
+                      call LVT_readvar_restart(ftn,&
+                           stats%max(m)%count_model_value_total(:,k,l))
                    enddo
                 enddo
-                if(LVT_metrics%max%computeSC.eq.1) then 
+                if(LVT_metrics%max%computeSC.eq.1) then
                    do k=1,model%selectNlevs
-                      do l=1,LVT_rc%nasc         
+                      do l=1,LVT_rc%nasc
                          call LVT_readvar_restart(ftn,&
                               stats%max(m)%model_value_asc(:,k,l))
+                         call LVT_readvar_restart(ftn,&
+                              stats%max(m)%count_model_value_asc(:,k,l))
                       enddo
                    enddo
                 endif
-                if(LVT_metrics%max%computeADC.eq.1) then 
+                if(LVT_metrics%max%computeADC.eq.1) then
                    do k=1,model%selectNlevs
-                      do l=1,LVT_rc%nadc         
+                      do l=1,LVT_rc%nadc
                          call LVT_readvar_restart(ftn,&
                               stats%max(m)%model_value_adc(:,k,l))
+                         call LVT_readvar_restart(ftn,&
+                              stats%max(m)%count_model_value_adc(:,k,l))
                       enddo
                    enddo
                 endif
-                
-                if(LVT_rc%obssource(2).ne."none") then 
-                   if(obs%selectNlevs.ge.1) then 
+
+                if(LVT_rc%obssource(2).ne."none") then
+                   if(obs%selectNlevs.ge.1) then
                       do k=1,obs%selectNlevs
                          do l=1,LVT_rc%strat_nlevels
                             call LVT_readvar_restart(ftn,&
                                  stats%max(m)%obs_value_total(:,k,l))
+                            call LVT_readvar_restart(ftn,&
+                                 stats%max(m)%count_obs_value_total(:,k,l))
                          enddo
                       enddo
-                      
-                      if(LVT_metrics%max%computeSC.eq.1) then 
+
+                      if(LVT_metrics%max%computeSC.eq.1) then
                          do k=1,obs%selectNlevs
                             do l=1,LVT_rc%nasc
                                call LVT_readvar_restart(ftn,&
                                     stats%max(m)%obs_value_asc(:,k,l))
+                               call LVT_readvar_restart(ftn,&
+                                    stats%max(m)%count_obs_value_asc(:,k,l))
                             enddo
                          enddo
                       endif
-                      if(LVT_metrics%max%computeADC.eq.1) then 
+                      if(LVT_metrics%max%computeADC.eq.1) then
                          do k=1,obs%selectNlevs
                             do l=1,LVT_rc%nasc
                                call LVT_readvar_restart(ftn,&
                                     stats%max(m)%obs_value_adc(:,k,l))
+                               call LVT_readvar_restart(ftn,&
+                                    stats%max(m)%count_obs_value_adc(:,k,l))
                             enddo
                          enddo
                       endif
@@ -1662,6 +1761,5 @@ contains
        stats => stats%next
     end do
   end subroutine LVT_readrestart_Max
-
 
 end module LVT_MaxMod

--- a/lvt/metrics/LVT_MinMod.F90
+++ b/lvt/metrics/LVT_MinMod.F90
@@ -9,14 +9,14 @@
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
 !
 !BOP
-! 
+!
 ! !MODULE: LVT_MinMod
 ! \label(LVT_MinMod)
 !
 ! !INTERFACE:
 module LVT_MinMod
-! 
-! !USES:   
+!
+! !USES:
   use LVT_coreMod
   use LVT_histDataMod
   use LVT_statsDataMod
@@ -24,20 +24,24 @@ module LVT_MinMod
   use LVT_TSMod
   use LVT_logMod
   use LVT_CIMod
+
+  implicit none
+
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This module handles the computations required to compute minimum values
-!  (temporally) of desired variables from the LIS output
-! 
+!  (temporally) of desired variables from the datastreams.
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
+! !REVISION HISTORY:
 !  2 Oct 2008    Sujay Kumar  Initial Specification
-! 
+!  5 Feb 2021    David Mocko  Fixed time series output and code clean-up
+!
 !EOP
 !BOP
 !-----------------------------------------------------------------------------
@@ -51,153 +55,185 @@ module LVT_MinMod
   public :: LVT_writerestart_Min
   public :: LVT_readrestart_Min
 !EOP
-  
+
   private
 
 contains
   subroutine LVT_initMin(selectNlevs, stats,metric)
-! !ARGUMENTS: 
+! !ARGUMENTS:
     integer                 :: selectNlevs(LVT_rc%nDataStreams)
     type(LVT_statsEntry)    :: stats
     type(LVT_metricEntry)   :: metric
 !
-! !DESCRIPTION: 
-! 
+! !DESCRIPTION:
+!
 !  This routine initializes the datastructures required to support
-!  the Min computations. 
+!  the Min computations.
 !
 !EOP
+    integer                 :: m
 
-    integer                 :: m 
-    
     allocate(stats%min(LVT_rc%nensem))
 
     do m=1,LVT_rc%nensem
-       if(metric%selectOpt.eq.1) then 
+       if(metric%selectOpt.eq.1) then
           allocate(stats%min(m)%model_value_total(LVT_rc%ngrid, &
                selectNlevs(1), &
                LVT_rc%strat_nlevels))
           stats%min(m)%model_value_total = 1E10
-          allocate(stats%min(m)%model_value_ci(selectNlevs(1),&
+          allocate(stats%min(m)%count_model_value_total(LVT_rc%ngrid, &
+               selectNlevs(1), &
+               LVT_rc%strat_nlevels))
+          stats%min(m)%count_model_value_total = 0
+          allocate(stats%min(m)%model_value_ci(selectNlevs(1), &
                LVT_rc%strat_nlevels))
           stats%min(m)%model_value_ci = LVT_rc%udef
-          
-          if(metric%computeSC.eq.1) then 
+
+          if(metric%computeSC.eq.1) then
              allocate(stats%min(m)%model_value_asc(LVT_rc%ngrid, &
-                  selectNlevs(1),&
+                  selectNlevs(1), &
                   LVT_rc%nasc))
              stats%min(m)%model_value_asc = 1E10
+             allocate(stats%min(m)%count_model_value_asc(LVT_rc%ngrid, &
+                  selectNlevs(1), &
+                  LVT_rc%nasc))
+             stats%min(m)%count_model_value_asc = 0
           endif
-          if(metric%computeADC.eq.1) then 
+          if(metric%computeADC.eq.1) then
              allocate(stats%min(m)%model_value_adc(LVT_rc%ngrid, &
-                  selectNlevs(2),&
+                  selectNlevs(2), &
                   LVT_rc%nadc))
              stats%min(m)%model_value_adc = 1E10
+             allocate(stats%min(m)%count_model_value_adc(LVT_rc%ngrid, &
+                  selectNlevs(2), &
+                  LVT_rc%nadc))
+             stats%min(m)%count_model_value_adc = 0
           endif
-          
-          if(LVT_rc%obssource(2).ne."none") then 
-             if(selectNlevs(2).ge.1) then 
+
+          if(LVT_rc%obssource(2).ne."none") then
+             if(selectNlevs(2).ge.1) then
                 allocate(stats%min(m)%obs_value_total(LVT_rc%ngrid, &
                      selectNlevs(2), &
                      LVT_rc%strat_nlevels))
                 stats%min(m)%obs_value_total = 1E10
-                allocate(stats%min(m)%obs_value_ci(selectNlevs(2),&
+                allocate(stats%min(m)%count_obs_value_total(LVT_rc%ngrid, &
+                     selectNlevs(2), &
+                     LVT_rc%strat_nlevels))
+                stats%min(m)%count_obs_value_total = 0
+                allocate(stats%min(m)%obs_value_ci(selectNlevs(2), &
                      LVT_rc%strat_nlevels))
                 stats%min(m)%obs_value_ci = LVT_rc%udef
-                
-                if(metric%computeSC.eq.1) then 
+
+                if(metric%computeSC.eq.1) then
                    allocate(stats%min(m)%obs_value_asc(LVT_rc%ngrid, &
-                        selectNlevs(2),&
+                        selectNlevs(2), &
                         LVT_rc%nasc))
                    stats%min(m)%obs_value_asc = 1E10
+                   allocate(stats%min(m)%count_obs_value_asc(LVT_rc%ngrid, &
+                        selectNlevs(2), &
+                        LVT_rc%nasc))
+                   stats%min(m)%count_obs_value_asc = 0
                 endif
-                if(metric%computeADC.eq.1) then 
+                if(metric%computeADC.eq.1) then
                    allocate(stats%min(m)%obs_value_adc(LVT_rc%ngrid, &
-                        selectNlevs(2),&
+                        selectNlevs(2), &
                         LVT_rc%nadc))
                    stats%min(m)%obs_value_adc = 1E10
+                   allocate(stats%min(m)%count_obs_value_adc(LVT_rc%ngrid, &
+                        selectNlevs(2), &
+                        LVT_rc%nadc))
+                   stats%min(m)%count_obs_value_adc = 0
                 endif
              endif
           endif
        endif
-       if(metric%timeOpt.eq.1) then 
-          allocate(stats%min(m)%model_value_ts(LVT_rc%ngrid,&
+
+       if(metric%timeOpt.eq.1) then
+          allocate(stats%min(m)%model_value_ts(LVT_rc%ngrid, &
                selectNlevs(1), &
                LVT_rc%strat_nlevels))
           stats%min(m)%model_value_ts = 1E10
-          
+          allocate(stats%min(m)%count_model_value_ts(LVT_rc%ngrid, &
+               selectNlevs(1), &
+               LVT_rc%strat_nlevels))
+          stats%min(m)%count_model_value_ts = 0
+
           allocate(stats%min(m)%tavg_model_value_ts(LVT_rc%ngrid, &
                selectNlevs(1), &
                LVT_rc%strat_nlevels))
+          stats%min(m)%tavg_model_value_ts = 1E10
           allocate(stats%min(m)%tavg_count_model_value_ts(LVT_rc%ngrid, &
                selectNlevs(1), &
                LVT_rc%strat_nlevels))
-          stats%min(m)%tavg_model_value_ts = 0.0
-          stats%min(m)%tavg_count_model_value_ts = 0 
-          
-          if(LVT_rc%obssource(2).ne."none") then 
-             if(selectNlevs(2).ge.1) then 
-                allocate(stats%min(m)%obs_value_ts(LVT_rc%ngrid,&
-                     selectNlevs(1), &
+          stats%min(m)%tavg_count_model_value_ts = 0
+
+          if(LVT_rc%obssource(2).ne."none") then
+             if(selectNlevs(2).ge.1) then
+                allocate(stats%min(m)%obs_value_ts(LVT_rc%ngrid, &
+                     selectNlevs(2), &
                      LVT_rc%strat_nlevels))
                 stats%min(m)%obs_value_ts = 1E10
-                
+                allocate(stats%min(m)%count_obs_value_ts(LVT_rc%ngrid, &
+                     selectNlevs(2), &
+                     LVT_rc%strat_nlevels))
+                stats%min(m)%count_obs_value_ts = 0
+
                 allocate(stats%min(m)%tavg_obs_value_ts(LVT_rc%ngrid, &
                      selectNlevs(2), &
                      LVT_rc%strat_nlevels))
+                stats%min(m)%tavg_obs_value_ts = 1E10
                 allocate(stats%min(m)%tavg_count_obs_value_ts(LVT_rc%ngrid, &
                      selectNlevs(2), &
                      LVT_rc%strat_nlevels))
-                stats%min(m)%tavg_obs_value_ts = 0.0
-                stats%min(m)%tavg_count_obs_value_ts = 0 
+                stats%min(m)%tavg_count_obs_value_ts = 0
              endif
           endif
        endif
     enddo
+
 !-------------------------------------------------------------------------
 ! Number of passes required to compute the metric
 !-------------------------------------------------------------------------
-
-    metric%npass = 1    
-    if(LVT_rc%obssource(2).ne."none") then 
-       metric%obsData = .true. 
+    metric%npass = 1
+    if(LVT_rc%obssource(2).ne."none") then
+       metric%obsData = .true.
     else
-       metric%obsData = .false. 
+       metric%obsData = .false.
     endif
-    metric%stdevFlag = .false. 
+    metric%stdevFlag = .false.
 
   end subroutine LVT_initMin
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_diagnoseMin
 ! \label{LVT_diagnoseMin}
 !
-! !INTERFACE: 
+! !INTERFACE:
   subroutine LVT_diagnoseMin(pass)
-! 
-! !USES:     
+!
+! !USES:
 
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-!   This subroutine issues the calls to update the computations for 
+! !DESCRIPTION:
+!   This subroutine issues the calls to update the computations for
 !   calculating the min of desired variables.
 !
-!   The methods invoked are: 
+!   The methods invoked are:
 !   \begin{description}
 !    \item[diagnoseSingleModelMin](\ref{diagnoseSingleModelMin})
-!     updates the min computation for a single variable 
+!     updates the min computation for a single variable
 !   \end{description}
-! 
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 !BOP
     integer       :: pass
@@ -206,9 +242,9 @@ contains
     type(LVT_metadataEntry), pointer :: obs
     type(LVT_statsEntry)   , pointer :: stats
 
-    if(pass.eq.1) then 
+    if(pass.eq.LVT_metrics%min%npass) then
        if(LVT_metrics%min%selectOpt.eq.1.or.&
-            LVT_metrics%min%timeOpt.eq.1) then 
+            LVT_metrics%min%timeOpt.eq.1) then
 
           call LVT_getDataStream1Ptr(model)
           call LVT_getDataStream2Ptr(obs)
@@ -226,38 +262,38 @@ contains
   end subroutine LVT_diagnoseMin
 
 !BOP
-! 
+!
 ! !ROUTINE: diagnoseSingleMin
 ! \label{diagnoseSingleMin}
 !
-! !INTERFACE: 
+! !INTERFACE:
   subroutine diagnoseSingleMin(model, obs, stats,metric)
-! 
-! !USES:   
+!
+! !USES:
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-!   This routine updates the min computation of the 
-!   specified variable. 
+! !DESCRIPTION:
+!   This routine updates the min computation of the
+!   specified variable.
 !
-!  The arguments are: 
+!  The arguments are:
 !
 !  \begin{description}
 !   \item[model] model variable object
 !   \item[stats] object to hold the updated statistics
 !  \end{description}
-! 
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 !BOP
-! !ARGUMENTS: 
+! !ARGUMENTS:
     type(LVT_metaDataEntry) :: model
     type(LVT_metadataEntry) :: obs
     type(LVT_statsEntry)    :: stats
@@ -266,172 +302,207 @@ contains
     integer    :: t,k,m,m_k,o_k,tind
 
     if(stats%selectOpt.eq.1.and.&
-         model%selectNlevs.ge.1) then        
+         model%selectNlevs.ge.1) then
        do t=1,LVT_rc%ngrid
           do k=1,model%selectNlevs
-             do m =1, LVT_rc%nensem
+             do m=1,LVT_rc%nensem
                 m_k = k+model%startNlevs -1
-                o_k = k+obs%startNlevs -1
-
                 if(model%count(t,m,m_k).gt.0) then
-                   if(metric%selectOpt.eq.1) then 
-                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                   if(metric%selectOpt.eq.1) then
+                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                          if(model%value(t,m,m_k).lt.&
-                              stats%min(m)%model_value_total(t,k,1)) then 
+                              stats%min(m)%model_value_total(t,k,1)) then
                             stats%min(m)%model_value_total(t,k,1) = &
                                  model%value(t,m,m_k)
                          endif
+                         stats%min(m)%count_model_value_total(t,k,1) = &
+                              stats%min(m)%count_model_value_total(t,k,1) + 1
                       endif
                    endif
-                   
-                   if(metric%timeOpt.eq.1) then 
-                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+
+                   if(metric%timeOpt.eq.1) then
+                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                          if(model%value(t,m,m_k).lt.&
-                              stats%min(m)%model_value_ts(t,k,1)) then 
+                              stats%min(m)%model_value_ts(t,k,1)) then
                             stats%min(m)%model_value_ts(t,k,1) = &
                                  model%value(t,m,m_k)
                          endif
+                         stats%min(m)%count_model_value_ts(t,k,1) = &
+                              stats%min(m)%count_model_value_ts(t,k,1) + 1
                       endif
                    endif
-                   if(metric%computeSC.eq.1) then 
-                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                   if(metric%computeSC.eq.1) then
+                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                          call LVT_getSeasonalCycleTimeIndex(LVT_rc%scInterval,&
                               tind)
                          if(model%value(t,m,m_k).lt.&
-                              stats%min(m)%model_value_asc(t,k,tind)) then 
+                              stats%min(m)%model_value_asc(t,k,tind)) then
                             stats%min(m)%model_value_asc(t,k,tind) = &
                                  model%value(t,m,m_k)
                          endif
+                         stats%min(m)%count_model_value_asc(t,k,tind) = &
+                              stats%min(m)%count_model_value_asc(t,k,tind) + 1
                       endif
                    endif
-                   if(metric%computeADC.eq.1) then 
-                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                   if(metric%computeADC.eq.1) then
+                      if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                          call LVT_getADCTimeIndex(tind)
                          if(model%value(t,m,m_k).lt.&
-                              stats%min(m)%model_value_adc(t,k,tind)) then 
+                              stats%min(m)%model_value_adc(t,k,tind)) then
                             stats%min(m)%model_value_adc(t,k,tind) = &
                                  model%value(t,m,m_k)
                          endif
+                         stats%min(m)%count_model_value_adc(t,k,tind) = &
+                              stats%min(m)%count_model_value_adc(t,k,tind) + 1
                       endif
                    endif
-                   if(LVT_rc%strat_nlevels.gt.1) then 
+                   if(LVT_rc%strat_nlevels.gt.1) then
                       if(LVT_stats%strat_var(t,m,k).gt.&
                            LVT_rc%strat_var_threshold) then
                          if(metric%selectOpt.eq.1) then
-                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then  
+                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                                if(model%value(t,m,m_k).lt.&
-                                    stats%min(m)%model_value_total(t,k,2)) then 
+                                    stats%min(m)%model_value_total(t,k,2)) then
                                   stats%min(m)%model_value_total(t,k,2) = &
                                        model%value(t,m,m_k)
                                endif
+                               stats%min(m)%count_model_value_total(t,k,2) = &
+                                    stats%min(m)%count_model_value_total(t,k,2) + 1
                             endif
                          endif
-                         if(metric%timeOpt.eq.1) then 
-                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                         if(metric%timeOpt.eq.1) then
+                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                                if(model%value(t,m,m_k).lt.&
-                                    stats%min(m)%model_value_ts(t,k,2)) then 
+                                    stats%min(m)%model_value_ts(t,k,2)) then
                                   stats%min(m)%model_value_ts(t,k,2) = &
                                        model%value(t,m,m_k)
                                endif
+                               stats%min(m)%count_model_value_ts(t,k,2) = &
+                                    stats%min(m)%count_model_value_ts(t,k,2) + 1
                             endif
                          endif
                       elseif(LVT_stats%strat_var(t,m,k).le.&
                            LVT_rc%strat_var_threshold) then
-                         if(metric%selectOpt.eq.1) then 
-                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                         if(metric%selectOpt.eq.1) then
+                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                                if(model%value(t,m,m_k).lt.&
-                                    stats%min(m)%model_value_total(t,k,3)) then 
+                                    stats%min(m)%model_value_total(t,k,3)) then
                                   stats%min(m)%model_value_total(t,k,3) = &
                                        model%value(t,m,m_k)
                                endif
+                               stats%min(m)%count_model_value_total(t,k,3) = &
+                                    stats%min(m)%count_model_value_total(t,k,3) + 1
                             endif
                          endif
-                         if(metric%timeOpt.eq.1) then 
-                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then 
+                         if(metric%timeOpt.eq.1) then
+                            if(model%value(t,m,m_k).ne.LVT_rc%udef) then
                                if(model%value(t,m,m_k).lt.&
-                                    stats%min(m)%model_value_ts(t,k,3)) then 
+                                    stats%min(m)%model_value_ts(t,k,3)) then
                                   stats%min(m)%model_value_ts(t,k,3) = &
                                        model%value(t,m,m_k)
                                endif
+                               stats%min(m)%count_model_value_ts(t,k,3) = &
+                                    stats%min(m)%count_model_value_ts(t,k,3) + 1
                             endif
                          endif
                       endif
                    endif
                 endif
-                
+             enddo
+          enddo
+
+          do k=1,obs%selectNlevs
+             do m=1,LVT_rc%nensem
+                o_k = k+obs%startNlevs -1
                 if(LVT_rc%obssource(2).ne."none") then
                    if(obs%selectNlevs.ge.1) then
-                      if(obs%count(t,m,o_k).gt.0) then 
+                      if(obs%count(t,m,o_k).gt.0) then
                          if(metric%selectOpt.eq.1.and.&
-                              obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                              obs%value(t,m,o_k).ne.LVT_rc%udef) then
                             if(obs%value(t,m,o_k).lt.&
-                                 stats%min(m)%obs_value_total(t,k,1)) then 
+                                 stats%min(m)%obs_value_total(t,k,1)) then
                                stats%min(m)%obs_value_total(t,k,1) = &
                                     obs%value(t,m,o_k)
                             endif
+                            stats%min(m)%count_obs_value_total(t,k,1) = &
+                                 stats%min(m)%count_obs_value_total(t,k,1) + 1
                          endif
-                         
+
                          if(metric%timeOpt.eq.1.and.&
-                              obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                              obs%value(t,m,o_k).ne.LVT_rc%udef) then
                             if(obs%value(t,m,o_k).lt.&
-                                 stats%min(m)%obs_value_ts(t,k,1)) then 
+                                 stats%min(m)%obs_value_ts(t,k,1)) then
                                stats%min(m)%obs_value_ts(t,k,1) = &
                                     obs%value(t,m,o_k)
                             endif
+                            stats%min(m)%count_obs_value_ts(t,k,1) = &
+                                 stats%min(m)%count_obs_value_ts(t,k,1) + 1
                          endif
                          if(metric%computeSC.eq.1.and.&
-                              obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                              obs%value(t,m,o_k).ne.LVT_rc%udef) then
                             call LVT_getSeasonalCycleTimeIndex(LVT_rc%scInterval,tind)
                             if(obs%value(t,m,o_k).lt.&
-                                 stats%min(m)%obs_value_asc(t,k,tind)) then 
+                                 stats%min(m)%obs_value_asc(t,k,tind)) then
                                stats%min(m)%obs_value_asc(t,k,tind) = &
                                     obs%value(t,m,o_k)
                             endif
+                            stats%min(m)%count_obs_value_asc(t,k,tind) = &
+                                 stats%min(m)%count_obs_value_asc(t,k,tind) + 1
                          endif
                          if(metric%computeADC.eq.1.and.&
-                              obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                              obs%value(t,m,o_k).ne.LVT_rc%udef) then
                             call LVT_getADCTimeIndex(tind)
                             if(obs%value(t,m,o_k).lt.&
-                                 stats%min(m)%obs_value_adc(t,k,tind)) then 
+                                 stats%min(m)%obs_value_adc(t,k,tind)) then
                                stats%min(m)%obs_value_adc(t,k,tind) = &
                                     obs%value(t,m,o_k)
                             endif
+                            stats%min(m)%count_obs_value_adc(t,k,tind) = &
+                                 stats%min(m)%count_obs_value_adc(t,k,tind) + 1
                          endif
-                         if(LVT_rc%strat_nlevels.gt.1) then 
+                         if(LVT_rc%strat_nlevels.gt.1) then
                             if(LVT_stats%strat_var(t,m,k).gt.&
                                  LVT_rc%strat_var_threshold) then
                                if(metric%selectOpt.eq.1 &
-                                    .and.obs%value(t,m,o_k).ne.LVT_rc%udef) then 
+                                    .and.obs%value(t,m,o_k).ne.LVT_rc%udef) then
                                   if(obs%value(t,m,o_k).lt.&
-                                       stats%min(m)%obs_value_total(t,k,2)) then 
+                                       stats%min(m)%obs_value_total(t,k,2)) then
                                      stats%min(m)%obs_value_total(t,k,2) = &
                                           obs%value(t,m,o_k)
                                   endif
+                                  stats%min(m)%count_obs_value_total(t,k,2) = &
+                                       stats%min(m)%count_obs_value_total(t,k,2) + 1
                                endif
-                               
+
                                if(metric%timeOpt.eq.1.and.&
-                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then 
-                                  if(obs%value(t,m,o_k).lt.stats%min(m)%obs_value_ts(t,k,2)) then 
+                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then
+                                  if(obs%value(t,m,o_k).lt.stats%min(m)%obs_value_ts(t,k,2)) then
                                      stats%min(m)%obs_value_ts(t,k,2) = &
                                           obs%value(t,m,o_k)
                                   endif
+                                  stats%min(m)%count_obs_value_ts(t,k,2) = &
+                                       stats%min(m)%count_obs_value_ts(t,k,2) + 1
                                endif
                             elseif(LVT_stats%strat_var(t,m,k).le.&
                                  LVT_rc%strat_var_threshold) then
                                if(metric%selectOpt.eq.1.and.&
-                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then 
-                                  if(obs%value(t,m,o_k).lt.stats%min(m)%obs_value_total(t,k,3)) then 
+                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then
+                                  if(obs%value(t,m,o_k).lt.stats%min(m)%obs_value_total(t,k,3)) then
                                      stats%min(m)%obs_value_total(t,k,3) = &
                                           obs%value(t,m,o_k)
                                   endif
+                                  stats%min(m)%count_obs_value_total(t,k,3) = &
+                                       stats%min(m)%count_obs_value_total(t,k,3) + 1
                                endif
-                               
+
                                if(metric%timeOpt.eq.1.and.&
-                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then 
-                                  if(obs%value(t,m,o_k).lt.stats%min(m)%obs_value_ts(t,k,3)) then 
+                                    obs%value(t,m,o_k).ne.LVT_rc%udef) then
+                                  if(obs%value(t,m,o_k).lt.stats%min(m)%obs_value_ts(t,k,3)) then
                                      stats%min(m)%obs_value_ts(t,k,3) = &
                                           obs%value(t,m,o_k)
                                   endif
+                                  stats%min(m)%count_obs_value_ts(t,k,3) = &
+                                       stats%min(m)%count_obs_value_ts(t,k,3) + 1
                                endif
                             endif
                          endif
@@ -445,35 +516,35 @@ contains
   end subroutine diagnoseSingleMin
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_computeMin
 ! \label{LVT_computeMin}
 !
-! !INTERFACE: 
+! !INTERFACE:
   subroutine LVT_computeMin(pass,alarm)
-! 
-! !USES:   
+!
+! !USES:
 
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-!   This subroutine issues the calls to compute the min values for 
+! !DESCRIPTION:
+!   This subroutine issues the calls to compute the min values for
 !   desired variables.
 !
-!   The methods invoked are: 
+!   The methods invoked are:
 !   \begin{description}
 !    \item[computeSingleModelMin](\ref{computeSingleModelMin})
 !     computes the min values for a single variable
 !   \end{description}
-! 
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 !BOP
     integer               :: pass
@@ -483,30 +554,31 @@ contains
     type(LVT_metadataEntry), pointer :: model
     type(LVT_metadataEntry), pointer :: obs
     type(LVT_statsEntry)   , pointer :: stats
-    
-    if(pass.eq.1) then 
+
+    if(pass.eq.LVT_metrics%min%npass) then
        if(LVT_metrics%min%selectOpt.eq.1.or.&
-            LVT_metrics%min%timeOpt.eq.1) then 
-          if(alarm) then 
+            LVT_metrics%min%timeOpt.eq.1) then
+          if(alarm) then
              if(LVT_metrics%min%timeOpt.eq.1.and.&
-                  LVT_metrics%min%extractTS.eq.1) then 
-                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then 
+                  LVT_metrics%min%extractTS.eq.1) then
+                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then
                    do m=1,LVT_rc%nensem
                       do i=1,LVT_rc%ntslocs
                          write(LVT_metrics%min%ftn_ts_loc(i,m),200,advance='no') &
                               LVT_rc%yr, '',LVT_rc%mo, '', LVT_rc%da, '', &
-                              LVT_rc%hr,'',LVT_rc%mn, '' 
+                              LVT_rc%hr,'',LVT_rc%mn, ''
                       enddo
                    enddo
                 else
                    do i=1,LVT_rc%ntslocs
                       write(LVT_metrics%min%ftn_ts_loc(i,1),200,advance='no') &
                            LVT_rc%yr, '',LVT_rc%mo, '', LVT_rc%da, '', &
-                           LVT_rc%hr,'',LVT_rc%mn, '' 
+                           LVT_rc%hr,'',LVT_rc%mn, ''
                    enddo
                 endif
              endif
           endif
+
 200       format(I4, a1, I2.2, a1, I2.2, a1, I2.2, a1, I2.2,a1)
 
           call LVT_getDataStream1Ptr(model)
@@ -514,19 +586,19 @@ contains
           call LVT_getstatsEntryPtr(stats)
 
           do while(associated(model))
-             
+
              call computeSingleMin(alarm,model,obs,stats,&
                   LVT_metrics%min)
-             
+
              model => model%next
              obs => obs%next
              stats => stats%next
           enddo
-          
-          if(alarm) then 
+
+          if(alarm) then
              if(LVT_metrics%min%timeOpt.eq.1.and.&
                   LVT_metrics%min%extractTS.eq.1) then
-                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then 
+                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then
                    do m=1,LVT_rc%nensem
                       do i=1,LVT_rc%ntslocs
                          write(LVT_metrics%min%ftn_ts_loc(i,m),fmt='(a1)') ''
@@ -536,46 +608,46 @@ contains
                    do i=1,LVT_rc%ntslocs
                       write(LVT_metrics%min%ftn_ts_loc(i,1),fmt='(a1)') ''
                    enddo
-                endif 
+                endif
              endif
           endif
        endif
     endif
   end subroutine LVT_computeMin
-  
+
 
 !BOP
-! 
+!
 ! !ROUTINE: computeSingleMin
 ! \label{computeSingleMin}
 !
-! !INTERFACE: 
+! !INTERFACE:
   subroutine computeSingleMin(alarm,model,obs,stats,metric)
-! 
-! !USES:   
-        
+!
+! !USES:
+
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine computes the min values
-!  The arguments are: 
+!  The arguments are:
 !
 !  \begin{description}
 !    \item[model] model variable object
 !    \item[stats] object to hold the updated statistics
 !  \end{description}
-! 
+!
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 !BOP
-! !ARGUMENTS: 
+! !ARGUMENTS:
     logical                 :: alarm
     type(LVT_metaDataEntry) :: model
     type(LVT_metaDataEntry) :: obs
@@ -584,11 +656,6 @@ contains
 !EOP
 
     integer  :: t,l,k,m
-    real     :: diff_field(LVT_rc%ngrid)
-    integer     :: count_model_asc(LVT_rc%ngrid,model%selectNlevs,LVT_rc%nasc)
-    integer     :: count_obs_asc(LVT_rc%ngrid,obs%selectNlevs,LVT_rc%nasc)
-    integer     :: count_model_adc(LVT_rc%ngrid,model%selectNlevs,LVT_rc%nadc)
-    integer     :: count_obs_adc(LVT_rc%ngrid,obs%selectNlevs,LVT_rc%nadc)
 
     real,    allocatable :: tavg_model_value_ts(:,:,:)
     real,    allocatable :: tavg_obs_value_ts(:,:,:)
@@ -599,43 +666,41 @@ contains
 
     real,    allocatable :: model_value_adc(:,:,:)
     real,    allocatable :: obs_value_adc(:,:,:)
-    
+
     real,    allocatable :: model_value_avg(:,:,:)
-    real,    allocatable :: obs_value_avg(:,:,:)   
+    real,    allocatable :: obs_value_avg(:,:,:)
 
-    count_model_asc = 1
-    count_model_adc = 1
-    count_obs_adc = 1
-
-    if(metric%timeOpt.eq.1) then 
+    if(metric%timeOpt.eq.1) then
        if(stats%selectOpt.eq.1.and.&
-            model%selectNlevs.ge.1) then 
+            model%selectNlevs.ge.1) then
           do t=1,LVT_rc%ngrid
              do m=1,LVT_rc%nensem
                 do k=1,model%selectNlevs
                    do l=1,LVT_rc%strat_nlevels
-                      if(stats%min(m)%model_value_ts(t,k,l).lt.1E10) then 
-                         stats%min(m)%model_value_ts(t,k,l) = &
-                              stats%min(m)%model_value_ts(t,k,l)
-
-                         stats%min(m)%tavg_model_value_ts(t,k,l) = & 
-                              stats%min(m)%tavg_model_value_ts(t,k,l) + &
-                              stats%min(m)%model_value_ts(t,k,l)
-                         stats%min(m)%tavg_count_model_value_ts(t,k,l) = & 
+                      if(stats%min(m)%count_model_value_ts(t,k,l).gt.0) then
+                         if(stats%min(m)%model_value_ts(t,k,l).lt. &
+                            stats%min(m)%tavg_model_value_ts(t,k,l)) then
+                            stats%min(m)%tavg_model_value_ts(t,k,l) = &
+                                 stats%min(m)%model_value_ts(t,k,l)
+                         endif
+                         stats%min(m)%tavg_count_model_value_ts(t,k,l) = &
                               stats%min(m)%tavg_count_model_value_ts(t,k,l) + 1
                       else
                          stats%min(m)%model_value_ts(t,k,l) = LVT_rc%udef
                       endif
-                      if(LVT_rc%obssource(2).ne."none") then 
-                         if(obs%selectNlevs.ge.1) then 
-                            if(stats%min(m)%obs_value_ts(t,k,l).lt.1E10) then 
-                               stats%min(m)%obs_value_ts(t,k,l) = &
-                                    stats%min(m)%obs_value_ts(t,k,l)
-                               
-                               stats%min(m)%tavg_obs_value_ts(t,k,l) = & 
-                                    stats%min(m)%tavg_obs_value_ts(t,k,l) + &
-                                    stats%min(m)%obs_value_ts(t,k,l)
-                               stats%min(m)%tavg_count_obs_value_ts(t,k,l) = & 
+                   enddo
+                enddo
+                do k=1,obs%selectNlevs
+                   do l=1,LVT_rc%strat_nlevels
+                      if(LVT_rc%obssource(2).ne."none") then
+                         if(obs%selectNlevs.ge.1) then
+                            if(stats%min(m)%count_obs_value_ts(t,k,l).gt.0) then
+                               if(stats%min(m)%obs_value_ts(t,k,l).lt. &
+                                  stats%min(m)%tavg_obs_value_ts(t,k,l)) then
+                                  stats%min(m)%tavg_obs_value_ts(t,k,l) = &
+                                       stats%min(m)%obs_value_ts(t,k,l)
+                               endif
+                               stats%min(m)%tavg_count_obs_value_ts(t,k,l) = &
                                     stats%min(m)%tavg_count_obs_value_ts(t,k,l) + 1
                             else
                                stats%min(m)%obs_value_ts(t,k,l) = LVT_rc%udef
@@ -647,25 +712,26 @@ contains
              enddo
           enddo
 
-          if(alarm) then 
-
+          if(alarm) then
              do t=1,LVT_rc%ngrid
                 do m=1,LVT_rc%nensem
                    do k=1,model%selectNlevs
                       do l=1,LVT_rc%strat_nlevels
-                         if(stats%min(m)%tavg_count_model_value_ts(t,k,l).gt.0) then 
-                            stats%min(m)%tavg_model_value_ts(t,k,l) = & 
-                                 stats%min(m)%tavg_model_value_ts(t,k,l) /&
-                                 stats%min(m)%tavg_count_model_value_ts(t,k,l) 
+                         if(stats%min(m)%tavg_count_model_value_ts(t,k,l).gt.0) then
+                            stats%min(m)%tavg_model_value_ts(t,k,l) = &
+                                 stats%min(m)%tavg_model_value_ts(t,k,l)
                          else
                             stats%min(m)%tavg_model_value_ts(t,k,l) = LVT_rc%udef
                          endif
-                         if(LVT_rc%obssource(2).ne."none") then 
-                            if(obs%selectNlevs.ge.1) then 
-                               if(stats%min(m)%tavg_count_obs_value_ts(t,k,l).gt.0) then 
-                                  stats%min(m)%tavg_obs_value_ts(t,k,l) = & 
-                                       stats%min(m)%tavg_obs_value_ts(t,k,l)/&
-                                       stats%min(m)%tavg_count_obs_value_ts(t,k,l)
+                      enddo
+                   enddo
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%strat_nlevels
+                         if(LVT_rc%obssource(2).ne."none") then
+                            if(obs%selectNlevs.ge.1) then
+                               if(stats%min(m)%tavg_count_obs_value_ts(t,k,l).gt.0) then
+                                  stats%min(m)%tavg_obs_value_ts(t,k,l) = &
+                                       stats%min(m)%tavg_obs_value_ts(t,k,l)
                                else
                                   stats%min(m)%tavg_obs_value_ts(t,k,l) = LVT_rc%udef
                                endif
@@ -676,12 +742,11 @@ contains
                 enddo
              enddo
 
-             if(metric%extractTS.eq.1) then 
-                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then 
+             if(metric%extractTS.eq.1) then
+                if(LVT_rc%lvt_wopt.eq."2d ensemble gridspace") then
                    do m=1,LVT_rc%nensem
-                      if(LVT_rc%obssource(2).ne."none"&
-                           .and.obs%selectNlevs.ge.1) then 
-
+                      if(LVT_rc%obssource(2).ne."none".and. &
+                            obs%selectNlevs.ge.1) then
                          call LVT_writeTSinfo(metric%ftn_ts_loc(:,m),&
                               model,&
                               LVT_rc%ngrid,&
@@ -695,23 +760,23 @@ contains
                               model,&
                               LVT_rc%ngrid,&
                               stats%min(m)%tavg_model_value_ts,&
-                              stats%min(m)%tavg_count_obs_value_ts)
+                              stats%min(m)%tavg_count_model_value_ts)
                       endif
                    enddo
                 else
-                   allocate(tavg_model_value_ts(LVT_rc%ngrid,&
-                        model%vlevels,&
+                   allocate(tavg_model_value_ts(LVT_rc%ngrid, &
+                        model%vlevels, &
                         LVT_rc%strat_nlevels))
                    tavg_model_value_ts = 0.0
 
-                   if(LVT_rc%obssource(2).ne."none".and.&
-                        obs%selectNlevs.ge.1) then 
+                   if(LVT_rc%obssource(2).ne."none".and. &
+                         obs%selectNlevs.ge.1) then
 
-                      allocate(tavg_obs_value_ts(LVT_rc%ngrid,&
-                           obs%vlevels,&
+                      allocate(tavg_obs_value_ts(LVT_rc%ngrid, &
+                           obs%vlevels, &
                            LVT_rc%strat_nlevels))
                       tavg_obs_value_ts = 0.0
-                      
+
                       do m=1,LVT_rc%nensem
                          do t=1,LVT_rc%ngrid
                             do k=1,model%selectNlevs
@@ -722,11 +787,11 @@ contains
                                   tavg_obs_value_ts(t,k,l) = &
                                        tavg_obs_value_ts(t,k,l) + &
                                        stats%min(m)%tavg_obs_value_ts(t,k,l)
-                                  
-                                  
+
+
                                enddo
                             enddo
-                         enddo                         
+                         enddo
                       enddo
 
                       do t=1,LVT_rc%ngrid
@@ -739,7 +804,7 @@ contains
                             enddo
                          enddo
                       enddo
-                      
+
                       call LVT_writeTSinfo(metric%ftn_ts_loc(:,1),&
                            model,&
                            LVT_rc%ngrid,&
@@ -747,7 +812,7 @@ contains
                            stats%min(1)%tavg_count_model_value_ts,&
                            LVT_rc%ngrid,&
                            tavg_obs_value_ts,&
-                           stats%min(m)%tavg_count_obs_value_ts)
+                           stats%min(1)%tavg_count_obs_value_ts)
                    else
                       do m=1,LVT_rc%nensem
                          do t=1,LVT_rc%ngrid
@@ -760,7 +825,7 @@ contains
                             enddo
                          enddo
                       enddo
-                      
+
                       do t=1,LVT_rc%ngrid
                          do k=1,model%selectNlevs
                             do l=1,LVT_rc%strat_nlevels
@@ -769,18 +834,17 @@ contains
                             enddo
                          enddo
                       enddo
-                      
+
                       call LVT_writeTSinfo(metric%ftn_ts_loc(:,1),&
                            model,&
                            LVT_rc%ngrid,&
                            tavg_model_value_ts,&
                            stats%min(1)%tavg_count_model_value_ts)
-
                    endif
                    deallocate(tavg_model_value_ts)
 
-                   if(LVT_rc%obssource(2).ne."none".and.&
-                        obs%selectNlevs.ge.1) then 
+                   if(LVT_rc%obssource(2).ne."none".and. &
+                         obs%selectNlevs.ge.1) then
                       deallocate(tavg_obs_value_ts)
                    endif
                 endif
@@ -789,35 +853,37 @@ contains
        endif
     endif
 
-       
-    if(LVT_rc%endtime.eq.1.and.metric%selectOpt.eq.1) then 
+    if(LVT_rc%endtime.eq.1.and.metric%selectOpt.eq.1) then
        if(stats%selectOpt.eq.1.and.&
-            model%selectNlevs.ge.1) then 
+            model%selectNlevs.ge.1) then
           do t=1,LVT_rc%ngrid
              do m=1,LVT_rc%nensem
                 do k=1,model%selectNlevs
                    do l=1,LVT_rc%strat_nlevels
-                      if(stats%min(m)%model_value_total(t,k,l).lt.1E10) then 
+                      if(stats%min(m)%count_model_value_total(t,k,l).gt.&
+                           LVT_rc%obsCountThreshold) then
                          stats%min(m)%model_value_total(t,k,l) = &
                               stats%min(m)%model_value_total(t,k,l)
                       else
                          stats%min(m)%model_value_total(t,k,l) = LVT_rc%udef
                       endif
                    enddo
-                   if(metric%computeSC.eq.1) then 
-                      do l=1, LVT_rc%nasc
-                         if(stats%min(m)%model_value_asc(t,k,l).lt.1E10) then 
+                   if(metric%computeSC.eq.1) then
+                      do l=1,LVT_rc%nasc
+                         if(stats%min(m)%count_model_value_asc(t,k,l).gt.&
+                              LVT_rc%SCCountThreshold) then
                             stats%min(m)%model_value_asc(t,k,l) = &
-                                 count_model_asc(t,1,l)           
+                                 stats%min(m)%count_model_value_asc(t,k,l)
                          else
                             stats%min(m)%model_value_asc(t,k,l) = LVT_rc%udef
                          endif
                       enddo
                    endif
-                   
-                   if(metric%computeADC.eq.1) then 
-                      do l=1, LVT_rc%nadc
-                         if(stats%min(m)%model_value_adc(t,k,l).lt.1E10) then 
+
+                   if(metric%computeADC.eq.1) then
+                      do l=1,LVT_rc%nadc
+                         if(stats%min(m)%count_model_value_adc(t,k,l).gt.&
+                              LVT_rc%ADCCountThreshold) then
                             stats%min(m)%model_value_adc(t,k,l) = &
                                  stats%min(m)%model_value_adc(t,k,l)
                          else
@@ -825,10 +891,13 @@ contains
                          endif
                       enddo
                    endif
-                   if(LVT_rc%obssource(2).ne."none") then 
+                enddo
+                do k=1,obs%selectNlevs
+                   if(LVT_rc%obssource(2).ne."none") then
                       if(obs%selectNlevs.ge.1) then
-                         do l=1,LVT_rc%strat_nlevels                      
-                            if(stats%min(m)%obs_value_total(t,k,l).lt.1E10) then 
+                         do l=1,LVT_rc%strat_nlevels
+                            if(stats%min(m)%count_obs_value_total(t,k,l).gt.&
+                                 LVT_rc%obsCountThreshold) then
                                stats%min(m)%obs_value_total(t,k,l) = &
                                     stats%min(m)%obs_value_total(t,k,l)
                             else
@@ -836,8 +905,9 @@ contains
                             endif
                          enddo
                          if(metric%computeSC.eq.1) then
-                            do l=1, LVT_rc%nasc 
-                               if(stats%min(m)%obs_value_asc(t,k,l).lt.1E10) then 
+                            do l=1,LVT_rc%nasc
+                               if(stats%min(m)%count_obs_value_asc(t,k,l).gt.&
+                                    LVT_rc%SCCountThreshold) then
                                   stats%min(m)%obs_value_asc(t,k,l) = &
                                        stats%min(m)%obs_value_asc(t,k,l)
                                else
@@ -845,10 +915,11 @@ contains
                                endif
                             enddo
                          endif
-                         
+
                          if(metric%computeADC.eq.1) then
-                            do l=1, LVT_rc%nadc  
-                               if(stats%min(m)%obs_value_adc(t,k,l).lt.1E10) then
+                            do l=1,LVT_rc%nadc
+                               if(stats%min(m)%count_obs_value_adc(t,k,l).gt.&
+                                    LVT_rc%ADCCountThreshold) then
                                   stats%min(m)%obs_value_adc(t,k,l) = &
                                        stats%min(m)%obs_value_adc(t,k,l)
                                else
@@ -861,17 +932,18 @@ contains
                 enddo
              enddo
           enddo
-          do m=1,LVT_rc%nensem          
+
+          do m=1,LVT_rc%nensem
              do k=1,model%selectNlevs
-                do l=1, LVT_rc%strat_nlevels
+                do l=1,LVT_rc%strat_nlevels
                    call LVT_computeCI(stats%min(m)%model_value_total(:,k,l),&
                         LVT_rc%ngrid,&
                         LVT_rc%pval_CI,stats%min(m)%model_value_ci(k,l))
                 enddo
              enddo
-             if(LVT_rc%obssource(2).ne."none") then 
+             if(LVT_rc%obssource(2).ne."none") then
                 do k=1,obs%selectNlevs
-                   do l=1, LVT_rc%strat_nlevels
+                   do l=1,LVT_rc%strat_nlevels
                       call LVT_computeCI(stats%min(m)%obs_value_total(:,k,l),&
                            LVT_rc%ngrid,&
                            LVT_rc%pval_CI,stats%min(m)%obs_value_ci(k,l))
@@ -879,57 +951,58 @@ contains
                 enddo
              endif
           enddo
+
 !----------------------------------------------------------------------
-!  External data based stratification 
+!  External data based stratification
 !----------------------------------------------------------------------
-          if(LVT_rc%data_based_strat.eq.1) then 
+          if(LVT_rc%data_based_strat.eq.1) then
 
              allocate(model_value_avg(LVT_rc%ngrid,&
                   model%vlevels,&
                   LVT_rc%strat_nlevels))
              model_value_avg = 0.0
-             
-             do m=1,LVT_rc%nensem        
-                do t=1,LVT_rc%ngrid                      
-                   do k=1,model%selectNlevs                
-                      do l=1, LVT_rc%strat_nlevels
+
+             do m=1,LVT_rc%nensem
+                do t=1,LVT_rc%ngrid
+                   do k=1,model%selectNlevs
+                      do l=1,LVT_rc%strat_nlevels
                          model_value_avg(t,k,l) = &
-                              model_value_avg(t,k,l) + & 
+                              model_value_avg(t,k,l) + &
                               stats%min(m)%model_value_total(t,k,l)
                       enddo
                    enddo
                 enddo
              enddo
-             
-             do t=1,LVT_rc%ngrid                      
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%strat_nlevels
+
+             do t=1,LVT_rc%ngrid
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%strat_nlevels
                       model_value_avg(t,k,l) = &
                            model_value_avg(t,k,l)/LVT_rc%nensem
                    enddo
                 enddo
              enddo
-             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
-                
+             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
+
                 allocate(obs_value_avg(LVT_rc%ngrid,&
                      obs%vlevels,&
                      LVT_rc%strat_nlevels))
                 obs_value_avg = 0.0
-                
-                do m=1,LVT_rc%nensem        
+
+                do m=1,LVT_rc%nensem
                    do t=1,LVT_rc%ngrid
-                      do k=1,obs%selectNlevs                
-                         do l=1, LVT_rc%strat_nlevels
+                      do k=1,obs%selectNlevs
+                         do l=1,LVT_rc%strat_nlevels
                             obs_value_avg(t,k,l) = &
-                                 obs_value_avg(t,k,l) + & 
+                                 obs_value_avg(t,k,l) + &
                                  stats%min(m)%obs_value_total(t,k,l)
                          enddo
                       enddo
                    enddo
                 enddo
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%strat_nlevels                
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%strat_nlevels
                          obs_value_avg(t,k,l) = &
                               obs_value_avg(t,k,l)/LVT_rc%nensem
                       enddo
@@ -938,18 +1011,17 @@ contains
                 call LVT_writeDataBasedStrat(model,obs,stats,metric,&
                      LVT_rc%ngrid, model_value_avg, &
                      LVT_rc%ngrid, obs_value_avg)
-                   
+
                 deallocate(obs_value_avg)
              else
-                   
+
                 call LVT_writeDataBasedStrat(model,obs,stats,metric,&
-                     LVT_rc%ngrid,model_value_avg)            
-                
+                     LVT_rc%ngrid,model_value_avg)
+
              endif
              deallocate(model_value_avg)
-                
           endif
-          
+
           if(metric%computeSC.eq.1) then
              allocate(model_value_asc(LVT_rc%ngrid,&
                   model%vlevels,&
@@ -959,17 +1031,17 @@ contains
                   LVT_rc%nasc))
 
              model_value_asc = 0.0
-             count_model_value_asc = 0 
+             count_model_value_asc = 0
 
              do t=1,LVT_rc%ngrid
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%nasc
-                      do m=1,LVT_rc%nensem        
-                         if(stats%min(m)%model_value_asc(t,k,l).ne.LVT_rc%udef) then 
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%nasc
+                      do m=1,LVT_rc%nensem
+                         if(stats%min(m)%model_value_asc(t,k,l).ne.LVT_rc%udef) then
                             model_value_asc(t,k,l) = &
-                                 model_value_asc(t,k,l) + & 
+                                 model_value_asc(t,k,l) + &
                                  stats%min(m)%model_value_asc(t,k,l)
-                            count_model_value_asc(t,k,l) = & 
+                            count_model_value_asc(t,k,l) = &
                                  count_model_value_asc(t,k,l) + 1
                          endif
                       enddo
@@ -978,11 +1050,11 @@ contains
              enddo
 
              do t=1,LVT_rc%ngrid
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%nasc
-                      if(count_model_value_asc(t,k,l).gt.0) then 
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%nasc
+                      if(count_model_value_asc(t,k,l).gt.0) then
                          model_value_asc(t,k,l) = &
-                              model_value_asc(t,k,l)/&
+                              model_value_asc(t,k,l) / &
                               count_model_value_asc(t,k,l)
                       else
                          model_value_asc(t,k,l) = LVT_rc%udef
@@ -991,46 +1063,46 @@ contains
                 enddo
              enddo
 
-             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                 allocate(obs_value_asc(LVT_rc%ngrid,&
                      obs%vlevels,&
                      LVT_rc%nasc))
-                
+
                 obs_value_asc = 0.0
 
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%nasc
-                         do m=1,LVT_rc%nensem          
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%nasc
+                         do m=1,LVT_rc%nensem
                             obs_value_asc(t,k,l) = &
-                                 obs_value_asc(t,k,l) + & 
+                                 obs_value_asc(t,k,l) + &
                                  stats%min(m)%obs_value_asc(t,k,l)
                          enddo
                       enddo
                    enddo
                 enddo
-                
+
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%nasc
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%nasc
                          obs_value_asc(t,k,l) = &
                               obs_value_asc(t,k,l)/LVT_rc%nensem
                       enddo
                    enddo
                 enddo
-             
+
                 call LVT_writeSeasonalCycleInfo(model,obs,stats,metric,&
                      LVT_rc%ngrid,model_value_asc,&
-                     count_model_asc,&
+                     stats%min(1)%count_model_value_asc,&
                      LVT_rc%ngrid,obs_value_asc,&
-                     count_obs_asc)   
+                     stats%min(1)%count_obs_value_asc)
 
                 deallocate(obs_value_asc)
-       
+
              else
                 call LVT_writeSeasonalCycleInfo(model,obs,stats,metric,&
                      LVT_rc%ngrid,model_value_asc,&
-                     count_model_asc)
+                     stats%min(1)%count_model_value_asc)
 
                 deallocate(model_value_asc)
              endif
@@ -1043,63 +1115,64 @@ contains
              model_value_adc = 0.0
 
              do t=1,LVT_rc%ngrid
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%nadc
-                      do m=1,LVT_rc%nensem          
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%nadc
+                      do m=1,LVT_rc%nensem
                          model_value_adc(t,k,l) = &
-                              model_value_adc(t,k,l) + & 
+                              model_value_adc(t,k,l) + &
                               stats%min(m)%model_value_adc(t,k,l)
                       enddo
                    enddo
                 enddo
              enddo
-             
+
              do t=1,LVT_rc%ngrid
-                do k=1,model%selectNlevs                
-                   do l=1, LVT_rc%nadc
+                do k=1,model%selectNlevs
+                   do l=1,LVT_rc%nadc
                       model_value_adc(t,k,l) = &
                            model_value_adc(t,k,l)/LVT_rc%nensem
                    enddo
                 enddo
              enddo
-             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+             if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                 allocate(obs_value_adc(LVT_rc%ngrid,&
                      obs%vlevels,&
                      LVT_rc%nadc))
-                
+
                 obs_value_adc = 0.0
 
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%nadc
-                         do m=1,LVT_rc%nensem          
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%nadc
+                         do m=1,LVT_rc%nensem
                             obs_value_adc(t,k,l) = &
-                                 obs_value_adc(t,k,l) + & 
+                                 obs_value_adc(t,k,l) + &
                                  stats%min(m)%obs_value_adc(t,k,l)
                          enddo
                       enddo
                    enddo
                 enddo
-                
+
                 do t=1,LVT_rc%ngrid
-                   do k=1,obs%selectNlevs                
-                      do l=1, LVT_rc%nadc
+                   do k=1,obs%selectNlevs
+                      do l=1,LVT_rc%nadc
                          obs_value_adc(t,k,l) = &
                               obs_value_adc(t,k,l)/LVT_rc%nensem
                       enddo
                    enddo
                 enddo
+
                 call LVT_writeAvgDiurnalCycleInfo(model,obs,stats,metric,&
                      LVT_rc%ngrid,model_value_adc,&
-                     count_model_adc,&
+                     stats%min(1)%count_model_value_adc,&
                      LVT_rc%ngrid,obs_value_adc,&
-                     count_obs_adc)      
-                
+                     stats%min(1)%count_obs_value_adc)
+
                 deallocate(obs_value_adc)
              else
                 call LVT_writeAvgDiurnalCycleInfo(model,obs,stats,metric,&
                      LVT_rc%ngrid,model_value_adc,&
-                     count_model_adc)
+                     stats%min(m)%count_model_value_adc)
 
                 deallocate(model_value_adc)
              endif
@@ -1109,31 +1182,28 @@ contains
   end subroutine computeSingleMin
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_writeMetric_Min
 ! \label(LVT_writeMetric_Min)
 !
 ! !INTERFACE:
   subroutine LVT_writeMetric_Min(pass,final,vlevels,stats,obs)
-! 
-! !USES:   
+!
+! !USES:
     use LVT_statsMod, only : LVT_writeSummaryStats
     use LVT_pluginIndices
     implicit none
 !
-! !INPUT PARAMETERS: 
-! 
+! !INPUT PARAMETERS:
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-! 
-!   This routine writes the computed Min values to 
-!   an external file. 
+! !DESCRIPTION:
+!   This routine writes the computed Min values to an external file.
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
-
 
     integer                 :: pass
     integer                 :: final
@@ -1165,12 +1235,12 @@ contains
 
     if(pass.eq.LVT_metrics%min%npass) then
        if(final.ne.1) then
-           if(stats%selectOpt.eq.1) then 
-              
+           if(stats%selectOpt.eq.1) then
+
               allocate(model_value_ts(LVT_rc%ngrid,LVT_rc%nensem))
               allocate(count_model_value_ts(LVT_rc%ngrid,LVT_rc%nensem))
 
-              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                  allocate(obs_value_ts(LVT_rc%ngrid,LVT_rc%nensem))
                  allocate(count_obs_value_ts(LVT_rc%ngrid,LVT_rc%nensem))
               endif
@@ -1180,27 +1250,27 @@ contains
                     do m=1,LVT_rc%nensem
                          model_value_ts(:,m) = &
                               stats%min(m)%tavg_model_value_ts(:,k,l)
-                         count_model_value_ts(:,m) = & 
+                         count_model_value_ts(:,m) = &
                               stats%min(m)%tavg_count_model_value_ts(:,k,l)
-                       if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                       if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                           obs_value_ts(:,m) = &
                                stats%min(m)%tavg_obs_value_ts(:,k,l)
-                          count_obs_value_ts(:,m) = & 
+                          count_obs_value_ts(:,m) = &
                                stats%min(m)%tavg_count_obs_value_ts(:,k,l)
                        endif
                     enddo
-                    if(LVT_metrics%min%timeOpt.eq.1) then 
-                       
+                    if(LVT_metrics%min%timeOpt.eq.1) then
+
                        call LVT_writevar_gridded(LVT_metrics%min%ftn_ts, &
                             model_value_ts(:,:),&
                             stats%vid_ts(LVT_MINid,1),k)
-                       
+
                        call LVT_writevar_gridded(LVT_metrics%min%ftn_ts, &
                             real(count_model_value_ts(:,:)),&
                             stats%vid_count_ts(LVT_MINid,1),k)
                     endif
-                    
-                    if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+
+                    if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                        call LVT_writevar_gridded(LVT_metrics%min%ftn_ts, &
                             obs_value_ts(:,:),&
                             stats%vid_ts(LVT_MINid,2),k)
@@ -1214,7 +1284,7 @@ contains
               deallocate(model_value_ts)
               deallocate(count_model_value_ts)
 
-              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                  deallocate(obs_value_ts)
                  deallocate(count_obs_value_ts)
               endif
@@ -1226,26 +1296,24 @@ contains
               allocate(model_value_total(LVT_rc%ngrid,LVT_rc%nensem))
               allocate(count_model_value_total(LVT_rc%ngrid,LVT_rc%nensem))
               allocate(model_value_ci(LVT_rc%nensem))
-              
-              count_model_value_total = 1
 
-              if(LVT_metrics%min%computeSC.eq.1) then 
+              if(LVT_metrics%min%computeSC.eq.1) then
                  allocate(model_value_asc(LVT_rc%ngrid,&
                       LVT_rc%nensem,&
                       LVT_rc%nasc))
                  if(LVT_rc%obssource(2).ne."none".and.&
-                      obs%selectNlevs.ge.1) then 
+                      obs%selectNlevs.ge.1) then
                     allocate(obs_value_asc(LVT_rc%ngrid,&
                          LVT_rc%nensem,&
                          LVT_rc%nasc))
                  endif
               endif
-              if(LVT_metrics%min%computeADC.eq.1) then 
+              if(LVT_metrics%min%computeADC.eq.1) then
                  allocate(model_value_adc(LVT_rc%ngrid,&
                       LVT_rc%nensem,&
-                      LVT_rc%nadc))        
+                      LVT_rc%nadc))
                  if(LVT_rc%obssource(2).ne."none".and.&
-                      obs%selectNlevs.ge.1) then 
+                      obs%selectNlevs.ge.1) then
                     allocate(obs_value_adc(LVT_rc%ngrid,&
                          LVT_rc%nensem,&
                          LVT_rc%nadc))
@@ -1253,57 +1321,59 @@ contains
 
               endif
 
-              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+              if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                  allocate(obs_value_total(LVT_rc%ngrid,LVT_rc%nensem))
                  allocate(count_obs_value_total(LVT_rc%ngrid,LVT_rc%nensem))
                  allocate(obs_value_ci(LVT_rc%nensem))
-
-                 count_obs_value_total = 1
-              endif                
+              endif
 
                 do k=1,vlevels
                    do l=1,LVT_rc%strat_nlevels
                       do m=1,LVT_rc%nensem
                          model_value_total(:,m) = &
                               stats%min(m)%model_value_total(:,k,l)
+                         count_model_value_total(:,m) = &
+                              stats%min(m)%count_model_value_total(:,k,l)
                          model_value_ci(m) = stats%min(m)%model_value_ci(k,l)
-                         
-                         if(LVT_metrics%min%computeSC.eq.1) then 
+
+                         if(LVT_metrics%min%computeSC.eq.1) then
                             do tind = 1,LVT_rc%nasc
-                               model_value_asc(:,m,tind) = & 
+                               model_value_asc(:,m,tind) = &
                                     stats%min(m)%model_value_asc(:,k,tind)
                             enddo
                          endif
 
-                         if(LVT_metrics%min%computeADC.eq.1) then 
+                         if(LVT_metrics%min%computeADC.eq.1) then
                             do tind = 1,LVT_rc%nadc
-                               model_value_adc(:,m,tind) = & 
+                               model_value_adc(:,m,tind) = &
                                     stats%min(m)%model_value_adc(:,k,tind)
                             enddo
                          endif
 
                          if(LVT_rc%obssource(2).ne."none".and.&
-                              obs%selectNlevs.ge.1) then 
+                              obs%selectNlevs.ge.1) then
                             obs_value_total(:,m) = &
                                  stats%min(m)%obs_value_total(:,k,l)
+                            count_obs_value_total(:,m) = &
+                                 stats%min(m)%count_obs_value_total(:,k,l)
                             obs_value_ci(m) = stats%min(m)%obs_value_ci(k,l)
 
-                            if(LVT_metrics%min%computeSC.eq.1) then 
+                            if(LVT_metrics%min%computeSC.eq.1) then
                                do tind = 1,LVT_rc%nasc
-                                  obs_value_asc(:,m,tind) = & 
+                                  obs_value_asc(:,m,tind) = &
                                        stats%min(m)%obs_value_asc(:,k,tind)
                                enddo
                             endif
-                            if(LVT_metrics%min%computeADC.eq.1) then 
+                            if(LVT_metrics%min%computeADC.eq.1) then
                                do tind = 1,LVT_rc%nadc
-                                  obs_value_adc(:,m,tind) = & 
+                                  obs_value_adc(:,m,tind) = &
                                        stats%min(m)%obs_value_adc(:,k,tind)
                                enddo
                             endif
-                            
+
                          endif
                       enddo
-                      if(LVT_metrics%min%selectOpt.eq.1) then 
+                      if(LVT_metrics%min%selectOpt.eq.1) then
                          call LVT_writevar_gridded(LVT_metrics%min%ftn_total, &
                               model_value_total(:,:),&
                               stats%vid_total(LVT_MINid,1),k)
@@ -1312,7 +1382,7 @@ contains
                               stats%vid_count_total(LVT_MINid,1),k)
 
                          if(LVT_rc%obssource(2).ne."none".and.&
-                              obs%selectNlevs.ge.1) then 
+                              obs%selectNlevs.ge.1) then
                             call LVT_writevar_gridded(LVT_metrics%min%ftn_total, &
                                  obs_value_total(:,:),&
                                  stats%vid_total(LVT_MINid,2),k)
@@ -1320,15 +1390,15 @@ contains
                                  real(count_obs_value_total(:,:)),&
                                  stats%vid_count_total(LVT_MINid,2),k)
                          endif
-                         
-                         if(LVT_metrics%min%computeSC.eq.1) then 
+
+                         if(LVT_metrics%min%computeSC.eq.1) then
                             do tind = 1,LVT_rc%nasc
                                call LVT_writevar_gridded(&
                                     LVT_metrics%min%ftn_total,&
                                     model_value_asc(:,:,tind),&
                                     stats%vid_sc_total(tind,LVT_MINid,1),k)
                             enddo
-                            if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                            if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                                do tind = 1,LVT_rc%nasc
                                   call LVT_writevar_gridded(&
                                        LVT_metrics%min%ftn_total,&
@@ -1337,14 +1407,14 @@ contains
                                enddo
                             endif
                          endif
-                         if(LVT_metrics%min%computeADC.eq.1) then 
+                         if(LVT_metrics%min%computeADC.eq.1) then
                             do tind = 1,LVT_rc%nadc
                                call LVT_writevar_gridded(&
                                     LVT_metrics%min%ftn_total,&
                                     model_value_adc(:,:,tind),&
                                     stats%vid_adc_total(tind,LVT_MINid,1),k)
                             enddo
-                            if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                            if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                                do tind = 1,LVT_rc%nadc
                                   call LVT_writevar_gridded(&
                                        LVT_metrics%min%ftn_total,&
@@ -1362,7 +1432,7 @@ contains
                               count_model_value_total(:,:),&
                               stats%standard_name,&
                               model_value_ci(:))
-                         if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                         if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                             call LVT_writeSummaryStats(&
                                  LVT_metrics%min%ftn_summ,&
                                  l,&
@@ -1381,20 +1451,20 @@ contains
                 deallocate(count_model_value_total)
                 deallocate(model_value_ci)
 
-                if(LVT_metrics%min%computeSC.eq.1) then 
+                if(LVT_metrics%min%computeSC.eq.1) then
                    deallocate(model_value_asc)
-                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                       deallocate(obs_value_asc)
                    endif
                 endif
-                if(LVT_metrics%min%computeADC.eq.1) then 
+                if(LVT_metrics%min%computeADC.eq.1) then
                    deallocate(model_value_adc)
-                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                   if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                       deallocate(obs_value_adc)
                    endif
                 endif
 
-                if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then 
+                if(LVT_rc%obssource(2).ne."none".and.obs%selectNlevs.ge.1) then
                    deallocate(obs_value_total)
                    deallocate(count_obs_value_total)
                    deallocate(obs_value_ci)
@@ -1407,25 +1477,26 @@ contains
   end subroutine LVT_writeMetric_Min
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_resetMetric_Min
 ! \label(LVT_resetMetric_Min)
 !
 ! !INTERFACE:
   subroutine LVT_resetMetric_Min(alarm)
-! 
-! !INPUT PARAMETERS: 
-    logical         :: alarm
-! 
+!
+! !USES:
+!
+! !INPUT PARAMETERS:
+    logical                :: alarm
+!
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
-! 
+! !DESCRIPTION:
 !  This routine resets required variables to support the
-!  temporal computation of Min alues. 
+!  temporal computation of Min values.
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
 
     integer                :: i,k,l,m
@@ -1433,30 +1504,35 @@ contains
     type(LVT_metadataEntry), pointer :: obs
     type(LVT_statsEntry)   , pointer :: stats
 
-
     call LVT_getDataStream1Ptr(model)
     call LVT_getDataStream1Ptr(obs)
     call LVT_getstatsEntryPtr(stats)
-    
+
     do while(associated(model))
-       if(stats%selectOpt.eq.1) then 
+       if(stats%selectOpt.eq.1) then
           do m=1,LVT_rc%nensem
              do k=1,model%selectNlevs
-                if(LVT_metrics%min%timeOpt.eq.1) then 
+                if(LVT_metrics%min%timeOpt.eq.1) then
                    do l=1,LVT_rc%strat_nlevels
                       stats%min(m)%model_value_ts(:,k,l) = 1E10
-                      if(alarm) then 
-                         stats%min(m)%tavg_model_value_ts(:,k,l) = 0.0
-                         stats%min(m)%tavg_count_model_value_ts(:,k,l) = 0.0
+                      stats%min(m)%count_model_value_ts(:,k,l) = 0
+                      if(alarm) then
+                         stats%min(m)%tavg_model_value_ts(:,k,l) = 1E10
+                         stats%min(m)%tavg_count_model_value_ts(:,k,l) = 0
                       endif
                    enddo
+                endif
+             enddo
+             do k=1,obs%selectNlevs
+                if(LVT_metrics%min%timeOpt.eq.1) then
                    if(LVT_rc%obssource(2).ne."none".and.&
-                        obs%selectNlevs.ge.1) then 
+                        obs%selectNlevs.ge.1) then
                       do l=1,LVT_rc%strat_nlevels
                          stats%min(m)%obs_value_ts(:,k,l) = 1E10
-                         if(alarm) then 
-                            stats%min(m)%tavg_obs_value_ts(:,k,l) = 0.0
-                            stats%min(m)%tavg_count_obs_value_ts(:,k,l) = 0.0
+                         stats%min(m)%count_obs_value_ts(:,k,l) = 0
+                         if(alarm) then
+                            stats%min(m)%tavg_obs_value_ts(:,k,l) = 1E10
+                            stats%min(m)%tavg_count_obs_value_ts(:,k,l) = 0
                          endif
                       enddo
                    endif
@@ -1464,7 +1540,7 @@ contains
              enddo
           enddo
        endif
-       
+
        model => model%next
        obs => obs%next
        stats => stats%next
@@ -1473,26 +1549,26 @@ contains
   end subroutine LVT_resetMetric_Min
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_writerestart_Min
-! 
+!
 ! !INTERFACE:
   subroutine LVT_writerestart_Min(ftn,pass)
-! !USES: 
+! !USES:
 
-! 
-! !ARGUMENTS: 
+!
+! !ARGUMENTS:
     integer                 :: ftn
     integer                 :: pass
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine writes the restart file for Min metric computations
-! 
-!EOP
-    
 !
-! !DESCRIPTION: 
-! 
+!EOP
+
+!
+! !DESCRIPTION:
+!
 !EOP
     integer              :: k,l,m
     type(LVT_metaDataEntry), pointer :: model
@@ -1502,57 +1578,69 @@ contains
     call LVT_getDataStream1Ptr(model)
     call LVT_getDataStream2Ptr(obs)
     call LVT_getstatsEntryPtr(stats)
-    
+
     do while(associated(model))
-       if(LVT_metrics%min%selectOpt.eq.1) then 
+       if(LVT_metrics%min%selectOpt.eq.1) then
           if(stats%selectOpt.eq.1.and.&
-               model%selectNlevs.ge.1) then 
+               model%selectNlevs.ge.1) then
              do m=1,LVT_rc%nensem
                 do k=1,model%selectNlevs
-                   do l=1,LVT_rc%strat_nlevels         
+                   do l=1,LVT_rc%strat_nlevels
                       call LVT_writevar_restart(ftn,&
                            stats%min(m)%model_value_total(:,k,l))
+                      call LVT_writevar_restart(ftn,&
+                           stats%min(m)%count_model_value_total(:,k,l))
                    enddo
                 enddo
-                if(LVT_metrics%min%computeSC.eq.1) then 
+                if(LVT_metrics%min%computeSC.eq.1) then
                    do k=1,model%selectNlevs
-                      do l=1,LVT_rc%nasc         
+                      do l=1,LVT_rc%nasc
                          call LVT_writevar_restart(ftn,&
                               stats%min(m)%model_value_asc(:,k,l))
+                         call LVT_writevar_restart(ftn,&
+                              stats%min(m)%count_model_value_asc(:,k,l))
                       enddo
                    enddo
                 endif
-                if(LVT_metrics%min%computeADC.eq.1) then 
+                if(LVT_metrics%min%computeADC.eq.1) then
                    do k=1,model%selectNlevs
-                      do l=1,LVT_rc%nadc         
+                      do l=1,LVT_rc%nadc
                          call LVT_writevar_restart(ftn,&
                               stats%min(m)%model_value_adc(:,k,l))
+                         call LVT_writevar_restart(ftn,&
+                              stats%min(m)%count_model_value_adc(:,k,l))
                       enddo
                    enddo
                 endif
-                
-                if(LVT_rc%obssource(2).ne."none") then 
-                   if(obs%selectNlevs.ge.1) then 
+
+                if(LVT_rc%obssource(2).ne."none") then
+                   if(obs%selectNlevs.ge.1) then
                       do k=1,obs%selectNlevs
                          do l=1,LVT_rc%strat_nlevels
                             call LVT_writevar_restart(ftn,&
                                  stats%min(m)%obs_value_total(:,k,l))
+                            call LVT_writevar_restart(ftn,&
+                                 stats%min(m)%count_obs_value_total(:,k,l))
                          enddo
                       enddo
-                      
-                      if(LVT_metrics%min%computeSC.eq.1) then 
+
+                      if(LVT_metrics%min%computeSC.eq.1) then
                          do k=1,obs%selectNlevs
                             do l=1,LVT_rc%nasc
                                call LVT_writevar_restart(ftn,&
                                     stats%min(m)%obs_value_asc(:,k,l))
+                               call LVT_writevar_restart(ftn,&
+                                    stats%min(m)%count_obs_value_asc(:,k,l))
                             enddo
                          enddo
                       endif
-                      if(LVT_metrics%min%computeADC.eq.1) then 
+                      if(LVT_metrics%min%computeADC.eq.1) then
                          do k=1,obs%selectNlevs
                             do l=1,LVT_rc%nasc
                                call LVT_writevar_restart(ftn,&
                                     stats%min(m)%obs_value_adc(:,k,l))
+                               call LVT_writevar_restart(ftn,&
+                                    stats%min(m)%count_obs_value_adc(:,k,l))
                             enddo
                          enddo
                       endif
@@ -1569,24 +1657,24 @@ contains
 
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_readrestart_Min
-! 
+!
 ! !INTERFACE:
   subroutine LVT_readrestart_Min(ftn)
-! !USES: 
-! 
-! !ARGUMENTS: 
+! !USES:
+!
+! !ARGUMENTS:
     integer                 :: ftn
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine reads the restart file for Min metric computations
-! 
-!EOP
-    
 !
-! !DESCRIPTION: 
-! 
+!EOP
+
+!
+! !DESCRIPTION:
+!
 !EOP
 
     integer              :: k,l,m,index
@@ -1597,57 +1685,69 @@ contains
     call LVT_getDataStream1Ptr(model)
     call LVT_getDataStream2Ptr(obs)
     call LVT_getstatsEntryPtr(stats)
-    
+
     do while(associated(model))
-       if(LVT_metrics%min%selectOpt.eq.1) then 
+       if(LVT_metrics%min%selectOpt.eq.1) then
           if(stats%selectOpt.eq.1.and.&
-               model%selectNlevs.ge.1) then 
+               model%selectNlevs.ge.1) then
              do m=1,LVT_rc%nensem
                 do k=1,model%selectNlevs
-                   do l=1,LVT_rc%strat_nlevels         
+                   do l=1,LVT_rc%strat_nlevels
                       call LVT_readvar_restart(ftn,&
                            stats%min(m)%model_value_total(:,k,l))
+                      call LVT_readvar_restart(ftn,&
+                           stats%min(m)%count_model_value_total(:,k,l))
                    enddo
                 enddo
-                if(LVT_metrics%min%computeSC.eq.1) then 
+                if(LVT_metrics%min%computeSC.eq.1) then
                    do k=1,model%selectNlevs
-                      do l=1,LVT_rc%nasc         
+                      do l=1,LVT_rc%nasc
                          call LVT_readvar_restart(ftn,&
                               stats%min(m)%model_value_asc(:,k,l))
+                         call LVT_readvar_restart(ftn,&
+                              stats%min(m)%count_model_value_asc(:,k,l))
                       enddo
                    enddo
                 endif
-                if(LVT_metrics%min%computeADC.eq.1) then 
+                if(LVT_metrics%min%computeADC.eq.1) then
                    do k=1,model%selectNlevs
-                      do l=1,LVT_rc%nadc         
+                      do l=1,LVT_rc%nadc
                          call LVT_readvar_restart(ftn,&
                               stats%min(m)%model_value_adc(:,k,l))
+                         call LVT_readvar_restart(ftn,&
+                              stats%min(m)%count_model_value_adc(:,k,l))
                       enddo
                    enddo
                 endif
-                
-                if(LVT_rc%obssource(2).ne."none") then 
-                   if(obs%selectNlevs.ge.1) then 
+
+                if(LVT_rc%obssource(2).ne."none") then
+                   if(obs%selectNlevs.ge.1) then
                       do k=1,obs%selectNlevs
                          do l=1,LVT_rc%strat_nlevels
                             call LVT_readvar_restart(ftn,&
                                  stats%min(m)%obs_value_total(:,k,l))
+                            call LVT_readvar_restart(ftn,&
+                                 stats%min(m)%count_obs_value_total(:,k,l))
                          enddo
                       enddo
-                      
-                      if(LVT_metrics%min%computeSC.eq.1) then 
+
+                      if(LVT_metrics%min%computeSC.eq.1) then
                          do k=1,obs%selectNlevs
                             do l=1,LVT_rc%nasc
                                call LVT_readvar_restart(ftn,&
                                     stats%min(m)%obs_value_asc(:,k,l))
+                               call LVT_readvar_restart(ftn,&
+                                    stats%min(m)%count_obs_value_asc(:,k,l))
                             enddo
                          enddo
                       endif
-                      if(LVT_metrics%min%computeADC.eq.1) then 
+                      if(LVT_metrics%min%computeADC.eq.1) then
                          do k=1,obs%selectNlevs
                             do l=1,LVT_rc%nasc
                                call LVT_readvar_restart(ftn,&
                                     stats%min(m)%obs_value_adc(:,k,l))
+                               call LVT_readvar_restart(ftn,&
+                                    stats%min(m)%count_obs_value_adc(:,k,l))
                             enddo
                          enddo
                       endif
@@ -1661,6 +1761,5 @@ contains
        stats => stats%next
     end do
   end subroutine LVT_readrestart_Min
-
 
 end module LVT_MinMod


### PR DESCRIPTION
This pull request fixes time series output for the
Max (maximum) and Min (minimum) metrics from LVT.

The MEAN metrics code was cleaned-up as well, but
the output for this metric will not change at all.

A testcase is coming soon.

Resolves: #705