### PR TITLE
Support compiling LISF without HDF-EOS2

### DIFF
--- a/ldt/DAobs/GLASSlai/readGLASSlaiObs.F90
+++ b/ldt/DAobs/GLASSlai/readGLASSlaiObs.F90
@@ -91,7 +91,7 @@ subroutine read_GLASSlai_data(n, fname, laiobs_ip)
   use GLASSlai_obsMod
 
   implicit none
-#if (defined USE_HDF4) 
+#if (defined USE_HDFEOS2)
 #include "hdf.f90"
 #endif
 !
@@ -120,7 +120,7 @@ subroutine read_GLASSlai_data(n, fname, laiobs_ip)
 !
 !EOP
 
-#if (defined USE_HDF4)
+#if (defined USE_HDFEOS2)
   integer,  parameter     :: nc=7200, nr=3600
   integer                 :: gdopen,gdattach,gdrdfld
   integer                 :: gddetach,gdclose

--- a/ldt/DAobs/NASA_AMSRE_sm/readNASA_AMSREsmObs.F90
+++ b/ldt/DAobs/NASA_AMSRE_sm/readNASA_AMSREsmObs.F90
@@ -100,7 +100,7 @@ subroutine read_AMSREsm(n, name)
   use NASA_AMSREsm_obsMod, only : NASA_AMSREsmobs
   implicit none
 
-#if (defined USE_HDF4) 
+#if (defined USE_HDFEOS2)
 #include "hdf.f90"
 #endif
 ! !ARGUMENTS:   
@@ -112,7 +112,7 @@ subroutine read_AMSREsm(n, name)
 !EOP
   real               :: sb_rqc(NASA_AMSREsmobs%mo)
 
-#if (defined USE_HDF4)
+#if (defined USE_HDFEOS2)
   !declare the hdf-eos library functions 
   integer              :: gdopen,gdattach,gddefboxreg,gdrdfld
   integer              :: gdgetpix,gdextreg,gddetach,gdclose

--- a/ldt/arch/Config.pl
+++ b/ldt/arch/Config.pl
@@ -784,6 +784,13 @@ else{
    printf misc_file "%s\n","#undef USE_HDF4 ";
 }
 
+if($use_hdfeos == 1) {
+   printf misc_file "%s\n","#define USE_HDFEOS2 ";
+}
+else{
+   printf misc_file "%s\n","#undef USE_HDFEOS2 ";
+}
+
 if($use_hdf5 == 1) {
    printf misc_file "%s\n","#define USE_HDF5 ";
 }

--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -873,6 +873,14 @@ $fflags77 = $fflags77." -DLIS_JULES";
 $fflags = $fflags." -DLIS_JULES";
 
 #
+# Kluge for SPORTDaily gfrac and VIIRSDaily gfrac readers
+# These readers require ZLIB, but this requirement is not captured by the
+# above library checks.
+#
+
+$ldflags = $ldflags." -lz";
+
+#
 # Write configure.lis and related files
 #
 
@@ -958,6 +966,13 @@ if($use_hdf4 == 1) {
 }
 else{
    printf misc_file "%s\n","#undef USE_HDF4 ";
+}
+
+if($use_hdfeos == 1) {
+   printf misc_file "%s\n","#define USE_HDFEOS2 ";
+}
+else{
+   printf misc_file "%s\n","#undef USE_HDFEOS2 ";
 }
 
 if($use_hdf5 == 1) {

--- a/lis/dataassim/obs/ANSA_SNWD/read_ANSASNWDsnow.F90
+++ b/lis/dataassim/obs/ANSA_SNWD/read_ANSASNWDsnow.F90
@@ -606,7 +606,7 @@ subroutine getMOD10data(n,k,name,tmp_obsl)
 !  or downscaled to the LIS domain
 !EOP
 
-#if (defined USE_HDF4) 
+#if (defined USE_HDFEOS2)
 #include "hdf.f90"
 #endif
   
@@ -615,7 +615,7 @@ subroutine getMOD10data(n,k,name,tmp_obsl)
   character*80         :: name
   real                 :: tmp_obsl(LIS_rc%obs_lnc(k)*LIS_rc%obs_lnr(k))
 
-#if (defined USE_HDF4)
+#if (defined USE_HDFEOS2)
   integer, parameter   :: modis_nc=7200, modis_nr=3600
   integer              :: local_nc, local_nr
 

--- a/lis/dataassim/obs/GCOMW_AMSR2L3SND/read_GCOMW_AMSR2L3SND.F90
+++ b/lis/dataassim/obs/GCOMW_AMSR2L3SND/read_GCOMW_AMSR2L3SND.F90
@@ -881,7 +881,7 @@ subroutine getMOD10data_AMSR2(n,k,name,tmp_obsl)
 !  to the AMSR2 observation grid
 !EOP
 
-#if (defined USE_HDF4) 
+#if (defined USE_HDFEOS2)
 #include "hdf.f90"
 #endif
   
@@ -890,7 +890,7 @@ subroutine getMOD10data_AMSR2(n,k,name,tmp_obsl)
   character*80         :: name
   real                 :: tmp_obsl(LIS_rc%obs_lnc(k)*LIS_rc%obs_lnr(k))
 
-#if (defined USE_HDF4)
+#if (defined USE_HDFEOS2)
   integer, parameter   :: modis_nc=7200, modis_nr=3600
   integer              :: local_nc, local_nr
 

--- a/lis/dataassim/obs/GLASS_Albedo/read_GLASSalbedo.F90
+++ b/lis/dataassim/obs/GLASS_Albedo/read_GLASSalbedo.F90
@@ -269,7 +269,7 @@ subroutine read_GLASS_ALBEDO_data(n, k, fname, source, albedoobs_bs_ip, &
   use GLASSalbedo_Mod, only : GLASSalbedo_struc
 
   implicit none
-#if (defined USE_HDF4) 
+#if (defined USE_HDFEOS2)
 #include "hdf.f90"
 #endif
 !
@@ -303,7 +303,7 @@ subroutine read_GLASS_ALBEDO_data(n, k, fname, source, albedoobs_bs_ip, &
 !
 !EOP
 
-#if (defined USE_HDF4)
+#if (defined USE_HDFEOS2)
   integer,  parameter     :: nc=7200, nr=3600
   integer                 :: gdopen,gdattach,gdrdfld
   integer                 :: gddetach,gdclose

--- a/lis/dataassim/obs/GLASS_LAI/read_GLASSlai.F90
+++ b/lis/dataassim/obs/GLASS_LAI/read_GLASSlai.F90
@@ -294,7 +294,7 @@ subroutine read_GLASS_LAI_data(n, k, fname, laiobs_ip)
   use GLASSlai_Mod, only : GLASSlai_struc
 
   implicit none
-#if (defined USE_HDF4) 
+#if (defined USE_HDFEOS2)
 #include "hdf.f90"
 #endif
 !
@@ -324,7 +324,7 @@ subroutine read_GLASS_LAI_data(n, k, fname, laiobs_ip)
 !
 !EOP
 
-#if (defined USE_HDF4)
+#if (defined USE_HDFEOS2)
   integer,  parameter     :: nc=7200, nr=3600
   integer                 :: gdopen,gdattach,gdrdfld
   integer                 :: gddetach,gdclose

--- a/lis/dataassim/obs/PMW_snow/read_PMW_snow.F90
+++ b/lis/dataassim/obs/PMW_snow/read_PMW_snow.F90
@@ -403,7 +403,7 @@ subroutine read_PMWSnow_HDFEOS(n,name)
   use PMW_snow_Mod, only : PMW_snow_struc
   implicit none
 
-#if (defined USE_HDF4) 
+#if (defined USE_HDFEOS2)
 #include "hdf.f90"
 #endif
 ! !ARGUMENTS:   
@@ -418,7 +418,7 @@ subroutine read_PMWSnow_HDFEOS(n,name)
   real                 :: sb_qc(PMW_snow_struc(n)%mo)
   real                 :: snowobs(PMW_snow_struc(n)%mo)
 
-#if (defined USE_HDF4)
+#if (defined USE_HDFEOS2)
   !declare the hdf-eos library functions 
   integer              :: gdopen,gdattach,gdrdfld
   integer              :: gddetach,gdclose

--- a/lis/dataassim/obs/SSMI_SNWD/read_SSMISNWDsnow.F90
+++ b/lis/dataassim/obs/SSMI_SNWD/read_SSMISNWDsnow.F90
@@ -478,7 +478,7 @@ subroutine getMOD10data_SSMI(n,k,name,tmp_obsl)
 !  to the SSMI observation grid
 !EOP
 
-#if (defined USE_HDF4) 
+#if (defined USE_HDFEOS2)
 #include "hdf.f90"
 #endif
   
@@ -487,7 +487,7 @@ subroutine getMOD10data_SSMI(n,k,name,tmp_obsl)
   character*80         :: name
   real                 :: tmp_obsl(LIS_rc%obs_lnc(k)*LIS_rc%obs_lnr(k))
 
-#if (defined USE_HDF4)
+#if (defined USE_HDFEOS2)
   integer, parameter   :: modis_nc=7200, modis_nr=3600
   integer              :: local_nc, local_nr
 

--- a/lvt/arch/Config.pl
+++ b/lvt/arch/Config.pl
@@ -659,6 +659,13 @@ else{
    printf misc_file "%s\n","#undef USE_HDF4 ";
 }
 
+if($use_hdfeos == 1) {
+   printf misc_file "%s\n","#define USE_HDFEOS2 ";
+}
+else{
+   printf misc_file "%s\n","#undef USE_HDFEOS2 ";
+}
+
 if($use_hdf5 == 1) {
    printf misc_file "%s\n","#define USE_HDF5 ";
 }

--- a/lvt/datastreams/GLASSalbedo/readGLASSalbedoObs.F90
+++ b/lvt/datastreams/GLASSalbedo/readGLASSalbedoObs.F90
@@ -123,7 +123,7 @@ subroutine read_GLASS_ALBEDO_data(source, fname, albedoobs_ip)
   use GLASSalbedoobsMod
 
   implicit none
-#if (defined USE_HDF4) 
+#if (defined USE_HDFEOS2)
 #include "hdf.f90"
 #endif
 !
@@ -150,14 +150,14 @@ subroutine read_GLASS_ALBEDO_data(source, fname, albedoobs_ip)
 !
 !EOP
 
-#if (defined USE_HDF4)
+#if (defined USE_HDFEOS2)
   integer                 :: k
   real*8                  :: cornerlat(2), cornerlon(2)
   integer,  parameter     :: nc=7200, nr=3600
   integer                 :: gdopen,gdattach,gdrdfld
   integer                 :: gddetach,gdclose
   integer                 :: file_id,grid_id,region_id,c,r,c1,r1,i
-  integer		  :: iret,iret1,iret2,iret3,iret4,iret5,iret6
+  integer                 :: iret,iret1,iret2,iret3,iret4,iret5,iret6
   character*50            :: grid_name,albedo_name
   character*50            :: albedo_name_ws_vis,albedo_name_bs_vis,albedo_name_ws_nir,albedo_name_bs_nir,albedo_name_ws_sw,albedo_name_bs_sw
   integer                 :: start(2), edge(2), stride(2)

--- a/lvt/datastreams/GLASSlai/readGLASSlaiObs.F90
+++ b/lvt/datastreams/GLASSlai/readGLASSlaiObs.F90
@@ -97,7 +97,7 @@ subroutine read_GLASS_LAI_data(source, fname, laiobs_ip)
   use GLASSlaiobsMod
 
   implicit none
-#if (defined USE_HDF4) 
+#if (defined USE_HDFEOS2)
 #include "hdf.f90"
 #endif
 !
@@ -124,7 +124,7 @@ subroutine read_GLASS_LAI_data(source, fname, laiobs_ip)
 !
 !EOP
 
-#if (defined USE_HDF4)
+#if (defined USE_HDFEOS2)
   integer                 :: k
   real*8                  :: cornerlat(2), cornerlon(2)
   integer,  parameter     :: nc=7200, nr=3600

--- a/lvt/datastreams/NASA_AMSRE_sm/readNASA_AMSREsmObs.F90
+++ b/lvt/datastreams/NASA_AMSRE_sm/readNASA_AMSREsmObs.F90
@@ -99,7 +99,7 @@ subroutine read_AMSREsm(source, name)
   use LVT_logmod,          only : LVT_logunit
   use NASA_AMSREsm_obsMod, only : NASA_AMSREsmobs
   implicit none
-#if (defined USE_HDF4) 
+#if (defined USE_HDFEOS2)
 #include "hdf.f90"
 #endif
 !
@@ -121,7 +121,7 @@ subroutine read_AMSREsm(source, name)
 !EOP
   real                 :: sb_rqc(NASA_AMSREsmobs(source)%mo)
 
-#if (defined USE_HDF4)
+#if (defined USE_HDFEOS2)
   !declare the hdf-eos library functions 
   integer              :: gdopen,gdattach,gddefboxreg,gdrdfld
   integer              :: gdgetpix,gdextreg,gddetach,gdclose


### PR DESCRIPTION
Several data assimilation obs readers require HDF-EOS2 support, but they
were checking for HDF4.  Thus if you disabled HDF-EOS2 at configure-time with

"Use HDFEOS? (1-yes, 0-no, default=1): 0"

then these routines would fail to compile.