### PR TITLE
Replace LDT/LIS/LVT_flush with intrinsic flush

### DIFF
--- a/ldt/DAobs/SMOPS/readSMOPSsmObs.F90
+++ b/ldt/DAobs/SMOPS/readSMOPSsmObs.F90
@@ -306,7 +306,7 @@ subroutine read_SMOPS_data(n, fname, smobs_ip)
       call grib_open_file(ftn,trim(fname),'r',iret)
       if(iret.ne.0) then
          write(LDT_logunit,*) 'Could not open file: ',trim(fname)
-         call LDT_flush(LDT_logunit)
+         flush(LDT_logunit)
          call LDT_endrun()
       endif
       call grib_multi_support_on

--- a/ldt/USAFSI/LDT_bratsethMod.F90
+++ b/ldt/USAFSI/LDT_bratsethMod.F90
@@ -313,7 +313,7 @@ contains
    subroutine LDT_bratseth_calc_inv_data_dens(this, silent)
 
       ! Imports
-      use LDT_logMod, only: LDT_logunit, LDT_flush
+      use LDT_logMod, only: LDT_logunit
 
       ! Defaults
       implicit none
@@ -492,7 +492,7 @@ contains
    subroutine LDT_bratseth_calc_ob_anas(this, converg_thresh, silent)
 
       ! Imports
-      use LDT_logMod, only: LDT_logunit, LDT_flush
+      use LDT_logMod, only: LDT_logunit
 
       ! Defaults
       implicit none
@@ -670,7 +670,7 @@ contains
                  this%npasses, ' iterations!'
             write(LDT_logunit,*) &
                  '[WARN] Will stop iterating'
-            call LDT_flush(LDT_logunit)
+            flush(LDT_logunit)
             exit
          end if
 

--- a/ldt/core/LDT_domainMod.F90
+++ b/ldt/core/LDT_domainMod.F90
@@ -1360,7 +1360,7 @@ end subroutine LDT_timeInit
                    '[ERR] No dominant surface model type found!'
               write(LDT_logunit,*) &
                    'c,r,fgrd: ',c,r,fgrd(c,r,:)
-              call LDT_flush(LDT_logunit)
+              flush(LDT_logunit)
               call LDT_endrun()
            end if
 
@@ -1395,7 +1395,7 @@ end subroutine LDT_timeInit
                    '[ERR] No surface tiles remain!'
               write(LDT_logunit,*) &
                    'c,r,fgrd: ',c,r,fgrd(c,r,:)
-              call LDT_flush(LDT_logunit)
+              flush(LDT_logunit)
               call LDT_endrun()
            end if
 

--- a/ldt/core/LDT_logMod.F90
+++ b/ldt/core/LDT_logMod.F90
@@ -34,7 +34,6 @@ module LDT_logMod
                              !  to the diagnostic log
   public :: LDT_abort        ! generates a standard abort message
   public :: LDT_alert        ! generates a standard alert message
-  public :: LDT_flush        ! flushes any unwrittend writes to the log
   public :: LDT_endrun       ! ends the program
   public :: LDT_verify       ! checks a return a code for success
   public :: LDT_warning      ! checks a return code and issue a warning
@@ -308,38 +307,7 @@ contains
 8000 format (a)   
       
   end subroutine LDT_alert
-!BOP
-!
-! !ROUTINE: LDT_flush
-! \label{LDT_flush}
-!   
-! !REVISION HISTORY: 
-!  16 Nov 2004    James Geiger Initial Specification
-! 
-  subroutine LDT_flush(unit)
-    
-    implicit none
-    
-    integer :: unit
-! 
-! !DESCRIPTION: 
-!   This routine is a generic interface to the system flush routine.
-!
-!   The arguments are: 
-!   \begin{description}
-!   \item [unit]
-!     unit to be flushed out 
-!   \end{description}
-!
-!EOP
 
-#if ( defined AIX )
-    call flush_(unit)
-#else
-    call flush(unit)
-#endif   
-  end subroutine LDT_flush
-  
 !BOP
 ! !ROUTINE: check_error
 ! 
@@ -496,7 +464,7 @@ contains
 !
 !EOP
     write(LDT_logunit,*)'endrun is being called'
-    call LDT_flush( LDT_logunit )   ! Flush all output to standard output
+    flush( LDT_logunit )   ! Flush all output to standard output
 
 #if (defined SPMD) 
 !    call mpi_abort (MPI_COMM_WORLD, 1)         ! LDT

--- a/ldt/core/LDT_logMod.F90
+++ b/ldt/core/LDT_logMod.F90
@@ -456,12 +456,6 @@ contains
 !  Routine to be called to terminate the program. This routine
 !  flushes the output streams and aborts the mpi processes.
 !
-!  The routines invoked are: 
-!  \begin{description}
-!   \item[LDT\_flush](\ref{LDT_flush}) \newline
-!     flushes the output streams
-!  \end{description}
-!
 !EOP
     write(LDT_logunit,*)'endrun is being called'
     flush( LDT_logunit )   ! Flush all output to standard output

--- a/ldt/runmodes/ANNproc/LDT_init_ANNproc.F90
+++ b/ldt/runmodes/ANNproc/LDT_init_ANNproc.F90
@@ -27,7 +27,7 @@
     call LDT_timeInit
     call LDT_domainInit
     call LDT_ANNinit()
-    call LDT_flush(LDT_logunit)
+    flush(LDT_logunit)
 
   end subroutine LDT_init_ANNproc
   

--- a/ldt/runmodes/ANNproc/LDT_run_ANNproc.F90
+++ b/ldt/runmodes/ANNproc/LDT_run_ANNproc.F90
@@ -27,7 +27,7 @@ subroutine LDT_run_ANNproc
            call LDT_readANNoutputData(n)
            call LDT_tavgANNdata(n)
            call LDT_outputANN(n)
-           call LDT_flush(LDT_logunit)
+           flush(LDT_logunit)
         enddo
      enddo
   enddo

--- a/ldt/runmodes/DApreproc/LDT_init_DApreproc.F90
+++ b/ldt/runmodes/DApreproc/LDT_init_DApreproc.F90
@@ -31,7 +31,7 @@
     call LDT_DApreprocInit
     call LDT_DAobsDataInit
     call LDT_DAmetricsInit
-    call LDT_flush(LDT_logunit)
+    flush(LDT_logunit)
 
   end subroutine LDT_init_DApreproc
   

--- a/ldt/runmodes/DApreproc/LDT_run_DApreproc.F90
+++ b/ldt/runmodes/DApreproc/LDT_run_DApreproc.F90
@@ -31,7 +31,7 @@ subroutine LDT_run_DApreproc
            call LDT_tavgDAobsData(n)
            call LDT_diagnoseDAobsMetrics(n,i)
            call LDT_computeDAobsMetrics(n,i)
-           call LDT_flush(LDT_logunit)
+           flush(LDT_logunit)
         enddo
      enddo
   enddo

--- a/ldt/runmodes/EnsRstpreproc/LDT_init_EnsRstpreproc.F90
+++ b/ldt/runmodes/EnsRstpreproc/LDT_init_EnsRstpreproc.F90
@@ -26,7 +26,7 @@
     call LDT_paramProcInit    
     call LDT_domainInit
     call LDT_ensRstInit
-    call LDT_flush(LDT_logunit)
+    flush(LDT_logunit)
 
   end subroutine LDT_init_EnsRstpreproc
   

--- a/ldt/runmodes/LISHydropreproc/LDT_init_LISHydropreproc.F90
+++ b/ldt/runmodes/LISHydropreproc/LDT_init_LISHydropreproc.F90
@@ -25,7 +25,7 @@
 
     call LDT_paramProcInit(flag)          
 
-    call LDT_flush(LDT_logunit)
+    flush(LDT_logunit)
 
   end subroutine LDT_init_LISHydropreproc
   

--- a/ldt/runmodes/LSMparamproc/LDT_init_LSMparamproc.F90
+++ b/ldt/runmodes/LSMparamproc/LDT_init_LSMparamproc.F90
@@ -23,7 +23,7 @@
 
     call LDT_paramProcInit          
 
-    call LDT_flush(LDT_logunit)
+    flush(LDT_logunit)
 
   end subroutine LDT_init_LSMparamproc
   

--- a/ldt/runmodes/MetTimeDScale/LDT_run_MetTimeDScale.F90
+++ b/ldt/runmodes/MetTimeDScale/LDT_run_MetTimeDScale.F90
@@ -45,7 +45,7 @@ subroutine LDT_run_MetTimeDScale
          call LDT_metforcing_reset()                  ! Reset metforcing variables
          call LDT_resetForcingVars()                  ! Reset variables
       enddo     ! Pass 1,2 loops
-      call LDT_flush(LDT_logunit)
+      flush(LDT_logunit)
    enddo        ! LDT runmode completed running
 
   write(LDT_logunit,*) "--------------------------------"

--- a/ldt/runmodes/Metforcproc/LDT_run_MetforcProc.F90
+++ b/ldt/runmodes/Metforcproc/LDT_run_MetforcProc.F90
@@ -27,7 +27,7 @@ subroutine LDT_run_MetforcProc
             call LDT_output_met_forcing(n)
 !        endif
       enddo
-      call LDT_flush(LDT_logunit)
+      flush(LDT_logunit)
    enddo
 
 

--- a/ldt/runmodes/NUWRFpreproc/LDT_init_NUWRFpreproc.F90
+++ b/ldt/runmodes/NUWRFpreproc/LDT_init_NUWRFpreproc.F90
@@ -23,7 +23,7 @@
     call LDT_paramProcConfig 
     call LDT_NUWRFprocInit
 !    call LDT_domainInit
-    call LDT_flush(LDT_logunit)
+    flush(LDT_logunit)
 
   end subroutine LDT_init_NUWRFpreproc
   

--- a/ldt/runmodes/OPTUEproc/LDT_init_OPTUEparamproc.F90
+++ b/ldt/runmodes/OPTUEproc/LDT_init_OPTUEparamproc.F90
@@ -26,7 +26,7 @@
 
     call LDT_optue_init
 
-    call LDT_flush(LDT_logunit)
+    flush(LDT_logunit)
 
   end subroutine LDT_init_OPTUEparamproc
   

--- a/ldt/runmodes/StatDscaleMetForc/LDT_run_StatDscaleMetForc.F90
+++ b/ldt/runmodes/StatDscaleMetForc/LDT_run_StatDscaleMetForc.F90
@@ -36,7 +36,7 @@ subroutine LDT_run_StatDscaleMetForc
         call LDT_metforcing_reset()               
         call LDT_resetForcingVars()               
      
-        call LDT_flush(LDT_logunit)
+        flush(LDT_logunit)
      enddo
 
   elseif(LDT_rc%statDscaleMode.eq."forecast") then 

--- a/ldt/runmodes/USAFSI/LDT_init_usafsi.F90
+++ b/ldt/runmodes/USAFSI/LDT_init_usafsi.F90
@@ -11,7 +11,7 @@ subroutine LDT_init_USAFSI()
 
    ! Imports
    use LDT_domainMod, only: LDT_setDomainSpecs
-   use LDT_logMod, only: LDT_logunit, LDT_flush
+   use LDT_logMod, only: LDT_logunit
    use LDT_paramProcMod, only: LDT_paramProcConfig
    use LDT_usafsiMod, only: LDT_usafsiInit
 
@@ -25,6 +25,6 @@ subroutine LDT_init_USAFSI()
    call LDT_setDomainSpecs()
    call LDT_paramProcConfig()
    call LDT_usafsiInit()
-   call LDT_flush(LDT_logunit)
+   flush(LDT_logunit)
 
 end subroutine LDT_init_USAFSI

--- a/ldt/runmodes/climoRstproc/LDT_init_climoRstproc.F90
+++ b/ldt/runmodes/climoRstproc/LDT_init_climoRstproc.F90
@@ -28,7 +28,7 @@
     call LDT_domainInit
     call LDT_climoRstProcInit
     call LDT_coreinit
-    call LDT_flush(LDT_logunit)
+    flush(LDT_logunit)
 
   end subroutine LDT_init_climoRstproc
   

--- a/ldt/runmodes/rstTransformProc/LDT_init_rstTransformProc.F90
+++ b/ldt/runmodes/rstTransformProc/LDT_init_rstTransformProc.F90
@@ -26,7 +26,7 @@
     call LDT_paramProcInit
     call LDT_domainInit
     call LDT_rstTransformProcInit
-    call LDT_flush(LDT_logunit)
+    flush(LDT_logunit)
 
   end subroutine LDT_init_rstTransformProc
   

--- a/lis/core/LIS_domainMod.F90
+++ b/lis/core/LIS_domainMod.F90
@@ -1026,7 +1026,7 @@ end subroutine LIS_quilt_b_domain
                    '[ERR] No dominant surface model type found!'
               write(LIS_logunit,*) &
                    'c,r,fgrd: ',c,r,fgrd(c,r,:)
-              call LIS_flush(LIS_logunit)
+              flush(LIS_logunit)
               call LIS_endrun()
            end if
 
@@ -1068,7 +1068,7 @@ end subroutine LIS_quilt_b_domain
                 "  Thus, surface tiles set to '0' for gridpoint:"
               write(LIS_logunit,*) &
                    'c,r,fgrd: ',c,r,fgrd(c,r,:)
-              call LIS_flush(LIS_logunit)
+              flush(LIS_logunit)
               call LIS_endrun()
            end if
 

--- a/lis/core/LIS_forecastMod.F90
+++ b/lis/core/LIS_forecastMod.F90
@@ -166,7 +166,7 @@ contains
        if (ios .ne. 0) then
           write(LIS_logunit,*)'[ERR] problem creating directory ', &
                trim(c_string)
-          call LIS_flush(LIS_logunit)
+          flush(LIS_logunit)
        end if
 #endif
        rst_fname = trim(LIS_rc%odir)//'/FCST/LIS_RST_FCST_'

--- a/lis/core/LIS_historyMod.F90
+++ b/lis/core/LIS_historyMod.F90
@@ -6008,7 +6008,7 @@ contains
                 elseif(form==2) then
                    write(ftn_stats,998) mvar,vmean,vstdev,vmin,vmax
                 endif
-                call lis_flush(ftn_stats)
+                flush(ftn_stats)
              endif
           endif
           deallocate(gtmp1)
@@ -6086,7 +6086,7 @@ contains
                 elseif(form==2) then
                    write(ftn_stats,998) mvar,vmean,vstdev,vmin,vmax
                 endif
-                call lis_flush(ftn_stats)
+                flush(ftn_stats)
              endif
           endif
           deallocate(gtmp)
@@ -6168,7 +6168,7 @@ contains
                    elseif(form==2) then
                       write(ftn_stats,998) mvar,vmean,vstdev,vmin,vmax
                    endif
-                   call lis_flush(ftn_stats)
+                   flush(ftn_stats)
                 endif
              endif
              deallocate(gtmp)
@@ -6270,7 +6270,7 @@ contains
                    elseif(form==2) then
                       write(ftn_stats,998) mvar,vmean,vstdev,vmin,vmax
                    endif
-                   call lis_flush(ftn_stats)
+                   flush(ftn_stats)
                 endif
              endif
              deallocate(gtmp_ens)
@@ -6420,7 +6420,7 @@ contains
                 elseif(form==2) then
                    write(ftn_stats,998) mvar,vmean,vstdev,vmin,vmax
                 endif
-                call lis_flush(ftn_stats)
+                flush(ftn_stats)
              endif
           endif
           deallocate(gtmp)
@@ -6502,7 +6502,7 @@ contains
                    elseif(form==2) then
                       write(ftn_stats,998) mvar,vmean,vstdev,vmin,vmax
                    endif
-                   call lis_flush(ftn_stats)
+                   flush(ftn_stats)
                 endif
              endif
              deallocate(gtmp)
@@ -6604,7 +6604,7 @@ contains
                    elseif(form==2) then
                       write(ftn_stats,998) mvar,vmean,vstdev,vmin,vmax
                    endif
-                   call lis_flush(ftn_stats)
+                   flush(ftn_stats)
                 endif
              endif
              deallocate(gtmp_ens)
@@ -8352,7 +8352,7 @@ subroutine write_stats(var, size, mvar, ftn_stats, form)
       elseif ( form == 2 ) then 
          write(ftn_stats,998) mvar,vmean,vstdev,vmin,vmax
       endif
-      call lis_flush(ftn_stats)
+      flush(ftn_stats)
    endif
 
 998 FORMAT(1X,A18,4E14.3)

--- a/lis/core/LIS_logMod.F90
+++ b/lis/core/LIS_logMod.F90
@@ -136,6 +136,8 @@ contains
 !     18 oct 2017 Replaced call to "abort" with call to LIS_endrun.  Also
 !                 all call to LIS_flush.  This helps write all data to
 !                 file and prevent hangs...................Eric Kemp/GSFC
+!     17 feb 2021 Replaced LIS_flush with calls to Fortran's intrinsic
+!                 flush routine.....................Brendan McAndrew/GSFC
 ! !INTERFACE:    
   subroutine LIS_abort( abort_message )
 
@@ -465,12 +467,6 @@ contains
 !  !DESCRIPTION: 
 !  Routine to be called to terminate the program. This routines 
 !  flushes the output streams and aborts the mpi processes.
-!
-!  The routines invoked are: 
-!  \begin{description}
-!   \item[LIS\_flush](\ref{LIS_flush}) \newline
-!     flushes the output streams
-!  \end{description}
 !
 !EOP
     write(LIS_logunit,*)'[ERR] endrun is being called'

--- a/lis/core/LIS_logMod.F90
+++ b/lis/core/LIS_logMod.F90
@@ -33,7 +33,6 @@ module LIS_logMod
                         ! to the diagnostic log
   public :: LIS_abort  ! generates a standard abort message
   public :: LIS_alert  ! generates a standard alert message
-  public :: LIS_flush ! flushes any unwrittend writes to the log
   public :: LIS_getNextUnitNumber   !get the next available unit number
   public :: LIS_releaseUnitNumber   !release the unit number!
   public :: LIS_endrun  ! Ends the program
@@ -190,7 +189,7 @@ contains
     do i = 1, 20
        write (ftn, 6000, err = 9000) abort_message(i)
     enddo
-    call LIS_flush(ftn) ! EMK
+    flush(ftn) ! EMK
     call LIS_releaseUnitNumber(ftn)
 
     ! EMK...Use LIS_endrun. Safer for MPI runs.
@@ -318,38 +317,7 @@ contains
 8000 format (a)   
       
   end subroutine LIS_alert
-!BOP
-!
-! !ROUTINE: LIS_flush
-! \label{LIS_flush}
-!   
-! !REVISION HISTORY: 
-!  16 Nov 2004    James Geiger Initial Specification
-! 
-  subroutine LIS_flush(unit)
-    
-    implicit none
-    
-    integer :: unit
-! 
-! !DESCRIPTION: 
-!   This routine is a generic interface to the system flush routine.
-!
-!   The arguments are: 
-!   \begin{description}
-!   \item [unit]
-!     unit to be flushed out 
-!   \end{description}
-!
-!EOP
-
-#if ( defined AIX )
-    call flush_(unit)
-#else
-    call flush(unit)
-#endif   
-  end subroutine LIS_flush
-  
+ 
 !BOP
 ! !ROUTINE: check_error
 ! 
@@ -506,7 +474,7 @@ contains
 !
 !EOP
     write(LIS_logunit,*)'[ERR] endrun is being called'
-    call lis_flush( LIS_logunit )   ! Flush all output to standard output
+    flush( LIS_logunit )   ! Flush all output to standard output
 #if (defined SPMD) 
     call mpi_abort (LIS_mpi_comm, 1, ierr)
 #else

--- a/lis/core/LIS_readConfig.F90
+++ b/lis/core/LIS_readConfig.F90
@@ -108,7 +108,7 @@ subroutine LIS_readConfig()
        if (ios .ne. 0) then
           write(LIS_logunit,*)'[ERR] Problem creating directory ', &
                trim(diag_dir)
-          call LIS_flush(LIS_logunit)
+          flush(LIS_logunit)
        end if
     end if
   endif

--- a/lis/metforcing/usaf/AGRMET_fillgaps.F90
+++ b/lis/metforcing/usaf/AGRMET_fillgaps.F90
@@ -15,7 +15,7 @@
 subroutine AGRMET_fillgaps(n,ip,varfield)
 ! !USES:
   use LIS_coreMod,       only : LIS_rc, LIS_domain
-  use LIS_logMod,        only : LIS_logunit, LIS_endrun, LIS_abort, LIS_flush
+  use LIS_logMod,        only : LIS_logunit, LIS_endrun, LIS_abort
   use AGRMET_forcingMod, only : agrmet_struc
 
   implicit none
@@ -89,7 +89,7 @@ subroutine AGRMET_fillgaps(n,ip,varfield)
                     ! EMK...Force abort with logging!
                     write(LIS_logunit,*) &
                          '[ERR] AGRMET fillgaps failed, stopping..',kk,c,r
-                    call LIS_flush(LIS_logunit)
+                    flush(LIS_logunit)
                     message(1) = 'program: LIS'
                     message(2) = ' routine: AGRMET_fillgaps'
                     message(3) = ' Cannot fill gap in forcing data!'

--- a/lis/metforcing/usaf/AGRMET_fldbld.F90
+++ b/lis/metforcing/usaf/AGRMET_fldbld.F90
@@ -24,7 +24,7 @@ subroutine AGRMET_fldbld(n,order,julhr)
 ! !USES: 
   use AGRMET_forcingMod, only : agrmet_struc
   use LIS_coreMod,       only : LIS_masterproc
-  use LIS_logMod,        only : LIS_logunit, LIS_endrun, LIS_abort, LIS_flush,&
+  use LIS_logMod,        only : LIS_logunit, LIS_endrun, LIS_abort,&
        LIS_alert
   use LIS_timeMgrMod,    only : LIS_julhr_date
 
@@ -105,7 +105,7 @@ subroutine AGRMET_fldbld(n,order,julhr)
                 '[ERR] No GFS background found for ',yyyymmddhh
         end if
         write(LIS_logunit,*) ' ABORTING!'
-        call LIS_flush(LIS_logunit)
+        flush(LIS_logunit)
         message(:) = ''
         message(1) = '[ERR] Program:  LIS'
         message(2) = '  Routine:  AGRMET_fldbld.'

--- a/lis/metforcing/usaf/AGRMET_fldbld_galwem.F90
+++ b/lis/metforcing/usaf/AGRMET_fldbld_galwem.F90
@@ -26,7 +26,7 @@
 subroutine AGRMET_fldbld_galwem(n,order,julhr,rc)
 ! !USES: 
   use LIS_coreMod,       only : LIS_rc
-  use LIS_logMod,        only : LIS_logunit, LIS_abort, LIS_verify, LIS_flush
+  use LIS_logMod,        only : LIS_logunit, LIS_abort, LIS_verify
   use LIS_timeMgrMod,    only : LIS_julhr_date
   use AGRMET_forcingMod, only : agrmet_struc
 
@@ -416,8 +416,7 @@ subroutine AGRMET_fldbld_read_galwem(n, fg_filename, ifguess, jfguess,     &
                                      agr_pres_sfc,rc)
 ! !USES:
   use LIS_coreMod, only : LIS_rc
-  use LIS_logMod,  only : LIS_logunit, LIS_abort, LIS_alert, LIS_verify, &
-       LIS_flush
+  use LIS_logMod,  only : LIS_logunit, LIS_abort, LIS_alert, LIS_verify
 
 #if (defined USE_GRIBAPI)
   use grib_api
@@ -707,7 +706,7 @@ subroutine AGRMET_fldbld_read_galwem(n, fg_filename, ifguess, jfguess,     &
      case default ! Internal error, we shouldn't be here
         write(LIS_logunit,*)'[WARN] Unknown grib_message ',grib_msg
         write(LIS_logunit,*)'Aborting...'
-        call LIS_flush(LIS_logunit)
+        flush(LIS_logunit)
         write(cstat,'(i9)',iostat=istat1) ierr
         message(1) = 'Program: LIS'
         message(2) = '  Subroutine:  AGRMET_fldbld_read_galwem.'

--- a/lis/metforcing/usaf/AGRMET_fldbld_gfs.F90
+++ b/lis/metforcing/usaf/AGRMET_fldbld_gfs.F90
@@ -1781,7 +1781,7 @@ integer function set_plevel(editionNumber,pds9,level)
 
    ! Imports
    use LIS_coreMod, only: LIS_masterproc
-   use LIS_logmod, only: LIS_logunit,LIS_flush,LIS_abort, &
+   use LIS_logmod, only: LIS_logunit,LIS_abort, &
       LIS_alert,LIS_endrun
    use LIS_mpiMod
 
@@ -1807,7 +1807,7 @@ integer function set_plevel(editionNumber,pds9,level)
         '[ERR] Unknown GRIB edition ',editionNumber
       write(LIS_logunit,*) &
         'ABORTING...'
-      call LIS_flush(LIS_logunit)
+      flush(LIS_logunit)
       messages(:) = ''
       messages(1) = '[ERR] Program: LIS'
       messages(2) = '  Routine: set_plevel'

--- a/lis/metforcing/usaf/EMK_precipMod.F90.qc_attempt
+++ b/lis/metforcing/usaf/EMK_precipMod.F90.qc_attempt
@@ -508,7 +508,7 @@ contains
       use AGRMET_forcingMod, only : agrmet_struc
       use LIS_coreMod, only: LIS_domain, LIS_rc
       use LIS_LMLCMod, only: LIS_LMLC
-      use LIS_logMod, only: LIS_logunit, LIS_flush, LIS_endrun
+      use LIS_logMod, only: LIS_logunit, LIS_endrun
 
       ! Defaults
       implicit none
@@ -565,7 +565,7 @@ contains
          write(LIS_logunit,*)'[ERR] Invalid imax dimension for SSM/I!'
          write(LIS_logunit,*)'Received ', imax
          write(LIS_logunit,*)'Only support 512, 1024, or 1400'
-         call LIS_flush(LIS_logunit)
+         flush(LIS_logunit)
          call LIS_endrun()         
       end if
 
@@ -629,7 +629,7 @@ contains
 
          write(LIS_logunit,*)'[ERR] Lat/lon SSM/I data not supported yet!'
          write(LIS_logunit,*)'Modify EMK_addSSMIObsData and recompile!'
-         call LIS_flush(LIS_logunit)
+         flush(LIS_logunit)
          call LIS_endrun()
 
       end if ! Lat/Lon case
@@ -885,7 +885,7 @@ contains
       use LIS_coreMod, only     : LIS_rc, LIS_masterproc, LIS_domain
       use LIS_fileIOMod, only: LIS_putget
       use LIS_LMLCMod, only: LIS_LMLC
-      use LIS_logMod, only: LIS_logunit, LIS_endrun, LIS_alert, LIS_flush
+      use LIS_logMod, only: LIS_logunit, LIS_endrun, LIS_alert
       use LIS_timeMgrMod, only : LIS_julhr_date
 
       ! Defaults
@@ -1003,7 +1003,7 @@ contains
                     '[ERR] Invalid imax dimension for GEO_PRECIP!'
                write(LIS_logunit,*)'Received ',imax
                write(LIS_logunit,*)'Only support 512, 1024, or 4096!'
-               call LIS_flush(LIS_logunit)
+               flush(LIS_logunit)
                call LIS_endrun()
             end if
 
@@ -1204,7 +1204,7 @@ contains
                        '[ERR] Lat/lon GEO_PRECIP data not supported yet!'
                   write(LIS_logunit,*)&
                        'Modify EMK_addGeoPrecipObsData and recompile!'
-                  call LIS_flush(LIS_logunit)
+                  flush(LIS_logunit)
                   call LIS_endrun()
 
                end if
@@ -1923,7 +1923,7 @@ contains
 
       ! Imports
       use LIS_coreMod, only: LIS_npes, LIS_localPet, LIS_rc, LIS_domain
-      use LIS_logMod, only : LIS_logunit, LIS_endrun, LIS_flush, LIS_endrun
+      use LIS_logMod, only : LIS_logunit, LIS_endrun, LIS_endrun
       use LIS_mpiMod
 
       ! Defaults
@@ -4413,7 +4413,7 @@ contains
 
       ! Imports
       use LIS_coreMod, only: LIS_rc
-      use LIS_logMod, only: LIS_logunit, LIS_flush
+      use LIS_logMod, only: LIS_logunit
 
       ! Defaults
       implicit none

--- a/lis/metforcing/usaf/USAF_ImergHHMod.F90
+++ b/lis/metforcing/usaf/USAF_ImergHHMod.F90
@@ -163,7 +163,7 @@ contains
       use HDF5
 #endif
       use LIS_coreMod, only: LIS_masterproc
-      use LIS_logMod, only:  LIS_logunit, LIS_abort, LIS_flush, LIS_endrun, &
+      use LIS_logMod, only:  LIS_logunit, LIS_abort, LIS_endrun, &
            LIS_alert
       use LIS_mpiMod
 
@@ -202,7 +202,7 @@ contains
               '[ERR] update30minImergHHPrecip Invalid time level ',itime
          write(LIS_logunit,*) 'Must be in range from 1 to ',this%ntimes
          write(LIS_logunit,*)'Must be in range from 1 to ',this%ntimes
-         call LIS_flush(LIS_logunit)
+         flush(LIS_logunit)
          message(:) = ''
          message(1) = '[ERR] Program:  LIS'
          message(2) = '  Routine: update30minImergHHPrecip.'
@@ -357,7 +357,7 @@ contains
       write(LIS_logunit,*) &
            'Recompile with HDF5 and try again!'
       write(LIS_logunit,*)'ABORTING'
-      call LIS_flush(LIS_logunit)
+      flush(LIS_logunit)
       message(:) = ''
       message(1) = '[ERR] Program: LIS'
       message(2) = '  Routine update30minImergHHPrecip.'
@@ -989,7 +989,7 @@ contains
       ! Imports
       use ESMF
       use LIS_coreMod, only: LIS_masterproc
-      use LIS_logMod, only:  LIS_logunit, LIS_abort, LIS_flush, LIS_endrun, &
+      use LIS_logMod, only:  LIS_logunit, LIS_abort, LIS_endrun, &
            LIS_alert
 #if (defined SPMD)
       use LIS_mpiMod, only: LIS_MPI_COMM
@@ -1101,7 +1101,7 @@ contains
               '[ERR] Valid options are 3B-HHR, 3B-HHR-E, 3B-HHR-L'
          write(LIS_logunit,*) &
               '[ERR] Found ',trim(product)
-         call LIS_flush(LIS_logunit)
+         flush(LIS_logunit)
          message(:) = ''
          message(1) = '[ERR] Program:  LIS'
          message(2) = '  Routine: create_imerg_HH_filename.'

--- a/lis/metforcing/usaf/USAF_bratsethMod.F90
+++ b/lis/metforcing/usaf/USAF_bratsethMod.F90
@@ -604,7 +604,7 @@ contains
 
       ! Imports
       use AGRMET_forcingMod, only : agrmet_struc
-      use LIS_logMod, only: LIS_logunit, LIS_flush, LIS_endrun
+      use LIS_logMod, only: LIS_logunit, LIS_endrun
 
       ! Defaults
       implicit none
@@ -658,7 +658,7 @@ contains
          write(LIS_logunit,*)'[ERR] Invalid imax dimension for SSM/I!'
          write(LIS_logunit,*)'Received ', imax
          write(LIS_logunit,*)'Only support 512, 1024, or 1400'
-         call LIS_flush(LIS_logunit)
+         flush(LIS_logunit)
          call LIS_endrun()
       end if
 
@@ -725,7 +725,7 @@ contains
 
          write(LIS_logunit,*)'[ERR] Lat/lon SSM/I data not supported yet!'
          write(LIS_logunit,*)'Modify USAF_addSSMIObsData and recompile!'
-         call LIS_flush(LIS_logunit)
+         flush(LIS_logunit)
          call LIS_endrun()
 
       end if ! Lat/Lon case
@@ -748,7 +748,7 @@ contains
       use AGRMET_forcingMod, only: agrmet_struc
       use LIS_coreMod, only: LIS_rc, LIS_masterproc
       use LIS_logMod, only: LIS_abort, LIS_endrun, LIS_getNextUnitNumber, &
-           LIS_releaseUnitNumber, LIS_logunit, LIS_flush, LIS_alert
+           LIS_releaseUnitNumber, LIS_logunit, LIS_alert
       use LIS_mpiMod
       use LIS_timeMgrMod, only: LIS_julhr_date
 
@@ -855,7 +855,7 @@ contains
             write(LIS_logunit,*) &
                  '[ERR] No NWP background precipitation found for ',yyyymmddhh
             write(LIS_logunit,*) ' ABORTING!'
-            call LIS_flush(LIS_logunit)
+            flush(LIS_logunit)
             message(:) = ''
             message(1) = '[ERR] Program:  LIS'
             message(2) = '  Routine:  USAF_getBackNWP.'
@@ -1073,7 +1073,7 @@ contains
       use AGRMET_forcingMod, only : agrmet_struc
       use LIS_coreMod, only     : LIS_masterproc
       use LIS_fileIOMod, only: LIS_putget
-      use LIS_logMod, only: LIS_logunit, LIS_endrun, LIS_alert, LIS_flush
+      use LIS_logMod, only: LIS_logunit, LIS_endrun, LIS_alert
       use LIS_timeMgrMod, only : LIS_julhr_date
 
       ! Defaults
@@ -1196,7 +1196,7 @@ contains
                     '[ERR] Invalid imax dimension for GEO_PRECIP!'
                write(LIS_logunit,*)'Received ',imax
                write(LIS_logunit,*)'Only support 512, 1024, or 4096!'
-               call LIS_flush(LIS_logunit)
+               flush(LIS_logunit)
                call LIS_endrun()
             end if
 
@@ -1402,7 +1402,7 @@ contains
                        '[ERR] Lat/lon GEO_PRECIP data not supported yet!'
                   write(LIS_logunit,*)&
                        'Modify USAF_addGeoPrecipObsData and recompile!'
-                  call LIS_flush(LIS_logunit)
+                  flush(LIS_logunit)
                   call LIS_endrun()
 
                end if
@@ -1779,7 +1779,7 @@ contains
 
       ! Imports
       use LIS_coreMod, only: LIS_localPet, LIS_rc
-      use LIS_logMod, only : LIS_logunit, LIS_endrun, LIS_flush, LIS_endrun
+      use LIS_logMod, only : LIS_logunit, LIS_endrun, LIS_endrun
       use LIS_mpiMod
 
       ! Defaults
@@ -1895,7 +1895,7 @@ contains
                                 '[ERR]: job, network, oErrScaleLength: ', &
                                 job, trim(this%net(job)), &
                                 this%oErrScaleLength(job)
-                           call LIS_flush(LIS_logunit)
+                           flush(LIS_logunit)
                         end if
 
                         num = num + &
@@ -1984,7 +1984,7 @@ contains
       ! Imports
       use AGRMET_forcingMod, only: agrmet_struc
       use LIS_coreMod, only : LIS_localPet, LIS_rc
-      use LIS_logMod, only : LIS_logunit, LIS_endrun, LIS_flush
+      use LIS_logMod, only : LIS_logunit, LIS_endrun
       use LIS_mpiMod
       use USAF_OBAMod, only: OBA, createOBA, assignOBA
 
@@ -2347,7 +2347,7 @@ contains
               ' iterations!'
 	   write(LIS_logunit,*) &
 	      '[WARN] Will stop iterating'
-           call LIS_flush(LIS_logunit)
+           flush(LIS_logunit)
 	   exit
 	end if
       end do ! Iterate until convergence
@@ -3111,7 +3111,7 @@ contains
       write(LIS_logunit,*) &
            '[ERR] check_grib_file requires GRIB-API or ECCODES library'
       write(LIS_logunit,*) '[ERR] please recompile LIS'
-      call LIS_flush(LIS_logunit)
+      flush(LIS_logunit)
       message(:) = ''
       message(1) = '[ERR] Program:  LIS'
       message(2) = '  Routine: check_grib_file.'
@@ -6212,7 +6212,7 @@ contains
 
       ! Imports
       use AGRMET_forcingMod, only : agrmet_struc
-      use LIS_logMod, only: LIS_endrun, LIS_flush, LIS_logunit
+      use LIS_logMod, only: LIS_endrun, LIS_logunit
 
       ! Defaults
       implicit none
@@ -6281,7 +6281,7 @@ contains
               'Source is ',trim(src)
          write(LIS_logunit, *) &
               'ABORTING....'
-         call LIS_flush(LIS_logunit)
+         flush(LIS_logunit)
          call LIS_endrun()
       end if
 !      TRACE_EXIT("bratseth_setPrcpStats")
@@ -6296,7 +6296,7 @@ contains
 
       ! Imports
       use AGRMET_forcingMod, only : agrmet_struc
-      use LIS_logMod, only: LIS_endrun, LIS_flush, LIS_logunit
+      use LIS_logMod, only: LIS_endrun, LIS_logunit
 
       ! Defaults
       implicit none
@@ -6369,7 +6369,7 @@ contains
               'Source is ',trim(src)
          write(LIS_logunit, *) &
               'ABORTING....'
-         call LIS_flush(LIS_logunit)
+         flush(LIS_logunit)
          call LIS_endrun()
       end if
       TRACE_EXIT("bratseth_setScrnStats")

--- a/lis/metforcing/usaf/readagrmetpcpforcinganalysis.F90
+++ b/lis/metforcing/usaf/readagrmetpcpforcinganalysis.F90
@@ -20,7 +20,7 @@ subroutine readagrmetpcpforcinganalysis(n,findex, order)
 ! !USES:
   use LIS_coreMod, only         : LIS_rc,LIS_domain, LIS_masterproc
   use LIS_timeMgrMod, only      : LIS_julhr_date, LIS_get_julhr
-  use LIS_logMod, only          : LIS_logunit, lis_flush, LIS_endrun
+  use LIS_logMod, only          : LIS_logunit, LIS_endrun
   use LIS_fileIOMod, only       : LIS_putget
   use AGRMET_forcingMod, only : agrmet_struc
 

--- a/lis/metforcing/usaf/readcrd_agrmet.F90
+++ b/lis/metforcing/usaf/readcrd_agrmet.F90
@@ -38,7 +38,7 @@ subroutine readcrd_agrmet()
   use ESMF
   use LIS_coreMod,    only : LIS_rc, LIS_config, LIS_masterproc
   use LIS_logMod,     only : LIS_logunit, LIS_verify, LIS_abort, &
-       LIS_flush, LIS_endrun
+       LIS_endrun
 #if (defined SPMD)
   use LIS_mpiMod, only: LIS_MPI_COMM
 #endif
@@ -293,7 +293,7 @@ subroutine readcrd_agrmet()
         write(LIS_logunit,*) &
              '[ERR] Illegal value for IMERG Probability Liquid Precip Threshold'
         write(LIS_logunit,*)'ABORTING!'
-        call LIS_flush(LIS_logunit)
+        flush(LIS_logunit)
         message(1) = &             
              '[ERR] Illegal value for IMERG Probability Liquid Precip Threshold'           
 #if (defined SPMD)
@@ -1107,7 +1107,7 @@ subroutine readcrd_agrmet()
         if (ios .ne. 0) then
            write(LIS_logunit,*)'ERR creating directory ', &
                 trim(agrmet_struc(n)%analysisdir)
-           call LIS_flush(LIS_logunit)
+           flush(LIS_logunit)
         end if
      end if
 

--- a/lis/optUE/algorithm/GA/GeneticAlgorithm.F90
+++ b/lis/optUE/algorithm/GA/GeneticAlgorithm.F90
@@ -425,7 +425,7 @@ module GeneticAlgorithm
 ! !USES:   
       use LIS_coreMod
       use LIS_optUEMod,        only : LIS_ObjectiveFunc, LIS_feasibleSpace
-      use LIS_logMod,          only : LIS_flush, LIS_logunit, LIS_verify, LIS_endrun
+      use LIS_logMod,          only : LIS_logunit, LIS_verify, LIS_endrun
 
 ! 
 ! !DESCRIPTION: 

--- a/lis/optUE/algorithm/SCEUA/ShuffledComplexEvolution.F90
+++ b/lis/optUE/algorithm/SCEUA/ShuffledComplexEvolution.F90
@@ -956,7 +956,7 @@ module ShuffledComplexEvolution
 ! !USES:   
     use LIS_coreMod,         only : LIS_rc
     use LIS_optUEMod,        only : LIS_ObjectiveFunc, LIS_feasibleSpace
-    use LIS_logMod,          only : LIS_flush, LIS_logunit, LIS_verify
+    use LIS_logMod,          only : LIS_logunit, LIS_verify
 ! 
 ! !DESCRIPTION: 
 !   This method computes the objective function values for each parameter set,

--- a/lis/runmodes/RTMforward/RTMforward_runMod.F90
+++ b/lis/runmodes/RTMforward/RTMforward_runMod.F90
@@ -119,7 +119,7 @@ contains
          LIS_routing_writerestart
     use LIS_RTMMod,          only : LIS_RTM_run,LIS_RTM_output
     use LIS_appMod,         only : LIS_runAppModel, LIS_outputAppModel
-    use LIS_logMod,          only : LIS_flush, LIS_logunit
+    use LIS_logMod,          only : LIS_logunit
 !
 ! !DESCRIPTION:
 ! 
@@ -178,7 +178,7 @@ contains
              call LIS_outputAppModel(n)
           endif
        enddo
-       call LIS_flush(LIS_logunit)
+       flush(LIS_logunit)
     enddo
   end subroutine lis_run_RTMforward
 

--- a/lis/runmodes/agrmetmode/agrmet_runMod.F90
+++ b/lis/runmodes/agrmetmode/agrmet_runMod.F90
@@ -115,7 +115,7 @@ contains
     use LIS_DAobservationsMod, only : LIS_readDAobservations, &
                                       LIS_perturb_DAobservations
     use LIS_dataAssimMod,      only : LIS_dataassim_run, LIS_dataassim_output
-    use LIS_logMod,            only : LIS_flush, LIS_logunit
+    use LIS_logMod,            only : LIS_logunit
 !
 ! !DESCRIPTION:
 ! 
@@ -177,7 +177,7 @@ contains
           endif
        enddo
        call LIS_ticktime 
-       call LIS_flush(LIS_logunit)
+       flush(LIS_logunit)
     enddo
   end subroutine lis_run_agrmet
 

--- a/lis/runmodes/forecast/forecast_runMod.F90
+++ b/lis/runmodes/forecast/forecast_runMod.F90
@@ -196,7 +196,7 @@ contains
                 call LIS_outputAppModel(n)
              endif
           enddo
-          call LIS_flush(LIS_logunit)
+          flush(LIS_logunit)
        enddo
 
  !      call LIS_forecast_writerestart

--- a/lis/runmodes/gce_cpl_mode/lis_gce_run.F90
+++ b/lis/runmodes/gce_cpl_mode/lis_gce_run.F90
@@ -21,7 +21,7 @@ subroutine lis_gce_run()
   use LIS_DAobservationsMod, only : LIS_readDAobservations, &
        LIS_perturb_DAobservations
   use LIS_dataAssimMod,    only : LIS_dataassim_run, LIS_dataassim_output
-  use LIS_logMod,          only : lis_flush, LIS_logunit, LIS_verify
+  use LIS_logMod,          only : LIS_logunit, LIS_verify
   use lisgceGridCompMod,   only : lisgce_import, lisgce_export
 
   implicit none
@@ -125,7 +125,7 @@ subroutine lis_gce_run()
   call LIS_surfaceModel_run(n)
   call LIS_surfaceModel_output(n)  
   call LIS_surfaceModel_writerestart(n)
-  call LIS_flush(LIS_logunit)
+  flush(LIS_logunit)
 
   call LIS_surfaceModel_setexport(n)
   

--- a/lis/runmodes/landslide_optUE/landslideOptUE_runMod.F90
+++ b/lis/runmodes/landslide_optUE/landslideOptUE_runMod.F90
@@ -103,7 +103,7 @@ contains
     use LIS_coreMod,         only : LIS_rc
     use LIS_optUEMod, only : LIS_isOptStopCriterionTrue,&
          LIS_runOptUE
-    use LIS_logMod,          only : LIS_logunit, LIS_flush
+    use LIS_logMod,          only : LIS_logunit
 !
 ! !DESCRIPTION:
 ! 

--- a/lis/runmodes/paramEstimation/paramEstim_runMod.F90
+++ b/lis/runmodes/paramEstimation/paramEstim_runMod.F90
@@ -119,12 +119,12 @@ contains
     use LIS_appMod,          only : LIS_appModel_init
     use LIS_paramsMod,       only : LIS_param_reset, LIS_param_init, LIS_param_finalize
     use LIS_timeMgrMod,      only : LIS_resetClock, LIS_timemgr_init
-    use LIS_logMod,          only : LIS_flush, LIS_logunit
+    use LIS_logMod,          only : LIS_logunit
     use LIS_optUEMod
     use LIS_PE_HandlerMod,   only : LIS_readPEobs, LIS_computePEobjectiveFunc,&
          LIS_resetPEObjectiveFunc, LIS_resetPEobs,LIS_updatePEObjectiveFunc,&
          LIS_setPEDecisionSpace
-    use LIS_logMod,          only : LIS_logunit, LIS_flush
+    use LIS_logMod,          only : LIS_logunit
 !
 ! !DESCRIPTION:
 ! 
@@ -180,7 +180,7 @@ contains
     use LIS_routingMod,      only : LIS_routing_run, LIS_routing_writeoutput, &
          LIS_routing_writerestart
     use LIS_RTMMod,          only : LIS_RTM_run,LIS_RTM_output
-    use LIS_logMod,          only : LIS_flush, LIS_logunit
+    use LIS_logMod,          only : LIS_logunit
 
     integer, intent(in) :: n
 

--- a/lis/runmodes/retrospective/retrospective_runMod.F90
+++ b/lis/runmodes/retrospective/retrospective_runMod.F90
@@ -125,7 +125,7 @@ contains
     use LIS_irrigationMod,     only : LIS_irrigation_run,LIS_irrigation_output
     use LIS_appMod,            only : LIS_runAppModel, LIS_outputAppModel
     use LIS_RTMMod,            only : LIS_RTM_run, LIS_RTM_output
-    use LIS_logMod,            only : LIS_flush, LIS_logunit
+    use LIS_logMod,            only : LIS_logunit
 !
 ! !DESCRIPTION:
 ! 
@@ -214,7 +214,7 @@ contains
              call LIS_outputAppModel(n)
           endif
        enddo
-       call LIS_flush(LIS_logunit)
+       flush(LIS_logunit)
     enddo
   end subroutine lis_run_retrospective
 
@@ -225,7 +225,7 @@ contains
   subroutine lis_final_retrospective
 ! !USES:
     use LIS_coreMod,         only : LIS_finalize
-    use LIS_logMod,          only : LIS_flush, LIS_logunit
+    use LIS_logMod,          only : LIS_logunit
     use LIS_surfaceModelMod, only : LIS_surfaceModel_finalize
     use LIS_paramsMod,       only : LIS_param_finalize
     use LIS_metforcingMod,   only : LIS_metforcing_finalize

--- a/lis/runmodes/smootherDA/smootherDA_runMod.F90
+++ b/lis/runmodes/smootherDA/smootherDA_runMod.F90
@@ -168,7 +168,7 @@ contains
                 call updateIncrementsFlag(n)
              endif
           enddo
-          call LIS_flush(LIS_logunit)
+          flush(LIS_logunit)
        enddo
 
        if(LIS_rc%endtime.ne.1) then 

--- a/lis/runmodes/wrf_cpl_mode/liswrffinalize_coupled.F90
+++ b/lis/runmodes/wrf_cpl_mode/liswrffinalize_coupled.F90
@@ -20,7 +20,7 @@ subroutine liswrffinalize_coupled()
   use LIS_timeMgrMod,        only : LIS_timemgr_set
   use LIS_surfaceModelMod,   only : LIS_surfaceModel_output,         &
                                     LIS_surfaceModel_writerestart
-  use LIS_logMod,            only : LIS_verify, LIS_flush, LIS_logunit
+  use LIS_logMod,            only : LIS_verify, LIS_logunit
   use LIS_irrigationMod,     only : LIS_irrigation_output ! EMK
 !EOP
  
@@ -53,6 +53,6 @@ subroutine liswrffinalize_coupled()
 
   write(unit=LIS_logunit,fmt=*) 'LIS cycle completed'
 
- call LIS_flush(LIS_logunit)
+ flush(LIS_logunit)
 
 end subroutine liswrffinalize_coupled

--- a/lis/runmodes/wrf_cpl_mode/liswrfinit_coupled.F90
+++ b/lis/runmodes/wrf_cpl_mode/liswrfinit_coupled.F90
@@ -26,7 +26,7 @@ subroutine liswrfinit_coupled(nx,ny,wrf_mpi_comm_compute_tasks)
   use LIS_dataAssimMod,    only : LIS_dataassim_init
   use LIS_paramsMod,        only : LIS_param_init
   use LISWRFGridCompMod,    only : LISWRF_alloc_states
-  use LIS_logMod,           only : LIS_logunit, LIS_flush
+  use LIS_logMod,           only : LIS_logunit
 
   use LIS_tbotAdjustMod,    only : LIS_createTmnUpdate
   use LIS_irrigationMod,    only : LIS_irrigation_init ! EMK
@@ -75,7 +75,7 @@ subroutine liswrfinit_coupled(nx,ny,wrf_mpi_comm_compute_tasks)
        call LISWRF_alloc_states
        call LIS_core_init
 
-       call LIS_flush(LIS_logunit)
+       flush(LIS_logunit)
        LIS_initialized = .true.
 
     endif

--- a/lis/runmodes/wrf_cpl_mode/liswrfrun_coupled.F90
+++ b/lis/runmodes/wrf_cpl_mode/liswrfrun_coupled.F90
@@ -270,6 +270,6 @@ subroutine liswrfrun_coupled(n)
 
   call LIS_surfaceModel_setexport(n)
 
-  call LIS_flush(LIS_logunit)
+  flush(LIS_logunit)
 
 end subroutine liswrfrun_coupled

--- a/lis/surfacemodels/land/noah.2.7.1/SFLXALL_SRC_VER_2.7.1.F90.old
+++ b/lis/surfacemodels/land/noah.2.7.1/SFLXALL_SRC_VER_2.7.1.F90.old
@@ -489,7 +489,7 @@
       ELSE
         SNDENS = SNEQV/SNOWH
         if(snowh < sneqv) write(logunit,*)'snow ',ntl,sneqv,snowh, sndens
-        call LIS_flush(logunit)
+        flush(logunit)
         SNCOND = CSNOW(SNDENS) 
       ENDIF
 

--- a/lis/surfacemodels/land/noah.2.7.1/SFLXALL_SRC_VER_2.7.1.F90.wrf
+++ b/lis/surfacemodels/land/noah.2.7.1/SFLXALL_SRC_VER_2.7.1.F90.wrf
@@ -488,7 +488,7 @@
       ELSE
         SNDENS = SNEQV/SNOWH
         if(snowh < sneqv) write(logunit,*)'snow ',ntl,sneqv,snowh, sndens
-        call LIS_flush(logunit)
+        flush(logunit)
         SNCOND = CSNOW(SNDENS) 
       ENDIF
 

--- a/lvt/core/LVT_domainMod.F90
+++ b/lvt/core/LVT_domainMod.F90
@@ -2051,7 +2051,7 @@ contains
                    '[ERR] No dominant surface model type found!'
               write(LVT_logunit,*) &
                    'c,r,fgrd: ',c,r,fgrd(c,r,:)
-              call LVT_flush(LVT_logunit)
+              flush(LVT_logunit)
               call LVT_endrun()
            end if
 
@@ -2086,7 +2086,7 @@ contains
                    '[ERR] No surface tiles remain!'
               write(LVT_logunit,*) &
                    'c,r,fgrd: ',c,r,fgrd(c,r,:)
-              call LVT_flush(LVT_logunit)
+              flush(LVT_logunit)
               call LVT_endrun()
            end if
 

--- a/lvt/core/LVT_logMod.F90
+++ b/lvt/core/LVT_logMod.F90
@@ -51,7 +51,6 @@ module LVT_logMod
                         ! to the diagnostic log
   public :: LVT_abort  ! generates a standard abort message
   public :: LVT_alert  ! generates a standard alert message
-  public :: LVT_flush ! flushes any unwrittend writes to the log
   public :: LVT_getNextUnitNumber   !get the next available unit number
   public :: LVT_releaseUnitNumber   !release the unit number!
   public :: LVT_endrun
@@ -385,47 +384,7 @@ contains
 8000 format (a)   
       
   end subroutine LVT_alert
-!BOP
-! 
-! !ROUTINE: LVT_flush
-! \label{LVT_flush}
-!
-! !INTERFACE:
-  subroutine LVT_flush(unit)
-! 
-! !USES:   
-    implicit none
-!
-! !INPUT PARAMETERS: 
-! 
-! !OUTPUT PARAMETERS:
-!
-! !DESCRIPTION: 
-!   This routine is a generic interface to the system flush routine.
-!
-!   The arguments are: 
-!   \begin{description}
-!   \item [unit]
-!     unit to be flushed out 
-!   \end{description}
-! 
-! !FILES USED:
-!
-! !REVISION HISTORY: 
-!  16 Nov 2004    James Geiger Initial Specification
-! 
-!EOP
-!BOP
-    integer :: unit
-!EOP
-
-#if ( defined AIX )
-    call flush_(unit)
-#else
-    call flush(unit)
-#endif   
-  end subroutine LVT_flush
-  
+ 
 !BOP
 ! 
 ! !ROUTINE: check_error

--- a/lvt/runmodes/557post/LVT_init_557post.F90
+++ b/lvt/runmodes/557post/LVT_init_557post.F90
@@ -66,7 +66,7 @@
     call LVT_statsInit()
     call LVT_checkTavgSpecs()
     call LVT_core_init()
-    call LVT_flush(LVT_logunit)
+    flush(LVT_logunit)
     
   end subroutine LVT_init_557post
   

--- a/lvt/runmodes/557post/LVT_run_557post.F90
+++ b/lvt/runmodes/557post/LVT_run_557post.F90
@@ -52,7 +52,7 @@ subroutine LVT_run_557post
         call LVT_tavgDataStreams
         call LVT_writeDataStreams
         call LVT_resetDataStreams
-        call LVT_flush(LVT_logunit)
+        flush(LVT_logunit)
      enddo
   enddo
   write(LVT_logunit,*) '[INFO] Finished LVT analysis'

--- a/lvt/runmodes/Benchmarking/LVT_init_Benchmarking.F90
+++ b/lvt/runmodes/Benchmarking/LVT_init_Benchmarking.F90
@@ -43,7 +43,7 @@
     call LVT_DataStreamsinit()
     call LVT_trainingInit()
     call LVT_checkTavgSpecs()
-    call LVT_flush(LVT_logunit)
+    flush(LVT_logunit)
 
   end subroutine LVT_init_Benchmarking
   

--- a/lvt/runmodes/Benchmarking/LVT_run_Benchmarking.F90
+++ b/lvt/runmodes/Benchmarking/LVT_run_Benchmarking.F90
@@ -53,7 +53,7 @@ subroutine LVT_run_Benchmarking
         call LVT_runTraining(i)
         call LVT_writeTrainingOutput(i)
         call LVT_resetDataStreams
-        call LVT_flush(LVT_logunit)
+        flush(LVT_logunit)
      enddo    
   enddo
   write(LVT_logunit,*) '[INFO] Finished LVT analysis'

--- a/lvt/runmodes/DAobs/LVT_init_DAobs.F90
+++ b/lvt/runmodes/DAobs/LVT_init_DAobs.F90
@@ -42,6 +42,6 @@
     call LVT_LISModelDataInit()
     call LVT_obsDataInit()
     call LVT_statsInit()
-    call LVT_flush(LVT_logunit)
+    flush(LVT_logunit)
 
   end subroutine LVT_init_DAobs

--- a/lvt/runmodes/DAobs/LVT_run_DAobs.F90
+++ b/lvt/runmodes/DAobs/LVT_run_DAobs.F90
@@ -56,7 +56,7 @@ subroutine LVT_run_DAobs
         call LVT_tavgObsData
         call LVT_diagnoseStats(i)
         call LVT_computeStats(i)
-        call LVT_flush(LVT_logunit)
+        flush(LVT_logunit)
      enddo    
   enddo
 

--- a/lvt/runmodes/DAstats/LVT_init_DAstats.F90
+++ b/lvt/runmodes/DAstats/LVT_init_DAstats.F90
@@ -37,7 +37,7 @@
     call LVT_domainInit()
     call LVT_statsInit()
     call LVT_DAInit()
-    call LVT_flush(LVT_logunit)
+    flush(LVT_logunit)
 
   end subroutine LVT_init_DAstats
   

--- a/lvt/runmodes/DAstats/LVT_run_DAstats.F90
+++ b/lvt/runmodes/DAstats/LVT_run_DAstats.F90
@@ -46,7 +46,7 @@ subroutine LVT_run_DAstats
         call LVT_readDataMask
         call LVT_readLISDAData(i)
         call LVT_computeDAStats(i)
-        call LVT_flush(LVT_logunit)
+        flush(LVT_logunit)
      enddo    
   enddo
 end subroutine LVT_run_DAstats

--- a/lvt/runmodes/DataComp/LVT_init_DataComp.F90
+++ b/lvt/runmodes/DataComp/LVT_init_DataComp.F90
@@ -44,7 +44,7 @@
     call LVT_statsInit()
     call LVT_checkTavgSpecs()
     call LVT_core_init()
-    call LVT_flush(LVT_logunit)
+    flush(LVT_logunit)
 
   end subroutine LVT_init_DataComp
   

--- a/lvt/runmodes/DataComp/LVT_run_DataComp.F90
+++ b/lvt/runmodes/DataComp/LVT_run_DataComp.F90
@@ -54,7 +54,7 @@ subroutine LVT_run_DataComp
         call LVT_diagnoseStats(i)
         call LVT_computeStats(i)
         call LVT_resetDataStreams
-        call LVT_flush(LVT_logunit)
+        flush(LVT_logunit)
      enddo
   enddo
   write(LVT_logunit,*) '[INFO] Finished LVT analysis'

--- a/lvt/runmodes/USAFSIpost/LVT_init_USAFSIpost.F90
+++ b/lvt/runmodes/USAFSIpost/LVT_init_USAFSIpost.F90
@@ -11,7 +11,7 @@
 subroutine LVT_init_USAFSIpost()
 
    ! Imports
-   use LVT_logmod, only: LVT_logunit, LVT_endrun, LVT_flush
+   use LVT_logmod, only: LVT_logunit, LVT_endrun
 
    ! Defaults
    implicit none
@@ -20,7 +20,7 @@ subroutine LVT_init_USAFSIpost()
    call read_usafsipost_settings()
 
    ! Other initialize steps
-   call LVT_flush(LVT_logunit)
+   flush(LVT_logunit)
 
 contains
 

--- a/lvt/runmodes/optUE/LVT_init_optUE.F90
+++ b/lvt/runmodes/optUE/LVT_init_optUE.F90
@@ -35,7 +35,7 @@
     
     call LVT_domainInit()
     call LVT_optUEInit()
-    call LVT_flush(LVT_logunit)
+    flush(LVT_logunit)
 
   end subroutine LVT_init_optUE
   

--- a/lvt/runmodes/optUE/LVT_run_optUE.F90
+++ b/lvt/runmodes/optUE/LVT_run_optUE.F90
@@ -40,7 +40,7 @@ subroutine LVT_run_optUE
   do i=1,LVT_optuectl%maxIter
      call LVT_readoptUEData(i)
      call LVT_computeoptUEStats(i)
-     call LVT_flush(LVT_logunit)
+     flush(LVT_logunit)
   enddo
 end subroutine LVT_run_optUE
   


### PR DESCRIPTION
Replaces calls to `LDT_flush`, `LIS_flush`, and `LVT_flush` with calls to the intrinsic `flush` added in Fortran 2003. The `*_flush` routines are also removed.

All components compile without issue with Intel 19 and GNU4 compilers. I tested LIS with the internal testsuite and all cases passed (output and logs are identical).

Resolves #413