### PR TITLE
Call LIS_lsm_DAmapTileSpaceToObsSpace instead of LIS_mapTileSpaceToObsSpace

### DIFF
--- a/lis/surfacemodels/land/jules.5.x/da_snodep/jules5x_map_snodep.F90
+++ b/lis/surfacemodels/land/jules.5.x/da_snodep/jules5x_map_snodep.F90
@@ -25,7 +25,7 @@ subroutine jules5x_map_snodep(n,k,OBS_State,LSM_Incr_State)
   use ESMF
   use LIS_coreMod, only : LIS_rc
   use LIS_logMod,  only : LIS_verify
-  use LIS_DAobservationsMod
+  use LIS_lsmMod
   use jules5x_lsmMod
 
   implicit none
@@ -101,8 +101,7 @@ subroutine jules5x_map_snodep(n,k,OBS_State,LSM_Incr_State)
 
   do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
 
-     call LIS_mapTileSpaceToObsSpace(n, k, LIS_rc%lsm_index, &
-          t, st_id, en_id)
+     call LIS_lsm_DAmapTileSpaceToObsSpace(n, k, t, st_id, en_id)
 
 ! Assume here that st_id and en_id are the same and that we are
 ! working with an model grid finer than the observation grid

--- a/lis/surfacemodels/land/jules.5.x/da_usafsi/jules5x_map_usafsi.F90
+++ b/lis/surfacemodels/land/jules.5.x/da_usafsi/jules5x_map_usafsi.F90
@@ -27,7 +27,7 @@ subroutine jules5x_map_usafsi(n,k,OBS_State,LSM_Incr_State)
   use ESMF
   use LIS_coreMod,  only : LIS_rc
   use LIS_logMod,   only : LIS_verify
-  use LIS_DAobservationsMod
+  use LIS_lsmMod
   use jules5x_lsmMod
 
   implicit none
@@ -103,8 +103,7 @@ subroutine jules5x_map_usafsi(n,k,OBS_State,LSM_Incr_State)
 
   do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
 
-     call LIS_mapTileSpaceToObsSpace(n, k, LIS_rc%lsm_index, &
-          t, st_id, en_id)
+     call LIS_lsm_DAmapTileSpaceToObsSpace(n, k, t, st_id, en_id)
 
 ! Assume here that st_id and en_id are the same and that we are
 ! working with an model grid finer than the observation grid


### PR DESCRIPTION
The routine LIS_mapTileSpaceToObsSpace was broken into LIS_surfaceModel_DAmapTileSpaceToObsSpace, LIS_lsm_DAmapTileSpaceToObsSpace, and LIS_routing_DAmapTileSpaceToObsSpace.

The code in jules5x_map_snodep.F90 and jules5x_map_usafsi.F90 was
calling the old routine, which leads to a compile-time error.