### PR TITLE
Update LSM parameter file name for USAFSI

### DIFF
--- a/ldt/USAFSI/ldt.config.sample
+++ b/ldt/USAFSI/ldt.config.sample
@@ -1,7 +1,7 @@
 
 # Overall driver options
 LDT running mode:                   "USAFSI analysis"
-Processed LSM parameter filename:   LDTOUT/lis_input.10km_noah_juleslandmask.cap.nc
+Processed LSM parameter filename:   LDTOUT/lis_input.global.noah39.nc # When using LIS-Noah
 LIS number of nests:                 1
 Number of surface model types:       0
 Number of met forcing sources: 0

--- a/ldt/configs/README_USAFSI
+++ b/ldt/configs/README_USAFSI
@@ -1,0 +1,1 @@
+For USAFSI sample ldt.config file, look at ldt/USAFSI/ldt.config.sample.


### PR DESCRIPTION
### Description

Updated name of LSM parameter file in ldt.config.sample for USAFSI.

The older file name was for LIS 7.2.  A new file exists for LIS 7.3 and 7.4 and should be used instead.

(As a bonus, I also added a README_USAFSI in ldt/configs to point USAFSI users to the correct file.)

This is intended for the Air Force LISF 7.4 release.

Resolves #721 
