### PR TITLE
Update Users' Guides for LISF 557WW 7.4.0 release

### DIFF
--- a/docs/LDT_users_guide/LDT_usersguide.adoc
+++ b/docs/LDT_users_guide/LDT_usersguide.adoc
@@ -1,6 +1,6 @@
 = Land Data Toolkit (LDT): LDT {lisfrevision} Users' Guide
-:revnumber: 1.11
-:revdate: 25 Jan 2021
+:revnumber: 1.12
+:revdate: 4 Mar 2021
 :doctype: book
 :sectnums:
 :toc:

--- a/docs/LDT_users_guide/revision_table.adoc
+++ b/docs/LDT_users_guide/revision_table.adoc
@@ -2,6 +2,7 @@
 |====
 | Revision | Summary of Changes             | Date
 
+| 1.12     | LISF 557WW 7.4.0 release       | Mar 4, 2021
 | 1.11     | LDT 557WW 7.3.3 release        | Jan 25, 2021
 | 1.10     | LISF Public 7.3.0 release      | Dec 21, 2020
 | 1.9      | LDT 557WW 7.3.0 release        | Aug 24, 2020

--- a/docs/LIS_users_guide/LIS_usersguide.adoc
+++ b/docs/LIS_users_guide/LIS_usersguide.adoc
@@ -1,6 +1,6 @@
 = Land Information System (LIS): LIS {lisfrevision} Users' Guide
-:revnumber: 1.14
-:revdate: 25 Jan 2021
+:revnumber: 1.15
+:revdate: 4 Mar 2021
 :doctype: book
 :sectnums:
 :toc:

--- a/docs/LIS_users_guide/revision_table.adoc
+++ b/docs/LIS_users_guide/revision_table.adoc
@@ -2,6 +2,7 @@
 |====
 |Revision | Summary of Changes                         | Date
 
+|1.15     | Updates for LISF 557WW 7.4.0 release       | Mar 4, 2021
 |1.14     | Updates for LIS 557WW 7.3.3 release        | Jan 25, 2021
 |1.13     | LISF Public 7.3.0 release                  | Dec 21, 2020
 |1.12     | LIS 557WW 7.3.0 release                    | Aug 24, 2020

--- a/docs/LVT_users_guide/LVT_usersguide.adoc
+++ b/docs/LVT_users_guide/LVT_usersguide.adoc
@@ -1,6 +1,6 @@
 = Land surface Verification Toolkit (LVT): LVT {lisfrevision} Users' Guide
-:revnumber: 1.6
-:revdate: 21 Dec 2020
+:revnumber: 1.7
+:revdate: 4 Mar 2021
 :doctype: book
 :sectnums:
 :toc:

--- a/docs/LVT_users_guide/revision_table.adoc
+++ b/docs/LVT_users_guide/revision_table.adoc
@@ -2,6 +2,7 @@
 |===
 | Revision | Summary of Changes              | Date
 
+| 1.7      | LISF 557WW 7.4.0 release        | Mar 4, 2021
 | 1.6      | LISF Public 7.3.0 release       | Dec 21, 2020
 | 1.5      | LVT 557WW 7.3.0 release         | Aug 24, 2020
 | 1.4      | LVT 557WW 7.3 release candidate 4 | Aug 28, 2019

--- a/ldt/configs/ldt.config.adoc
+++ b/ldt/configs/ldt.config.adoc
@@ -3953,6 +3953,23 @@ LPRM vegetation optical depth observation directory: ../LPRM_VOD
 LPRM vegetation optical depth data designation:      'X-band'
 ....
 
+`SMOS NRT NN soil moisture observation directory:` specifies the location of the data directory containing the SMOS NRT NN data.
+
+.Example _ldt.config_ entry
+....
+MOS NRT NN soil moisture observation directory: ./SMOS_NRT_NN
+....
+
+`SMOS NRT NN search radius for openwater proximity detection:` specifies the radius in which LDT search to detect open water. Then removes all pixels within the radius in the CDF calculations.
+
+.Example _ldt.config_ entry
+....
+SMOS NRT NN search radius for openwater proximity detection: 3
+....
+
+[[ssec-hymapopts]]
+=== HYMAP routing options
+
 This section describes the parameters needed for the HYMAP and the HYMAP2 routing models.  The config entries only have "`HYMAP`" within them, as they apply to both HYMAP versions.
 
 `HYMAP river width map:` specifies the name of the HYMAP river width data file.
@@ -4440,21 +4457,4 @@ Glacier fraction upper right lon:   179.995
 Glacier fraction resolution (dx):   0.01
 Glacier fraction resolution (dy):   0.01
 ....
-
-
-`SMOS NRT NN soil moisture observation directory:` specifies the location of the data directory containing the SMOS NRT NN data.
-
-.Example _ldt.config_ entry
-....
-MOS NRT NN soil moisture observation directory: ./SMOS_NRT_NN
-....
-
-
-`SMOS NRT NN search radius for openwater proximity detection:` specifies the radius in which LDT search to detect open water. Then removes all pixels within the radius in the CDF calculations.
-
-.Example _ldt.config_ entry
-....
-SMOS NRT NN search radius for openwater proximity detection: 3
-....
-
 

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -1163,6 +1163,7 @@ Acceptable values are:
 |"`USAFSI`"                     | USAF Snow and Ice Analysis
 |"`SMAP(NASA) vegetation optical depth`"  | NASA L-band vegetation optical depth 
 |"`MCD15A2H LAI`"               | MODIS MCD15A2H v006 LAI product
+|"`SMOS NRT NN soil moisture`"  | SMOS Level 2 Soil Moisture Near Real Time Neural Network
 |====
 
 .Example _lis.config_ entry
@@ -3115,6 +3116,50 @@ SMOS(NESDIS) soil moisture use scaled standard deviation model:
 SMOS(NESDIS) model CDF file:
 SMOS(NESDIS) observation CDF file:
 SMOS(NESDIS) soil moisture number of bins in the CDF:
+....
+
+
+[[sssec_smosnrtnnsmda,SMOS NRT NN soil moisture assimilation]]
+==== SMOS NRT NN soil moisture assimilation
+
+`SMOS NRT NN soil moisture data directory:` specifies the SMOS NRT NN soil
+moisture data directory
+
+`SMOS NRT NN soil moisture use scaled standard deviation model:` specifies
+whether the observation error standard deviation is to be scaled using model
+and observation standard deviation.
+
+`SMOS NRT NN model CDF file:` specifies the name of the model CDF file
+(observations will be scaled into this climatology).
+
+`SMOS NRT NN observation CDF file:` specifies the name of the observation
+CDF file.
+
+`SMOS NRT NN soil moisture number of bins in the CDF:` specifies the number of
+bins in the CDF.
+
+`SMOS NRT NN CDF read option:` specifies whether to read all months of
+or to read month by month from a monthly CDF file.
+
+Acceptable values are:
+
+|====
+|Value    | Description
+
+|0 | Read all months
+|1 | Read month by month
+|====
+
+NOTE: Select 0 for yearly CDF data
+
+.Example _lis.config_ entry
+....
+SMOS NRT NN soil moisture data directory: ./SMOS_NRT_NN
+SMOS NRT NN soil moisture use scaled standard deviation model: 0
+SMOS NRT NN model CDF file:               ../DA_proc_LSM/LDTOUT/noah39_cdf.nc
+SMOS NRT NN observation CDF file:         ../DA_proc_SMOS/LDTOUT/SMOS_cdf.nc
+SMOS NRT NN soil moisture number of bins in the CDF:           100
+SMOS NRT NN CDF read option:       1
 ....
 
 
@@ -10458,51 +10503,4 @@ Acceptable values for the timestep units are:
 Units of months assumes a 30-day month.
 
 Units of years assumes a 365-day year.
-
-
-....
-[[sssec_smosnrtnnsmda,SMOS NRT NN soil moisture assimilation]]
-==== SMOS NRT NN soil moisture assimilation
-
-`SMOS NRT NN soil moisture data directory:` specifies the SMOS NRT NN soil
-moisture data directory
-
-`SMOS NRT NN soil moisture use scaled standard deviation model:` specifies
-whether the observation error standard deviation is to be scaled using model
-and observation standard deviation.
-
-`SMOS NRT NN model CDF file:` specifies the name of the model CDF file
-(observations will be scaled into this climatology).
-
-`SMOS NRT NN observation CDF file:` specifies the name of the observation
-CDF file.
-
-`SMOS NRT NN soil moisture number of bins in the CDF:` specifies the number of
-bins in the CDF.
-
-`SMOS NRT NN CDF read option:` specifies whether to read all months of
-or to read month by month from a monthly CDF file.
-
-Acceptable values are:
-
-|====
-|Value    | Description
-
-|0 | Read all months
-|1 | Read month by month
-|====
-
-NOTE: Select 0 for yearly CDF data
-
-.Example _lis.config_ entry
-....
-SMOS NRT NN soil moisture data directory: ./SMOS_NRT_NN
-SMOS NRT NN soil moisture use scaled standard deviation model: 0
-SMOS NRT NN model CDF file:               ../DA_proc_LSM/LDTOUT/noah39_cdf.nc
-SMOS NRT NN observation CDF file:         ../DA_proc_SMOS/LDTOUT/SMOS_cdf.nc
-SMOS NRT NN soil moisture number of bins in the CDF:           100
-SMOS NRT NN CDF read option:       1
-....
-
-
 


### PR DESCRIPTION
This updates the Users' Guides for the LISF 557WW 7.4.0 release.

Note that I did not update the titles of these documents, only the revision history.  The titles are reserved for the public releases.