### PR TITLE
Added LVT restart capability for PSS, PODY, and PODN.

### DIFF
--- a/lvt/metrics/LVT_PODNMod.F90
+++ b/lvt/metrics/LVT_PODNMod.F90
@@ -1120,60 +1120,154 @@ contains
   end subroutine LVT_resetMetric_PODN
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_writerestart_PODN
-! 
+!
 ! !INTERFACE:
   subroutine LVT_writerestart_PODN(ftn,pass)
-! !USES: 
+! !USES:
 
-! 
-! !ARGUMENTS: 
+!
+! !ARGUMENTS:
     integer                 :: ftn
     integer                 :: pass
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine writes the restart file for PODN metric computations
-! 
-!EOP
-    
 !
-! !DESCRIPTION: 
-! 
 !EOP
-    if(LVT_metrics%podn%selectOpt.eq.1) then 
-       
-       print*, 'The writerestart method is not implemented for PODN'
 
-    end if
-    
+    integer :: k, l, m
+    type(LVT_metaDataEntry), pointer :: model
+    type(LVT_metaDataEntry), pointer :: obs
+    type(LVT_statsEntry),    pointer :: stats
+
+    call LVT_getDataStream1Ptr(model)
+    call LVT_getDataStream2Ptr(obs)
+    call LVT_getstatsEntryPtr(stats)
+
+    do while (associated(model))
+       if (LVT_metrics%podn%selectOpt .eq. 1) then
+          if (stats%selectOpt .eq. 1 .and. obs%selectNlevs .ge. 1) then
+             do m = 1, LVT_rc%nensem
+
+                do k = 1, model%selectNlevs
+                   do l = 1, LVT_rc%strat_nlevels
+                      call LVT_writevar_restart(ftn, &
+                           stats%podn(m)%value_total_b(:,k,l))
+                      call LVT_writevar_restart(ftn, &
+                           stats%podn(m)%value_total_d(:,k,l))
+                      call LVT_writevar_restart(ftn, &
+                           stats%podn(m)%count_value_total(:,k,l))
+                   end do ! l
+                end do ! k
+
+                if (LVT_metrics%podn%computeSC .eq. 1) then
+                   do k = 1, model%selectNlevs
+                      do l = 1, LVT_rc%nasc
+                         call LVT_writevar_restart(ftn, &
+                              stats%podn(m)%value_asc(:,k,l))
+                         call LVT_writevar_restart(ftn, &
+                              stats%podn(m)%count_value_asc(:,k,l))
+                      end do ! l
+                   end do ! k
+                end if
+
+                if (LVT_metrics%podn%computeADC .eq. 1) then
+                   do k = 1, model%selectNlevs
+                      do l = 1, LVT_rc%nadc
+                         call LVT_writevar_restart(ftn, &
+                              stats%podn(m)%value_adc(:,k,l))
+                         call LVT_writevar_restart(ftn, &
+                              stats%podn(m)%count_value_adc(:,k,l))
+                      end do ! l
+                   end do ! k
+                end if
+
+             end do ! m
+          end if
+       end if
+
+       model => model%next
+       obs => obs%next
+       stats => stats%next
+
+    end do
+
   end subroutine LVT_writerestart_PODN
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_readrestart_PODN
-! 
+!
 ! !INTERFACE:
   subroutine LVT_readrestart_PODN(ftn)
-! !USES: 
+! !USES:
 
-! 
-! !ARGUMENTS: 
+!
+! !ARGUMENTS:
     integer                 :: ftn
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine reads the restart file for PODN metric computations
-! 
-!EOP
-    
 !
-! !DESCRIPTION: 
-! 
 !EOP
-    if(LVT_metrics%podn%selectOpt.eq.1) then 
-       
-       print*, 'The readrestart method is not implemented for PODN'
 
-    end if
-    
+    type(LVT_metaDataEntry), pointer :: model
+    type(LVT_metaDataEntry), pointer :: obs
+    type(LVT_statsEntry),    pointer :: stats
+    integer              :: k, l, m
+
+    call LVT_getDataStream1Ptr(model)
+    call LVT_getDataStream2Ptr(obs)
+    call LVT_getstatsEntryPtr(stats)
+
+    do while (associated(model))
+       if (LVT_metrics%podn%selectOpt .eq. 1) then
+          if (stats%selectOpt .eq. 1 .and. obs%selectNlevs .ge. 1) then
+             do m = 1, LVT_rc%nensem
+
+                do k = 1, model%selectNlevs
+                   do l = 1, LVT_rc%strat_nlevels
+                      call LVT_readvar_restart(ftn, &
+                           stats%podn(m)%value_total_b(:,k,l))
+                      call LVT_readvar_restart(ftn, &
+                           stats%podn(m)%value_total_d(:,k,l))
+                      call LVT_readvar_restart(ftn, &
+                           stats%podn(m)%count_value_total(:,k,l))
+                   end do ! l
+                end do ! k
+
+                if (LVT_metrics%podn%computeSC .eq. 1) then
+                   do k = 1, model%selectNlevs
+                      do l = 1, LVT_rc%nasc
+                         call LVT_readvar_restart(ftn, &
+                              stats%podn(m)%value_asc(:,k,l))
+                         call LVT_readvar_restart(ftn, &
+                              stats%podn(m)%count_value_asc(:,k,l))
+                      end do ! l
+                   end do ! k
+                end if
+
+                if (LVT_metrics%podn%computeADC .eq. 1) then
+                   do k = 1, model%selectNlevs
+                      do l = 1, LVT_rc%nadc
+                         call LVT_readvar_restart(ftn, &
+                              stats%podn(m)%value_adc(:,k,l))
+                         call LVT_readvar_restart(ftn, &
+                              stats%podn(m)%count_value_adc(:,k,l))
+                      end do ! l
+                   end do ! k
+                end if
+
+             end do ! m
+          end if
+       end if
+
+       model => model%next
+       obs   => obs%next
+       stats => stats%next
+
+    end do
+
   end subroutine LVT_readrestart_PODN
 end module LVT_PODNMod

--- a/lvt/metrics/LVT_PODYMod.F90
+++ b/lvt/metrics/LVT_PODYMod.F90
@@ -1123,60 +1123,154 @@ contains
   end subroutine LVT_resetMetric_PODY
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_writerestart_PODY
-! 
+!
 ! !INTERFACE:
   subroutine LVT_writerestart_PODY(ftn,pass)
-! !USES: 
+! !USES:
 
-! 
-! !ARGUMENTS: 
+!
+! !ARGUMENTS:
     integer                 :: ftn
     integer                 :: pass
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine writes the restart file for PODY metric computations
-! 
-!EOP
-    
 !
-! !DESCRIPTION: 
-! 
 !EOP
-    if(LVT_metrics%pody%selectOpt.eq.1) then 
-       
-       print*, 'The writerestart method is not implemented for PODY'
 
-    end if
-    
+    integer :: k, l, m
+    type(LVT_metaDataEntry), pointer :: model
+    type(LVT_metaDataEntry), pointer :: obs
+    type(LVT_statsEntry),    pointer :: stats
+
+    call LVT_getDataStream1Ptr(model)
+    call LVT_getDataStream2Ptr(obs)
+    call LVT_getstatsEntryPtr(stats)
+
+    do while (associated(model))
+       if (LVT_metrics%pody%selectOpt .eq. 1) then
+          if (stats%selectOpt .eq. 1 .and. obs%selectNlevs .ge. 1) then
+             do m = 1, LVT_rc%nensem
+
+                do k = 1, model%selectNlevs
+                   do l = 1, LVT_rc%strat_nlevels
+                      call LVT_writevar_restart(ftn, &
+                           stats%pody(m)%value_total_a(:,k,l))
+                      call LVT_writevar_restart(ftn, &
+                           stats%pody(m)%value_total_c(:,k,l))
+                      call LVT_writevar_restart(ftn, &
+                           stats%pody(m)%count_value_total(:,k,l))
+                   end do ! l
+                end do ! k
+
+                if (LVT_metrics%pody%computeSC .eq. 1) then
+                   do k = 1, model%selectNlevs
+                      do l = 1, LVT_rc%nasc
+                         call LVT_writevar_restart(ftn, &
+                              stats%pody(m)%value_asc(:,k,l))
+                         call LVT_writevar_restart(ftn, &
+                              stats%pody(m)%count_value_asc(:,k,l))
+                      end do ! l
+                   end do ! k
+                end if
+
+                if (LVT_metrics%pody%computeADC .eq. 1) then
+                   do k = 1, model%selectNlevs
+                      do l = 1, LVT_rc%nadc
+                         call LVT_writevar_restart(ftn, &
+                              stats%pody(m)%value_adc(:,k,l))
+                         call LVT_writevar_restart(ftn, &
+                              stats%pody(m)%count_value_adc(:,k,l))
+                      end do ! l
+                   end do ! k
+                end if
+
+             end do ! m
+          end if
+       end if
+
+       model => model%next
+       obs => obs%next
+       stats => stats%next
+
+    end do
+
   end subroutine LVT_writerestart_PODY
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_readrestart_PODY
-! 
+!
 ! !INTERFACE:
   subroutine LVT_readrestart_PODY(ftn)
-! !USES: 
+! !USES:
 
-! 
-! !ARGUMENTS: 
+!
+! !ARGUMENTS:
     integer                 :: ftn
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine reads the restart file for PODY metric computations
-! 
-!EOP
-    
 !
-! !DESCRIPTION: 
-! 
 !EOP
-    if(LVT_metrics%pody%selectOpt.eq.1) then 
-       
-       print*, 'The readrestart method is not implemented for PODY'
 
-    end if
-    
+    type(LVT_metaDataEntry), pointer :: model
+    type(LVT_metaDataEntry), pointer :: obs
+    type(LVT_statsEntry),    pointer :: stats
+    integer              :: k, l, m
+
+    call LVT_getDataStream1Ptr(model)
+    call LVT_getDataStream2Ptr(obs)
+    call LVT_getstatsEntryPtr(stats)
+
+    do while (associated(model))
+       if (LVT_metrics%pody%selectOpt .eq. 1) then
+          if (stats%selectOpt .eq. 1 .and. obs%selectNlevs .ge. 1) then
+             do m = 1, LVT_rc%nensem
+
+                do k = 1, model%selectNlevs
+                   do l = 1, LVT_rc%strat_nlevels
+                      call LVT_readvar_restart(ftn, &
+                           stats%pody(m)%value_total_a(:,k,l))
+                      call LVT_readvar_restart(ftn, &
+                           stats%pody(m)%value_total_c(:,k,l))
+                      call LVT_readvar_restart(ftn, &
+                           stats%pody(m)%count_value_total(:,k,l))
+                   end do ! l
+                end do ! k
+
+                if (LVT_metrics%pody%computeSC .eq. 1) then
+                   do k = 1, model%selectNlevs
+                      do l = 1, LVT_rc%nasc
+                         call LVT_readvar_restart(ftn, &
+                              stats%pody(m)%value_asc(:,k,l))
+                         call LVT_readvar_restart(ftn, &
+                              stats%pody(m)%count_value_asc(:,k,l))
+                      end do ! l
+                   end do ! k
+                end if
+
+                if (LVT_metrics%pody%computeADC .eq. 1) then
+                   do k = 1, model%selectNlevs
+                      do l = 1, LVT_rc%nadc
+                         call LVT_readvar_restart(ftn, &
+                              stats%pody(m)%value_adc(:,k,l))
+                         call LVT_readvar_restart(ftn, &
+                              stats%pody(m)%count_value_adc(:,k,l))
+                      end do ! l
+                   end do ! k
+                end if
+
+             end do ! m
+          end if
+       end if
+
+       model => model%next
+       obs   => obs%next
+       stats => stats%next
+
+    end do
+
   end subroutine LVT_readrestart_PODY
 end module LVT_PODYMod

--- a/lvt/metrics/LVT_PSSMod.F90
+++ b/lvt/metrics/LVT_PSSMod.F90
@@ -1278,60 +1278,162 @@ contains
   end subroutine LVT_resetMetric_PSS
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_writerestart_PSS
-! 
+!
 ! !INTERFACE:
   subroutine LVT_writerestart_PSS(ftn,pass)
-! !USES: 
+! !USES:
 
-! 
-! !ARGUMENTS: 
+!
+! !ARGUMENTS:
     integer                 :: ftn
     integer                 :: pass
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine writes the restart file for PSS metric computations
-! 
-!EOP
-    
 !
-! !DESCRIPTION: 
-! 
 !EOP
-    if(LVT_metrics%pss%selectOpt.eq.1) then 
-       
-       print*, 'The writerestart method is not implemented for PSS'
 
-    end if
-    
+    integer :: k, l, m
+    type(LVT_metaDataEntry), pointer :: model
+    type(LVT_metaDataEntry), pointer :: obs
+    type(LVT_statsEntry),    pointer :: stats
+
+    call LVT_getDataStream1Ptr(model)
+    call LVT_getDataStream2Ptr(obs)
+    call LVT_getstatsEntryPtr(stats)
+
+    do while (associated(model))
+       if (LVT_metrics%pss%selectOpt .eq. 1) then
+          if (stats%selectOpt .eq. 1 .and. obs%selectNlevs .ge. 1) then
+             do m = 1, LVT_rc%nensem
+
+                do k = 1, model%selectNlevs
+                   do l = 1, LVT_rc%strat_nlevels
+                      call LVT_writevar_restart(ftn, &
+                           stats%pss(m)%value_total_a(:,k,l))
+                      call LVT_writevar_restart(ftn, &
+                           stats%pss(m)%value_total_b(:,k,l))
+                      call LVT_writevar_restart(ftn, &
+                           stats%pss(m)%value_total_c(:,k,l))
+                      call LVT_writevar_restart(ftn, &
+                           stats%pss(m)%value_total_d(:,k,l))
+                      call LVT_writevar_restart(ftn, &
+                           stats%pss(m)%count_value_total(:,k,l))
+                   end do ! l
+                end do ! k
+
+                if (LVT_metrics%pss%computeSC .eq. 1) then
+                   do k = 1, model%selectNlevs
+                      do l = 1, LVT_rc%nasc
+                         call LVT_writevar_restart(ftn, &
+                              stats%pss(m)%value_asc(:,k,l))
+                         call LVT_writevar_restart(ftn, &
+                              stats%pss(m)%count_value_asc(:,k,l))
+                      end do ! l
+                   end do ! k
+                end if
+
+                if (LVT_metrics%pss%computeADC .eq. 1) then
+                   do k = 1, model%selectNlevs
+                      do l = 1, LVT_rc%nadc
+                         call LVT_writevar_restart(ftn, &
+                              stats%pss(m)%value_adc(:,k,l))
+                         call LVT_writevar_restart(ftn, &
+                              stats%pss(m)%count_value_adc(:,k,l))
+                      end do ! l
+                   end do ! k
+                end if
+
+             end do ! m
+          end if
+       end if
+
+       model => model%next
+       obs => obs%next
+       stats => stats%next
+
+    end do
+
   end subroutine LVT_writerestart_PSS
 
 !BOP
-! 
+!
 ! !ROUTINE: LVT_readrestart_PSS
-! 
+!
 ! !INTERFACE:
   subroutine LVT_readrestart_PSS(ftn)
-! !USES: 
+! !USES:
 
-! 
-! !ARGUMENTS: 
+!
+! !ARGUMENTS:
     integer                 :: ftn
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine reads the restart file for PSS metric computations
-! 
-!EOP
-    
 !
-! !DESCRIPTION: 
-! 
 !EOP
-    if(LVT_metrics%pss%selectOpt.eq.1) then 
-       
-       print*, 'The readrestart method is not implemented for PSS'
 
-    end if
-    
+    type(LVT_metaDataEntry), pointer :: model
+    type(LVT_metaDataEntry), pointer :: obs
+    type(LVT_statsEntry),    pointer :: stats
+    integer              :: k, l, m
+
+    call LVT_getDataStream1Ptr(model)
+    call LVT_getDataStream2Ptr(obs)
+    call LVT_getstatsEntryPtr(stats)
+
+    do while (associated(model))
+       if (LVT_metrics%pss%selectOpt .eq. 1) then
+          if (stats%selectOpt .eq. 1 .and. obs%selectNlevs .ge. 1) then
+             do m = 1, LVT_rc%nensem
+
+                do k = 1, model%selectNlevs
+                   do l = 1, LVT_rc%strat_nlevels
+                      call LVT_readvar_restart(ftn, &
+                           stats%pss(m)%value_total_a(:,k,l))
+                      call LVT_readvar_restart(ftn, &
+                           stats%pss(m)%value_total_b(:,k,l))
+                      call LVT_readvar_restart(ftn, &
+                           stats%pss(m)%value_total_c(:,k,l))
+                      call LVT_readvar_restart(ftn, &
+                           stats%pss(m)%value_total_d(:,k,l))
+                      call LVT_readvar_restart(ftn, &
+                           stats%pss(m)%count_value_total(:,k,l))
+                   end do ! l
+                end do ! k
+
+                if (LVT_metrics%pss%computeSC .eq. 1) then
+                   do k = 1, model%selectNlevs
+                      do l = 1, LVT_rc%nasc
+                         call LVT_readvar_restart(ftn, &
+                              stats%pss(m)%value_asc(:,k,l))
+                         call LVT_readvar_restart(ftn, &
+                              stats%pss(m)%count_value_asc(:,k,l))
+                      end do ! l
+                   end do ! k
+                end if
+
+                if (LVT_metrics%pss%computeADC .eq. 1) then
+                   do k = 1, model%selectNlevs
+                      do l = 1, LVT_rc%nadc
+                         call LVT_readvar_restart(ftn, &
+                              stats%pss(m)%value_adc(:,k,l))
+                         call LVT_readvar_restart(ftn, &
+                              stats%pss(m)%count_value_adc(:,k,l))
+                      end do ! l
+                   end do ! k
+                end if
+
+             end do ! m
+          end if
+       end if
+
+       model => model%next
+       obs   => obs%next
+       stats => stats%next
+
+    end do
+
   end subroutine LVT_readrestart_PSS
 end module LVT_PSSMod


### PR DESCRIPTION
### Description

PSS. PODY, and PODN data are not written to LVT restart files.  This pull request fixes that error.

Resolves #737 
