### PR TITLE
Replace "==" with "=" in compile script

### DIFF
--- a/lis/compile
+++ b/lis/compile
@@ -64,7 +64,7 @@ dashes="-------------------------------------------------------------------"
 echo $dashes
 
 # Sanity check
-if [ "$skip_lis" == "YES" ] ; then
+if [ "$skip_lis" = "YES" ] ; then
     if [ "$compile_autotune" != "YES" ] ; then
         echo "[ERR] Using -n without -u"
         echo "Nothing will be compiled!"


### PR DESCRIPTION
### Description

The "==" operator is a non-standard alias for "=", and it is not supported by
the dash shell, which is `/bin/sh` in my Singularity container.

Resolves #739