### PR TITLE
Fix GRACE DA for NoahMP.3.6 (LIS) and 0.25 deg GRACE reader (LDT)

### DIFF
--- a/ldt/DAobs/GRACE_tws/GRACEtws_obsMod.F90
+++ b/ldt/DAobs/GRACE_tws/GRACEtws_obsMod.F90
@@ -379,6 +379,48 @@ contains
             LDT_rc%lnc(n)*LDT_rc%lnr(n),&
             GRACEtwsobs%n11)
     endif
+!Bailing: These are GRACE product descriptions which are diff 
+! currently, I use LDT_rc%gridDesc(n,9) to determine if it is 
+   if (LDT_rc%gridDesc(n,9).lt.0.5)then  !0.25 GRACE                     
+    gridDesci = 0                                            
+    gridDesci(1) = 0                                         
+    gridDesci(2) = 1440                                       
+    gridDesci(3) = 720                                      
+    gridDesci(4) = -89.875                                  
+    gridDesci(5) = -179.875                                
+    gridDesci(6) = 128                                   
+    gridDesci(7) = 89.875                                
+    gridDesci(8) = 179.875                              
+    gridDesci(9) = 0.25                                
+    gridDesci(10) = 0.25                              
+    gridDesci(20) = 64                              
+   elseif (LDT_rc%gridDesc(n,9).lt.1.0 .and. LDT_rc%gridDesc(n,9).gt.0.25)then  !0.5 GRACE                     
+    gridDesci = 0                                            
+    gridDesci(1) = 0                                         
+    gridDesci(2) = 720                                       
+    gridDesci(3) = 360                                      
+    gridDesci(4) = -89.75                                  
+    gridDesci(5) = -179.75                                
+    gridDesci(6) = 128                                   
+    gridDesci(7) = 89.75                                
+    gridDesci(8) = 179.75                              
+    gridDesci(9) = 0.5                                
+    gridDesci(10) = 0.5                              
+    gridDesci(20) = 64                              
+   else                                            ! 1.0 GRACE
+    gridDesci = 0                                 
+    gridDesci(1) = 0                             
+    gridDesci(2) = 360                          
+    gridDesci(3) = 180                         
+    gridDesci(4) = -89.5                      
+    gridDesci(5) = -179.5                    
+    gridDesci(6) = 128                      
+    gridDesci(7) = 89.5                    
+    gridDesci(8) = 179.5                  
+    gridDesci(9) =  1.0                  
+    gridDesci(10) = 1.0                 
+    gridDesci(20) = 64                 
+   end if 
 
 
     ! Define ASCAT Obs grid domain and resolution
@@ -388,7 +430,24 @@ contains
   
     !  Latest GRACE TWS Mascon 0.5 deg dataset (B. Li):
 !    elseif( LDT_rc%gridDesc(n,9) == 0.5 ) then
-    if(GRACEtwsobs%datasource.eq."GRACE TWS Mascon 0.5 deg") then 
+    if(GRACEtwsobs%datasource.eq."GRACE TWS Mascon 0.25 deg") then 
+       GRACEtwsobs%gracenc = 1440
+       GRACEtwsobs%gracenr = 720
+       
+       gridDesci = 0
+       gridDesci(1) = 0
+       gridDesci(2) = GRACEtwsobs%gracenc
+       gridDesci(3) = GRACEtwsobs%gracenr
+       gridDesci(4) = -89.875
+       gridDesci(5) = -179.875
+       gridDesci(6) = 128
+       gridDesci(7) = 89.875
+       gridDesci(8) = 179.875
+       gridDesci(9) = 0.25
+       gridDesci(10) = 0.25
+       gridDesci(20) = 64
+    ! -- Original GRACE TWS 1.0 deg datasets:
+    elseif(GRACEtwsobs%datasource.eq."GRACE TWS Mascon 0.5 deg") then 
        GRACEtwsobs%gracenc = 720
        GRACEtwsobs%gracenr = 360
        
@@ -404,7 +463,6 @@ contains
        gridDesci(9) = 0.5
        gridDesci(10) = 0.5
        gridDesci(20) = 64
-    ! -- Original GRACE TWS 1.0 deg datasets:
     elseif(GRACEtwsobs%datasource.eq."GRACE TWS Original 1 deg") then 
        GRACEtwsobs%gracenc = 360
        GRACEtwsobs%gracenr = 180

--- a/ldt/DAobs/GRACE_tws/readGRACEtwsObs.F90
+++ b/ldt/DAobs/GRACE_tws/readGRACEtwsObs.F90
@@ -431,7 +431,9 @@ subroutine readGRACEtwsObs(n)
      
      dt = float((currTime-GRACEtwsobs%refTime))/24.0
 
-    if(GRACEtwsobs%datasource.eq."GRACE TWS Mascon 0.5 deg") then 
+    if(GRACEtwsobs%datasource.eq."GRACE TWS Mascon 0.25 deg") then 
+       md_nc=720
+    elseif(GRACEtwsobs%datasource.eq."GRACE TWS Mascon 0.5 deg") then 
        md_nc=360
     elseif(GRACEtwsobs%datasource.eq."GRACE TWS Original 1 deg") then 
        md_nc=180

--- a/lis/dataassim/obs/GRACE/read_GRACEobs.F90
+++ b/lis/dataassim/obs/GRACE/read_GRACEobs.F90
@@ -63,9 +63,9 @@ subroutine read_GRACEobs(n,k, OBS_State, OBS_Pert_State)
   integer             :: gid(LIS_rc%obs_ngrid(k))
   integer             :: assimflag(LIS_rc%obs_ngrid(k))
 
-  character*100       :: GRACEobsdir
+  character*200       :: GRACEobsdir ! Natt, change 100 to 200
   logical             :: file_exists
-  character*100       :: name
+  character*200       :: name ! Natt, change 100 to 200
 
   integer             :: col,row
   logical             :: data_upd
@@ -250,6 +250,10 @@ subroutine read_GRACEobs(n,k, OBS_State, OBS_Pert_State)
                  call LIS_verify(status)
               endif
            endif
+        else
+            ! Natt: Let's print it out when LIS cannot find the file
+            write(LIS_logunit,*)  '[WARNING] GRACE data not found ',trim(name)
+            
         endif
      endif
   end if

--- a/lis/surfacemodels/land/noahmp.3.6/NoahMP36_readrst.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/NoahMP36_readrst.F90
@@ -22,16 +22,20 @@
 ! !INTERFACE:
 subroutine NoahMP36_readrst()
 ! !USES:
-  use LIS_coreMod, only    : LIS_rc, LIS_masterproc
-  use LIS_historyMod, only : LIS_readvar_restart
-  use LIS_logMod, only     : LIS_logunit, LIS_endrun, &
-       LIS_getNextUnitNumber,   &
-       LIS_releaseUnitNumber,   &
-       LIS_verify                
-  use NoahMP36_lsmMod
-  
+    use LIS_coreMod, only    : LIS_rc, LIS_masterproc
+    use LIS_historyMod, only : LIS_readvar_restart
+    use LIS_logMod, only     : LIS_logunit, LIS_endrun, &
+                               LIS_getNextUnitNumber,   &
+                               LIS_releaseUnitNumber,   &
+                               LIS_verify                
+    use NoahMP36_lsmMod
+    !WN
+    use ESMF
+    use LIS_fileIOMod
+    use LIS_timeMgrMod
+    !-----------------
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-  use netcdf
+    use netcdf
 #endif
 
 !
@@ -89,253 +93,285 @@ subroutine NoahMP36_readrst()
 !      initializes the NoahMP36 state variables
 ! \end{description}
 !EOP
-  
-  implicit none
+ 
+    implicit none
+ 
+    integer           :: t, l
+    integer           :: nc, nr, npatch
+    integer           :: n
+    integer           :: ftn
+    integer           :: status
+    real, allocatable :: tmptilen(:)
+    logical           :: file_exists
+    character*20      :: wformat
+    !WN
+    character*100     :: filen
+    integer           :: yr,mo,da,hr,mn,ss,doy
+    real*8            :: time
+    real              :: gmt
+    real              :: ts 
 
-  integer           :: t, l
-  integer           :: nc, nr, npatch
-  integer           :: n
-  integer           :: ftn
-  integer           :: status
-  real, allocatable :: tmptilen(:)
-  logical           :: file_exists
-  character*20      :: wformat
 
-  do n=1, LIS_rc%nnest
-     wformat = trim(NOAHMP36_struc(n)%rformat)
-     ! coldstart
-     if(LIS_rc%startcode .eq. "coldstart") then  
-        call NoahMP36_coldstart(LIS_rc%lsm_index)
+    do n=1, LIS_rc%nnest
+        wformat = trim(NOAHMP36_struc(n)%rformat)
+        ! coldstart
+        if(LIS_rc%startcode .eq. "coldstart") then  
+            call NoahMP36_coldstart(LIS_rc%lsm_index)
         ! restart
-     elseif(LIS_rc%startcode .eq. "restart") then
-        allocate(tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index)))
-        ! check the existance of restart file
-        inquire(file=NOAHMP36_struc(n)%rfile, exist=file_exists)
-        If (.not. file_exists) then 
-           write(LIS_logunit,*) "NoahMP36 restart file ", NOAHMP36_struc(n)%rfile," does not exist "
-           write(LIS_logunit,*) "Program stopping ..."
-           call LIS_endrun
-        endif
-        write(LIS_logunit,*) "NoahMP36 restart file used: ", NOAHMP36_struc(n)%rfile
+        elseif(LIS_rc%startcode .eq. "restart") then
+        !WN ---create restart filename based on timewindow for EnKS
+                if(LIS_rc%runmode.eq."ensemble smoother") then
+                  if(LIS_rc%iterationId(n).gt.1) then
+                    if(NOAHMP36_struc(n)%rstInterval.eq.2592000) then
+                     !create the restart filename based on the timewindow start time
+                      call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
+                           dd=da,calendar=LIS_calendar,rc=status)
+                      hr = 0
+                      mn = 0
+                      ss = 0
+                      call LIS_tick(time,doy,gmt,yr,mo,da,hr,mn,ss,(-1)*LIS_rc%ts)
+                    else
+                      call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
+                           dd=da,calendar=LIS_calendar,rc=status)
+                      hr = 0
+                      mn = 0
+                      ss = 0
+                    endif
 
-        ! open restart file
-        if(wformat .eq. "binary") then
-           ftn = LIS_getNextUnitNumber()
-           open(ftn, file=NOAHMP36_struc(n)%rfile, form="unformatted")
-           read(ftn) nc, nr, npatch  !time, veg class, no. tiles
+                    call LIS_create_restart_filename(n,filen,'SURFACEMODEL','NOAHMP36', &
+                         yr,mo,da,hr,mn,ss, wformat=wformat)
+                    NOAHMP36_struc(n)%rfile = filen
+                  endif
+                endif
 
-           ! check for grid space conflict
-           if((nc .ne. LIS_rc%gnc(n)) .or. (nr .ne. LIS_rc%gnr(n))) then
-              write(LIS_logunit,*) NOAHMP36_struc(n)%rfile, "grid space mismatch - NoahMP36 halted"
-              call LIS_endrun
-           endif
-
-           if(npatch .ne. LIS_rc%glbnpatch_red(n, LIS_rc%lsm_index)) then
-              write(LIS_logunit,*) "restart tile space mismatch, halting..."
-              call LIS_endrun
-           endif
-        elseif(wformat .eq. "netcdf") then
+            allocate(tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index)))
+            ! check the existance of restart file
+            inquire(file=NOAHMP36_struc(n)%rfile, exist=file_exists)
+            If (.not. file_exists) then 
+                write(LIS_logunit,*) "NoahMP36 restart file ", NOAHMP36_struc(n)%rfile," does not exist "
+                write(LIS_logunit,*) "Program stopping ..."
+                call LIS_endrun
+            endif
+            write(LIS_logunit,*) "NoahMP36 restart file used: ", NOAHMP36_struc(n)%rfile
+        
+            ! open restart file
+            if(wformat .eq. "binary") then
+                ftn = LIS_getNextUnitNumber()
+                open(ftn, file=NOAHMP36_struc(n)%rfile, form="unformatted")
+                read(ftn) nc, nr, npatch  !time, veg class, no. tiles
+ 
+                ! check for grid space conflict
+                if((nc .ne. LIS_rc%gnc(n)) .or. (nr .ne. LIS_rc%gnr(n))) then
+                    write(LIS_logunit,*) NOAHMP36_struc(n)%rfile, "grid space mismatch - NoahMP36 halted"
+                    call LIS_endrun
+                endif
+            
+                if(npatch .ne. LIS_rc%glbnpatch_red(n, LIS_rc%lsm_index)) then
+                    write(LIS_logunit,*) "restart tile space mismatch, halting..."
+                    call LIS_endrun
+                endif
+            elseif(wformat .eq. "netcdf") then
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-           status = nf90_open(path=NOAHMP36_struc(n)%rfile, &
-                mode=NF90_NOWRITE, ncid=ftn)
-           call LIS_verify(status, "Error opening file "//NOAHMP36_struc(n)%rfile)
+                status = nf90_open(path=NOAHMP36_struc(n)%rfile, &
+                                   mode=NF90_NOWRITE, ncid=ftn)
+                call LIS_verify(status, "Error opening file "//NOAHMP36_struc(n)%rfile)
 #endif
-        endif
-
-        ! read: snow albedo at last time step
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%albold, &
-             varname="ALBOLD", wformat=wformat)
-
-        ! read: snow mass at the last time step
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%sneqvo, &
-             varname="SNEQVO", wformat=wformat)
-
-        ! read: snow/soil temperature
-        do l=1, NOAHMP36_struc(n)%nsoil + NOAHMP36_struc(n)%nsnow
-           call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SSTC", &
-                dim=l, vlevels = NOAHMP36_struc(n)%nsoil + NOAHMP36_struc(n)%nsnow,&
-                wformat=wformat)
-           do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-              NOAHMP36_struc(n)%noahmp36(t)%sstc(l) = tmptilen(t)
-           enddo
-        enddo
-
-        ! read: volumetric liquid soil moisture
-        do l=1, NOAHMP36_struc(n)%nsoil ! TODO: check loop
-           call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SH2O", &
-                dim=l, vlevels = NOAHMP36_struc(n)%nsoil, wformat=wformat)
-           do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-              NOAHMP36_struc(n)%noahmp36(t)%sh2o(l) = tmptilen(t)
-           enddo
-        enddo
-
-        ! read: volumetric soil moisture, ice + liquid
-        do l=1, NOAHMP36_struc(n)%nsoil ! TODO: check loop
-           call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SMC", &
-                dim=l, vlevels = NOAHMP36_struc(n)%nsoil, wformat=wformat)
-           do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-              NOAHMP36_struc(n)%noahmp36(t)%smc(l) = tmptilen(t)
-           enddo
-        enddo
-
-        ! read: canopy air temperature
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%tah, &
-             varname="TAH", wformat=wformat)
-
-        ! read: canopy air vapor pressure
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%eah, &
-             varname="EAH", wformat=wformat)
-
-        ! read: wetted or snowed fraction of canopy
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%fwet, &
-             varname="FWET", wformat=wformat)
-
-        ! read: intercepted liquid water
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%canliq, &
-             varname="CANLIQ", wformat=wformat)
-
-        ! read: intercepted ice mass
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%canice, &
-             varname="CANICE", wformat=wformat)
-
-        ! read: vegetation temperature
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%tv, &
-             varname="TV", wformat=wformat)
-
-        ! read: ground temperature (skin temperature)
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%tg, &
-             varname="TG", wformat=wformat)
-
-        ! read: snowfall on the ground
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%qsnow, &
-             varname="QSNOW", wformat=wformat)
-
-        ! read: actual number of snow layers
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%isnow, &
-             varname="ISNOW", wformat=wformat)
-
-        ! read: snow/soil layer-bottom depth from snow surface
-        do l=1, NOAHMP36_struc(n)%nsoil + NOAHMP36_struc(n)%nsnow
-           call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="ZSS", &
-                dim=l, vlevels = NOAHMP36_struc(n)%nsoil + NOAHMP36_struc(n)%nsnow, &
-                wformat=wformat)
-           do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-              NOAHMP36_struc(n)%noahmp36(t)%zss(l) = tmptilen(t)
-           enddo
-        enddo
-
-        ! read: snow height
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%snowh, &
-             varname="SNOWH", wformat=wformat)
-
-        ! read: snow water equivalent
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%sneqv, &
-             varname="SNEQV", wformat=wformat)
-
-        ! read: snow-layer ice
-        do l=1, NOAHMP36_struc(n)%nsnow ! TODO: check loop
-           call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SNOWICE", &
-                dim=l, vlevels = NOAHMP36_struc(n)%nsnow, wformat=wformat)
-           do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-              NOAHMP36_struc(n)%noahmp36(t)%snowice(l) = tmptilen(t)
-           enddo
-        enddo
-
-        ! read: snow-layer liquid water
-        do l=1, NOAHMP36_struc(n)%nsnow ! TODO: check loop
-           call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SNOWLIQ", &
-                dim=l, vlevels = NOAHMP36_struc(n)%nsnow, wformat=wformat)
-           do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-              NOAHMP36_struc(n)%noahmp36(t)%snowliq(l) = tmptilen(t)
-           enddo
-        enddo
-
-        ! read: depth to water table
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%zwt, &
-             varname="ZWT", wformat=wformat)
-
-        ! read: water storage in aquifer
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%wa, &
-             varname="WA", wformat=wformat)
-
-        ! read: water in aquifer and saturated soil
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%wt, &
-             varname="WT", wformat=wformat)
-
-        ! read: lake water storage
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%wslake, &
-             varname="WSLAKE", wformat=wformat)
-
-        ! read: leaf mass
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%lfmass, &
-             varname="LFMASS", wformat=wformat)
-
-        ! read: mass of fine roots
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%rtmass, &
-             varname="RTMASS", wformat=wformat)
-
-        ! read: stem mass
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%stmass, &
-             varname="STMASS", wformat=wformat)
-
-        ! read: mass of wood including woody roots
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%wood, &
-             varname="WOOD", wformat=wformat)
-
-        ! read: stable carbon in deep soil
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%stblcp, &
-             varname="STBLCP", wformat=wformat)
-
-        ! read: short-lived carbon in shallow soil
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%fastcp, &
-             varname="FASTCP", wformat=wformat)
-
-        ! read: leaf area index
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%lai, &
-             varname="LAI", wformat=wformat)
-
-        ! read: stem area index
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%sai, &
-             varname="SAI", wformat=wformat)
-
-        ! read: momentum drag coefficient
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%cm, &
-             varname="CM", wformat=wformat)
-
-        ! read: sensible heat exchange coefficient
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%ch, &
-             varname="CH", wformat=wformat)
-
-        ! read: snow aging term
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%tauss, &
-             varname="TAUSS", wformat=wformat)
-
-        ! read: soil water content between bottom of the soil and water table
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%smcwtd, &
-             varname="SMCWTD", wformat=wformat)
-
-        ! read: recharge to or from the water table when deep
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%deeprech, &
-             varname="DEEPRECH", wformat=wformat)
-
-        ! read: recharge to or from the water table when shallow
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%rech, &
-             varname="RECH", wformat=wformat)
-
-        ! read: reference height for air temperature and humidity 
-        call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%zlvl, &
-             varname="ZLVL", wformat=wformat)
-        ! close restart file
-        if(wformat .eq. "binary") then
-           call LIS_releaseUnitNumber(ftn)
-        elseif(wformat .eq. "netcdf") then
+            endif
+ 
+            ! read: snow albedo at last time step
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%albold, &
+                                     varname="ALBOLD", wformat=wformat)
+ 
+            ! read: snow mass at the last time step
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%sneqvo, &
+                                     varname="SNEQVO", wformat=wformat)
+ 
+            ! read: snow/soil temperature
+            do l=1, NOAHMP36_struc(n)%nsoil + NOAHMP36_struc(n)%nsnow
+                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SSTC", &
+                                         dim=l, vlevels = NOAHMP36_struc(n)%nsoil + NOAHMP36_struc(n)%nsnow,&
+                                         wformat=wformat)
+                do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+                    NOAHMP36_struc(n)%noahmp36(t)%sstc(l) = tmptilen(t)
+                enddo
+            enddo
+ 
+            ! read: volumetric liquid soil moisture
+            do l=1, NOAHMP36_struc(n)%nsoil ! TODO: check loop
+                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SH2O", &
+                                         dim=l, vlevels = NOAHMP36_struc(n)%nsoil, wformat=wformat)
+                do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+                    NOAHMP36_struc(n)%noahmp36(t)%sh2o(l) = tmptilen(t)
+                enddo
+            enddo
+ 
+            ! read: volumetric soil moisture, ice + liquid
+            do l=1, NOAHMP36_struc(n)%nsoil ! TODO: check loop
+                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SMC", &
+                                         dim=l, vlevels = NOAHMP36_struc(n)%nsoil, wformat=wformat)
+                do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+                   NOAHMP36_struc(n)%noahmp36(t)%smc(l) = tmptilen(t)
+                enddo
+            enddo
+            
+            ! read: canopy air temperature
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%tah, &
+                                     varname="TAH", wformat=wformat)
+ 
+            ! read: canopy air vapor pressure
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%eah, &
+                                     varname="EAH", wformat=wformat)
+ 
+            ! read: wetted or snowed fraction of canopy
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%fwet, &
+                                     varname="FWET", wformat=wformat)
+ 
+            ! read: intercepted liquid water
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%canliq, &
+                                     varname="CANLIQ", wformat=wformat)
+ 
+            ! read: intercepted ice mass
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%canice, &
+                                     varname="CANICE", wformat=wformat)
+ 
+            ! read: vegetation temperature
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%tv, &
+                                     varname="TV", wformat=wformat)
+ 
+            ! read: ground temperature (skin temperature)
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%tg, &
+                                     varname="TG", wformat=wformat)
+ 
+            ! read: snowfall on the ground
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%qsnow, &
+                                     varname="QSNOW", wformat=wformat)
+ 
+            ! read: actual number of snow layers
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%isnow, &
+                                     varname="ISNOW", wformat=wformat)
+ 
+            ! read: snow/soil layer-bottom depth from snow surface
+            do l=1, NOAHMP36_struc(n)%nsoil + NOAHMP36_struc(n)%nsnow
+                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="ZSS", &
+                                         dim=l, vlevels = NOAHMP36_struc(n)%nsoil + NOAHMP36_struc(n)%nsnow, &
+                                         wformat=wformat)
+                do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+                    NOAHMP36_struc(n)%noahmp36(t)%zss(l) = tmptilen(t)
+                enddo
+            enddo
+ 
+            ! read: snow height
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%snowh, &
+                                     varname="SNOWH", wformat=wformat)
+ 
+            ! read: snow water equivalent
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%sneqv, &
+                                     varname="SNEQV", wformat=wformat)
+ 
+            ! read: snow-layer ice
+            do l=1, NOAHMP36_struc(n)%nsnow ! TODO: check loop
+                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SNOWICE", &
+                                         dim=l, vlevels = NOAHMP36_struc(n)%nsnow, wformat=wformat)
+                do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+                    NOAHMP36_struc(n)%noahmp36(t)%snowice(l) = tmptilen(t)
+                enddo
+            enddo
+ 
+            ! read: snow-layer liquid water
+            do l=1, NOAHMP36_struc(n)%nsnow ! TODO: check loop
+                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SNOWLIQ", &
+                                         dim=l, vlevels = NOAHMP36_struc(n)%nsnow, wformat=wformat)
+                do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+                    NOAHMP36_struc(n)%noahmp36(t)%snowliq(l) = tmptilen(t)
+                enddo
+            enddo
+ 
+            ! read: depth to water table
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%zwt, &
+                                     varname="ZWT", wformat=wformat)
+ 
+            ! read: water storage in aquifer
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%wa, &
+                                     varname="WA", wformat=wformat)
+ 
+            ! read: water in aquifer and saturated soil
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%wt, &
+                                     varname="WT", wformat=wformat)
+ 
+            ! read: lake water storage
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%wslake, &
+                                     varname="WSLAKE", wformat=wformat)
+ 
+            ! read: leaf mass
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%lfmass, &
+                                     varname="LFMASS", wformat=wformat)
+ 
+            ! read: mass of fine roots
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%rtmass, &
+                                     varname="RTMASS", wformat=wformat)
+ 
+            ! read: stem mass
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%stmass, &
+                                     varname="STMASS", wformat=wformat)
+ 
+            ! read: mass of wood including woody roots
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%wood, &
+                                     varname="WOOD", wformat=wformat)
+ 
+            ! read: stable carbon in deep soil
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%stblcp, &
+                                     varname="STBLCP", wformat=wformat)
+ 
+            ! read: short-lived carbon in shallow soil
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%fastcp, &
+                                     varname="FASTCP", wformat=wformat)
+ 
+            ! read: leaf area index
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%lai, &
+                                     varname="LAI", wformat=wformat)
+ 
+            ! read: stem area index
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%sai, &
+                                     varname="SAI", wformat=wformat)
+ 
+            ! read: momentum drag coefficient
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%cm, &
+                                     varname="CM", wformat=wformat)
+ 
+            ! read: sensible heat exchange coefficient
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%ch, &
+                                     varname="CH", wformat=wformat)
+ 
+            ! read: snow aging term
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%tauss, &
+                                     varname="TAUSS", wformat=wformat)
+ 
+            ! read: soil water content between bottom of the soil and water table
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%smcwtd, &
+                                     varname="SMCWTD", wformat=wformat)
+ 
+            ! read: recharge to or from the water table when deep
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%deeprech, &
+                                     varname="DEEPRECH", wformat=wformat)
+ 
+            ! read: recharge to or from the water table when shallow
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%rech, &
+                                     varname="RECH", wformat=wformat)
+        
+            ! read: reference height for air temperature and humidity 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%zlvl, &
+                                     varname="ZLVL", wformat=wformat)
+            ! close restart file
+            if(wformat .eq. "binary") then
+                call LIS_releaseUnitNumber(ftn)
+            elseif(wformat .eq. "netcdf") then
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-           status = nf90_close(ftn)
-           call LIS_verify(status, "Error in nf90_close in NoahMP36_readrst")
+                status = nf90_close(ftn)
+                call LIS_verify(status, "Error in nf90_close in NoahMP36_readrst")
 #endif
-        endif
-        deallocate(tmptilen)
-     endif
-  enddo
+            endif
+            deallocate(tmptilen)
+        endif    
+    enddo
 end subroutine NoahMP36_readrst
-
+        

--- a/lis/surfacemodels/land/noahmp.3.6/NoahMP36_readrst.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/NoahMP36_readrst.F90
@@ -15,8 +15,8 @@
 !
 ! !REVISION HISTORY:
 !  This subroutine is generated with the Model Implementation Toolkit developed
-!  by Shugong Wang for the NASA Land Information System Version 7. The initial 
-!  specification of the subroutine is defined by Sujay Kumar. 
+!  by Shugong Wang for the NASA Land Information System Version 7. The initial
+!  specification of the subroutine is defined by Sujay Kumar.
 !   9/4/14: Shugong Wang; initial implementation for LIS 7 and NoahMP36
 !
 ! !INTERFACE:
@@ -27,7 +27,7 @@ subroutine NoahMP36_readrst()
     use LIS_logMod, only     : LIS_logunit, LIS_endrun, &
                                LIS_getNextUnitNumber,   &
                                LIS_releaseUnitNumber,   &
-                               LIS_verify                
+                               LIS_verify
     use NoahMP36_lsmMod
     !WN
     use ESMF
@@ -93,9 +93,9 @@ subroutine NoahMP36_readrst()
 !      initializes the NoahMP36 state variables
 ! \end{description}
 !EOP
- 
+
     implicit none
- 
+
     integer           :: t, l
     integer           :: nc, nr, npatch
     integer           :: n
@@ -109,13 +109,13 @@ subroutine NoahMP36_readrst()
     integer           :: yr,mo,da,hr,mn,ss,doy
     real*8            :: time
     real              :: gmt
-    real              :: ts 
+    real              :: ts
 
 
     do n=1, LIS_rc%nnest
         wformat = trim(NOAHMP36_struc(n)%rformat)
         ! coldstart
-        if(LIS_rc%startcode .eq. "coldstart") then  
+        if(LIS_rc%startcode .eq. "coldstart") then
             call NoahMP36_coldstart(LIS_rc%lsm_index)
         ! restart
         elseif(LIS_rc%startcode .eq. "restart") then
@@ -123,13 +123,15 @@ subroutine NoahMP36_readrst()
                 if(LIS_rc%runmode.eq."ensemble smoother") then
                   if(LIS_rc%iterationId(n).gt.1) then
                     if(NOAHMP36_struc(n)%rstInterval.eq.2592000) then
-                     !create the restart filename based on the timewindow start time
+                     !create the restart filename based on the timewindow
+                     ! start time
                       call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
                            dd=da,calendar=LIS_calendar,rc=status)
                       hr = 0
                       mn = 0
                       ss = 0
-                      call LIS_tick(time,doy,gmt,yr,mo,da,hr,mn,ss,(-1)*LIS_rc%ts)
+                      call LIS_tick(time,doy,gmt,yr,mo,da,hr,mn,ss, &
+                           (-1)*LIS_rc%ts)
                     else
                       call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
                            dd=da,calendar=LIS_calendar,rc=status)
@@ -138,7 +140,8 @@ subroutine NoahMP36_readrst()
                       ss = 0
                     endif
 
-                    call LIS_create_restart_filename(n,filen,'SURFACEMODEL','NOAHMP36', &
+                    call LIS_create_restart_filename(n,filen,'SURFACEMODEL', &
+                         'NOAHMP36', &
                          yr,mo,da,hr,mn,ss, wformat=wformat)
                     NOAHMP36_struc(n)%rfile = filen
                   endif
@@ -147,231 +150,280 @@ subroutine NoahMP36_readrst()
             allocate(tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index)))
             ! check the existance of restart file
             inquire(file=NOAHMP36_struc(n)%rfile, exist=file_exists)
-            If (.not. file_exists) then 
-                write(LIS_logunit,*) "NoahMP36 restart file ", NOAHMP36_struc(n)%rfile," does not exist "
+            If (.not. file_exists) then
+                write(LIS_logunit,*) "NoahMP36 restart file ", &
+                     NOAHMP36_struc(n)%rfile," does not exist "
                 write(LIS_logunit,*) "Program stopping ..."
                 call LIS_endrun
             endif
-            write(LIS_logunit,*) "NoahMP36 restart file used: ", NOAHMP36_struc(n)%rfile
-        
+            write(LIS_logunit,*) "NoahMP36 restart file used: ", &
+                 NOAHMP36_struc(n)%rfile
+
             ! open restart file
             if(wformat .eq. "binary") then
                 ftn = LIS_getNextUnitNumber()
                 open(ftn, file=NOAHMP36_struc(n)%rfile, form="unformatted")
                 read(ftn) nc, nr, npatch  !time, veg class, no. tiles
- 
+
                 ! check for grid space conflict
                 if((nc .ne. LIS_rc%gnc(n)) .or. (nr .ne. LIS_rc%gnr(n))) then
-                    write(LIS_logunit,*) NOAHMP36_struc(n)%rfile, "grid space mismatch - NoahMP36 halted"
+                    write(LIS_logunit,*) NOAHMP36_struc(n)%rfile, &
+                         "grid space mismatch - NoahMP36 halted"
                     call LIS_endrun
                 endif
-            
+
                 if(npatch .ne. LIS_rc%glbnpatch_red(n, LIS_rc%lsm_index)) then
-                    write(LIS_logunit,*) "restart tile space mismatch, halting..."
+                    write(LIS_logunit,*) &
+                         "restart tile space mismatch, halting..."
                     call LIS_endrun
                 endif
             elseif(wformat .eq. "netcdf") then
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
                 status = nf90_open(path=NOAHMP36_struc(n)%rfile, &
                                    mode=NF90_NOWRITE, ncid=ftn)
-                call LIS_verify(status, "Error opening file "//NOAHMP36_struc(n)%rfile)
+                call LIS_verify(status, &
+                     "Error opening file "//NOAHMP36_struc(n)%rfile)
 #endif
             endif
- 
+
             ! read: snow albedo at last time step
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%albold, &
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%albold, &
                                      varname="ALBOLD", wformat=wformat)
- 
+
             ! read: snow mass at the last time step
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%sneqvo, &
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%sneqvo, &
                                      varname="SNEQVO", wformat=wformat)
- 
+
             ! read: snow/soil temperature
             do l=1, NOAHMP36_struc(n)%nsoil + NOAHMP36_struc(n)%nsnow
-                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SSTC", &
-                                         dim=l, vlevels = NOAHMP36_struc(n)%nsoil + NOAHMP36_struc(n)%nsnow,&
-                                         wformat=wformat)
+                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, &
+                     varname="SSTC", &
+                     dim=l, &
+                     vlevels = NOAHMP36_struc(n)%nsoil + &
+                               NOAHMP36_struc(n)%nsnow, &
+                     wformat=wformat)
                 do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
                     NOAHMP36_struc(n)%noahmp36(t)%sstc(l) = tmptilen(t)
                 enddo
             enddo
- 
+
             ! read: volumetric liquid soil moisture
             do l=1, NOAHMP36_struc(n)%nsoil ! TODO: check loop
-                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SH2O", &
-                                         dim=l, vlevels = NOAHMP36_struc(n)%nsoil, wformat=wformat)
+                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, &
+                     varname="SH2O", &
+                     dim=l, vlevels = NOAHMP36_struc(n)%nsoil, wformat=wformat)
                 do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
                     NOAHMP36_struc(n)%noahmp36(t)%sh2o(l) = tmptilen(t)
                 enddo
             enddo
- 
+
             ! read: volumetric soil moisture, ice + liquid
             do l=1, NOAHMP36_struc(n)%nsoil ! TODO: check loop
-                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SMC", &
-                                         dim=l, vlevels = NOAHMP36_struc(n)%nsoil, wformat=wformat)
+                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, &
+                     varname="SMC", &
+                     dim=l, vlevels = NOAHMP36_struc(n)%nsoil, wformat=wformat)
                 do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
                    NOAHMP36_struc(n)%noahmp36(t)%smc(l) = tmptilen(t)
                 enddo
             enddo
-            
+
             ! read: canopy air temperature
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%tah, &
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%tah, &
                                      varname="TAH", wformat=wformat)
- 
+
             ! read: canopy air vapor pressure
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%eah, &
-                                     varname="EAH", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%eah, &
+                 varname="EAH", wformat=wformat)
+
             ! read: wetted or snowed fraction of canopy
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%fwet, &
-                                     varname="FWET", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%fwet, &
+                 varname="FWET", wformat=wformat)
+
             ! read: intercepted liquid water
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%canliq, &
-                                     varname="CANLIQ", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%canliq, &
+                 varname="CANLIQ", wformat=wformat)
+
             ! read: intercepted ice mass
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%canice, &
-                                     varname="CANICE", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%canice, &
+                 varname="CANICE", wformat=wformat)
+
             ! read: vegetation temperature
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%tv, &
-                                     varname="TV", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%tv, &
+                 varname="TV", wformat=wformat)
+
             ! read: ground temperature (skin temperature)
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%tg, &
-                                     varname="TG", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%tg, &
+                 varname="TG", wformat=wformat)
+
             ! read: snowfall on the ground
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%qsnow, &
-                                     varname="QSNOW", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%qsnow, &
+                 varname="QSNOW", wformat=wformat)
+
             ! read: actual number of snow layers
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%isnow, &
-                                     varname="ISNOW", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%isnow, &
+                 varname="ISNOW", wformat=wformat)
+
             ! read: snow/soil layer-bottom depth from snow surface
             do l=1, NOAHMP36_struc(n)%nsoil + NOAHMP36_struc(n)%nsnow
-                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="ZSS", &
-                                         dim=l, vlevels = NOAHMP36_struc(n)%nsoil + NOAHMP36_struc(n)%nsnow, &
-                                         wformat=wformat)
+                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, &
+                     varname="ZSS", &
+                     dim=l, &
+                     vlevels = NOAHMP36_struc(n)%nsoil + &
+                               NOAHMP36_struc(n)%nsnow, &
+                               wformat=wformat)
                 do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
                     NOAHMP36_struc(n)%noahmp36(t)%zss(l) = tmptilen(t)
                 enddo
             enddo
- 
+
             ! read: snow height
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%snowh, &
-                                     varname="SNOWH", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%snowh, &
+                 varname="SNOWH", wformat=wformat)
+
             ! read: snow water equivalent
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%sneqv, &
-                                     varname="SNEQV", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%sneqv, &
+                 varname="SNEQV", wformat=wformat)
+
             ! read: snow-layer ice
             do l=1, NOAHMP36_struc(n)%nsnow ! TODO: check loop
-                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SNOWICE", &
-                                         dim=l, vlevels = NOAHMP36_struc(n)%nsnow, wformat=wformat)
+                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, &
+                     varname="SNOWICE", &
+                     dim=l, vlevels = NOAHMP36_struc(n)%nsnow, wformat=wformat)
                 do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
                     NOAHMP36_struc(n)%noahmp36(t)%snowice(l) = tmptilen(t)
                 enddo
             enddo
- 
+
             ! read: snow-layer liquid water
             do l=1, NOAHMP36_struc(n)%nsnow ! TODO: check loop
-                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SNOWLIQ", &
-                                         dim=l, vlevels = NOAHMP36_struc(n)%nsnow, wformat=wformat)
+                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, &
+                     varname="SNOWLIQ", &
+                     dim=l, vlevels = NOAHMP36_struc(n)%nsnow, wformat=wformat)
                 do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
                     NOAHMP36_struc(n)%noahmp36(t)%snowliq(l) = tmptilen(t)
                 enddo
             enddo
- 
+
             ! read: depth to water table
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%zwt, &
-                                     varname="ZWT", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%zwt, &
+                 varname="ZWT", wformat=wformat)
+
             ! read: water storage in aquifer
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%wa, &
-                                     varname="WA", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%wa, &
+                 varname="WA", wformat=wformat)
+
             ! read: water in aquifer and saturated soil
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%wt, &
-                                     varname="WT", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%wt, &
+                 varname="WT", wformat=wformat)
+
             ! read: lake water storage
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%wslake, &
-                                     varname="WSLAKE", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%wslake, &
+                 varname="WSLAKE", wformat=wformat)
+
             ! read: leaf mass
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%lfmass, &
-                                     varname="LFMASS", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%lfmass, &
+                 varname="LFMASS", wformat=wformat)
+
             ! read: mass of fine roots
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%rtmass, &
-                                     varname="RTMASS", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%rtmass, &
+                 varname="RTMASS", wformat=wformat)
+
             ! read: stem mass
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%stmass, &
-                                     varname="STMASS", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%stmass, &
+                 varname="STMASS", wformat=wformat)
+
             ! read: mass of wood including woody roots
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%wood, &
-                                     varname="WOOD", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%wood, &
+                 varname="WOOD", wformat=wformat)
+
             ! read: stable carbon in deep soil
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%stblcp, &
-                                     varname="STBLCP", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%stblcp, &
+                 varname="STBLCP", wformat=wformat)
+
             ! read: short-lived carbon in shallow soil
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%fastcp, &
-                                     varname="FASTCP", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%fastcp, &
+                 varname="FASTCP", wformat=wformat)
+
             ! read: leaf area index
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%lai, &
-                                     varname="LAI", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%lai, &
+                 varname="LAI", wformat=wformat)
+
             ! read: stem area index
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%sai, &
-                                     varname="SAI", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%sai, &
+                 varname="SAI", wformat=wformat)
+
             ! read: momentum drag coefficient
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%cm, &
-                                     varname="CM", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%cm, &
+                 varname="CM", wformat=wformat)
+
             ! read: sensible heat exchange coefficient
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%ch, &
-                                     varname="CH", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%ch, &
+                 varname="CH", wformat=wformat)
+
             ! read: snow aging term
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%tauss, &
-                                     varname="TAUSS", wformat=wformat)
- 
-            ! read: soil water content between bottom of the soil and water table
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%smcwtd, &
-                                     varname="SMCWTD", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%tauss, &
+                 varname="TAUSS", wformat=wformat)
+
+            ! read: soil water content between bottom of the soil and water
+            ! table
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%smcwtd, &
+                 varname="SMCWTD", wformat=wformat)
+
             ! read: recharge to or from the water table when deep
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%deeprech, &
-                                     varname="DEEPRECH", wformat=wformat)
- 
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%deeprech, &
+                 varname="DEEPRECH", wformat=wformat)
+
             ! read: recharge to or from the water table when shallow
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%rech, &
-                                     varname="RECH", wformat=wformat)
-        
-            ! read: reference height for air temperature and humidity 
-            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP36_struc(n)%noahmp36%zlvl, &
-                                     varname="ZLVL", wformat=wformat)
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%rech, &
+                 varname="RECH", wformat=wformat)
+
+            ! read: reference height for air temperature and humidity
+            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, &
+                 NOAHMP36_struc(n)%noahmp36%zlvl, &
+                 varname="ZLVL", wformat=wformat)
             ! close restart file
             if(wformat .eq. "binary") then
                 call LIS_releaseUnitNumber(ftn)
             elseif(wformat .eq. "netcdf") then
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
                 status = nf90_close(ftn)
-                call LIS_verify(status, "Error in nf90_close in NoahMP36_readrst")
+                call LIS_verify(status, &
+                     "Error in nf90_close in NoahMP36_readrst")
 #endif
             endif
             deallocate(tmptilen)
-        endif    
+        endif
     enddo
 end subroutine NoahMP36_readrst
-        
+

--- a/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_descale_tws.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_descale_tws.F90
@@ -25,7 +25,7 @@ subroutine noahmp36_descale_tws(n, LSM_State, LSM_Incr_State)
   use LIS_constantsMod,  only : LIS_CONST_RHOFW ! Natt
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in)    :: n
   type(ESMF_State)       :: LSM_State
   type(ESMF_State)       :: LSM_Incr_State
@@ -34,8 +34,8 @@ subroutine noahmp36_descale_tws(n, LSM_State, LSM_Incr_State)
 !
 !  Descales twsoisture related state prognostic variables for
 !  data assimilation
-! 
-!  The arguments are: 
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[n] index of the nest \newline
 !  \item[LSM\_State] ESMF State container for LSM state variables \newline
@@ -50,7 +50,7 @@ subroutine noahmp36_descale_tws(n, LSM_State, LSM_Incr_State)
   real, pointer        :: gwsIncr(:)
   integer              :: t
   integer              :: status
-  
+
 ! Natt
   type(ESMF_Field)       :: sm1Field
   type(ESMF_Field)       :: sm2Field
@@ -77,7 +77,7 @@ subroutine noahmp36_descale_tws(n, LSM_State, LSM_Incr_State)
   real, pointer          :: sweincr(:)
   real, pointer          :: snodincr(:)
 
-#if 0 
+#if 0
   call ESMF_StateGet(LSM_State,"Groundwater Storage",gwField,rc=status)
   call LIS_verify(status,&
        "ESMF_StateSet: Groundwater Storage failed in noahmp36_settws")
@@ -86,7 +86,8 @@ subroutine noahmp36_descale_tws(n, LSM_State, LSM_Incr_State)
   call LIS_verify(status,&
        "ESMF_FieldGet: Groundwater Storage failed in noahmp36_settws")
 
-  call ESMF_StateGet(LSM_Incr_State, "Groundwater Storage",gwIncrField,rc=status)
+  call ESMF_StateGet(LSM_Incr_State, "Groundwater Storage",gwIncrField, &
+       rc=status)
   call LIS_verify(status,&
        "ESMF_StateSet: Groundwater Storage failed in noahmp36_descale")
 
@@ -103,50 +104,66 @@ subroutine noahmp36_descale_tws(n, LSM_State, LSM_Incr_State)
   ! Natt
   ! Descale TWS states
   call ESMF_StateGet(LSM_State,"Soil Moisture Layer 1",sm1Field,rc=status)
-  call LIS_verify(status,'ESMF_StateGet failed for sm1 in noahmp36_descale_tws')
+  call LIS_verify(status, &
+       'ESMF_StateGet failed for sm1 in noahmp36_descale_tws')
   call ESMF_StateGet(LSM_State,"Soil Moisture Layer 2",sm2Field,rc=status)
-  call LIS_verify(status,'ESMF_StateGet failed for sm2 in noahmp36_descale_tws')
+  call LIS_verify(status, &
+       'ESMF_StateGet failed for sm2 in noahmp36_descale_tws')
   call ESMF_StateGet(LSM_State,"Soil Moisture Layer 3",sm3Field,rc=status)
-  call LIS_verify(status,'ESMF_StateGet failed for sm3 in noahmp36_descale_tws')
+  call LIS_verify(status, &
+       'ESMF_StateGet failed for sm3 in noahmp36_descale_tws')
   call ESMF_StateGet(LSM_State,"Soil Moisture Layer 4",sm4Field,rc=status)
-  call LIS_verify(status,'ESMF_StateGet failed for sm4 in noahmp36_descale_tws')
+  call LIS_verify(status, &
+       'ESMF_StateGet failed for sm4 in noahmp36_descale_tws')
   call ESMF_StateGet(LSM_State,"SWE",sweField,rc=status)
-  call LIS_verify(status,'ESMF_StateGet failed for SWE in noahmp36_descale_tws')
+  call LIS_verify(status, &
+       'ESMF_StateGet failed for SWE in noahmp36_descale_tws')
   call ESMF_StateGet(LSM_State,"Snowdepth",snodField,rc=status)
-  call LIS_verify(status,'ESMF_StateGet failed for Snowdepth in noahmp36_descale_tws')
-  
+  call LIS_verify(status, &
+       'ESMF_StateGet failed for Snowdepth in noahmp36_descale_tws')
+
   call ESMF_FieldGet(sm1Field,localDE=0,farrayPtr=soilm1,rc=status)
-  call LIS_verify(status,'ESMF_FieldGet failed for sm1 in noahmp36_descale_tws')
+  call LIS_verify(status, &
+       'ESMF_FieldGet failed for sm1 in noahmp36_descale_tws')
   call ESMF_FieldGet(sm2Field,localDE=0,farrayPtr=soilm2,rc=status)
-  call LIS_verify(status,'ESMF_FieldGet failed for sm2 in noahmp36_descale_tws')
+  call LIS_verify(status, &
+       'ESMF_FieldGet failed for sm2 in noahmp36_descale_tws')
   call ESMF_FieldGet(sm3Field,localDE=0,farrayPtr=soilm3,rc=status)
-  call LIS_verify(status,'ESMF_FieldGet failed for sm3 in noahmp36_descale_tws')
+  call LIS_verify(status, &
+       'ESMF_FieldGet failed for sm3 in noahmp36_descale_tws')
   call ESMF_FieldGet(sm4Field,localDE=0,farrayPtr=soilm4,rc=status)
-  call LIS_verify(status,'ESMF_FieldGet failed for sm4 in noahmp36_descale_tws')
+  call LIS_verify(status, &
+       'ESMF_FieldGet failed for sm4 in noahmp36_descale_tws')
   call ESMF_FieldGet(sweField,localDE=0,farrayPtr=swe,rc=status)
-  call LIS_verify(status,'ESMF_FieldGet failed for SWE in noahmp36_descale_tws')
+  call LIS_verify(status, &
+       'ESMF_FieldGet failed for SWE in noahmp36_descale_tws')
   call ESMF_FieldGet(snodField,localDE=0,farrayPtr=snod,rc=status)
-  call LIS_verify(status,'ESMF_FieldGet failed for Snowdepth in noahmp36_descale_tws')
-  
+  call LIS_verify(status, &
+       'ESMF_FieldGet failed for Snowdepth in noahmp36_descale_tws')
+
   ! Natt
   ! Descale TWS state increment
-  call ESMF_StateGet(LSM_Incr_State,"Soil Moisture Layer 1",sm1IncrField,rc=status)
+  call ESMF_StateGet(LSM_Incr_State,"Soil Moisture Layer 1",sm1IncrField, &
+       rc=status)
   call LIS_verify(status,&
        "ESMF_StateGet: Soil Moisture Layer 1 failed in noahmp36_descale_tws")
-  call ESMF_StateGet(LSM_Incr_State,"Soil Moisture Layer 2",sm2IncrField,rc=status)
+  call ESMF_StateGet(LSM_Incr_State,"Soil Moisture Layer 2",sm2IncrField, &
+       rc=status)
   call LIS_verify(status,&
        "ESMF_StateGet: Soil Moisture Layer 2 failed in noahmp36_descale_tws")
-  call ESMF_StateGet(LSM_Incr_State,"Soil Moisture Layer 3",sm3IncrField,rc=status)
+  call ESMF_StateGet(LSM_Incr_State,"Soil Moisture Layer 3",sm3IncrField, &
+       rc=status)
   call LIS_verify(status,&
        "ESMF_StateGet: Soil Moisture Layer 3 failed in noahmp36_descale_tws")
-  call ESMF_StateGet(LSM_Incr_State,"Soil Moisture Layer 4",sm4IncrField,rc=status)
+  call ESMF_StateGet(LSM_Incr_State,"Soil Moisture Layer 4",sm4IncrField, &
+       rc=status)
   call LIS_verify(status,&
        "ESMF_StateGet: Soil Moisture Layer 4 failed in noahmp36_descale_tws")
   call ESMF_StateGet(LSM_Incr_State,"SWE",sweIncrField,rc=status)
   call LIS_verify(status)
   call ESMF_StateGet(LSM_Incr_State,"Snowdepth",snodIncrField,rc=status)
   call LIS_verify(status)
-  
+
   call ESMF_FieldGet(sm1IncrField,localDE=0,farrayPtr=soilmIncr1,rc=status)
   call LIS_verify(status,&
        "ESMF_FieldGet: Soil Moisture Layer 1 failed in noahmp36_descale_tws")
@@ -163,25 +180,32 @@ subroutine noahmp36_descale_tws(n, LSM_State, LSM_Incr_State)
   call LIS_verify(status)
   call ESMF_FieldGet(snodIncrField,localDE=0,farrayPtr=snodincr,rc=status)
   call LIS_verify(status)
-  
-  
+
   do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
-     soilm1(t) = soilm1(t) / (NOAHMP36_struc(n)%sldpth(1)*LIS_CONST_RHOFW) ! mm -> m3m-3
-     soilm2(t) = soilm2(t) / (NOAHMP36_struc(n)%sldpth(2)*LIS_CONST_RHOFW) ! mm -> m3m-3
-     soilm3(t) = soilm3(t) / (NOAHMP36_struc(n)%sldpth(3)*LIS_CONST_RHOFW) ! mm -> m3m-3
-     soilm4(t) = soilm4(t) / (NOAHMP36_struc(n)%sldpth(4)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     soilm1(t) = soilm1(t) / &
+          (NOAHMP36_struc(n)%sldpth(1)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     soilm2(t) = soilm2(t) / &
+          (NOAHMP36_struc(n)%sldpth(2)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     soilm3(t) = soilm3(t) / &
+          (NOAHMP36_struc(n)%sldpth(3)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     soilm4(t) = soilm4(t) / &
+          (NOAHMP36_struc(n)%sldpth(4)*LIS_CONST_RHOFW) ! mm -> m3m-3
      swe(t)    = swe(t) / 1000.0  ! mm -> m
      snod(t)   = snod(t) / 1000.0 ! mm -> m
-     
-     soilmIncr1(t) = soilmIncr1(t) / (NOAHMP36_struc(n)%sldpth(1)*LIS_CONST_RHOFW) ! mm -> m3m-3
-     soilmIncr2(t) = soilmIncr2(t) / (NOAHMP36_struc(n)%sldpth(2)*LIS_CONST_RHOFW) ! mm -> m3m-3
-     soilmIncr3(t) = soilmIncr3(t) / (NOAHMP36_struc(n)%sldpth(3)*LIS_CONST_RHOFW) ! mm -> m3m-3
-     soilmIncr4(t) = soilmIncr4(t) / (NOAHMP36_struc(n)%sldpth(4)*LIS_CONST_RHOFW) ! mm -> m3m-3
+
+     soilmIncr1(t) = soilmIncr1(t) / &
+          (NOAHMP36_struc(n)%sldpth(1)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     soilmIncr2(t) = soilmIncr2(t) / &
+          (NOAHMP36_struc(n)%sldpth(2)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     soilmIncr3(t) = soilmIncr3(t) / &
+          (NOAHMP36_struc(n)%sldpth(3)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     soilmIncr4(t) = soilmIncr4(t) / &
+          (NOAHMP36_struc(n)%sldpth(4)*LIS_CONST_RHOFW) ! mm -> m3m-3
      sweincr(t)    = sweincr(t) / 1000.0  ! mm -> m
      snodincr(t)   = snodincr(t) / 1000.0 ! mm -> m
 
   enddo
- 
+
 
 end subroutine noahmp36_descale_tws
 

--- a/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_descale_tws.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_descale_tws.F90
@@ -22,6 +22,7 @@ subroutine noahmp36_descale_tws(n, LSM_State, LSM_Incr_State)
   use LIS_coreMod, only : LIS_rc
   use LIS_logMod,  only  : LIS_verify
   use noahmp36_lsmMod
+  use LIS_constantsMod,  only : LIS_CONST_RHOFW ! Natt
 
   implicit none
 ! !ARGUMENTS: 
@@ -49,6 +50,32 @@ subroutine noahmp36_descale_tws(n, LSM_State, LSM_Incr_State)
   real, pointer        :: gwsIncr(:)
   integer              :: t
   integer              :: status
+  
+! Natt
+  type(ESMF_Field)       :: sm1Field
+  type(ESMF_Field)       :: sm2Field
+  type(ESMF_Field)       :: sm3Field
+  type(ESMF_Field)       :: sm4Field
+  type(ESMF_Field)       :: sweField
+  type(ESMF_Field)       :: snodField
+  type(ESMF_Field)       :: sm1IncrField
+  type(ESMF_Field)       :: sm2IncrField
+  type(ESMF_Field)       :: sm3IncrField
+  type(ESMF_Field)       :: sm4IncrField
+  type(ESMF_Field)       :: sweIncrField
+  type(ESMF_Field)       :: snodIncrField
+  real, pointer          :: soilm1(:)
+  real, pointer          :: soilm2(:)
+  real, pointer          :: soilm3(:)
+  real, pointer          :: soilm4(:)
+  real, pointer          :: swe(:)
+  real, pointer          :: snod(:)
+  real, pointer          :: soilmIncr1(:)
+  real, pointer          :: soilmIncr2(:)
+  real, pointer          :: soilmIncr3(:)
+  real, pointer          :: soilmIncr4(:)
+  real, pointer          :: sweincr(:)
+  real, pointer          :: snodincr(:)
 
 #if 0 
   call ESMF_StateGet(LSM_State,"Groundwater Storage",gwField,rc=status)
@@ -72,6 +99,88 @@ subroutine noahmp36_descale_tws(n, LSM_State, LSM_Incr_State)
      gwsIncr(t) = gwsIncr(t)*10.0
   enddo
 #endif
+
+  ! Natt
+  ! Descale TWS states
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 1",sm1Field,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for sm1 in noahmp36_descale_tws')
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 2",sm2Field,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for sm2 in noahmp36_descale_tws')
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 3",sm3Field,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for sm3 in noahmp36_descale_tws')
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 4",sm4Field,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for sm4 in noahmp36_descale_tws')
+  call ESMF_StateGet(LSM_State,"SWE",sweField,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for SWE in noahmp36_descale_tws')
+  call ESMF_StateGet(LSM_State,"Snowdepth",snodField,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for Snowdepth in noahmp36_descale_tws')
+  
+  call ESMF_FieldGet(sm1Field,localDE=0,farrayPtr=soilm1,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for sm1 in noahmp36_descale_tws')
+  call ESMF_FieldGet(sm2Field,localDE=0,farrayPtr=soilm2,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for sm2 in noahmp36_descale_tws')
+  call ESMF_FieldGet(sm3Field,localDE=0,farrayPtr=soilm3,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for sm3 in noahmp36_descale_tws')
+  call ESMF_FieldGet(sm4Field,localDE=0,farrayPtr=soilm4,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for sm4 in noahmp36_descale_tws')
+  call ESMF_FieldGet(sweField,localDE=0,farrayPtr=swe,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for SWE in noahmp36_descale_tws')
+  call ESMF_FieldGet(snodField,localDE=0,farrayPtr=snod,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for Snowdepth in noahmp36_descale_tws')
+  
+  ! Natt
+  ! Descale TWS state increment
+  call ESMF_StateGet(LSM_Incr_State,"Soil Moisture Layer 1",sm1IncrField,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateGet: Soil Moisture Layer 1 failed in noahmp36_descale_tws")
+  call ESMF_StateGet(LSM_Incr_State,"Soil Moisture Layer 2",sm2IncrField,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateGet: Soil Moisture Layer 2 failed in noahmp36_descale_tws")
+  call ESMF_StateGet(LSM_Incr_State,"Soil Moisture Layer 3",sm3IncrField,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateGet: Soil Moisture Layer 3 failed in noahmp36_descale_tws")
+  call ESMF_StateGet(LSM_Incr_State,"Soil Moisture Layer 4",sm4IncrField,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateGet: Soil Moisture Layer 4 failed in noahmp36_descale_tws")
+  call ESMF_StateGet(LSM_Incr_State,"SWE",sweIncrField,rc=status)
+  call LIS_verify(status)
+  call ESMF_StateGet(LSM_Incr_State,"Snowdepth",snodIncrField,rc=status)
+  call LIS_verify(status)
+  
+  call ESMF_FieldGet(sm1IncrField,localDE=0,farrayPtr=soilmIncr1,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 1 failed in noahmp36_descale_tws")
+  call ESMF_FieldGet(sm2IncrField,localDE=0,farrayPtr=soilmIncr2,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 2 failed in noahmp36_descale_tws")
+  call ESMF_FieldGet(sm3IncrField,localDE=0,farrayPtr=soilmIncr3,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 3 failed in noahmp36_descale_tws")
+  call ESMF_FieldGet(sm4IncrField,localDE=0,farrayPtr=soilmIncr4,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 4 failed in noahmp36_descale_tws")
+  call ESMF_FieldGet(sweIncrField,localDE=0,farrayPtr=sweincr,rc=status)
+  call LIS_verify(status)
+  call ESMF_FieldGet(snodIncrField,localDE=0,farrayPtr=snodincr,rc=status)
+  call LIS_verify(status)
+  
+  
+  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     soilm1(t) = soilm1(t) / (NOAHMP36_struc(n)%sldpth(1)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     soilm2(t) = soilm2(t) / (NOAHMP36_struc(n)%sldpth(2)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     soilm3(t) = soilm3(t) / (NOAHMP36_struc(n)%sldpth(3)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     soilm4(t) = soilm4(t) / (NOAHMP36_struc(n)%sldpth(4)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     swe(t)    = swe(t) / 1000.0  ! mm -> m
+     snod(t)   = snod(t) / 1000.0 ! mm -> m
+     
+     soilmIncr1(t) = soilmIncr1(t) / (NOAHMP36_struc(n)%sldpth(1)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     soilmIncr2(t) = soilmIncr2(t) / (NOAHMP36_struc(n)%sldpth(2)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     soilmIncr3(t) = soilmIncr3(t) / (NOAHMP36_struc(n)%sldpth(3)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     soilmIncr4(t) = soilmIncr4(t) / (NOAHMP36_struc(n)%sldpth(4)*LIS_CONST_RHOFW) ! mm -> m3m-3
+     sweincr(t)    = sweincr(t) / 1000.0  ! mm -> m
+     snodincr(t)   = snodincr(t) / 1000.0 ! mm -> m
+
+  enddo
  
 
 end subroutine noahmp36_descale_tws

--- a/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_gettws.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_gettws.F90
@@ -95,7 +95,7 @@ subroutine noahmp36_gettws(n, LSM_State)
      soilm3(t) = NOAHMP36_struc(n)%noahmp36(t)%smc(3)
      soilm4(t) = NOAHMP36_struc(n)%noahmp36(t)%smc(4)
      gws(t)    = NOAHMP36_struc(n)%noahmp36(t)%wa
-     swe(t) = noahmp36_struc(n)%noahmp36(t)%sneqv/1000.0 !to m
+     swe(t) = noahmp36_struc(n)%noahmp36(t)%sneqv/1000.0 ! to m
      snod(t) = noahmp36_struc(n)%noahmp36(t)%snowh
   enddo
 

--- a/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_scale_tws.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_scale_tws.F90
@@ -25,7 +25,7 @@ subroutine noahmp36_scale_tws(n, LSM_State)
   use LIS_constantsMod,  only : LIS_CONST_RHOFW ! Natt
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in)    :: n
   type(ESMF_State)       :: LSM_State
 !
@@ -33,8 +33,8 @@ subroutine noahmp36_scale_tws(n, LSM_State)
 !
 !  Scales twsoisture related state prognostic variables for
 !  data assimilation
-! 
-!  The arguments are: 
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[n] index of the nest \newline
 !  \item[LSM\_State] ESMF State container for LSM state variables \newline
@@ -42,12 +42,12 @@ subroutine noahmp36_scale_tws(n, LSM_State)
 !EOP
 
 !Wanshu
- 
+
   type(ESMF_Field)     :: gwField
   real, pointer        :: gws(:)
   integer              :: t
   integer              :: status
-  
+
 ! Natt
   type(ESMF_Field)       :: sm1Field
   type(ESMF_Field)       :: sm2Field
@@ -62,8 +62,8 @@ subroutine noahmp36_scale_tws(n, LSM_State)
   real, pointer          :: swe(:)
   real, pointer          :: snod(:)
 
-  
-#if 0 
+
+#if 0
   call ESMF_StateGet(LSM_State,"Groundwater Storage",gwField,rc=status)
   call LIS_verify(status,&
        "ESMF_StateSet: Groundwater Storage failed in noahmp36_settws")
@@ -90,8 +90,9 @@ subroutine noahmp36_scale_tws(n, LSM_State)
   call ESMF_StateGet(LSM_State,"SWE",sweField,rc=status)
   call LIS_verify(status,'ESMF_StateGet failed for SWE in noahmp36_scale_tws')
   call ESMF_StateGet(LSM_State,"Snowdepth",snodField,rc=status)
-  call LIS_verify(status,'ESMF_StateGet failed for Snowdepth in noahmp36_scale_tws')
-  
+  call LIS_verify(status, &
+       'ESMF_StateGet failed for Snowdepth in noahmp36_scale_tws')
+
   call ESMF_FieldGet(sm1Field,localDE=0,farrayPtr=soilm1,rc=status)
   call LIS_verify(status,'ESMF_FieldGet failed for sm1 in noahmp36_scale_tws')
   call ESMF_FieldGet(sm2Field,localDE=0,farrayPtr=soilm2,rc=status)
@@ -103,17 +104,21 @@ subroutine noahmp36_scale_tws(n, LSM_State)
   call ESMF_FieldGet(sweField,localDE=0,farrayPtr=swe,rc=status)
   call LIS_verify(status,'ESMF_FieldGet failed for SWE in noahmp36_scale_tws')
   call ESMF_FieldGet(snodField,localDE=0,farrayPtr=snod,rc=status)
-  call LIS_verify(status,'ESMF_FieldGet failed for Snowdepth in noahmp36_scale_tws')
-  
+  call LIS_verify(status, &
+       'ESMF_FieldGet failed for Snowdepth in noahmp36_scale_tws')
+
   do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
-     soilm1(t) = soilm1(t) * NOAHMP36_struc(n)%sldpth(1)*LIS_CONST_RHOFW ! m3m-3 -> mm
-     soilm2(t) = soilm2(t) * NOAHMP36_struc(n)%sldpth(2)*LIS_CONST_RHOFW ! m3m-3 -> mm
-     soilm3(t) = soilm3(t) * NOAHMP36_struc(n)%sldpth(3)*LIS_CONST_RHOFW ! m3m-3 -> mm
-     soilm4(t) = soilm4(t) * NOAHMP36_struc(n)%sldpth(4)*LIS_CONST_RHOFW ! m3m-3 -> mm
+     soilm1(t) = soilm1(t) * &
+          NOAHMP36_struc(n)%sldpth(1)*LIS_CONST_RHOFW ! m3m-3 -> mm
+     soilm2(t) = soilm2(t) * &
+          NOAHMP36_struc(n)%sldpth(2)*LIS_CONST_RHOFW ! m3m-3 -> mm
+     soilm3(t) = soilm3(t) * &
+          NOAHMP36_struc(n)%sldpth(3)*LIS_CONST_RHOFW ! m3m-3 -> mm
+     soilm4(t) = soilm4(t) * &
+          NOAHMP36_struc(n)%sldpth(4)*LIS_CONST_RHOFW ! m3m-3 -> mm
      swe(t)    = swe(t) * 1000.0  ! m -> mm
      snod(t)   = snod(t) * 1000.0 ! m -> mm
   enddo
-  
-  
+
 end subroutine noahmp36_scale_tws
 

--- a/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_scale_tws.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_scale_tws.F90
@@ -22,6 +22,7 @@ subroutine noahmp36_scale_tws(n, LSM_State)
   use LIS_coreMod, only : LIS_rc
   use LIS_logMod,  only  : LIS_verify
   use noahmp36_lsmMod
+  use LIS_constantsMod,  only : LIS_CONST_RHOFW ! Natt
 
   implicit none
 ! !ARGUMENTS: 
@@ -47,6 +48,21 @@ subroutine noahmp36_scale_tws(n, LSM_State)
   integer              :: t
   integer              :: status
   
+! Natt
+  type(ESMF_Field)       :: sm1Field
+  type(ESMF_Field)       :: sm2Field
+  type(ESMF_Field)       :: sm3Field
+  type(ESMF_Field)       :: sm4Field
+  type(ESMF_Field)       :: sweField
+  type(ESMF_Field)       :: snodField
+  real, pointer          :: soilm1(:)
+  real, pointer          :: soilm2(:)
+  real, pointer          :: soilm3(:)
+  real, pointer          :: soilm4(:)
+  real, pointer          :: swe(:)
+  real, pointer          :: snod(:)
+
+  
 #if 0 
   call ESMF_StateGet(LSM_State,"Groundwater Storage",gwField,rc=status)
   call LIS_verify(status,&
@@ -61,5 +77,43 @@ subroutine noahmp36_scale_tws(n, LSM_State)
   enddo
 #endif
 
+  ! Natt
+  ! Scale TWS states to mm (Note, GWS is already in mm)
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 1",sm1Field,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for sm1 in noahmp36_scale_tws')
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 2",sm2Field,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for sm2 in noahmp36_scale_tws')
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 3",sm3Field,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for sm3 in noahmp36_scale_tws')
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 4",sm4Field,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for sm4 in noahmp36_scale_tws')
+  call ESMF_StateGet(LSM_State,"SWE",sweField,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for SWE in noahmp36_scale_tws')
+  call ESMF_StateGet(LSM_State,"Snowdepth",snodField,rc=status)
+  call LIS_verify(status,'ESMF_StateGet failed for Snowdepth in noahmp36_scale_tws')
+  
+  call ESMF_FieldGet(sm1Field,localDE=0,farrayPtr=soilm1,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for sm1 in noahmp36_scale_tws')
+  call ESMF_FieldGet(sm2Field,localDE=0,farrayPtr=soilm2,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for sm2 in noahmp36_scale_tws')
+  call ESMF_FieldGet(sm3Field,localDE=0,farrayPtr=soilm3,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for sm3 in noahmp36_scale_tws')
+  call ESMF_FieldGet(sm4Field,localDE=0,farrayPtr=soilm4,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for sm4 in noahmp36_scale_tws')
+  call ESMF_FieldGet(sweField,localDE=0,farrayPtr=swe,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for SWE in noahmp36_scale_tws')
+  call ESMF_FieldGet(snodField,localDE=0,farrayPtr=snod,rc=status)
+  call LIS_verify(status,'ESMF_FieldGet failed for Snowdepth in noahmp36_scale_tws')
+  
+  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     soilm1(t) = soilm1(t) * NOAHMP36_struc(n)%sldpth(1)*LIS_CONST_RHOFW ! m3m-3 -> mm
+     soilm2(t) = soilm2(t) * NOAHMP36_struc(n)%sldpth(2)*LIS_CONST_RHOFW ! m3m-3 -> mm
+     soilm3(t) = soilm3(t) * NOAHMP36_struc(n)%sldpth(3)*LIS_CONST_RHOFW ! m3m-3 -> mm
+     soilm4(t) = soilm4(t) * NOAHMP36_struc(n)%sldpth(4)*LIS_CONST_RHOFW ! m3m-3 -> mm
+     swe(t)    = swe(t) * 1000.0  ! m -> mm
+     snod(t)   = snod(t) * 1000.0 ! m -> mm
+  enddo
+  
+  
 end subroutine noahmp36_scale_tws
 

--- a/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_settws.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_settws.F90
@@ -1,7 +1,9 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
-! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
 !
-! Copyright (c) 2015 United States Government as represented by the
+! Copyright (c) 2020 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------

--- a/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_settws.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_settws.F90
@@ -24,15 +24,15 @@ subroutine noahmp36_settws(n, LSM_State)
   use module_sf_noahlsm_36
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in)    :: n
   type(ESMF_State)       :: LSM_State
 !
 ! !DESCRIPTION:
-!  
+!
 !  This routine assigns the soil moisture prognostic variables to noah's
-!  model space. 
-! 
+!  model space.
+!
 !EOP
   real, parameter        :: MIN_GWS_THRESHOLD = 0.00
   real, parameter        :: MAX_GWS_THRESHOLD = 7000.0
@@ -40,8 +40,8 @@ subroutine noahmp36_settws(n, LSM_State)
   real, parameter        :: ZSOIL = 2 !mm
   real, parameter        :: ROUS = 0.2 ! specific yield
   !Bailing changed this to be WLTSMC
-  real, parameter        :: MIN_THRESHOLD = 0.02 
-!  real                   :: MIN_THRESHOLD 
+  real, parameter        :: MIN_THRESHOLD = 0.02
+!  real                   :: MIN_THRESHOLD
   real                   :: MAX_THRESHOLD
   real                   :: sm_threshold
   type(ESMF_Field)       :: sm1Field
@@ -72,7 +72,8 @@ subroutine noahmp36_settws(n, LSM_State)
   integer                :: SOILTYP           ! soil type index [-]
   real                   :: SMCMAX , SMCWLT
   real                   :: tmp(LIS_rc%nensem(n)), tmp0(LIS_rc%nensem(n))
-  real                   :: tmp1(LIS_rc%nensem(n)),tmp2(LIS_rc%nensem(n)),tmp3(LIS_rc%nensem(n)),tmp4(LIS_rc%nensem(n))
+  real                   :: tmp1(LIS_rc%nensem(n)),tmp2(LIS_rc%nensem(n)), &
+       tmp3(LIS_rc%nensem(n)),tmp4(LIS_rc%nensem(n))
   real                   :: tmp5(LIS_rc%nensem(n))
   logical                :: update_flag_tile(LIS_rc%npatch(n,LIS_rc%lsm_index))
   logical                :: flag_ens(LIS_rc%ngrid(n))
@@ -80,13 +81,16 @@ subroutine noahmp36_settws(n, LSM_State)
   logical                :: update_flag_ens(LIS_rc%ngrid(n))
   logical                :: update_flag_new(LIS_rc%ngrid(n))
   integer                :: RESULT, icount
-  real                   :: MaxEnsSM1 ,MaxEnsSM2 ,MaxEnsSM3 ,MaxEnsSM4, MaxEnsGWS !Wanshu
-  real                   :: MinEnsSM1 ,MinEnsSM2 ,MinEnsSM3 ,MinEnsSM4, MinEnsGWS !Wanshu
-  real                   :: MaxEns_sh2o1, MaxEns_sh2o2, MaxEns_sh2o3, MaxEns_sh2o4
+  real                   :: MaxEnsSM1 ,MaxEnsSM2 ,MaxEnsSM3 ,MaxEnsSM4, &
+       MaxEnsGWS !Wanshu
+  real                   :: MinEnsSM1 ,MinEnsSM2 ,MinEnsSM3 ,MinEnsSM4, &
+       MinEnsGWS !Wanshu
+  real                   :: MaxEns_sh2o1, MaxEns_sh2o2, MaxEns_sh2o3, &
+       MaxEns_sh2o4
   real                   :: smc_rnd, smc_tmp, gws_tmp !Wanshu
-  real                   :: sh2o_tmp, sh2o_rnd 
+  real                   :: sh2o_tmp, sh2o_rnd
   real                   :: dsneqv,dsnowh,swe_old, snowh_old
-  
+
   call ESMF_StateGet(LSM_State,"Soil Moisture Layer 1",sm1Field,rc=status)
   call LIS_verify(status,&
        "ESMF_StateSet: Soil Moisture Layer 1 failed in noahmp36_settws")
@@ -133,26 +137,27 @@ subroutine noahmp36_settws(n, LSM_State)
        "ESMF_FieldGet: Snowdepth failed in noahmp36_settws")
 
 
-  update_flag = .true. 
-  update_flag_tile= .true. 
+  update_flag = .true.
+  update_flag_tile= .true.
 
   do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
-  
- ! MN: NOTE: SMCMAX and SMCWLT are not stored in the data structure but we 
- !       can get module variables MAXSMC and WLTSMC from the module_sf_noahlsm_36       
-     SOILTYP = NOAHMP36_struc(n)%noahmp36(t)%soiltype        
+
+     ! MN: NOTE: SMCMAX and SMCWLT are not stored in the data structure but we
+     !       can get module variables MAXSMC and WLTSMC from the
+     !       module_sf_noahlsm_36
+     SOILTYP = NOAHMP36_struc(n)%noahmp36(t)%soiltype
      MAX_THRESHOLD = MAXSMC (SOILTYP)
      !MIN_THRESHOLD = WLTSMC (SOILTYP)
      sm_threshold = MAXSMC (SOILTYP) - 0.02
      !sm_threshold = NOAHMP36_struc(n)%noahmp36(t)%smcmax - 0.02
      !MAX_THRESHOLD = NOAHMP36_struc(n)%noahmp36(t)%smcmax
-     
+
      gid = LIS_domain(n)%gindex(&
           LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col,&
-          LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row) 
-     
+          LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row)
+
      !MN: delta = X(+) - X(-)
-     !NOTE: "noahmp36_updatesoilm.F90" updates the soilm_(t)     
+     !NOTE: "noahmp36_updatesoilm.F90" updates the soilm_(t)
      delta1 = soilm1(t)-NOAHMP36_struc(n)%noahmp36(t)%smc(1)
      delta2 = soilm2(t)-NOAHMP36_struc(n)%noahmp36(t)%smc(2)
      delta3 = soilm3(t)-NOAHMP36_struc(n)%noahmp36(t)%smc(3)
@@ -162,41 +167,49 @@ subroutine noahmp36_settws(n, LSM_State)
      delta5 = gws(t)-NOAHMP36_struc(n)%noahmp36(t)%wa
 
 
-     ! MN: check    MIN_THRESHOLD < volumetric liquid soil moisture < threshold 
-     if(soilm1(t).ge.MIN_THRESHOLD .and. soilm1(t).lt. sm_threshold) then 
+     ! MN: check  MIN_THRESHOLD < volumetric liquid soil moisture < threshold
+     if(soilm1(t).ge.MIN_THRESHOLD .and. soilm1(t).lt. sm_threshold) then
         update_flag(gid) = update_flag(gid).and.(.true.)
         ! MN save the flag for each tile (col*row*ens)   (64*44)*20
         update_flag_tile(t) = update_flag_tile(t).and.(.true.)
      else
-        write(LIS_logunit,*) 'problem updating sm1 ', soilm1(t),NOAHMP36_struc(n)%noahmp36(t)%smc(1),NOAHMP36_struc(n)%noahmp36(t)%sh2o(1)
+        write(LIS_logunit,*) 'problem updating sm1 ', soilm1(t), &
+             NOAHMP36_struc(n)%noahmp36(t)%smc(1), &
+             NOAHMP36_struc(n)%noahmp36(t)%sh2o(1)
         update_flag(gid) = update_flag(gid).and.(.false.)
         update_flag_tile(t) = update_flag_tile(t).and.(.false.)
      endif
-     if(soilm2(t).ge.MIN_THRESHOLD .and. soilm2(t).lt.sm_threshold) then 
+     if(soilm2(t).ge.MIN_THRESHOLD .and. soilm2(t).lt.sm_threshold) then
         update_flag(gid) = update_flag(gid).and.(.true.)
         update_flag_tile(t) = update_flag_tile(t).and.(.true.)
      else
         update_flag(gid) = update_flag(gid).and.(.false.)
         update_flag_tile(t) = update_flag_tile(t).and.(.false.)
-        write(LIS_logunit,*) 'problem updating sm2 ', soilm2(t),NOAHMP36_struc(n)%noahmp36(t)%smc(2),NOAHMP36_struc(n)%noahmp36(t)%sh2o(2),WLTSMC(SOILTYP)
+        write(LIS_logunit,*) 'problem updating sm2 ', soilm2(t), &
+             NOAHMP36_struc(n)%noahmp36(t)%smc(2), &
+             NOAHMP36_struc(n)%noahmp36(t)%sh2o(2),WLTSMC(SOILTYP)
      endif
-     if(soilm3(t).ge.MIN_THRESHOLD .and. soilm3(t).lt.sm_threshold) then 
+     if(soilm3(t).ge.MIN_THRESHOLD .and. soilm3(t).lt.sm_threshold) then
         update_flag(gid) = update_flag(gid).and.(.true.)
         update_flag_tile(t) = update_flag_tile(t).and.(.true.)
      else
         update_flag(gid) = update_flag(gid).and.(.false.)
         update_flag_tile(t) = update_flag_tile(t).and.(.false.)
-        write(LIS_logunit,*) 'problem updating sm3 ', soilm3(t),NOAHMP36_struc(n)%noahmp36(t)%smc(3),NOAHMP36_struc(n)%noahmp36(t)%sh2o(3),WLTSMC(SOILTYP)
+        write(LIS_logunit,*) 'problem updating sm3 ', soilm3(t), &
+             NOAHMP36_struc(n)%noahmp36(t)%smc(3), &
+             NOAHMP36_struc(n)%noahmp36(t)%sh2o(3),WLTSMC(SOILTYP)
      endif
-     if(soilm4(t).ge.MIN_THRESHOLD .and. soilm4(t).lt.sm_threshold) then 
+     if(soilm4(t).ge.MIN_THRESHOLD .and. soilm4(t).lt.sm_threshold) then
         update_flag(gid) = update_flag(gid).and.(.true.)
         update_flag_tile(t) = update_flag_tile(t).and.(.true.)
      else
         update_flag(gid) = update_flag(gid).and.(.false.)
         update_flag_tile(t) = update_flag_tile(t).and.(.false.)
-        write(LIS_logunit,*) 'problem updating sm4 ', soilm4(t),NOAHMP36_struc(n)%noahmp36(t)%smc(4),NOAHMP36_struc(n)%noahmp36(t)%sh2o(4),WLTSMC(SOILTYP)
+        write(LIS_logunit,*) 'problem updating sm4 ', soilm4(t), &
+             NOAHMP36_struc(n)%noahmp36(t)%smc(4), &
+             NOAHMP36_struc(n)%noahmp36(t)%sh2o(4),WLTSMC(SOILTYP)
      endif
-!     noahmp36_struc(n)%noahmp36(t)%wa = gws(t)
+     !     noahmp36_struc(n)%noahmp36(t)%wa = gws(t)
      !Wanshu
      if(gws(t).gt. MIN_GWS_THRESHOLD .and. gws(t).lt.MAX_GWS_THRESHOLD) then
         update_flag(gid) = update_flag(gid).and.(.true.)
@@ -204,41 +217,43 @@ subroutine noahmp36_settws(n, LSM_State)
      else
         update_flag(gid) = update_flag(gid).and.(.false.)
         update_flag_tile(t) = update_flag_tile(t).and.(.false.)
-     !-------
+        !-------
      endif
   enddo
 
 !-----------------------------------------------------------------------------
-! MN create new falg: if update falg for 50% of the ensemble members is true 
-! then update the state variabels 
+! MN create new falg: if update falg for 50% of the ensemble members is true
+! then update the state variabels
 !-----------------------------------------------------------------------------
   update_flag_ens = .True.
   do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)/LIS_rc%nensem(n)
-     gid =i 
+     gid =i
      flag_tmp=update_flag_tile((i-1)*LIS_rc%nensem(n)+1:(i)*LIS_rc%nensem(n))
-     RESULT = COUNT(flag_tmp) 
+     RESULT = COUNT(flag_tmp)
      if (RESULT.lt.LIS_rc%nensem(n)*0.5) then   !>10/20*100 = 50%
         update_flag_ens(gid)= .False.
      endif
      update_flag_new(gid)= update_flag(gid).or.update_flag_ens(gid)  ! new flag
   enddo
-    
+
   ! update step
-  ! loop over grid points 
+  ! loop over grid points
   do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)/LIS_rc%nensem(n)
-     
-     gid =i 
-     
+
+     gid =i
+
      !if(update_flag(gid)) then
-     if(update_flag_new(gid)) then 
-!-------------------------------------------------------------------------
-       ! 1- update the states
-       ! 1-1- if update flag for tile is TRUE --> apply the DA update    
-       ! 1-2- if update flag for tile is FALSE --> resample the states  
-       ! 2- adjust the states
-!-------------------------------------------------------------------------
-! store update value for  cases that update_flag_tile & update_flag_new are TRUE! update_flag_tile = TRUE --> means met the both min and max threshold 
-      
+     if(update_flag_new(gid)) then
+        !----------------------------------------------------------------------
+        ! 1- update the states
+        ! 1-1- if update flag for tile is TRUE --> apply the DA update
+        ! 1-2- if update flag for tile is FALSE --> resample the states
+        ! 2- adjust the states
+        !---------------------------------------------------------------------
+        ! store update value for  cases that update_flag_tile &
+        ! update_flag_new are TRUE
+        ! update_flag_tile = TRUE --> means met the both min and max threshold
+
         tmp1 = LIS_rc%udef
         tmp2 = LIS_rc%udef
         tmp3 = LIS_rc%udef
@@ -248,18 +263,18 @@ subroutine noahmp36_settws(n, LSM_State)
 
         do m=1,LIS_rc%nensem(n)
            t = (i-1)*LIS_rc%nensem(n)+m
- 
-	  if(update_flag_tile(t)) then
-          
-           tmp1(m) = soilm1(t) 
-           tmp2(m) = soilm2(t) 
-           tmp3(m) = soilm3(t) 
-           tmp4(m) = soilm4(t) 
-           tmp5(m) = gws(t)
 
-          endif
+           if(update_flag_tile(t)) then
+
+              tmp1(m) = soilm1(t)
+              tmp2(m) = soilm2(t)
+              tmp3(m) = soilm3(t)
+              tmp4(m) = soilm4(t)
+              tmp5(m) = gws(t)
+
+           endif
         enddo
-        
+
         MaxEnsSM1 = -10000
         MaxEnsSM2 = -10000
         MaxEnsSM3 = -10000
@@ -274,7 +289,7 @@ subroutine noahmp36_settws(n, LSM_State)
 
 
         do m=1,LIS_rc%nensem(n)
-           if(tmp1(m).ne.LIS_rc%udef) then 
+           if(tmp1(m).ne.LIS_rc%udef) then
               MaxEnsSM1 = max(MaxEnsSM1, tmp1(m))
               MaxEnsSM2 = max(MaxEnsSM2, tmp2(m))
               MaxEnsSM3 = max(MaxEnsSM3, tmp3(m))
@@ -286,88 +301,92 @@ subroutine noahmp36_settws(n, LSM_State)
               MinEnsSM3 = min(MinEnsSM3, tmp3(m))
               MinEnsSM4 = min(MinEnsSM4, tmp4(m))
               MinEnsGWS = min(MinEnsGWS, tmp5(m)) !Wanshu
-              
+
            endif
         enddo
-        
-        ! loop over tile       
+
+        ! loop over tile
         do m=1,LIS_rc%nensem(n)
            t = (i-1)*LIS_rc%nensem(n)+m
-             SOILTYP = NOAHMP36_struc(n)%noahmp36(t)%soiltype        
-             MAX_THRESHOLD = MAXSMC (SOILTYP)
-             !MIN_THRESHOLD = WLTSMC (SOILTYP)
-             sm_threshold = MAXSMC (SOILTYP) - 0.02
-           
-           ! MN check update status for each tile  
+           SOILTYP = NOAHMP36_struc(n)%noahmp36(t)%soiltype
+           MAX_THRESHOLD = MAXSMC (SOILTYP)
+           !MIN_THRESHOLD = WLTSMC (SOILTYP)
+           sm_threshold = MAXSMC (SOILTYP) - 0.02
+
+           ! MN check update status for each tile
            if(update_flag_tile(t)) then
-              
+
               delta1 = soilm1(t)-NOAHMP36_struc(n)%noahmp36(t)%smc(1)
               delta2 = soilm2(t)-NOAHMP36_struc(n)%noahmp36(t)%smc(2)
               delta3 = soilm3(t)-NOAHMP36_struc(n)%noahmp36(t)%smc(3)
               delta4 = soilm4(t)-NOAHMP36_struc(n)%noahmp36(t)%smc(4)
-              
+
               !Wanshu
-              delta5=gws(t)-NOAHMP36_struc(n)%noahmp36(t)%wa              
+              delta5=gws(t)-NOAHMP36_struc(n)%noahmp36(t)%wa
 
               NOAHMP36_struc(n)%noahmp36(t)%sh2o(1) =&
                    NOAHMP36_struc(n)%noahmp36(t)%sh2o(1)+&
                    delta1
               NOAHMP36_struc(n)%noahmp36(t)%smc(1) = soilm1(t)
               !Wanshu
-!              NOAHMP36_struc(n)%noahmp36(t)%wa = gws(t)
+              !              NOAHMP36_struc(n)%noahmp36(t)%wa = gws(t)
 
-              NOAHMP36_struc(n)%noahmp36(t)%sh2o(2) = NOAHMP36_struc(n)%noahmp36(t)%sh2o(2)+&
-                      delta2 
+              NOAHMP36_struc(n)%noahmp36(t)%sh2o(2) = &
+                   NOAHMP36_struc(n)%noahmp36(t)%sh2o(2) + &
+                   delta2
               NOAHMP36_struc(n)%noahmp36(t)%smc(2) = soilm2(t)
-! MN: Test shutdown the update for 4th layer   
-              NOAHMP36_struc(n)%noahmp36(t)%sh2o(3) = NOAHMP36_struc(n)%noahmp36(t)%sh2o(3)+&
-                      delta3 
+              ! MN: Test shutdown the update for 4th layer
+              NOAHMP36_struc(n)%noahmp36(t)%sh2o(3) = &
+                   NOAHMP36_struc(n)%noahmp36(t)%sh2o(3) + &
+                   delta3
               NOAHMP36_struc(n)%noahmp36(t)%smc(3) = soilm3(t)
 
-              NOAHMP36_struc(n)%noahmp36(t)%sh2o(4) = NOAHMP36_struc(n)%noahmp36(t)%sh2o(4)+&
-                      delta4 
+              NOAHMP36_struc(n)%noahmp36(t)%sh2o(4) = &
+                   NOAHMP36_struc(n)%noahmp36(t)%sh2o(4) + &
+                   delta4
               NOAHMP36_struc(n)%noahmp36(t)%smc(4) = soilm4(t)
 
               ! Bailing: add this check for liquid smc
-              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(1)<MIN_THRESHOLD ) & 
-                 NOAHMP36_struc(n)%noahmp36(t)%sh2o(1) = MIN_THRESHOLD
-              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(1)>MAX_THRESHOLD ) & 
-                 NOAHMP36_struc(n)%noahmp36(t)%sh2o(1) = MAX_THRESHOLD
-              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(2)<MIN_THRESHOLD ) & 
-                 NOAHMP36_struc(n)%noahmp36(t)%sh2o(2) = MIN_THRESHOLD
-              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(2)>MAX_THRESHOLD ) & 
-                 NOAHMP36_struc(n)%noahmp36(t)%sh2o(2) = MAX_THRESHOLD
-              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(3)<MIN_THRESHOLD ) & 
-                 NOAHMP36_struc(n)%noahmp36(t)%sh2o(3) = MIN_THRESHOLD
-              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(3)>MAX_THRESHOLD ) & 
-                 NOAHMP36_struc(n)%noahmp36(t)%sh2o(3) = MAX_THRESHOLD
-              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(4)<MIN_THRESHOLD ) & 
-                 NOAHMP36_struc(n)%noahmp36(t)%sh2o(4) = MIN_THRESHOLD
-              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(4)>MAX_THRESHOLD ) & 
-                 NOAHMP36_struc(n)%noahmp36(t)%sh2o(4) = MAX_THRESHOLD
-             !Wanshu
-              if(NOAHMP36_struc(n)%noahmp36(t)%wa+delta5.gt.MIN_GWS_THRESHOLD.and.&
-                   NOAHMP36_struc(n)%noahmp36(t)%wa+delta5.lt.MAX_GWS_THRESHOLD) then
+              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(1)<MIN_THRESHOLD ) &
+                   NOAHMP36_struc(n)%noahmp36(t)%sh2o(1) = MIN_THRESHOLD
+              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(1)>MAX_THRESHOLD ) &
+                   NOAHMP36_struc(n)%noahmp36(t)%sh2o(1) = MAX_THRESHOLD
+              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(2)<MIN_THRESHOLD ) &
+                   NOAHMP36_struc(n)%noahmp36(t)%sh2o(2) = MIN_THRESHOLD
+              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(2)>MAX_THRESHOLD ) &
+                   NOAHMP36_struc(n)%noahmp36(t)%sh2o(2) = MAX_THRESHOLD
+              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(3)<MIN_THRESHOLD ) &
+                   NOAHMP36_struc(n)%noahmp36(t)%sh2o(3) = MIN_THRESHOLD
+              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(3)>MAX_THRESHOLD ) &
+                   NOAHMP36_struc(n)%noahmp36(t)%sh2o(3) = MAX_THRESHOLD
+              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(4)<MIN_THRESHOLD ) &
+                   NOAHMP36_struc(n)%noahmp36(t)%sh2o(4) = MIN_THRESHOLD
+              if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(4)>MAX_THRESHOLD ) &
+                   NOAHMP36_struc(n)%noahmp36(t)%sh2o(4) = MAX_THRESHOLD
+              !Wanshu
+              if(NOAHMP36_struc(n)%noahmp36(t)%wa+delta5.gt. &
+                   MIN_GWS_THRESHOLD.and.&
+                   NOAHMP36_struc(n)%noahmp36(t)%wa+delta5.lt. &
+                   MAX_GWS_THRESHOLD) then
                  NOAHMP36_struc(n)%noahmp36(t)%wa=gws(t)
-              elseif(gws(t).lt.MIN_GWS_THRESHOLD.or.gws(t).gt.MAX_GWS_THRESHOLD) then
-                    write(LIS_logunit,*) 'setgws',t,gws(t)
+              elseif(gws(t).lt.MIN_GWS_THRESHOLD .or. &
+                   gws(t).gt.MAX_GWS_THRESHOLD) then
+                 write(LIS_logunit,*) 'setgws',t,gws(t)
               endif
-           else               
+           else
               ! use mean value
-              ! Assume sh2o = smc (i.e. ice content=0) 
+              ! Assume sh2o = smc (i.e. ice content=0)
               smc_tmp = (MaxEnsSM1 - MinEnsSM1)/2 + MinEnsSM1
-              NOAHMP36_struc(n)%noahmp36(t)%sh2o(1) = smc_tmp 
+              NOAHMP36_struc(n)%noahmp36(t)%sh2o(1) = smc_tmp
               NOAHMP36_struc(n)%noahmp36(t)%smc(1) = smc_tmp
-              
-              
-              smc_tmp = (MaxEnsSM2 - MinEnsSM2)/2 + MinEnsSM2            
+
+              smc_tmp = (MaxEnsSM2 - MinEnsSM2)/2 + MinEnsSM2
               NOAHMP36_struc(n)%noahmp36(t)%sh2o(2) = smc_tmp
               NOAHMP36_struc(n)%noahmp36(t)%smc(2) = smc_tmp
-              
+
               smc_tmp = (MaxEnsSM3 - MinEnsSM3)/2 + MinEnsSM3
               NOAHMP36_struc(n)%noahmp36(t)%sh2o(3) = smc_tmp
               NOAHMP36_struc(n)%noahmp36(t)%smc(3) = smc_tmp
-              
 
               smc_tmp = (MaxEnsSM4 - MinEnsSM4)/2 + MinEnsSM4
               NOAHMP36_struc(n)%noahmp36(t)%sh2o(4) = smc_tmp
@@ -375,73 +394,73 @@ subroutine noahmp36_settws(n, LSM_State)
 
               gws_tmp = (MaxEnsGWS - MinEnsGWS)/2 + MinEnsGWS
               NOAHMP36_struc(n)%noahmp36(t)%wa = gws_tmp
- 
+
            endif ! flag for each tile
 
         enddo ! loop over tile
- 
-       
-     else ! if update_flag_new(gid) is FALSE   
-        if(LIS_rc%pert_bias_corr.eq.1) then           
-!--------------------------------------------------------------------------
-! if no update is made, then we need to readjust the ensemble if pert bias
-! correction is turned on because the forcing perturbations may cause 
-! biases to persist. 
-!--------------------------------------------------------------------------
-           write(LIS_logunit,*) '[WARNING] more than half of the ens violate the bounds',gid
-        
-           bounds_violation = .true. 
+
+     else ! if update_flag_new(gid) is FALSE
+        if(LIS_rc%pert_bias_corr.eq.1) then
+           !-------------------------------------------------------------------
+           ! if no update is made, then we need to readjust the ensemble if
+           ! pert bias correction is turned on because the forcing
+           ! perturbations may cause biases to persist.
+           !-------------------------------------------------------------------
+           write(LIS_logunit,*) &
+                '[WARNING] more than half of the ens violate the bounds',gid
+
+           bounds_violation = .true.
            nIter = 0
-           ens_flag = .true. 
-           
-           do while(bounds_violation) 
+           ens_flag = .true.
+
+           do while(bounds_violation)
               niter = niter + 1
               t_unpert = i*LIS_rc%nensem(n)
               do j=1,4
                  delta(j) = 0.0
                  do m=1,LIS_rc%nensem(n)-1
                     t = (i-1)*LIS_rc%nensem(n)+m
-                    
-                    if(m.ne.LIS_rc%nensem(n)) then 
+
+                    if(m.ne.LIS_rc%nensem(n)) then
                        delta(j) = delta(j) + &
                             (NOAHMP36_struc(n)%noahmp36(t)%smc(j) - &
                             NOAHMP36_struc(n)%noahmp36(t_unpert)%smc(j))
                     endif
-                    
+
                  enddo
               enddo
 
-              delta(5) = 0 
+              delta(5) = 0
               do m=1,LIS_rc%nensem(n)-1
                  t = (i-1)*LIS_rc%nensem(n)+m
-                 
-                 if(m.ne.LIS_rc%nensem(n)) then 
+
+                 if(m.ne.LIS_rc%nensem(n)) then
                     delta(5) = delta(5) + &
                          (NOAHMP36_struc(n)%noahmp36(t)%wa - &
                          NOAHMP36_struc(n)%noahmp36(t_unpert)%wa)
                  endif
-                 
+
               enddo
-              
+
               do j=1,4
                  delta(j) =delta(j)/(LIS_rc%nensem(n)-1)
                  do m=1,LIS_rc%nensem(n)-1
                     t = (i-1)*LIS_rc%nensem(n)+m
-                    SOILTYP = NOAHMP36_struc(n)%noahmp36(t)%soiltype  
+                    SOILTYP = NOAHMP36_struc(n)%noahmp36(t)%soiltype
                     MAX_THRESHOLD = MAXSMC (SOILTYP)
                     !MIN_THRESHOLD = WLTSMC (SOILTYP)
                     sm_threshold = MAXSMC (SOILTYP) - 0.02
-                    
+
                     tmpval = NOAHMP36_struc(n)%noahmp36(t)%smc(j) - &
                          delta(j)
-                    if(tmpval.le.MIN_THRESHOLD) then 
+                    if(tmpval.le.MIN_THRESHOLD) then
                        NOAHMP36_struc(n)%noahmp36(t)%sh2o(j) = &
                             max(NOAHMP36_struc(n)%noahmp36(t_unpert)%sh2o(j),&
                             MIN_THRESHOLD)
                        NOAHMP36_struc(n)%noahmp36(t)%smc(j) = &
                             max(NOAHMP36_struc(n)%noahmp36(t_unpert)%smc(j),&
                             MIN_THRESHOLD)
-                       ens_flag(m) = .false. 
+                       ens_flag(m) = .false.
                     elseif(tmpval.ge.sm_threshold) then
                        NOAHMP36_struc(n)%noahmp36(t)%sh2o(j) = &
                             min(NOAHMP36_struc(n)%noahmp36(t_unpert)%sh2o(j),&
@@ -449,7 +468,7 @@ subroutine noahmp36_settws(n, LSM_State)
                        NOAHMP36_struc(n)%noahmp36(t)%smc(j) = &
                             min(NOAHMP36_struc(n)%noahmp36(t_unpert)%smc(j),&
                             sm_threshold)
-                       ens_flag(m) = .false. 
+                       ens_flag(m) = .false.
                     endif
                  enddo
               enddo
@@ -457,30 +476,30 @@ subroutine noahmp36_settws(n, LSM_State)
               delta(5) =delta(5)/(LIS_rc%nensem(n)-1)
               do m=1,LIS_rc%nensem(n)-1
                  t = (i-1)*LIS_rc%nensem(n)+m
-                 
+
                  tmpval = NOAHMP36_struc(n)%noahmp36(t)%wa - &
                       delta(5)
-                 if(tmpval.le.MIN_GWS_THRESHOLD) then 
+                 if(tmpval.le.MIN_GWS_THRESHOLD) then
                     NOAHMP36_struc(n)%noahmp36(t)%wa = &
                          max(NOAHMP36_struc(n)%noahmp36(t_unpert)%wa,&
                          MIN_GWS_THRESHOLD)
-                    ens_flag(m) = .false. 
+                    ens_flag(m) = .false.
                  elseif(tmpval.ge.MAX_GWS_THRESHOLD) then
                     NOAHMP36_struc(n)%noahmp36(t)%wa = &
                          min(NOAHMP36_struc(n)%noahmp36(t_unpert)%wa,&
                          MAX_GWS_THRESHOLD)
-                    ens_flag(m) = .false. 
+                    ens_flag(m) = .false.
                  endif
               enddo
-              
-!--------------------------------------------------------------------------
-! Recalculate the deltas and adjust the ensemble
-!--------------------------------------------------------------------------
+
+              !----------------------------------------------------------------
+              ! Recalculate the deltas and adjust the ensemble
+              !----------------------------------------------------------------
               do j=1,4
                  delta(j) = 0.0
                  do m=1,LIS_rc%nensem(n)-1
                     t = (i-1)*LIS_rc%nensem(n)+m
-                    if(m.ne.LIS_rc%nensem(n)) then 
+                    if(m.ne.LIS_rc%nensem(n)) then
                        delta(j) = delta(j) + &
                             (NOAHMP36_struc(n)%noahmp36(t)%smc(j) - &
                             NOAHMP36_struc(n)%noahmp36(t_unpert)%smc(j))
@@ -491,28 +510,28 @@ subroutine noahmp36_settws(n, LSM_State)
               delta(5) = 0.0
               do m=1,LIS_rc%nensem(n)-1
                  t = (i-1)*LIS_rc%nensem(n)+m
-                 if(m.ne.LIS_rc%nensem(n)) then 
+                 if(m.ne.LIS_rc%nensem(n)) then
                     delta(5) = delta(5) + &
                          (NOAHMP36_struc(n)%noahmp36(t)%wa - &
                          NOAHMP36_struc(n)%noahmp36(t_unpert)%wa)
                  endif
               enddo
-              
+
               do j=1,4
                  delta(j) =delta(j)/(LIS_rc%nensem(n)-1)
                  do m=1,LIS_rc%nensem(n)-1
                     t = (i-1)*LIS_rc%nensem(n)+m
-                    
-                    SOILTYP = NOAHMP36_struc(n)%noahmp36(t)%soiltype  
-                    MAX_THRESHOLD = MAXSMC (SOILTYP) 
+
+                    SOILTYP = NOAHMP36_struc(n)%noahmp36(t)%soiltype
+                    MAX_THRESHOLD = MAXSMC (SOILTYP)
                     !MIN_THRESHOLD = WLTSMC (SOILTYP)
-                    if(ens_flag(m)) then 
+                    if(ens_flag(m)) then
                        tmpval = NOAHMP36_struc(n)%noahmp36(t)%smc(j) - &
                             delta(j)
-                       
+
                        if(.not.(tmpval.le.MIN_THRESHOLD .or.&
-                            tmpval.gt.(MAX_THRESHOLD))) then 
-                          
+                            tmpval.gt.(MAX_THRESHOLD))) then
+
                           NOAHMP36_struc(n)%noahmp36(t)%smc(j) = &
                                NOAHMP36_struc(n)%noahmp36(t)%smc(j) - delta(j)
                           NOAHMP36_struc(n)%noahmp36(t)%sh2o(j) = &
@@ -520,110 +539,121 @@ subroutine noahmp36_settws(n, LSM_State)
                           bounds_violation = .false.
                        endif
                     endif
-                    
+
                     tmpval = NOAHMP36_struc(n)%noahmp36(t)%smc(j)
-                    
+
                     if(tmpval.le.MIN_THRESHOLD .or.&
-                         tmpval.gt.(MAX_THRESHOLD)) then 
-                       bounds_violation = .true. 
+                         tmpval.gt.(MAX_THRESHOLD)) then
+                       bounds_violation = .true.
                     else
                        bounds_violation = .false.
                     endif
                  enddo
               enddo
-              
+
               delta(5) =delta(5)/(LIS_rc%nensem(n)-1)
               do m=1,LIS_rc%nensem(n)-1
                  t = (i-1)*LIS_rc%nensem(n)+m
-                    
-                 if(ens_flag(m)) then 
+
+                 if(ens_flag(m)) then
                     tmpval = NOAHMP36_struc(n)%noahmp36(t)%wa - &
                          delta(5)
-                    
+
                     if(.not.(tmpval.le.MIN_GWS_THRESHOLD .or.&
-                         tmpval.gt.MAX_GWS_THRESHOLD)) then 
-                       
+                         tmpval.gt.MAX_GWS_THRESHOLD)) then
+
                        NOAHMP36_struc(n)%noahmp36(t)%wa = &
                             NOAHMP36_struc(n)%noahmp36(t)%wa - delta(5)
                        bounds_violation = .false.
                     endif
                  endif
-                 
+
                  tmpval = NOAHMP36_struc(n)%noahmp36(t)%wa
-                  
+
                  if(tmpval.le.MIN_GWS_THRESHOLD .or.&
-                      tmpval.gt.MAX_GWS_THRESHOLD) then 
-                    bounds_violation = .true. 
+                      tmpval.gt.MAX_GWS_THRESHOLD) then
+                    bounds_violation = .true.
                  else
                     bounds_violation = .false.
                  endif
               enddo
 
-              if(nIter.gt.10.and.bounds_violation) then 
-!--------------------------------------------------------------------------
-! All else fails, set to the bounds
-!--------------------------------------------------------------------------
-                 
-                 write(LIS_logunit,*) '[ERR] Ensemble structure violates physical bounds '
-                 write(LIS_logunit,*) '[ERR] Please adjust the perturbation settings ..'
+              if(nIter.gt.10.and.bounds_violation) then
+                 !-------------------------------------------------------------
+                 ! All else fails, set to the bounds
+                 !-------------------------------------------------------------
+
+                 write(LIS_logunit,*) &
+                      '[ERR] Ensemble structure violates physical bounds '
+                 write(LIS_logunit,*) &
+                      '[ERR] Please adjust the perturbation settings ..'
 
                  do j=1,4
                     do m=1,LIS_rc%nensem(n)
                        t = (i-1)*LIS_rc%nensem(n)+m
-                       
-                       SOILTYP = NOAHMP36_struc(n)%noahmp36(t)%soiltype  
-                       MAX_THRESHOLD = MAXSMC (SOILTYP)            
+
+                       SOILTYP = NOAHMP36_struc(n)%noahmp36(t)%soiltype
+                       MAX_THRESHOLD = MAXSMC (SOILTYP)
                        !MIN_THRESHOLD = WLTSMC (SOILTYP)
-                       
-                       if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(j).gt.MAX_THRESHOLD.or.&
-                            NOAHMP36_struc(n)%noahmp36(t)%smc(j).gt.MAX_THRESHOLD) then                        
+
+                       if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(j).gt. &
+                            MAX_THRESHOLD.or.&
+                            NOAHMP36_struc(n)%noahmp36(t)%smc(j).gt. &
+                            MAX_THRESHOLD) then
                           NOAHMP36_struc(n)%noahmp36(t)%sh2o(j) = MAX_THRESHOLD
                           NOAHMP36_struc(n)%noahmp36(t)%smc(j) = MAX_THRESHOLD
                        endif
-                       
-                       if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(j).lt.MIN_THRESHOLD.or.&
-                            NOAHMP36_struc(n)%noahmp36(t)%smc(j).lt.MIN_THRESHOLD) then                        
+
+                       if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(j).lt. &
+                            MIN_THRESHOLD.or.&
+                            NOAHMP36_struc(n)%noahmp36(t)%smc(j).lt. &
+                            MIN_THRESHOLD) then
                           NOAHMP36_struc(n)%noahmp36(t)%sh2o(j) = MIN_THRESHOLD
                           NOAHMP36_struc(n)%noahmp36(t)%smc(j) = MIN_THRESHOLD
                        endif
                     enddo
-                  call LIS_endrun()
-               enddo
+                    call LIS_endrun()
+                 enddo
 
-#if 0 
-               do m=1,LIS_rc%nensem(n)
-                  t = (i-1)*LIS_rc%nensem(n)+m
-                  
-                  if(NOAHMP36_struc(n)%noahmp36(t)%wa.gt.MAX_GWS_THRESHOLD) then 
-                     NOAHMP36_struc(n)%noahmp36(t)%wa = MAX_GWS_THRESHOLD
-                  endif
-                  
-                  if(NOAHMP36_struc(n)%noahmp36(t)%wa.lt.MIN_GWS_THRESHOLD) then 
-                     NOAHMP36_struc(n)%noahmp36(t)%wa = MIN_GWS_THRESHOLD
-                  endif
-               enddo
+#if 0
+                 do m=1,LIS_rc%nensem(n)
+                    t = (i-1)*LIS_rc%nensem(n)+m
+
+                    if(NOAHMP36_struc(n)%noahmp36(t)%wa.gt. &
+                         MAX_GWS_THRESHOLD) then
+                       NOAHMP36_struc(n)%noahmp36(t)%wa = MAX_GWS_THRESHOLD
+                    endif
+
+                    if(NOAHMP36_struc(n)%noahmp36(t)%wa.lt. &
+                         MIN_GWS_THRESHOLD) then
+                       NOAHMP36_struc(n)%noahmp36(t)%wa = MIN_GWS_THRESHOLD
+                    endif
+                 enddo
 #endif
-               do m=1,LIS_rc%nensem(n)-1
-                  t = (i-1)*LIS_rc%nensem(n)+m
-                  t_unpert = i*LIS_rc%nensem(n)
-                  
-                  if(.not.(NOAHMP36_struc(n)%noahmp36(t_unpert)%wa.le.MIN_GWS_THRESHOLD .or.&
-                       NOAHMP36_struc(n)%noahmp36(t_unpert)%wa.gt.(MAX_GWS_THRESHOLD))) then
-                     
-                     NOAHMP36_struc(n)%noahmp36(t)%wa = NOAHMP36_struc(n)%noahmp36(t_unpert)%wa
-                     
-                  endif
-               enddo
-               
-!               call LIS_endrun()
-            endif
-              
+                 do m=1,LIS_rc%nensem(n)-1
+                    t = (i-1)*LIS_rc%nensem(n)+m
+                    t_unpert = i*LIS_rc%nensem(n)
+
+                    if(.not.(NOAHMP36_struc(n)%noahmp36(t_unpert)%wa.le. &
+                         MIN_GWS_THRESHOLD .or.&
+                         NOAHMP36_struc(n)%noahmp36(t_unpert)%wa.gt. &
+                         (MAX_GWS_THRESHOLD))) then
+
+                       NOAHMP36_struc(n)%noahmp36(t)%wa = &
+                            NOAHMP36_struc(n)%noahmp36(t_unpert)%wa
+
+                    endif
+                 enddo
+
+                 !               call LIS_endrun()
+              endif
+
            end do
         endif
-        
+
      endif
   enddo
-  
+
   do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
 
      swe_old = noahmp36_struc(n)%noahmp36(t)%sneqv
@@ -632,30 +662,37 @@ subroutine noahmp36_settws(n, LSM_State)
      dsneqv = swe(t)*1000.0 - noahmp36_struc(n)%noahmp36(t)%sneqv !in mm
      dsnowh = snod(t) - noahmp36_struc(n)%noahmp36(t)%snowh  !in m
 
-!alternate option     
-#if 0 
+!alternate option
+#if 0
 !only update dshowh, update SWE based on density
      dsnowh = snod(t) - noahmp36_struc(n)%noahmp36(t)%snowh  !in m
      snow_dens = noahmp36_struc(n)%noahmp36(t)%sneqv/&
           noahmp36_struc(n)%noahmp36(t)%snowh
      swe_new = snow_dens*snod(t)
-     
+
      dsneqv = swe_new - noahmp36_struc(n)%noahmp36(t)%sneqv !in mm
 
 #endif
      call noahmp36_snow_update(n, t, dsneqv, dsnowh)
-     
+
      if(noahmp36_struc(n)%noahmp36(t)%sneqv.lt.0.or.&
-          noahmp36_struc(n)%noahmp36(t)%snowh.lt.0) then 
-        print*, dsneqv, dsnowh
-        print*, swe(t), snod(t)
-        stop
+          noahmp36_struc(n)%noahmp36(t)%snowh.lt.0) then
+        write(LIS_logunit,*)'[ERR] State update leads to negative snow!'
+        write(LIS_logunit,*)'[ERR] dsneqv, dsnowh = ', dsneqv, dsnowh
+        write(LIS_logunit,*)'[ERR] swe(t), snod(t) = ', swe(t), snod(t)
+        write(LIS_logunit,*)'[ERR] Stopping...'
+        call LIS_endrun()
+        !print*, dsneqv, dsnowh
+        !print*, swe(t), snod(t)
+        !stop
      endif
 
      if(noahmp36_struc(n)%noahmp36(t)%sneqv.gt.0.and.&
-          noahmp36_struc(n)%noahmp36(t)%snowh.le.0) then 
-        write(LIS_logunit,*) '[WARN] state update leads to positive SWE but zero snow depth'
-        write(LIS_logunit,*) '[WARN] ',noahmp36_struc(n)%noahmp36(t)%sneqv,&
+          noahmp36_struc(n)%noahmp36(t)%snowh.le.0) then
+        write(LIS_logunit,*) &
+             '[WARN] state update leads to positive SWE but zero snow depth'
+        write(LIS_logunit,*) &
+             '[WARN] ',noahmp36_struc(n)%noahmp36(t)%sneqv,&
              noahmp36_struc(n)%noahmp36(t)%snowh
         write(LIS_logunit,*) '[WARN] rejecting the update ...'
         noahmp36_struc(n)%noahmp36(t)%sneqv = swe_old
@@ -663,8 +700,9 @@ subroutine noahmp36_settws(n, LSM_State)
      endif
 
      if(noahmp36_struc(n)%noahmp36(t)%sneqv.le.0.and.&
-          noahmp36_struc(n)%noahmp36(t)%snowh.gt.0) then 
-        write(LIS_logunit,*) '[WARN] state update leads to positive snow depth but zero SWE'
+          noahmp36_struc(n)%noahmp36(t)%snowh.gt.0) then
+        write(LIS_logunit,*) &
+             '[WARN] state update leads to positive snow depth but zero SWE'
         write(LIS_logunit,*) '[WARN] ',noahmp36_struc(n)%noahmp36(t)%sneqv,&
              noahmp36_struc(n)%noahmp36(t)%snowh
         write(LIS_logunit,*) '[WARN] rejecting the update ...'

--- a/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_settws.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/da_tws/noahmp36_settws.F90
@@ -158,6 +158,7 @@ subroutine noahmp36_settws(n, LSM_State)
      !Wanshu
      delta5 = gws(t)-NOAHMP36_struc(n)%noahmp36(t)%wa
 
+
      ! MN: check    MIN_THRESHOLD < volumetric liquid soil moisture < threshold 
      if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(1)+delta1.gt.MIN_THRESHOLD .and.&
           NOAHMP36_struc(n)%noahmp36(t)%sh2o(1)+delta1.lt.&
@@ -310,19 +311,11 @@ subroutine noahmp36_settws(n, LSM_State)
               !Wanshu
 !              NOAHMP36_struc(n)%noahmp36(t)%wa = gws(t)
  
-              if(soilm1(t).lt.0) then 
-                 print*, 'setsoilm1 ',t,soilm1(t)
-                 stop
-              endif
               if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(2)+delta2.gt.MIN_THRESHOLD .and.&
                    NOAHMP36_struc(n)%noahmp36(t)%sh2o(2)+delta2.lt.sm_threshold) then 
                  NOAHMP36_struc(n)%noahmp36(t)%sh2o(2) = NOAHMP36_struc(n)%noahmp36(t)%sh2o(2)+&
                       soilm2(t)-NOAHMP36_struc(n)%noahmp36(t)%smc(2)
                  NOAHMP36_struc(n)%noahmp36(t)%smc(2) = soilm2(t)
-                 if(soilm2(t).lt.0) then 
-                    print*, 'setsoilm2 ',t,soilm2(t)
-                    stop
-                 endif
               endif
 ! MN: Test shutdown the update for 4th layer   
               if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(3)+delta3.gt.MIN_THRESHOLD .and.&
@@ -330,10 +323,6 @@ subroutine noahmp36_settws(n, LSM_State)
                  NOAHMP36_struc(n)%noahmp36(t)%sh2o(3) = NOAHMP36_struc(n)%noahmp36(t)%sh2o(3)+&
                       soilm3(t)-NOAHMP36_struc(n)%noahmp36(t)%smc(3)
                  NOAHMP36_struc(n)%noahmp36(t)%smc(3) = soilm3(t)
-                 if(soilm3(t).lt.0) then 
-                    print*, 'setsoilm3 ',t,soilm3(t)
-                    stop
-                 endif
               endif
 
               if(NOAHMP36_struc(n)%noahmp36(t)%sh2o(4)+delta4.gt.MIN_THRESHOLD .and.&
@@ -342,10 +331,6 @@ subroutine noahmp36_settws(n, LSM_State)
                       soilm4(t)-NOAHMP36_struc(n)%noahmp36(t)%smc(4)
                  NOAHMP36_struc(n)%noahmp36(t)%smc(4) = soilm4(t)
 
-                 if(soilm4(t).lt.0) then 
-                    print*, 'setsoilm4 ',t,soilm4(t)
-                    stop
-                 endif
               endif
              !Wanshu
               if(NOAHMP36_struc(n)%noahmp36(t)%wa+delta5.gt.MIN_GWS_THRESHOLD.and.&


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

**Note: all code changes in this pull request were made by @bailinglee and @KathyNie.** I am simply opening this pull request on their behalf because we needed to separate the fixes from the new features introduced together in #216.

Fixes made to LDT and NoahMP.3.6 have been cherry-picked from the original feature branch onto the support/lisf-public-7.3 branch. These changes are introduced here. See the original pull request, commit messages below, and Issue #61 for context on these changes.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->

* **LDT**: /discover/nobackup/projects/lis/PR_TESTCASES/216/testing_new/ldt

  Compile with default settings, run LDT, and compare to the output found in *TARGET_GRACEOBS* (provided [here](https://github.com/NASA-LIS/LISF/pull/216#issuecomment-580909388)).

* **LIS**: /discover/nobackup/projects/lis/PR_TESTCASES/216/testing_new/noahmp36/new-branch

  Compile with default settings, run LIS, and compare to the output in *TARGET_OUTPUT*. This target output was generated using an executable compiled from the original feature branch to make sure the new branch produces the same output (it is not identical, but _very_ close. Bailing has approved the output used for this comparison.


