### PR TITLE
Fix/557ww 7.4 configs

### DIFF
--- a/lis/configs/557WW-7.4-FOC/attribs/jules_sm_pertattribs.txt
+++ b/lis/configs/557WW-7.4-FOC/attribs/jules_sm_pertattribs.txt
@@ -1,6 +1,6 @@
 #perttype  std    std_max   zeromean  tcorr  xcorr ycorr ccorr
 Soil Moisture Layer 1
-  0  0.04     2.5             1        43200   0    0    1.0 0.0 0.0 0.0
+  0  0.006    2.5             1        43200   0    0    1.0 0.0 0.0 0.0
 Soil Moisture Layer 2
   0  0.00     2.5	      1        43200   0    0    0.0 1.0 0.0 0.0
 Soil Moisture Layer 3

--- a/lis/configs/557WW-7.4-FOC/attribs/noah_sm_pertattribs.txt
+++ b/lis/configs/557WW-7.4-FOC/attribs/noah_sm_pertattribs.txt
@@ -1,6 +1,6 @@
 #perttype  std    std_max   zeromean  tcorr  xcorr ycorr ccorr
 Soil Moisture Layer 1
-  0  0.006    2.5             1        43200   0    0    1.0 0.0 0.0 0.0
+  0  0.004    2.5             1        43200   0    0    1.0 0.0 0.0 0.0
 Soil Moisture Layer 2
   0  0.00     2.5	      1        43200   0    0    0.0 1.0 0.0 0.0
 Soil Moisture Layer 3

--- a/lis/configs/557WW-7.4-FOC/for_discover/ldt.config.global.jules50.cdf
+++ b/lis/configs/557WW-7.4-FOC/for_discover/ldt.config.global.jules50.cdf
@@ -128,7 +128,7 @@ Minimum cutoff percentage (aspect bands):         0.05
 # CDF generation options
 DA preprocessing method:                          "CDF generation"
 DA observation source:                            "LIS LSM soil moisture"
-Name of the preprocessed DA file:                 ./jules50_cdf_200obs
+Name of the preprocessed DA file:                 ./jules50_cdf_200obs.nc
 Apply anomaly correction to obs:                  0
 Temporal resolution of CDFs:                      "monthly"
 Number of bins to use in the CDF:                 100
@@ -158,8 +158,8 @@ Starting day:                                        2
 Starting hour:                                       0
 Starting minute:                                     0
 Starting second:                                     0
-Ending year:                                      2019
-Ending month:                                        6
+Ending year:                                      2020
+Ending month:                                        1
 Ending day:                                          1
 Ending hour:                                         0
 Ending minute:                                       0

--- a/lis/configs/557WW-7.4-FOC/for_discover/ldt.config.global.noah39.cdf
+++ b/lis/configs/557WW-7.4-FOC/for_discover/ldt.config.global.noah39.cdf
@@ -190,8 +190,8 @@ Starting day:                                        2
 Starting hour:                                       0
 Starting minute:                                     0
 Starting second:                                     0
-Ending year:                                      2019
-Ending month:                                        6
+Ending year:                                      2020
+Ending month:                                        1
 Ending day:                                          1
 Ending hour:                                         0
 Ending minute:                                       0

--- a/lis/configs/557WW-7.4-FOC/for_discover/ldt.config.global.noahmp401.cdf
+++ b/lis/configs/557WW-7.4-FOC/for_discover/ldt.config.global.noahmp401.cdf
@@ -163,7 +163,7 @@ Minimum cutoff percentage (aspect bands):         0.05
 # CDF generation options
 DA preprocessing method:                          "CDF generation"
 DA observation source:                            "LIS LSM soil moisture"
-Name of the preprocessed DA file:                 ./noahmp401_cdf_200obs
+Name of the preprocessed DA file:                 ./noahmp401_cdf_200obs.nc
 Apply anomaly correction to obs:                  0
 Temporal resolution of CDFs:                      "monthly"
 Number of bins to use in the CDF:                 100
@@ -193,8 +193,8 @@ Starting day:                                        2
 Starting hour:                                       0
 Starting minute:                                     0
 Starting second:                                     0
-Ending year:                                      2019
-Ending month:                                        6
+Ending year:                                      2020
+Ending month:                                        1
 Ending day:                                          1
 Ending hour:                                         0
 Ending minute:                                       0

--- a/lis/configs/557WW-7.4-FOC/for_discover/lis.config.global.jules50.discover
+++ b/lis/configs/557WW-7.4-FOC/for_discover/lis.config.global.jules50.discover
@@ -213,7 +213,7 @@ AGRMET SSMI data directory:                SSMI            # SSMI_LE, NONE, or S
 AGRMET SSMI imax:                          1024            # For 16th mesh polar stereographic
 AGRMET SSMI jmax:                          1024            # For 16th mesh polar stereographic
 
-# Do not use GEOPRECIP rainfall data -- use IMERG instead
+# Do not use GEOPRECIP rainfall data -- use IMERG instead.
 AGRMET use GEOPRECIP estimate:             0               # 0 = Do not use
 AGRMET GEOPRECIP data directory:           GEO             # GEO_LE, NONE, or GEO
 AGRMET GEOPRECIP imax:                     1024            # For 16th mesh polar stereographic
@@ -221,7 +221,7 @@ AGRMET GEOPRECIP jmax:                     1024            # For 16th mesh polar
 AGRMET GEO_PRECIP maximum temperature threshold:  278
 AGRMET GEO_PRECIP minimum temperature threshold:  273
 
-# Do not use CMORPH rainfall data -- use IMERG instead
+# Do not use CMORPH rainfall data -- use IMERG instead.
 AGRMET use CMORPH data:                    0               # 0 = Do not use
 AGRMET CMORPH data directory:              CMORPH          # Always CMORPH
 AGRMET CMORPH imax:                        4948
@@ -236,7 +236,7 @@ AGRMET CMORPH maximum temperature threshold:      278
 AGRMET CMORPH minimum temperature threshold:      273
 
 # Use IMERG rainfall data
-AGRMET use IMERG data:                     0               # 1 = Use
+AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
 AGRMET IMERG data directory:               ./IMERG/Early_V06B
 AGRMET IMERG product:                      3B-HHR-E        # Early Run

--- a/lis/configs/557WW-7.4-FOC/for_discover/lis.config.global.noah39.discover
+++ b/lis/configs/557WW-7.4-FOC/for_discover/lis.config.global.noah39.discover
@@ -213,7 +213,7 @@ AGRMET SSMI data directory:                SSMI            # SSMI_LE, NONE, or S
 AGRMET SSMI imax:                          1024            # For 16th mesh polar stereographic
 AGRMET SSMI jmax:                          1024            # For 16th mesh polar stereographic
 
-# Do not use GEOPRECIP rainfall data -- use IMERG instead
+# Do not use GEOPRECIP rainfall data -- use IMERG instead.
 AGRMET use GEOPRECIP estimate:             0               # 0 = Do not use
 AGRMET GEOPRECIP data directory:           GEO             # GEO_LE, NONE, or GEO
 AGRMET GEOPRECIP imax:                     1024            # For 16th mesh polar stereographic
@@ -221,7 +221,7 @@ AGRMET GEOPRECIP jmax:                     1024            # For 16th mesh polar
 AGRMET GEO_PRECIP maximum temperature threshold:  278
 AGRMET GEO_PRECIP minimum temperature threshold:  273
 
-# Do not use CMORPH rainfall data -- use IMERG instead
+# Do not use CMORPH rainfall data -- use IMERG instead.
 AGRMET use CMORPH data:                    0               # 0 = Do not use
 AGRMET CMORPH data directory:              CMORPH          # Always CMORPH
 AGRMET CMORPH imax:                        4948

--- a/lis/configs/557WW-7.4-FOC/for_discover/lis.config.global.noahmp401.discover
+++ b/lis/configs/557WW-7.4-FOC/for_discover/lis.config.global.noahmp401.discover
@@ -213,7 +213,7 @@ AGRMET SSMI data directory:                SSMI            # SSMI_LE, NONE, or S
 AGRMET SSMI imax:                          1024            # For 16th mesh polar stereographic
 AGRMET SSMI jmax:                          1024            # For 16th mesh polar stereographic
 
-# Do not use GEOPRECIP rainfall data -- use IMERG instead
+# Do not use GEOPRECIP rainfall data -- use IMERG instead.
 AGRMET use GEOPRECIP estimate:             0               # 0 = Do not use
 AGRMET GEOPRECIP data directory:           GEO             # GEO_LE, NONE, or GEO
 AGRMET GEOPRECIP imax:                     1024            # For 16th mesh polar stereographic
@@ -221,7 +221,7 @@ AGRMET GEOPRECIP jmax:                     1024            # For 16th mesh polar
 AGRMET GEO_PRECIP maximum temperature threshold:  278
 AGRMET GEO_PRECIP minimum temperature threshold:  273
 
-# Do not use CMORPH rainfall data -- use IMERG instead
+# Do not use CMORPH rainfall data -- use IMERG instead.
 AGRMET use CMORPH data:                    0               # 0 = Do not use
 AGRMET CMORPH data directory:              CMORPH          # Always CMORPH
 AGRMET CMORPH imax:                        4948

--- a/lis/configs/557WW-7.4-FOC/lis.config.global.jules50.ops
+++ b/lis/configs/557WW-7.4-FOC/lis.config.global.jules50.ops
@@ -211,12 +211,12 @@ AGRMET use timestamp on directories:       1
 
 # Do not use SSMI rainfall data -- use IMERG instead.
 AGRMET use SSMI data:                      0               # 0 = Do not use
-AGRMET SSMI zero use switch:               0               # 0 = Ignore zero precip estimates
+AGRMET SSMI zero use switch:               0               # 0 = do not use SSMI zeros
 AGRMET SSMI data directory:                SSMI            # SSMI_LE, NONE, or SSMI
 AGRMET SSMI imax:                          1024            # For 16th mesh polar stereographic
 AGRMET SSMI jmax:                          1024            # For 16th mesh polar stereographic
 
-# Do not use GEOPRECIP rainfall data -- use IMERG instead
+# Do not use GEOPRECIP rainfall data -- use IMERG instead.
 AGRMET use GEOPRECIP estimate:             0               # 0 = Do not use
 AGRMET GEOPRECIP data directory:           GEO             # GEO_LE, NONE, or GEO
 AGRMET GEOPRECIP imax:                     1024            # For 16th mesh polar stereographic
@@ -224,7 +224,7 @@ AGRMET GEOPRECIP jmax:                     1024            # For 16th mesh polar
 AGRMET GEO_PRECIP maximum temperature threshold:  278
 AGRMET GEO_PRECIP minimum temperature threshold:  273
 
-# Do not use CMORPH rainfall data -- use IMERG instead
+# Do not use CMORPH rainfall data -- use IMERG instead.
 AGRMET use CMORPH data:                    0               # 0 = Do not use
 AGRMET CMORPH data directory:              CMORPH          # Always CMORPH
 AGRMET CMORPH imax:                        4948

--- a/lis/configs/557WW-7.4-FOC/lis.config.global.jules50.ops.galwem10
+++ b/lis/configs/557WW-7.4-FOC/lis.config.global.jules50.ops.galwem10
@@ -216,7 +216,7 @@ AGRMET SSMI data directory:                SSMI            # SSMI_LE, NONE, or S
 AGRMET SSMI imax:                          1024            # For 16th mesh polar stereographic
 AGRMET SSMI jmax:                          1024            # For 16th mesh polar stereographic
 
-# Do not use GEOPRECIP rainfall data -- use IMERG instead
+# Do not use GEOPRECIP rainfall data -- use IMERG instead.
 AGRMET use GEOPRECIP estimate:             0               # 0 = Do not use
 AGRMET GEOPRECIP data directory:           GEO             # GEO_LE, NONE, or GEO
 AGRMET GEOPRECIP imax:                     1024            # For 16th mesh polar stereographic
@@ -224,7 +224,7 @@ AGRMET GEOPRECIP jmax:                     1024            # For 16th mesh polar
 AGRMET GEO_PRECIP maximum temperature threshold:  278
 AGRMET GEO_PRECIP minimum temperature threshold:  273
 
-# Do not use CMORPH rainfall data -- use IMERG instead
+# Do not use CMORPH rainfall data -- use IMERG instead.
 AGRMET use CMORPH data:                    0               # 0 = Do not use
 AGRMET CMORPH data directory:              CMORPH          # Always CMORPH
 AGRMET CMORPH imax:                        4948

--- a/lis/configs/557WW-7.4-FOC/lis.config.global.noah39.ops
+++ b/lis/configs/557WW-7.4-FOC/lis.config.global.noah39.ops
@@ -216,7 +216,7 @@ AGRMET SSMI data directory:                SSMI            # SSMI_LE, NONE, or S
 AGRMET SSMI imax:                          1024            # For 16th mesh polar stereographic
 AGRMET SSMI jmax:                          1024            # For 16th mesh polar stereographic
 
-# Do not use GEOPRECIP rainfall data -- use IMERG instead
+# Do not use GEOPRECIP rainfall data -- use IMERG instead.
 AGRMET use GEOPRECIP estimate:             0               # 0 = Do not use
 AGRMET GEOPRECIP data directory:           GEO             # GEO_LE, NONE, or GEO
 AGRMET GEOPRECIP imax:                     1024            # For 16th mesh polar stereographic
@@ -224,7 +224,7 @@ AGRMET GEOPRECIP jmax:                     1024            # For 16th mesh polar
 AGRMET GEO_PRECIP maximum temperature threshold:  278
 AGRMET GEO_PRECIP minimum temperature threshold:  273
 
-# Do not use CMORPH rainfall data -- use IMERG instead
+# Do not use CMORPH rainfall data -- use IMERG instead.
 AGRMET use CMORPH data:                    0               # 0 = Do not use
 AGRMET CMORPH data directory:              CMORPH          # Always CMORPH
 AGRMET CMORPH imax:                        4948

--- a/lis/configs/557WW-7.4-FOC/lis.config.global.noah39.ops.galwem10
+++ b/lis/configs/557WW-7.4-FOC/lis.config.global.noah39.ops.galwem10
@@ -216,7 +216,7 @@ AGRMET SSMI data directory:                SSMI            # SSMI_LE, NONE, or S
 AGRMET SSMI imax:                          1024            # For 16th mesh polar stereographic
 AGRMET SSMI jmax:                          1024            # For 16th mesh polar stereographic
 
-# Do not use GEOPRECIP rainfall data -- use IMERG instead
+# Do not use GEOPRECIP rainfall data -- use IMERG instead.
 AGRMET use GEOPRECIP estimate:             0               # 0 = Do not use
 AGRMET GEOPRECIP data directory:           GEO             # GEO_LE, NONE, or GEO
 AGRMET GEOPRECIP imax:                     1024            # For 16th mesh polar stereographic
@@ -224,7 +224,7 @@ AGRMET GEOPRECIP jmax:                     1024            # For 16th mesh polar
 AGRMET GEO_PRECIP maximum temperature threshold:  278
 AGRMET GEO_PRECIP minimum temperature threshold:  273
 
-# Do not use CMORPH rainfall data -- use IMERG instead
+# Do not use CMORPH rainfall data -- use IMERG instead.
 AGRMET use CMORPH data:                    0               # 0 = Do not use
 AGRMET CMORPH data directory:              CMORPH          # Always CMORPH
 AGRMET CMORPH imax:                        4948

--- a/lis/configs/557WW-7.4-FOC/lis.config.global.noahmp401.ops
+++ b/lis/configs/557WW-7.4-FOC/lis.config.global.noahmp401.ops
@@ -216,7 +216,7 @@ AGRMET SSMI data directory:                SSMI            # SSMI_LE, NONE, or S
 AGRMET SSMI imax:                          1024            # For 16th mesh polar stereographic
 AGRMET SSMI jmax:                          1024            # For 16th mesh polar stereographic
 
-# Do not use GEOPRECIP rainfall data -- use IMERG instead
+# Do not use GEOPRECIP rainfall data -- use IMERG instead.
 AGRMET use GEOPRECIP estimate:             0               # 0 = Do not use
 AGRMET GEOPRECIP data directory:           GEO             # GEO_LE, NONE, or GEO
 AGRMET GEOPRECIP imax:                     1024            # For 16th mesh polar stereographic
@@ -224,7 +224,7 @@ AGRMET GEOPRECIP jmax:                     1024            # For 16th mesh polar
 AGRMET GEO_PRECIP maximum temperature threshold:  278
 AGRMET GEO_PRECIP minimum temperature threshold:  273
 
-# Do not use CMORPH rainfall data -- use IMERG instead
+# Do not use CMORPH rainfall data -- use IMERG instead.
 AGRMET use CMORPH data:                    0               # 0 = Do not use
 AGRMET CMORPH data directory:              CMORPH          # Always CMORPH
 AGRMET CMORPH imax:                        4948

--- a/lis/configs/557WW-7.4-FOC/lis.config.global.noahmp401.ops.galwem10
+++ b/lis/configs/557WW-7.4-FOC/lis.config.global.noahmp401.ops.galwem10
@@ -216,7 +216,7 @@ AGRMET SSMI data directory:                SSMI            # SSMI_LE, NONE, or S
 AGRMET SSMI imax:                          1024            # For 16th mesh polar stereographic
 AGRMET SSMI jmax:                          1024            # For 16th mesh polar stereographic
 
-# Do not use GEOPRECIP rainfall data -- use IMERG instead
+# Do not use GEOPRECIP rainfall data -- use IMERG instead.
 AGRMET use GEOPRECIP estimate:             0               # 0 = Do not use
 AGRMET GEOPRECIP data directory:           GEO             # GEO_LE, NONE, or GEO
 AGRMET GEOPRECIP imax:                     1024            # For 16th mesh polar stereographic
@@ -224,7 +224,7 @@ AGRMET GEOPRECIP jmax:                     1024            # For 16th mesh polar
 AGRMET GEO_PRECIP maximum temperature threshold:  278
 AGRMET GEO_PRECIP minimum temperature threshold:  273
 
-# Do not use CMORPH rainfall data -- use IMERG instead
+# Do not use CMORPH rainfall data -- use IMERG instead.
 AGRMET use CMORPH data:                    0               # 0 = Do not use
 AGRMET CMORPH data directory:              CMORPH          # Always CMORPH
 AGRMET CMORPH imax:                        4948


### PR DESCRIPTION
Tweaks to the 557ww-7.4 config and attribs files:

1) Changed the JULES-5.0 and Noah-3.9 soil moisture DA model pertattribs files on the recommendation of the LIS DA team.  The new standard deviation values are now found in this files for 557ww-7.4.

2) Minor tweaks (primarily for consistency when comparing between various files) of the ldt.config and lis.config files for jules50, noah39, and noahmp401, for both ops mode and "for_discover".

It would be appreciated if @emkemp and @yhkwon81 confirm these changes before this PR is merged.
