### PR TITLE
Add registration call for AMSR2 snow depth DA

### DIFF
--- a/lis/plugins/LIS_lsmda_pluginMod.F90
+++ b/lis/plugins/LIS_lsmda_pluginMod.F90
@@ -2571,6 +2571,7 @@ subroutine LIS_lsmda_plugin
    call registerlsmdadescalestatevar(trim(LIS_noahmp401Id)//"+"//&
         trim(LIS_MCD15A2HlaiobsId)//char(0),noahmp401_descale_veg)
 
+#if ( defined DA_OBS_GCOMW_AMSR2L3SND )
    call registerlsmdainit(trim(LIS_noahmp401Id)//"+"//&
         trim(LIS_GCOMW_AMSR2L3sndobsId)//char(0),noahmp401_dasnow_init)
    call registerlsmdagetstatevar(trim(LIS_noahmp401Id)//"+"//&
@@ -2591,6 +2592,7 @@ subroutine LIS_lsmda_plugin
         trim(LIS_GCOMW_AMSR2L3sndobsId)//char(0),NoahMP401_updatesnowvars)
    call registerlsmdaqcobsstate(trim(LIS_noahmp401Id)//"+"//&
         trim(LIS_GCOMW_AMSR2L3sndobsId)//char(0),NoahMP401_qc_snowobs)
+#endif
 
 ! Yeosang Yoon, SNODEP DA
 #if ( defined DA_OBS_SNODEP )


### PR DESCRIPTION
### Description

Minor fix to LIS_lsmda_pluginMod.F90 to include registration call for AMSR2 snow depth DA.

### Testcase
Can use same test case as initial PR for AMSR2 DA with NoahMP401.
