### PR TITLE
Move #endif to enclose NoahMP401 snow DA plugins

### DIFF
--- a/lis/plugins/LIS_lsmda_pluginMod.F90
+++ b/lis/plugins/LIS_lsmda_pluginMod.F90
@@ -2643,7 +2643,6 @@ subroutine LIS_lsmda_plugin
    call registerlsmdadescalestatevar(trim(LIS_noahmp401Id)//"+"//&
         trim(LIS_usafsiobsId)//char(0),noahmp401_descale_usafsi)
 #endif
-#endif
 
 #if ( defined DA_OBS_ASO_SWE)
    call registerlsmdainit(trim(LIS_noahmp401Id)//"+"//&
@@ -2693,6 +2692,8 @@ subroutine LIS_lsmda_plugin
    call registerlsmdaqcobsstate(trim(LIS_noahmp401Id)//"+"//&
         trim(LIS_SNODASobsId)//char(0),NoahMP401_qc_snowobs)
 #endif 
+! end NoahMP.4.0.1
+#endif
 
 
 #if ( defined SM_CLSM_F2_5 )


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Moves an `#endif` to enclose the ASO and SNODAS DA plugin registration blocks within the NoahMP.4.0.1 block.

Resolves #769

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase

Tested with SNODAS testcase from #764.
