### PR TITLE
Adds Noah-MP precipitation timestep fix 

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
@@ -294,9 +294,9 @@ subroutine NoahMP401_main(n)
             tmp_lwdown     = NOAHMP401_struc(n)%noahmp401(t)%lwdown / NOAHMP401_struc(n)%forc_count
 
             ! prcp: total precipitation (rainfall+snowfall)
-            ! Both NoahMP-3.6.1 and NoahMP-4.0.1 requires total precipitation as forcing input.
-            ! In LIS/NoahMP-3.6.1, the input forcing is total precipitation [mm], but in
-            ! LIS/NoahMP-4.0.1, the forcing data provides precipitation rate [mm/s] !!!
+            ! Both Noah-MP-3.6 and Noah-MP-4.0.1 require total precipitation as forcing input.
+            ! In Noah-MP-3.6, the forcing is required to be precipitation rate [kg m-2 sec-1].
+            ! In Noah-MP-4.0.1, the forcing is required to be precipitation amount [kg m-2].
 
             ! T. Lahmers: Correct total precip for cases when model time step > forcing timestep. 
             ! Edit suggested by D. Mocko and K. Arsenault

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
@@ -297,7 +297,15 @@ subroutine NoahMP401_main(n)
             ! Both NoahMP-3.6.1 and NoahMP-4.0.1 requires total precipitation as forcing input.
             ! In LIS/NoahMP-3.6.1, the input forcing is total precipitation [mm], but in
             ! LIS/NoahMP-4.0.1, the forcing data provides precipitation rate [mm/s] !!!
-            tmp_prcp       = dt * (NOAHMP401_struc(n)%noahmp401(t)%prcp   / NOAHMP401_struc(n)%forc_count)
+
+            ! T. Lahmers: Correct total precip for cases when model time step > forcing timestep. 
+            ! Edit suggested by D. Mocko and K. Arsenault
+            if (NOAHMP401_struc(n)%ts > LIS_rc%ts) then
+                tmp_dt         = NOAHMP401_struc(n)%ts
+                tmp_prcp       = tmp_dt * (NOAHMP401_struc(n)%noahmp401(t)%prcp   / NOAHMP401_struc(n)%forc_count)
+            else
+                tmp_prcp       = dt * (NOAHMP401_struc(n)%noahmp401(t)%prcp   / NOAHMP401_struc(n)%forc_count)
+            endif
 
             ! check validity of tair
             if(tmp_tair .eq. LIS_rc%udef) then


### PR DESCRIPTION
Adds Noah-MP precipitation timestep fix for cases where LIS dt is greater than forcing dt

Description

Corrects issue #710

This pull request includes an update to Noah-MP v4.0.1. The lines to compute the precipitation assume that the Noah-MP timestep is less than or equal to the forcing timestep. In the event that the Noah-MP timestep exceeds the forcing timestep (i.e. is longer), forcing precipitation is multiplied by a shorter timestep and is therefore reduced.

This PR addresses that issue with an added if-statement that compares the model and forcing timestep. If the forcing timestep is shorter, then a temporary timestep (tmp_dt) is assigned to the model timestep and used and used for this calculation. If the condition is not true, the calculation used in previous version of Noah-MP remains valid.

Testcase

The benefits of this case are demonstrated in the directories:
/discover/nobackup/projects/nu-wrf/members/tlahmers/VALID_RUNS/LISF_precip_valid/run_ctrl
/discover/nobackup/projects/nu-wrf/members/tlahmers/VALID_RUNS/LISF_precip_valid/run_update

In the OUTPUT directories of the control simulation (run_ctrl), the error is issue #710 is demonstrated, as the Rainf_tavg and Snowf_tavg variables are half of their actual values. In this case, the Noah-MP timestep is 60 minutes and the IMERG forcing timestep is 30 minutes. In a case with all rain precipitation, this is easy to demonstrate as Rainf_tavg is half of the TotalPrecip_tavg variable due to the aforementioned logic error.

In the updated simulation (run_update), these errors are corrected, as Rainf_tavg (and Snowf_tavg) are double their values from the control simulation. For example, Rainf_tavg would be equivalent to TotalPrecip_tavg for cases of all rain.

This change is necessary for some model configurations where a long Noah-MP timestep is used with a higher resolution precipitation product (e.g. LIS/WRF-Hydro).