### PR TITLE
Load git v2.24.0

### DIFF
--- a/env/discover/lisf_7_intel_19_1_0_166
+++ b/env/discover/lisf_7_intel_19_1_0_166
@@ -79,8 +79,8 @@ module load comp/gcc/9.2.0
 module load comp/intel/19.1.0.166
 module load mpi/impi/20.0.0.166
 
-#module load tview/2019.0.4
-#module load git/2.24.0
+module load tview/2019.0.4
+module load git/2.24.0
 
 
 set   def_lis_jpeg        /discover/nobackup/projects/lis/libs/jpeg/8d_sles12.3

--- a/env/discover/lisf_7_intel_19_1_0_166_traceback-work-around
+++ b/env/discover/lisf_7_intel_19_1_0_166_traceback-work-around
@@ -81,8 +81,8 @@ module load mpi/impi/20.0.0.166
 module use -a /discover/swdev/gmao_SIteam/modulefiles-SLES12
 module load mpi/impi-prov/20.0.0.166
 
-#module load tview/2019.0.4
-#module load git/2.24.0
+module load tview/2019.0.4
+module load git/2.24.0
 
 
 set   def_lis_jpeg        /discover/nobackup/projects/lis/libs/jpeg/8d_sles12.3


### PR DESCRIPTION
This also loads tview/2019.0.4.

### Description

These two custom modulefiles for discover did not load git v2.24.0.

Resolves #783.
