### PR TITLE
fixed ANSA snow depth DA config settings in LIS user guide

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -2207,11 +2207,11 @@ of MODIS (MOD10C1) data.
 ....
 ANSA snow depth data directory:                  ./ANSASNWD
 ANSA snow depth lower left lat:                  -89.875
-ANSA snow depth lower left lon:                  -179.875
-ANSA snow depth upper right lat:                  89.875
-ANSA snow depth upper right lon:                 179.875
-ANSA snow depth resolution (dx):                  0.25
-ANSA snow depth resolution (dy):                  0.25
+ANSA snow depth lower left lon:                  -179.975
+ANSA snow depth upper right lat:                  89.975
+ANSA snow depth upper right lon:                 179.975
+ANSA snow depth resolution (dx):                  0.05
+ANSA snow depth resolution (dy):                  0.05
 ANSA snow depth use IMS data for snow detection:
 ANSA snow depth IMS data directory:
 ANSA snow depth use MODIS (MOD10C1) data for snow detection:


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Updates some of the lis.config options in the LIS user guide on ANSA snow depth DA. With settings currently in user guide, LIS results in a segmentation fault. 

Resolves #782 

### Testcase
An ANSA snow depth test case with these updated lis.config options can be found in /discover/nobackup/projects/eis_freshwater/mwrzesie/Runs_10km/DA_ANSA


