### PR TITLE
Update Issue template to point to Discussions tab

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: LISF Community Support
-    url: https://modelingguru.nasa.gov/community/atmospheric/lis
+    url: https://github.com/NASA-LIS/LISF/discussions
     about: Have a question? Search or ask here before opening an Issue.


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

The Issue template includes a button that directs user questions to "LISF Community Support." Previously this linked to ModelingGuru. This PR changes the link to point to our new Discussions tab.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

