### PR TITLE
Numerous changes to LIS 7.3 to satisfy gfortran 11.1.0

### DIFF
--- a/lis/core/LIS_alb_FTable.c
+++ b/lis/core/LIS_alb_FTable.c
@@ -44,8 +44,8 @@ struct albreadnode* albread_table = NULL;
 //
 // !INTERFACE:
 void FTN(registeralbedosetup)(char *j,
-                           void (*func)(int*),
-                           int len)
+                              void (*func)(int*),
+                              int len)
 // !DESCRIPTION:
 // Makes an entry in the registry for the routine to
 // setup albedo data reading routines

--- a/lis/core/LIS_alb_FTable.c
+++ b/lis/core/LIS_alb_FTable.c
@@ -10,49 +10,45 @@
 //BOP
 //
 // !MODULE: LIS_alb_FTable
-//  
+//
 //
 // !DESCRIPTION:
-//  Function table registries for storing the interface 
-//  implementations for managing different sources of 
+//  Function table registries for storing the interface
+//  implementations for managing different sources of
 //  albedo parameter data
 //EOP
-#include<stdio.h>
-#include<stdlib.h>
-#include<stdarg.h>
-#include<string.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "ftn_drv.h"
 
-struct albsetnode
-{ 
-  char *name;
-  void (*func)(int*);
+struct albsetnode {
+    char *name;
+    void (*func)(int*);
+    struct albsetnode* next;
+};
+struct albsetnode* albset_table = NULL;
 
-  struct albsetnode* next;
-} ;
-struct albsetnode* albset_table = NULL; 
-
-struct albreadnode
-{ 
-  char *name;
-  void (*func)(int*,void*,void*, float*, float*);
-
-  struct albreadnode* next;
-} ;
-struct albreadnode* albread_table = NULL; 
+struct albreadnode {
+    char *name;
+    void (*func)(int*, void*, void*, float*, float*);
+    struct albreadnode* next;
+};
+struct albreadnode* albread_table = NULL;
 
 //BOP
 // !ROUTINE: registeralbedosetup
 // \label{registeralbedosetup}
-// 
+//
 // !INTERFACE:
-void FTN(registeralbedosetup)(char *j,void (*func)(int*),int len)
-// !DESCRIPTION: 
-// Makes an entry in the registry for the routine to 
+void FTN(registeralbedosetup)(char *j, void (*func)(int*), int len)
+// !DESCRIPTION:
+// Makes an entry in the registry for the routine to
 // setup albedo data reading routines
 //
-// The arguments are: 
+// The arguments are:
 // \begin{description}
 // \item[i]
 //  index of the domain
@@ -60,30 +56,28 @@ void FTN(registeralbedosetup)(char *j,void (*func)(int*),int len)
 //  index of the albedo data source
 //  \end{description}
 //EOP
-{ 
-  int len1;
-  struct albsetnode* current;
-  struct albsetnode* pnode; 
-  // create node
-  
-  len1 = len + 1; // ensure that there is space for terminating null
-  pnode=(struct albsetnode*) malloc(sizeof(struct albsetnode));
-  pnode->name=(char*) calloc(len1,sizeof(char));
-  strncpy(pnode->name,j,len);
-  pnode->func = func;
-  pnode->next = NULL; 
+{
+    int len1;
+    struct albsetnode* current;
+    struct albsetnode* pnode;
+    // create node
 
-  if(albset_table == NULL){
-    albset_table = pnode;
-  }
-  else{
-    current = albset_table; 
-    while(current->next!=NULL){
-      current = current->next;
+    len1 = len + 1; // ensure that there is space for terminating null
+    pnode = (struct albsetnode*) malloc(sizeof(struct albsetnode));
+    pnode->name = (char*) calloc(len1, sizeof(char));
+    strncpy(pnode->name, j, len);
+    pnode->func = func;
+    pnode->next = NULL;
+
+    if (albset_table == NULL) {
+        albset_table = pnode;
+    } else {
+        current = albset_table;
+        while (current->next != NULL) {
+            current = current->next;
+        }
+        current->next = pnode;
     }
-    current->next = pnode; 
-  }
-
 }
 
 //BOP
@@ -91,13 +85,14 @@ void FTN(registeralbedosetup)(char *j,void (*func)(int*),int len)
 // \label{albedosetup}
 //
 // !INTERFACE:
-void FTN(albedosetup)(char *j, int *n, int len)
-//  
+//EMK Removed unused argument.
+void FTN(albedosetup)(char *j, int *n)
+//
 // !DESCRIPTION:
-// Invokes the routine from the registry to 
+// Invokes the routine from the registry to
 // setup albedo data reading
-// 
-// The arguments are: 
+//
+// The arguments are:
 // \begin{description}
 //  \item[n]
 //   index of the nest
@@ -105,104 +100,110 @@ void FTN(albedosetup)(char *j, int *n, int len)
 //  index of the albedo data source
 //  \end{description}
 //EOP
-{ 
-  struct albsetnode* current;
-  
-  current = albset_table;
-  while(strcmp(current->name,j)!=0){
-    current = current->next;
-  
-    if(current==NULL) {
-      printf("****************Error****************************\n"); 
-      printf("albedo setup routine for %s is not defined\n",j); 
-      printf("program will seg fault.....\n"); 
-      printf("****************Error****************************\n"); 
+{
+    struct albsetnode* current;
+
+    current = albset_table;
+    while (strcmp(current->name, j) != 0) {
+        current = current->next;
+
+        if (current == NULL) {
+            printf("****************Error****************************\n");
+            printf("albedo setup routine for %s is not defined\n",j);
+            printf("program will seg fault.....\n");
+            printf("****************Error****************************\n");
+        }
     }
-  }
-  current->func(n); 
+    current->func(n);
 }
 
 //BOP
 // !ROUTINE: registerreadalbedo
 // \label{registerreadalbedo}
-//  
+//
 // !INTERFACE:
-void FTN(registerreadalbedo)(char *j,void (*func)(int*, void*, void*, float*, float*), int len)
-// !DESCRIPTION: 
+void FTN(registerreadalbedo)(char *j,
+                             void (*func)(int*, void*, void*, float*, float*),
+                             int len)
+// !DESCRIPTION:
 // Creates an entry in the registry for the routine to
 // read albedo climatology data
-// 
-// The arguments are: 
+//
+// The arguments are:
 // \begin{description}
 //  \item[j]
 //   index of the albedo source
 //  \end{description}
 //EOP
-{ 
-  int len1;
-  struct albreadnode* current;
-  struct albreadnode* pnode; 
-  // create node
-  
-  len1 = len + 1; // ensure that there is space for terminating null
-  pnode=(struct albreadnode*) malloc(sizeof(struct albreadnode));
-  pnode->name=(char*) calloc(len1,sizeof(char));
-  strncpy(pnode->name,j,len);
-  pnode->func = func;
-  pnode->next = NULL; 
+{
+    int len1;
+    struct albreadnode* current;
+    struct albreadnode* pnode;
+    // create node
 
-  if(albread_table == NULL){
-    albread_table = pnode;
-  }
-  else{
-    current = albread_table; 
-    while(current->next!=NULL){
-      current = current->next;
+    len1 = len + 1; // ensure that there is space for terminating null
+    pnode = (struct albreadnode*) malloc(sizeof(struct albreadnode));
+    pnode->name = (char*) calloc(len1, sizeof(char));
+    strncpy(pnode->name, j, len);
+    pnode->func = func;
+    pnode->next = NULL;
+
+    if (albread_table == NULL) {
+        albread_table = pnode;
+    } else {
+        current = albread_table;
+        while (current->next != NULL) {
+            current = current->next;
+        }
+        current->next = pnode;
     }
-    current->next = pnode; 
-  }
-
 }
 
 //BOP
 // !ROUTINE: readalbedo
 // \label{readalbedo}
-// 
+//
 // !INTERFACE:
-void FTN(readalbedo)(char *j, int *n, void *time1, void *time2, float *array1, float *array2,int len)
-//  
-// !DESCRIPTION: 
-// Invokes the routines from the registry for 
+//EMK: Removed unused argment len.  Changed time1 and time2 arguments
+//to floats with relative weights, consistant with underlying
+//read_ALMIPIIalbedo Fortran routine.
+void FTN(readalbedo)(char *j, int *n, float *wt1, float *wt2,
+                     float *array1, float *array2)
+//
+// !DESCRIPTION:
+// Invokes the routines from the registry for
 // reading climatology albedo files
 //
-// The arguments are: 
+// The arguments are:
 // \begin{description}
-//  \item[n]
-//   index of the nest
 //  \item[j]
 //   index of the albedo source
-//  \item[time]
-//   time index value
-//  \item[array]
-//   pointer to the array containing the albedo data. 
+//  \item[n]
+//   index of the nest
+//  \item[wt1]
+//   weight of first time level
+//  \item[wt2]
+//   weight of second time level
+//  \item[array1]
+//   pointer to first array containing the albedo data.
+//  \item[array2]
+//   pointer to second array containing the albedo data.
+
 //  \end{description}
 //EOP
-{ 
-  struct albreadnode* current;
-  
-  current = albread_table;
-  while(strcmp(current->name,j)!=0){
-    current = current->next;
-    
-    if(current==NULL) {
-      printf("****************Error****************************\n"); 
-      printf("readalbedo routine for %s is not defined\n",j); 
-      printf("program will seg fault.....\n"); 
-      printf("****************Error****************************\n"); 
+{
+    struct albreadnode* current;
+
+    current = albread_table;
+    while (strcmp(current->name, j) != 0) {
+        current = current->next;
+
+        if (current == NULL) {
+            printf("****************Error****************************\n");
+            printf("readalbedo routine for %s is not defined\n",j);
+            printf("program will seg fault.....\n");
+            printf("****************Error****************************\n");
+        }
     }
-  }
-  current->func(n,time1,time2,array1,array2); 
+    current->func(n, wt1, wt2, array1, array2);
 }
-
-
-

--- a/lis/core/LIS_alb_FTable.c
+++ b/lis/core/LIS_alb_FTable.c
@@ -44,7 +44,7 @@ struct albreadnode* albread_table = NULL;
 //
 // !INTERFACE:
 void FTN(registeralbedosetup)(char *j,
-                           void (*func)(int*, float*, float*, float*, float*),
+                           void (*func)(int*),
                            int len)
 // !DESCRIPTION:
 // Makes an entry in the registry for the routine to
@@ -125,8 +125,8 @@ void FTN(albedosetup)(char *j, int *n)
 //
 // !INTERFACE:
 void FTN(registerreadalbedo)(char *j,
-                             void (*func)(int*, void*, void*, float*, float*),
-                             int len)
+                            void (*func)(int*, float*, float*, float*, float*),
+                            int len)
 // !DESCRIPTION:
 // Creates an entry in the registry for the routine to
 // read albedo climatology data

--- a/lis/core/LIS_alb_FTable.c
+++ b/lis/core/LIS_alb_FTable.c
@@ -33,7 +33,7 @@ struct albsetnode* albset_table = NULL;
 
 struct albreadnode {
     char *name;
-    void (*func)(int*, void*, void*, float*, float*);
+    void (*func)(int*, float*, float*, float*, float*);
     struct albreadnode* next;
 };
 struct albreadnode* albread_table = NULL;
@@ -43,7 +43,9 @@ struct albreadnode* albread_table = NULL;
 // \label{registeralbedosetup}
 //
 // !INTERFACE:
-void FTN(registeralbedosetup)(char *j, void (*func)(int*), int len)
+void FTN(registeralbedosetup)(char *j,
+                           void (*func)(int*, float*, float*, float*, float*),
+                           int len)
 // !DESCRIPTION:
 // Makes an entry in the registry for the routine to
 // setup albedo data reading routines

--- a/lis/core/LIS_alb_FTable.c
+++ b/lis/core/LIS_alb_FTable.c
@@ -87,8 +87,7 @@ void FTN(registeralbedosetup)(char *j,
 // \label{albedosetup}
 //
 // !INTERFACE:
-//EMK Removed unused argument.
-void FTN(albedosetup)(char *j, int *n)
+void FTN(albedosetup)(char *j, int *n, int len)
 //
 // !DESCRIPTION:
 // Invokes the routine from the registry to
@@ -166,11 +165,11 @@ void FTN(registerreadalbedo)(char *j,
 // \label{readalbedo}
 //
 // !INTERFACE:
-//EMK: Removed unused argment len.  Changed time1 and time2 arguments
+//EMK: Changed time1 and time2 arguments
 //to floats with relative weights, consistant with underlying
 //read_ALMIPIIalbedo Fortran routine.
 void FTN(readalbedo)(char *j, int *n, float *wt1, float *wt2,
-                     float *array1, float *array2)
+                     float *array1, float *array2, int len)
 //
 // !DESCRIPTION:
 // Invokes the routines from the registry for

--- a/lis/core/LIS_albedoMod.F90
+++ b/lis/core/LIS_albedoMod.F90
@@ -24,18 +24,18 @@ module LIS_albedoMod
 !
 ! !DESCRIPTION:
 !  The code in this file implements routines to read various sources of
-!  albedo parameter data. 
+!  albedo parameter data.
 !  \subsubsection{Overview}
-!  
-!  This routines in this module reads two sources of albedo: 
+!
+!  This routines in this module reads two sources of albedo:
 !   \begin{itemize}
 !     \item{Albedo climatology} \newline
 !     \item{Static, maximum albedo expected over deep snow} \newline
 !   \end{itemize}
-!  This module provides routines to read the albedo climatology (monthly) 
+!  This module provides routines to read the albedo climatology (monthly)
 !  data and allows the users to specify the frequency of climatology
-!  (in months). The climatological data is temporally interpolated  
-!  between months to the current simulation date. 
+!  (in months). The climatological data is temporally interpolated
+!  between months to the current simulation date.
 !
 ! !REVISION HISTORY:
 !
@@ -49,7 +49,7 @@ module LIS_albedoMod
   use LIS_histDataMod
 
   implicit none
-  
+
   PRIVATE
 !------------------------------------------------------------------------------
 ! !PUBLIC MEMBER FUNCTIONS:
@@ -71,7 +71,7 @@ module LIS_albedoMod
      character*100 :: albfile
      logical       :: firstInstance
      real, allocatable :: albsf1(:)
-     real, allocatable :: albsf2(:)  
+     real, allocatable :: albsf2(:)
      real, allocatable :: albsf(:)
      real, allocatable :: mxsnalb(:)
      real, allocatable :: albedo(:)
@@ -87,10 +87,10 @@ module LIS_albedoMod
 contains
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_albedo_setup
 ! \label{LIS_albedo_setup}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_albedo_setup
 ! !USES:
@@ -100,23 +100,23 @@ contains
 !
 ! !DESCRIPTION:
 !
-! Allocates memory for data structures for reading 
+! Allocates memory for data structures for reading
 ! in albedo datasets
-! 
-! The routines invoked are: 
+!
+! The routines invoked are:
 ! \begin{description}
 !  \item[LIS\_read\_mxsnalb](\ref{LIS_read_mxsnalb}) \newline
-!    method to read the max snow albedo 
+!    method to read the max snow albedo
 !   \item[readalbedo](\ref{readalbedo}) \newline
-!    invokes the generic method in the registry to read the 
+!    invokes the generic method in the registry to read the
 !    albedo climatology data
 !   \item[albedosetup](\ref{albedosetup}) \newline
-!    calls the registry to invoke the albedo setup method. 
+!    calls the registry to invoke the albedo setup method.
 ! \end{description}
 !EOP
     implicit none
     integer         :: n
-    integer         :: i 
+    integer         :: i
     integer         :: ndoms
     integer         :: t1, t2
     real            :: wt1, wt2
@@ -127,64 +127,65 @@ contains
     integer         :: rc,ios,nid
     logical         :: file_exists
 !------------------------------------------------------------------------------
-! If albedo datasets are to be used, the routine allocates memory for 
+! If albedo datasets are to be used, the routine allocates memory for
 ! each domain. Further, the routine sets the alarms for reading the
 ! climatology datasets
 !------------------------------------------------------------------------------
     TRACE_ENTER("alb_setup")
     allocate(lis_alb(LIS_rc%nnest))
 
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
        if(LIS_rc%usealbedomap(n).ne."none") ndoms = ndoms+1
     enddo
 
-    if(ndoms.gt.0) then 
+    if(ndoms.gt.0) then
        do n=1,LIS_rc%nnest
-          LIS_alb(n)%firstInstance = .true. 
+          LIS_alb(n)%firstInstance = .true.
        enddo
        do n=1,LIS_rc%nnest
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-             
+
           inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-          if(file_exists) then              
+          if(file_exists) then
              ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
                   mode=NF90_NOWRITE,ncid=nid)
              call LIS_verify(ios,'Error in nf90_open in read_albclimo')
-             
+
              ios = nf90_get_att(nid, NF90_GLOBAL, 'ALBEDO_DATA_INTERVAL', &
                   LIS_alb(n)%albIntervalType)
-             call LIS_verify(ios,'Error in nf90_get_att in read_albclimo')       
-             
+             call LIS_verify(ios,'Error in nf90_get_att in read_albclimo')
+
              ios = nf90_close(nid)
              call LIS_verify(ios,'Error in nf90_close in read_albclimo')
           else
-             write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), ' does not exist'
+             write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), &
+                  ' does not exist'
              write(LIS_logunit,*) '[ERR] program stopping ...'
              call LIS_endrun
           endif
 #endif
 
-          if(LIS_alb(n)%albIntervalType.eq."monthly") then 
+          if(LIS_alb(n)%albIntervalType.eq."monthly") then
              LIS_alb(n)%albInterval = 2592000
           elseif(LIS_alb(n)%albIntervalType.eq."quarterly") then
              LIS_alb(n)%albInterval = 10368000
           endif
        enddo
-       
+
        do n=1,LIS_rc%nnest
-          
+
           allocate(lis_alb(n)%albsf1(LIS_rc%ntiles(n)))
           allocate(lis_alb(n)%albsf2(LIS_rc%ntiles(n)))
           allocate(lis_alb(n)%albsf(LIS_rc%ntiles(n)))
           allocate(lis_alb(n)%albedo(LIS_rc%ntiles(n)))
-          
+
           lis_alb(n)%albsf1 = 0.0
           lis_alb(n)%albsf2 = 0.0
           lis_alb(n)%albsf = 0.0
           lis_alb(n)%albedo = 0.0
 
-          if(LIS_rc%usealbedomap(n).ne."LDT") then 
+          if(LIS_rc%usealbedomap(n).ne."LDT") then
              call albedosetup(trim(LIS_rc%usealbedomap(n))//char(0),n)
           endif
 
@@ -196,9 +197,9 @@ contains
                LIS_alb(n)%albIntervalType, t1,t2,wt1,wt2)
 
           allocate(value1(LIS_rc%lnc(n),LIS_rc%lnr(n)))
-          allocate(value2(LIS_rc%lnc(n),LIS_rc%lnr(n)))       
-       
-          if(LIS_rc%usealbedomap(n).eq."LDT") then 
+          allocate(value2(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+
+          if(LIS_rc%usealbedomap(n).eq."LDT") then
              call read_albedoclimo(n,t1,value1)
              call read_albedoclimo(n,t2,value2)
 
@@ -210,31 +211,31 @@ contains
                      LIS_domain(n)%tile(t)%row)
              enddo
              deallocate(value1)
-             deallocate(value2)            
-          else             
-             call albedosetup(trim(LIS_rc%usealbedomap(n))//char(0),n)               
-             call readalbedo(trim(LIS_rc%usealbedomap(n))//char(0),&
-                  n,wt1,wt1,LIS_alb(n)%albsf1,LIS_alb(n)%albsf2)
+             deallocate(value2)
+          else
+             call albedosetup(trim(LIS_rc%usealbedomap(n))//char(0),n)
+             call readalbedo(trim(LIS_rc%usealbedomap(n))//char(0), &
+                  n, wt1, wt1, LIS_alb(n)%albsf1, LIS_alb(n)%albsf2)
 
           endif
-!-------------------------------------------------------------------------  
+!-------------------------------------------------------------------------
 ! Interpolate the albedo fractions to daily values
-!-------------------------------------------------------------------------  
+!-------------------------------------------------------------------------
           do i=1,LIS_rc%ntiles(n)
-             if (lis_alb(n)%albsf1(i) .ne. -9999.000) then 
+             if (lis_alb(n)%albsf1(i) .ne. -9999.000) then
                 lis_alb(n)%albsf(i) = wt1 * lis_alb(n)%albsf1(i) + &
                      wt2 * lis_alb(n)%albsf2(i)
              endif
-          end do          
+          end do
        enddo
     endif
 
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
        if(LIS_rc%usemxsnalbmap(n).eq."LDT") ndoms = ndoms+1
     enddo
 
-    if(ndoms.gt.0) then 
+    if(ndoms.gt.0) then
        do n=1,LIS_rc%nnest
           allocate(lis_alb(n)%mxsnalb(LIS_rc%ntiles(n)))
           lis_alb(n)%mxsnalb = 0.0
@@ -246,26 +247,26 @@ contains
   end subroutine LIS_albedo_setup
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_read_mxsnalb
 ! \label{LIS_read_mxsnalb}
 !
 ! !INTERFACE:
   subroutine LIS_read_mxsnalb(n)
-! !USES: 
+! !USES:
 #if(defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
 #endif
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in) :: n
 
-! 
+!
 ! !DESCRIPTION:
-!  Reads the static albedo upper bound over deep snow 
-!  for each domain. 
-!  
+!  Reads the static albedo upper bound over deep snow
+!  for each domain.
+!
 !  The arguments are:
 !  \begin{description}
 !   \item[n]
@@ -274,7 +275,7 @@ contains
 !    mxsnalb for the region of interest
 !   \end{description}
 !
-!EOP      
+!EOP
 
   integer :: ios1
   integer :: ios,nid,mxsnalid,ncId, nrId
@@ -285,7 +286,7 @@ contains
 
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
   inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-  if(file_exists) then 
+  if(file_exists) then
 
      write(LIS_logunit,*)'[INFO] Reading max snow albedo map from ',&
           trim(LIS_rc%paramfile(n))
@@ -293,7 +294,7 @@ contains
      ios = nf90_open(path=LIS_rc%paramfile(n),&
           mode=NF90_NOWRITE,ncid=nid)
      call LIS_verify(ios,'Error in nf90_open in read_mxsnalb')
-     
+
      ios = nf90_inq_dimid(nid,"east_west",ncId)
      call LIS_verify(ios,'Error in nf90_inq_dimid in read_mxsnalb')
 
@@ -311,17 +312,18 @@ contains
 
      ios = nf90_get_var(nid,mxsnalid,mxsnal)
      call LIS_verify(ios,'Error in nf90_get_var in read_mxsnalb')
-     
+
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in read_mxsnalb')
-     
+
      tmpalb(:,:) = &
-          mxsnal(LIS_ews_halo_ind(n,LIS_localPet+1):&         
+          mxsnal(LIS_ews_halo_ind(n,LIS_localPet+1):&
           LIS_ewe_halo_ind(n,LIS_localPet+1), &
           LIS_nss_halo_ind(n,LIS_localPet+1): &
           LIS_nse_halo_ind(n,LIS_localPet+1))
   else
-     write(LIS_logunit,*) '[INFO] max snow albedo map: ',LIS_rc%paramfile(n), ' does not exist'
+     write(LIS_logunit,*) '[INFO] max snow albedo map: ', &
+          LIS_rc%paramfile(n), ' does not exist'
      write(LIS_logunit,*) '[INFO] program stopping ...'
      call LIS_endrun
   endif
@@ -335,33 +337,33 @@ contains
   end subroutine LIS_read_mxsnalb
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_read_albedo
 ! \label{LIS_read_albedo}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_read_albedo(n)
-! !USES: 
+! !USES:
 
 ! !ARGUMENTS:
     integer, intent(in) :: n
-! 
+!
 ! !DESCRIPTION:
-!  Reads the snow free albedo climatology data and 
+!  Reads the snow free albedo climatology data and
 !  temporally interpolates it to the current day
 !
-!  The arguments are: 
+!  The arguments are:
 !  \begin{description}
 !   \item [n]
 !     index of the domain or nest.
 !  \end{description}
 !
-! The routines invoked are: 
+! The routines invoked are:
 ! \begin{description}
 !   \item[LIS\_computeTemporalweights](\ref{LIS_computeTemporalWeights}) \newline
 !    computes the temporal interpolation weights
 !   \item[readalbedo](\ref{readalbedo}) \newline
-!    invokes the generic method in the registry to read the 
+!    invokes the generic method in the registry to read the
 !    albedo climatology data
 ! \end{description}
 !EOP
@@ -374,19 +376,19 @@ contains
     logical         :: albAlarmCheck
 
     TRACE_ENTER("alb_read")
-    if(LIS_rc%usealbedomap(n).ne."none") then 
+    if(LIS_rc%usealbedomap(n).ne."none") then
        albAlarmCheck = LIS_isAlarmRinging(LIS_rc,&
             "LIS albedo read alarm",&
             LIS_alb(n)%albIntervalType)
 
        call LIS_computeTemporalWeights(LIS_rc,&
             LIS_alb(n)%albIntervalType, t1,t2,wt1,wt2)
-       if(albAlarmCheck) then 
+       if(albAlarmCheck) then
 
-          if(LIS_rc%usealbedomap(n).eq."LDT") then 
+          if(LIS_rc%usealbedomap(n).eq."LDT") then
              allocate(value1(LIS_rc%lnc(n),LIS_rc%lnr(n)))
-             allocate(value2(LIS_rc%lnc(n),LIS_rc%lnr(n)))       
-             
+             allocate(value2(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+
              call read_albedoclimo(n,t1,value1)
              call read_albedoclimo(n,t2,value2)
 
@@ -399,22 +401,22 @@ contains
              deallocate(value1)
              deallocate(value2)
 
-          else                    
-             call readalbedo(trim(LIS_rc%usealbedomap(n))//char(0),n,wt1,wt2,&
-                  LIS_alb(n)%albsf1,LIS_alb(n)%albsf2)
+          else
+             call readalbedo(trim(LIS_rc%usealbedomap(n))//char(0), &
+                  n, wt1, wt2, LIS_alb(n)%albsf1, LIS_alb(n)%albsf2)
           endif
 
        endif
-!-------------------------------------------------------------------------  
+!-------------------------------------------------------------------------
 ! Interpolate the albedo fractions to daily values
-!-------------------------------------------------------------------------  
+!-------------------------------------------------------------------------
        do i=1,LIS_rc%ntiles(n)
-          if (lis_alb(n)%albsf1(i) .ne. -9999.000) then 
+          if (lis_alb(n)%albsf1(i) .ne. -9999.000) then
              lis_alb(n)%albsf(i) = wt1 * lis_alb(n)%albsf1(i) + &
                                    wt2 * lis_alb(n)%albsf2(i)
-!-------------------------------------------------------------------------  
+!-------------------------------------------------------------------------
 ! set albedo same as the snow free one, to be modified in agrmet forcing
-!-------------------------------------------------------------------------  
+!-------------------------------------------------------------------------
 !             lis_alb(n)%albedo = lis_alb(n)%albsf(i)
 
           endif
@@ -426,28 +428,28 @@ contains
 !BOP
 ! !ROUTINE: LIS_albedo_finalize
 ! \label{LIS_albedo_finalize}
-! 
+!
 ! !INTERFACE: albedo_finalize
   subroutine LIS_albedo_finalize
 !
 ! !USES:
 
     implicit none
-! 
+!
 ! !DESCRIPTION:
-! 
+!
 ! Deallocates objects created in this module
-! 
+!
 !EOP
     integer :: n
     integer :: ndoms
 
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
        if(LIS_rc%usealbedomap(n).ne."none") ndoms = ndoms+1
     enddo
 
-    if(ndoms.gt.0) then     
+    if(ndoms.gt.0) then
        do n=1,LIS_rc%nnest
           deallocate(lis_alb(n)%albsf1)
           deallocate(lis_alb(n)%albsf2)
@@ -456,12 +458,12 @@ contains
        enddo
     endif
 
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
        if(LIS_rc%usemxsnalbmap(n).eq."LDT") ndoms = ndoms+1
     enddo
 
-    if(ndoms.gt.0) then     
+    if(ndoms.gt.0) then
        do n=1,LIS_rc%nnest
           deallocate(lis_alb(n)%mxsnalb)
        enddo
@@ -472,31 +474,31 @@ contains
   end subroutine LIS_albedo_finalize
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_diagnosealbedo
 ! \label{LIS_diagnosealbedo}
-! 
-! !INTERFACE: 
+!
+! !INTERFACE:
   subroutine LIS_diagnosealbedo(n)
-! !USES: 
+! !USES:
 
 
 ! !ARGUMENTS:
     implicit none
-    integer, intent(in)   :: n 
+    integer, intent(in)   :: n
 
-! !DESCRIPTION: 
-!  This routine diagnoses the LIS albedo for history output. 
-! 
-!  The arguments are: 
+! !DESCRIPTION:
+!  This routine diagnoses the LIS albedo for history output.
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[n] index of the nest \newline
 !  \end{description}
-! 
-!  The routines called are: 
+!
+!  The routines called are:
 !  \begin{description}
 !  \item[LIS\_diagnoseOutputVar](\ref{LIS_diagnoseSurfaceOutputVar}) \newline
-!    generic routine to map a single variable to the LIS 
+!    generic routine to map a single variable to the LIS
 !    history writer
 !  \end{description}
 !EOP
@@ -504,10 +506,10 @@ contains
     integer :: t,c,r,gid
 
     TRACE_ENTER("alb_diag")
-    if(LIS_rc%usealbedomap(n).ne."none") then 
+    if(LIS_rc%usealbedomap(n).ne."none") then
        do t=1,LIS_rc%ntiles(n)
           temp1 = LIS_alb(n)%albsf(t)
-          if(temp1.ne.-9999.0) then 
+          if(temp1.ne.-9999.0) then
              temp2 = temp1*100.0
           else
              temp2 = -9999.0
@@ -520,10 +522,10 @@ contains
        enddo
     endif
 
-    if(LIS_rc%usemxsnalbmap(n).eq."LDT") then 
+    if(LIS_rc%usemxsnalbmap(n).eq."LDT") then
        do t=1,LIS_rc%ntiles(n)
           temp1 = lis_alb(n)%mxsnalb(t)
-          if(temp1.ne.-9999.0) then 
+          if(temp1.ne.-9999.0) then
              temp2 = temp1*100.0
           else
              temp2 = -9999.0
@@ -539,10 +541,10 @@ contains
   end subroutine LIS_diagnosealbedo
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_albedo_reset
 ! \label{LIS_albedo_reset}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_albedo_reset
 ! !USES:
@@ -550,23 +552,23 @@ contains
 !
 ! !DESCRIPTION:
 !
-! Resets data structures for reading 
+! Resets data structures for reading
 ! in albedo datasets
-! 
-! The routines invoked are: 
+!
+! The routines invoked are:
 ! \begin{description}
 !  \item[LIS\_read\_mxsnalb](\ref{LIS_read_mxsnalb}) \newline
-!    method to read the max snow albedo 
+!    method to read the max snow albedo
 !   \item[albedosetup](\ref{albedosetup}) \newline
-!    calls the registry to invoke the albedo setup method. 
+!    calls the registry to invoke the albedo setup method.
 !   \item[readalbedo](\ref{readalbedo}) \newline
-!    invokes the generic method in the registry to read the 
+!    invokes the generic method in the registry to read the
 !    albedo climatology data
 ! \end{description}
 !EOP
     implicit none
     integer         :: n
-    integer         :: i 
+    integer         :: i
     integer         :: ndoms
     integer         :: t1, t2,t
     real            :: wt1, wt2
@@ -575,7 +577,7 @@ contains
     real, allocatable :: value2(:,:) ! Temporary value holder for QQ2
     integer         :: rc
 !------------------------------------------------------------------------------
-! If albedo datasets are to be used, the routine allocates memory for 
+! If albedo datasets are to be used, the routine allocates memory for
 ! each domain. Further, the routine sets the alarms for reading the
 ! climatology datasets
 !------------------------------------------------------------------------------
@@ -585,31 +587,34 @@ contains
        if(LIS_rc%usealbedomap(n).ne."none") ndoms = ndoms+1
     enddo
 
-    if(ndoms.gt.0) then 
+    if(ndoms.gt.0) then
        do n=1,LIS_rc%nnest
-          
+
           lis_alb(n)%albsf1 = 0.0
           lis_alb(n)%albsf2 = 0.0
           lis_alb(n)%albsf = 0.0
           lis_alb(n)%albedo = 0.0
 
-          if(LIS_rc%usealbedomap(n).ne."LDT") then 
+          if(LIS_rc%usealbedomap(n).ne."LDT") then
              call albedosetup(trim(LIS_rc%usealbedomap(n))//char(0),n)
           endif
           call LIS_computeTemporalWeights(LIS_rc,&
                LIS_alb(n)%albIntervalType, t1,t2,wt1,wt2)
 
           allocate(value1(LIS_rc%lnc(n),LIS_rc%lnr(n)))
-          allocate(value2(LIS_rc%lnc(n),LIS_rc%lnr(n)))       
+          allocate(value2(LIS_rc%lnc(n),LIS_rc%lnr(n)))
 
-          if(LIS_rc%usealbedomap(n).eq."LDT") then 
+          if(LIS_rc%usealbedomap(n).eq."LDT") then
              call read_albedoclimo(n,t1,value1)
              call read_albedoclimo(n,t2,value2)
-          else                    
-             call readalbedo(trim(LIS_rc%usealbedomap(n))//char(0),&
-                  n,t1,value1)
-             call readalbedo(trim(LIS_rc%usealbedomap(n))//char(0),&
-                  n,t2,value2)
+          else
+             !EMK Corrected subroutine call.
+             !call readalbedo(trim(LIS_rc%usealbedomap(n))//char(0),&
+             !     n,t1,value1)
+             !call readalbedo(trim(LIS_rc%usealbedomap(n))//char(0),&
+             !     n,t2,value2)
+             call readalbedo(trim(LIS_rc%usealbedomap(n))//char(0), &
+                  n, wt1, wt2, value1, value2)
           endif
 
 
@@ -621,12 +626,12 @@ contains
           enddo
 
           deallocate(value1)
-          deallocate(value2)            
-!-------------------------------------------------------------------------  
+          deallocate(value2)
+!-------------------------------------------------------------------------
 ! Interpolate the albedo fractions to daily values
-!-------------------------------------------------------------------------  
+!-------------------------------------------------------------------------
           do i=1,LIS_rc%ntiles(n)
-             if (lis_alb(n)%albsf1(i) .ne. -9999.000) then 
+             if (lis_alb(n)%albsf1(i) .ne. -9999.000) then
                 lis_alb(n)%albsf(i) = wt1 * lis_alb(n)%albsf1(i) + &
                      wt2 * lis_alb(n)%albsf2(i)
              endif
@@ -634,12 +639,12 @@ contains
        enddo
     endif
 
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
        if(LIS_rc%usemxsnalbmap(n).ne."none") ndoms = ndoms+1
     enddo
 
-    if(ndoms.gt.0) then 
+    if(ndoms.gt.0) then
        do n=1,LIS_rc%nnest
           lis_alb(n)%mxsnalb = 0.0
           call LIS_read_mxsnalb(n)
@@ -664,22 +669,21 @@ contains
     use netcdf
 #endif
 
-    
     implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
     integer, intent(in) :: n
     integer             :: time
-    real, intent(inout) :: array(LIS_rc%lnc(n),LIS_rc%lnr(n))    
+    real, intent(inout) :: array(LIS_rc%lnc(n),LIS_rc%lnr(n))
 ! !DESCRIPTION:
 !  This subroutine reads the greenness data climatology
-!  
+!
 !  The arguments are:
 !  \begin{description}
 !   \item[n]
 !    index of n
 !   \end{description}
 !
-!EOP      
+!EOP
     integer :: status
     integer :: ios1
     integer :: ios,nid,albedoid,ncId, nrId,mid
@@ -687,67 +691,71 @@ contains
     integer :: year, month, q
     real, allocatable :: albedo(:,:,:)
     logical :: file_exists
-    
+
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
 
     q = time
-  
-    inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-    if(file_exists) then 
 
-       if(LIS_alb(n)%albIntervalType.eq."quarterly") then 
+    inquire(file=LIS_rc%paramfile(n), exist=file_exists)
+    if(file_exists) then
+
+       if(LIS_alb(n)%albIntervalType.eq."quarterly") then
           write(LIS_logunit,*)'[INFO] Reading albedo map for quarter ', q
-       elseif(LIS_alb(n)%albIntervaltype.eq."monthly") then 
+       elseif(LIS_alb(n)%albIntervaltype.eq."monthly") then
           write(LIS_logunit,*)'[INFO] Reading albedo map for month ', q
        endif
 
        ios = nf90_open(path=LIS_rc%paramfile(n),&
             mode=NF90_NOWRITE,ncid=nid)
        call LIS_verify(ios,'Error in nf90_open in read_albedoclimo')
-       
+
        ios = nf90_inq_dimid(nid,"east_west",ncId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_albedoclimo')
-       
+
        ios = nf90_inq_dimid(nid,"north_south",nrId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_albedoclimo')
 
-       if(LIS_alb(n)%albIntervalType.eq."quarterly") then 
+       if(LIS_alb(n)%albIntervalType.eq."quarterly") then
           ios = nf90_inq_dimid(nid,"quarter",mId)
           call LIS_verify(ios,'Error in nf90_inq_dimid in read_albedoclimo')
-       elseif(LIS_alb(n)%albIntervalType.eq."monthly") then 
+       elseif(LIS_alb(n)%albIntervalType.eq."monthly") then
           ios = nf90_inq_dimid(nid,"month",mId)
           call LIS_verify(ios,'Error in nf90_inq_dimid in read_albedoclimo')
        endif
 
        ios = nf90_inquire_dimension(nid,ncId, len=nc)
-       call LIS_verify(ios,'Error in nf90_inquire_dimension in read_albedoclimo')
-       
+       call LIS_verify(ios,&
+            'Error in nf90_inquire_dimension in read_albedoclimo')
+
        ios = nf90_inquire_dimension(nid,nrId, len=nr)
-       call LIS_verify(ios,'Error in nf90_inquire_dimension in read_albedoclimo')
+       call LIS_verify(ios,&
+            'Error in nf90_inquire_dimension in read_albedoclimo')
 
        ios = nf90_inquire_dimension(nid,mId, len=months)
-       call LIS_verify(ios,'Error in nf90_inquire_dimension in read_albedoclimo')
-       
+       call LIS_verify(ios,&
+            'Error in nf90_inquire_dimension in read_albedoclimo')
+
        allocate(albedo(LIS_rc%gnc(n),LIS_rc%gnr(n),months))
 
        ios = nf90_inq_varid(nid,'ALBEDO',albedoid)
        call LIS_verify(ios,'ALBEDO field not found in the LIS param file')
-       
+
        ios = nf90_get_var(nid,albedoid,albedo)
        call LIS_verify(ios,'Error in nf90_get_var in read_albedoclimo')
-       
+
        ios = nf90_close(nid)
        call LIS_verify(ios,'Error in nf90_close in read_albedoclimo')
-       
+
        array(:,:) = &
-            albedo(LIS_ews_halo_ind(n,LIS_localPet+1):&         
+            albedo(LIS_ews_halo_ind(n,LIS_localPet+1):&
             LIS_ewe_halo_ind(n,LIS_localPet+1), &
             LIS_nss_halo_ind(n,LIS_localPet+1): &
             LIS_nse_halo_ind(n,LIS_localPet+1),q)
 
        deallocate(albedo)
     else
-       write(LIS_logunit,*) '[ERR] albedo map: ',LIS_rc%paramfile(n), ' does not exist'
+       write(LIS_logunit,*) '[ERR] albedo map: ',LIS_rc%paramfile(n), &
+            ' does not exist'
        write(LIS_logunit,*) '[ERR] program stopping ...'
        call LIS_endrun
     endif

--- a/lis/core/LIS_emiss_FTable.c
+++ b/lis/core/LIS_emiss_FTable.c
@@ -169,7 +169,7 @@ void FTN(registerreademissivity)(char *j,
 // !INTERFACE:
 //EMK Fixed argument list
 void FTN(reademissivity)(char *j, int *n, float *wt1, float *wt2,
-                         float *array1, float *array2)
+                         float *array1, float *array2, int len)
 //
 // !DESCRIPTION:
 // Invokes the routine from the registry to

--- a/lis/core/LIS_emiss_FTable.c
+++ b/lis/core/LIS_emiss_FTable.c
@@ -10,47 +10,43 @@
 //BOP
 //
 // !MODULE: LIS_emiss_FTable
-//  
+//
 //
 // !DESCRIPTION:
-//  Function table registries for storing the interface 
-//  implementations for managing different sources of 
+//  Function table registries for storing the interface
+//  implementations for managing different sources of
 //  greenness fraction data
-//   
+//
 //EOP
-#include<stdio.h>
-#include<stdlib.h>
-#include<stdarg.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "ftn_drv.h"
 
-struct emisssetnode
-{ 
-  char *name;
-  void (*func)(int*);
+struct emisssetnode {
+    char *name;
+    void (*func)(int*);
+    struct emisssetnode* next;
+};
+struct emisssetnode* emissset_table = NULL;
 
-  struct emisssetnode* next;
-} ;
-struct emisssetnode* emissset_table = NULL; 
-
-struct emissreadnode
-{ 
-  char *name;
-  void (*func)(int*,void*,void*,float*,float*);
-
-  struct emissreadnode* next;
-} ;
-struct emissreadnode* emissread_table = NULL; 
+struct emissreadnode {
+    char *name;
+    void (*func)(int*, float*, float*, float*, float*);
+    struct emissreadnode* next;
+};
+struct emissreadnode* emissread_table = NULL;
 
 //BOP
 // !ROUTINE: registeremissivitysetup
 // \label{registeremissivitysetup}
-// 
+//
 // !INTERFACE:
-void FTN(registeremissivitysetup)(char *j,void (*func)(int*),int len)
-// !DESCRIPTION: 
-// Makes an entry in the registry for the routine to 
+void FTN(registeremissivitysetup)(char *j, void (*func)(int*), int len)
+// !DESCRIPTION:
+// Makes an entry in the registry for the routine to
 // setup emiss data reading routines
 //
 // The arguments are: 
@@ -61,30 +57,28 @@ void FTN(registeremissivitysetup)(char *j,void (*func)(int*),int len)
 //  index of the greenness data source
 //  \end{description}
 //EOP
-{ 
-  int len1;
-  struct emisssetnode* current;
-  struct emisssetnode* pnode; 
-  // create node
-  
-  len1 = len + 1; // ensure that there is space for terminating null
-  pnode=(struct emisssetnode*) malloc(sizeof(struct emisssetnode));
-  pnode->name=(char*) calloc(len1,sizeof(char));
-  strncpy(pnode->name,j,len);
-  pnode->func = func;
-  pnode->next = NULL; 
+{
+    int len1;
+    struct emisssetnode* current;
+    struct emisssetnode* pnode;
+    // create node
 
-  if(emissset_table == NULL){
-    emissset_table = pnode;
-  }
-  else{
-    current = emissset_table; 
-    while(current->next!=NULL){
-      current = current->next;
+    len1 = len + 1; // ensure that there is space for terminating null
+    pnode = (struct emisssetnode*) malloc(sizeof(struct emisssetnode));
+    pnode->name = (char*) calloc(len1, sizeof(char));
+    strncpy(pnode->name, j, len);
+    pnode->func = func;
+    pnode->next = NULL;
+
+    if (emissset_table == NULL) {
+        emissset_table = pnode;
+    } else {
+        current = emissset_table;
+        while (current->next != NULL) {
+            current = current->next;
+        }
+        current->next = pnode;
     }
-    current->next = pnode; 
-  }
-
 }
 
 //BOP
@@ -92,13 +86,13 @@ void FTN(registeremissivitysetup)(char *j,void (*func)(int*),int len)
 // \label{emissivitysetup}
 //
 // !INTERFACE:
-void FTN(emissivitysetup)(char *j,int *n, int len)
-//  
+void FTN(emissivitysetup)(char *j, int *n, int len)
+//
 // !DESCRIPTION:
-// Invokes the routine from the registry to 
+// Invokes the routine from the registry to
 // setup emiss data reading
-// 
-// The arguments are: 
+//
+// The arguments are:
 // \begin{description}
 //  \item[n]
 //   index of the nest
@@ -106,33 +100,37 @@ void FTN(emissivitysetup)(char *j,int *n, int len)
 //  index of the greenness data source
 //  \end{description}
 //EOP
-{ 
-  struct emisssetnode* current;
-  
-  current = emissset_table;
-  while(strcmp(current->name,j)!=0){
-    current = current->next;
-    if(current==NULL) {
-      printf("****************Error****************************\n"); 
-      printf("emissivitysetup routine for runmode %s is not defined\n",j); 
-      printf("program will seg fault.....\n"); 
-      printf("****************Error****************************\n"); 
+{
+    struct emisssetnode* current;
+
+    current = emissset_table;
+    while (strcmp(current->name, j) != 0) {
+        current = current->next;
+        if (current == NULL) {
+            printf("****************Error****************************\n");
+            printf("emissivitysetup routine for runmode %s is not defined\n",
+                   j);
+            printf("program will seg fault.....\n");
+            printf("****************Error****************************\n");
+        }
     }
-  }
-  current->func(n); 
+    current->func(n);
 }
 
 //BOP
 // !ROUTINE: registerreademissivity
 // \label{registerreademissivity}
-// 
+//
 // !INTERFACE:
-void FTN(registerreademissivity)(char *j,void (*func)(int*, void*, void*, float*, float*),int len)
-// !DESCRIPTION: 
-// Makes an entry in the registry for the routine to 
+// EMK Fixed argument list.
+void FTN(registerreademissivity)(char *j,
+                           void (*func)(int*, float*, float*, float*, float*),
+                           int len)
+// !DESCRIPTION:
+// Makes an entry in the registry for the routine to
 // read emiss data
 //
-// The arguments are: 
+// The arguments are:
 // \begin{description}
 // \item[i]
 //  index of the domain
@@ -140,30 +138,28 @@ void FTN(registerreademissivity)(char *j,void (*func)(int*, void*, void*, float*
 //  index of the greenness data source
 //  \end{description}
 //EOP
-{ 
-  int len1;
-  struct emissreadnode* current;
-  struct emissreadnode* pnode; 
-  // create node
-  
-  len1 = len + 1; // ensure that there is space for terminating null
-  pnode=(struct emissreadnode*) malloc(sizeof(struct emissreadnode));
-  pnode->name=(char*) calloc(len1,sizeof(char));
-  strncpy(pnode->name,j,len);
-  pnode->func = func;
-  pnode->next = NULL; 
+{
+    int len1;
+    struct emissreadnode* current;
+    struct emissreadnode* pnode;
+    // create node
 
-  if(emissread_table == NULL){
-    emissread_table = pnode;
-  }
-  else{
-    current = emissread_table; 
-    while(current->next!=NULL){
-      current = current->next;
+    len1 = len + 1; // ensure that there is space for terminating null
+    pnode = (struct emissreadnode*) malloc(sizeof(struct emissreadnode));
+    pnode->name = (char*) calloc(len1, sizeof(char));
+    strncpy(pnode->name, j, len);
+    pnode->func = func;
+    pnode->next = NULL;
+
+    if (emissread_table == NULL) {
+        emissread_table = pnode;
+    } else {
+        current = emissread_table;
+        while (current->next != NULL) {
+            current = current->next;
+        }
+        current->next = pnode;
     }
-    current->next = pnode; 
-  }
-
 }
 
 //BOP
@@ -171,13 +167,15 @@ void FTN(registerreademissivity)(char *j,void (*func)(int*, void*, void*, float*
 // \label{reademissivity}
 //
 // !INTERFACE:
-void FTN(reademissivity)(char *j,int *n, void *time1, void *time2, float *array1, float *array2, int len)
-//  
+//EMK Fixed argument list
+void FTN(reademissivity)(char *j, int *n, float *wt1, float *wt2,
+                         float *array1, float *array2)
+//
 // !DESCRIPTION:
-// Invokes the routine from the registry to 
-// reading emiss data 
-// 
-// The arguments are: 
+// Invokes the routine from the registry to
+// reading emiss data
+//
+// The arguments are:
 // \begin{description}
 //  \item[n]
 //   index of the nest
@@ -189,20 +187,21 @@ void FTN(reademissivity)(char *j,int *n, void *time1, void *time2, float *array1
 //  pointer to the greenness data
 //  \end{description}
 //EOP
-{ 
-  struct emissreadnode* current;
-  
-  current = emissread_table;
-  while(strcmp(current->name,j)!=0){
-    current = current->next;
-    if(current==NULL) {
-      printf("****************Error****************************\n"); 
-      printf("reademissivity routine for runmode %s is not defined\n",j); 
-      printf("program will seg fault.....\n"); 
-      printf("****************Error****************************\n"); 
+{
+    struct emissreadnode* current;
+
+    current = emissread_table;
+    while (strcmp(current->name, j) != 0) {
+        current = current->next;
+        if (current == NULL) {
+            printf("****************Error****************************\n");
+            printf("reademissivity routine for runmode %s is not defined\n",
+                   j);
+            printf("program will seg fault.....\n");
+            printf("****************Error****************************\n");
+        }
     }
-  }
-  current->func(n,time1, time2, array1, array2); 
+    current->func(n, wt1, wt2, array1, array2);
 }
 
 

--- a/lis/core/LIS_laisai_FTable.c
+++ b/lis/core/LIS_laisai_FTable.c
@@ -10,59 +10,51 @@
 //BOP
 //
 // !MODULE: LIS_laisai_FTable
-//  
+//
 // !DESCRIPTION:
-//  Function table registries for storing the interface 
-//  implementations for managing different sources of 
+//  Function table registries for storing the interface
+//  implementations for managing different sources of
 //  LAI and SAI data
 //EOP
-#include<stdio.h>
-#include<stdlib.h>
-#include<stdarg.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include<string.h>
 
 #include "ftn_drv.h"
-struct laisetnode
-{ 
-  char *name;
-  void (*func)(int*);
+struct laisetnode {
+    char *name;
+    void (*func)(int*);
+    struct laisetnode* next;
+};
+struct laisetnode* laiset_table = NULL;
 
-  struct laisetnode* next;
-} ;
-struct laisetnode* laiset_table = NULL; 
+struct saisetnode {
+    char *name;
+    void (*func)(int*);
+    struct saisetnode* next;
+};
+struct saisetnode* saiset_table = NULL;
 
-struct saisetnode
-{ 
-  char *name;
-  void (*func)(int*);
+struct laireadnode {
+    char *name;
+    void (*func)(int*, float*, float*, float*, float*);
+    struct laireadnode* next;
+};
+struct laireadnode* lairead_table = NULL;
 
-  struct saisetnode* next;
-} ;
-struct saisetnode* saiset_table = NULL; 
-
-struct laireadnode
-{ 
-  char *name;
-  void (*func)(int*,void*, void*, float*, float*);
-
-  struct laireadnode* next;
-} ;
-struct laireadnode* lairead_table = NULL; 
-
-struct saireadnode
-{ 
-  char *name;
-  void (*func)(int*,void*,float*);
-
-  struct saireadnode* next;
-} ;
-struct saireadnode* sairead_table = NULL; 
+struct saireadnode {
+    char *name;
+    void (*func)(int*, void*, float*);
+    struct saireadnode* next;
+};
+struct saireadnode* sairead_table = NULL;
 //BOP
 // !ROUTINE: registerlaisetup
 // \label{registerlaisetup}
 //
 // !INTERFACE:
-void FTN(registerlaisetup)(char *j,void (*func)(int*), int len)
+void FTN(registerlaisetup)(char *j, void (*func)(int*), int len)
 // !DESCRIPTION:
 // Makes an entry in the registry for the routine to
 // setup lai data reading routines
@@ -76,29 +68,27 @@ void FTN(registerlaisetup)(char *j,void (*func)(int*), int len)
 //  \end{description}
 //EOP
 {
-  int len1;
-  struct laisetnode* current;
-  struct laisetnode* pnode; 
-  // create node
-  
-  len1 = len + 1; // ensure that there is space for terminating null
-  pnode=(struct laisetnode*) malloc(sizeof(struct laisetnode));
-  pnode->name=(char*) calloc(len1,sizeof(char));
-  strncpy(pnode->name,j,len);
-  pnode->func = func;
-  pnode->next = NULL; 
+    int len1;
+    struct laisetnode* current;
+    struct laisetnode* pnode;
+    // create node
 
-  if(laiset_table == NULL){
-    laiset_table = pnode;
-  }
-  else{
-    current = laiset_table; 
-    while(current->next!=NULL){
-      current = current->next;
+    len1 = len + 1; // ensure that there is space for terminating null
+    pnode = (struct laisetnode*) malloc(sizeof(struct laisetnode));
+    pnode->name = (char*) calloc(len1,sizeof(char));
+    strncpy(pnode->name, j, len);
+    pnode->func = func;
+    pnode->next = NULL;
+
+    if (laiset_table == NULL) {
+        laiset_table = pnode;
+    } else {
+        current = laiset_table;
+        while (current->next != NULL) {
+            current = current->next;
+        }
+        current->next = pnode;
     }
-    current->next = pnode; 
-  }
-
 }
 
 //BOP
@@ -121,19 +111,19 @@ void FTN(laisetup)(char *j, int *n, int len)
 //  \end{description}
 //EOP
 {
-  struct laisetnode* current;
-  
-  current = laiset_table;
-  while(strcmp(current->name,j)!=0){
-    current = current->next;
-    if(current==NULL) {
-      printf("****************Error****************************\n"); 
-      printf("laisetup routine for  %s is not defined\n",j); 
-      printf("program will seg fault.....\n"); 
-      printf("****************Error****************************\n"); 
+    struct laisetnode* current;
+
+    current = laiset_table;
+    while (strcmp(current->name, j) != 0) {
+        current = current->next;
+        if(current == NULL) {
+            printf("****************Error****************************\n");
+            printf("laisetup routine for  %s is not defined\n",j);
+            printf("program will seg fault.....\n");
+            printf("****************Error****************************\n");
+        }
     }
-  }
-  current->func(n); 
+    current->func(n);
 }
 
 //BOP
@@ -141,7 +131,7 @@ void FTN(laisetup)(char *j, int *n, int len)
 // \label{registersaisetup}
 //
 // !INTERFACE:
-void FTN(registersaisetup)(char *j,void (*func)(int*), int len)
+void FTN(registersaisetup)(char *j, void (*func)(int*), int len)
 // !DESCRIPTION:
 // Makes an entry in the registry for the routine to
 // setup sai data reading routines
@@ -155,29 +145,27 @@ void FTN(registersaisetup)(char *j,void (*func)(int*), int len)
 //  \end{description}
 //EOP
 {
-  int len1;
-  struct saisetnode* current;
-  struct saisetnode* pnode; 
-  // create node
-  
-  len1 = len + 1; // ensure that there is space for terminating null
-  pnode=(struct saisetnode*) malloc(sizeof(struct saisetnode));
-  pnode->name=(char*) calloc(len1,sizeof(char));
-  strncpy(pnode->name,j,len);
-  pnode->func = func;
-  pnode->next = NULL; 
+    int len1;
+    struct saisetnode* current;
+    struct saisetnode* pnode;
+    // create node
 
-  if(saiset_table == NULL){
-    saiset_table = pnode;
-  }
-  else{
-    current = saiset_table; 
-    while(current->next!=NULL){
-      current = current->next;
+    len1 = len + 1; // ensure that there is space for terminating null
+    pnode = (struct saisetnode*) malloc(sizeof(struct saisetnode));
+    pnode->name = (char*) calloc(len1,sizeof(char));
+    strncpy(pnode->name, j, len);
+    pnode->func = func;
+    pnode->next = NULL;
+
+    if (saiset_table == NULL) {
+        saiset_table = pnode;
+    } else {
+        current = saiset_table;
+        while (current->next != NULL) {
+            current = current->next;
+        }
+        current->next = pnode;
     }
-    current->next = pnode; 
-  }
-
 }
 
 //BOP
@@ -200,19 +188,19 @@ void FTN(saisetup)(char *j, int *n, int len)
 //  \end{description}
 //EOP
 {
-  struct saisetnode* current;
-  
-  current = saiset_table;
-  while(strcmp(current->name,j)!=0){
-    current = current->next;
-    if(current==NULL) {
-      printf("****************Error****************************\n"); 
-      printf("saisetup routine for  %s is not defined\n",j); 
-      printf("program will seg fault.....\n"); 
-      printf("****************Error****************************\n"); 
+    struct saisetnode* current;
+
+    current = saiset_table;
+    while (strcmp(current->name, j) != 0) {
+        current = current->next;
+        if (current == NULL) {
+            printf("****************Error****************************\n");
+            printf("saisetup routine for  %s is not defined\n",j);
+            printf("program will seg fault.....\n");
+            printf("****************Error****************************\n");
+        }
     }
-  }
-  current->func(n); 
+    current->func(n);
 }
 
 
@@ -221,43 +209,43 @@ void FTN(saisetup)(char *j, int *n, int len)
 // \label{registerreadlai}
 //
 // !INTERFACE:
-void FTN(registerreadlai)(char *j, void (*func)(int*, void*, void*, float*, float*),int len)
-//  
-// !DESCRIPTION: 
-//  Creates an entry in the registry for the routines to 
+void FTN(registerreadlai)(char *j,
+                          void (*func)(int*, float*, float*, float*, float*),
+                          int len)
+//
+// !DESCRIPTION:
+//  Creates an entry in the registry for the routines to
 //  read LAI data
-// 
-//  The arguments are: 
+//
+//  The arguments are:
 //  \begin{description}
 //   \item[j]
 //    index of the LAI source
 //   \end{description}
 //
 //EOP
-{ 
-  int len1;
-  struct laireadnode* current;
-  struct laireadnode* pnode; 
-  // create node
-  
-  len1 = len + 1; // ensure that there is space for terminating null
-  pnode=(struct laireadnode*) malloc(sizeof(struct laireadnode));
-  pnode->name=(char*) calloc(len1,sizeof(char));
-  strncpy(pnode->name,j,len);
-  pnode->func = func;
-  pnode->next = NULL; 
+{
+    int len1;
+    struct laireadnode* current;
+    struct laireadnode* pnode;
+    // create node
 
-  if(lairead_table == NULL){
-    lairead_table = pnode;
-  }
-  else{
-    current = lairead_table; 
-    while(current->next!=NULL){
-      current = current->next;
+    len1 = len + 1; // ensure that there is space for terminating null
+    pnode = (struct laireadnode*) malloc(sizeof(struct laireadnode));
+    pnode->name = (char*) calloc(len1, sizeof(char));
+    strncpy(pnode->name, j, len);
+    pnode->func = func;
+    pnode->next = NULL;
+
+    if (lairead_table == NULL) {
+        lairead_table = pnode;
+    } else {
+        current = lairead_table;
+        while (current->next != NULL) {
+            current = current->next;
+        }
+        current->next = pnode;
     }
-    current->next = pnode; 
-  }
-
 }
 
 //BOP
@@ -265,12 +253,13 @@ void FTN(registerreadlai)(char *j, void (*func)(int*, void*, void*, float*, floa
 // \label{readlai}
 //
 // !INTERFACE:
-void FTN(readlai)(char *j, int *n, void *time1, void *time2, float *array1, float *array2, int len)
-//  
-// !DESCRIPTION: 
-// Invokes the routine from the registry to read LAI data. 
-// 
-//  The arguments are: 
+void FTN(readlai)(char *j, int *n, float *wt1, float *wt2,
+                  float *array1, float *array2)
+//
+// !DESCRIPTION:
+// Invokes the routine from the registry to read LAI data.
+//
+//  The arguments are:
 //  \begin{description}
 //   \item[n]
 //    index of the nest
@@ -284,73 +273,71 @@ void FTN(readlai)(char *j, int *n, void *time1, void *time2, float *array1, floa
 //   time of found file
 //   \end{description}
 //EOP
-{ 
-  struct laireadnode* current;
-  
-  current = lairead_table;
-  while(strcmp(current->name,j)!=0){
-    current = current->next;
-    if(current==NULL) {
-      printf("****************Error****************************\n"); 
-      printf("readlai routine for  %s is not defined\n",j); 
-      printf("program will seg fault.....\n"); 
-      printf("****************Error****************************\n"); 
+{
+    struct laireadnode* current;
+
+    current = lairead_table;
+    while (strcmp(current->name, j) != 0) {
+        current = current->next;
+        if (current == NULL) {
+            printf("****************Error****************************\n");
+            printf("readlai routine for  %s is not defined\n",j);
+            printf("program will seg fault.....\n");
+            printf("****************Error****************************\n");
+        }
     }
-  }
-  current->func(n,time1,time2,array1,array2);
+    current->func(n, wt1, wt2, array1, array2);
 }
 //BOP
 // !ROUTINE: registerreadsai
 // \label{registerreadsai}
-//  
+//
 // !INTERFACE:
 void FTN(registerreadsai)(char *j, void (*func)(int*, void*, float*), int len)
-// !DESCRIPTION: 
-//  Creates an entry in the registry for the routines to 
+// !DESCRIPTION:
+//  Creates an entry in the registry for the routines to
 //  read SAI data
 //
-//  The arguments are: 
+//  The arguments are:
 //  \begin{description}
 //   \item[j]
 //    index of the SAI source
 //   \end{description}
 //EOP
-{ 
-  int len1;
-  struct saireadnode* current;
-  struct saireadnode* pnode; 
-  // create node
-  
-  len1 = len + 1; // ensure that there is space for terminating null
-  pnode=(struct saireadnode*) malloc(sizeof(struct saireadnode));
-  pnode->name=(char*) calloc(len1,sizeof(char));
-  strncpy(pnode->name,j,len);
-  pnode->func = func;
-  pnode->next = NULL; 
+{
+    int len1;
+    struct saireadnode* current;
+    struct saireadnode* pnode;
+    // create node
 
-  if(sairead_table == NULL){
-    sairead_table = pnode;
-  }
-  else{
-    current = sairead_table; 
-    while(current->next!=NULL){
-      current = current->next;
+    len1 = len + 1; // ensure that there is space for terminating null
+    pnode = (struct saireadnode*) malloc(sizeof(struct saireadnode));
+    pnode->name = (char*) calloc(len1, sizeof(char));
+    strncpy(pnode->name, j, len);
+    pnode->func = func;
+    pnode->next = NULL;
+
+    if (sairead_table == NULL){
+        sairead_table = pnode;
+    } else {
+        current = sairead_table;
+        while (current->next != NULL ){
+            current = current->next;
+        }
+        current->next = pnode;
     }
-    current->next = pnode; 
-  }
-
 }
 //BOP
 // !ROUTINE: readsai
 // \label{readsai}
-//  
+//
 // !INTERFACE:
 void FTN(readsai)(char *j, int *n, void *time, float* array, int len)
 //
-// !DESCRIPTION: 
-// Invokes the routine from the registry to read SAI data. 
+// !DESCRIPTION:
+// Invokes the routine from the registry to read SAI data.
 //
-//  The arguments are: 
+//  The arguments are:
 //  \begin{description}
 //   \item[n]
 //    index of nest
@@ -360,53 +347,22 @@ void FTN(readsai)(char *j, int *n, void *time, float* array, int len)
 //    time
 //  \item[array]
 //  pointer to the SAI data
-//   \end{description} 
+//   \end{description}
 //EOP
-{ 
-  struct saireadnode* current;
-  
-  current = sairead_table;
-  while(strcmp(current->name,j)!=0){
-    current = current->next;
-    if(current==NULL) {
-      printf("****************Error****************************\n"); 
-      printf("readsai routing for %s is not defined\n",j); 
-      printf("program will seg fault.....\n"); 
-      printf("****************Error****************************\n"); 
+{
+    struct saireadnode* current;
+
+    current = sairead_table;
+    while (strcmp(current->name, j) != 0) {
+        current = current->next;
+        if (current == NULL) {
+            printf("****************Error****************************\n");
+            printf("readsai routing for %s is not defined\n",j);
+            printf("program will seg fault.....\n");
+            printf("****************Error****************************\n");
+        }
     }
-  }
-  current->func(n,time,array); 
+  current->func(n, time, array);
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 

--- a/lis/core/LIS_laisai_FTable.c
+++ b/lis/core/LIS_laisai_FTable.c
@@ -75,7 +75,7 @@ void FTN(registerlaisetup)(char *j, void (*func)(int*), int len)
 
     len1 = len + 1; // ensure that there is space for terminating null
     pnode = (struct laisetnode*) malloc(sizeof(struct laisetnode));
-    pnode->name = (char*) calloc(len1,sizeof(char));
+    pnode->name = (char*) calloc(len1, sizeof(char));
     strncpy(pnode->name, j, len);
     pnode->func = func;
     pnode->next = NULL;
@@ -152,7 +152,7 @@ void FTN(registersaisetup)(char *j, void (*func)(int*), int len)
 
     len1 = len + 1; // ensure that there is space for terminating null
     pnode = (struct saisetnode*) malloc(sizeof(struct saisetnode));
-    pnode->name = (char*) calloc(len1,sizeof(char));
+    pnode->name = (char*) calloc(len1, sizeof(char));
     strncpy(pnode->name, j, len);
     pnode->func = func;
     pnode->next = NULL;

--- a/lis/core/LIS_laisai_FTable.c
+++ b/lis/core/LIS_laisai_FTable.c
@@ -254,7 +254,7 @@ void FTN(registerreadlai)(char *j,
 //
 // !INTERFACE:
 void FTN(readlai)(char *j, int *n, float *wt1, float *wt2,
-                  float *array1, float *array2)
+                  float *array1, float *array2, int len)
 //
 // !DESCRIPTION:
 // Invokes the routine from the registry to read LAI data.

--- a/lis/core/LIS_roughness_FTable.c
+++ b/lis/core/LIS_roughness_FTable.c
@@ -10,50 +10,47 @@
 //BOP
 //
 // !MODULE: LIS_roughness_FTable
-//  
+//
 //
 // !DESCRIPTION:
-//  Function table registries for storing the interface 
-//  implementations for managing different sources of 
+//  Function table registries for storing the interface
+//  implementations for managing different sources of
 //  greenness fraction data
-//   
+//
 //EOP
-#include<stdio.h>
-#include<stdlib.h>
-#include<stdarg.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "ftn_drv.h"
 
-struct roughnesssetnode
-{ 
-  char *name;
-  void (*func)(int*);
+struct roughnesssetnode {
+    char *name;
+    void (*func)(int*);
+    struct roughnesssetnode* next;
+};
+struct roughnesssetnode* roughnessset_table = NULL;
 
-  struct roughnesssetnode* next;
-} ;
-struct roughnesssetnode* roughnessset_table = NULL; 
-
-struct roughnessreadnode
-{ 
-  char *name;
-  void (*func)(int*,void*,void*, float*, float*);
-
-  struct roughnessreadnode* next;
-} ;
-struct roughnessreadnode* roughnessread_table = NULL; 
+struct roughnessreadnode {
+    char *name;
+    //EMK Fixed argument list
+    void (*func)(int*, float*, float*, float*, float*);
+    struct roughnessreadnode* next;
+};
+struct roughnessreadnode* roughnessread_table = NULL;
 
 //BOP
 // !ROUTINE: registerroughnesssetup
 // \label{registerroughnesssetup}
-// 
+//
 // !INTERFACE:
-void FTN(registerroughnesssetup)(char *j,void (*func)(int*),int len)
-// !DESCRIPTION: 
-// Makes an entry in the registry for the routine to 
+void FTN(registerroughnesssetup)(char *j, void (*func)(int*), int len)
+// !DESCRIPTION:
+// Makes an entry in the registry for the routine to
 // setup roughness data reading routines
 //
-// The arguments are: 
+// The arguments are:
 // \begin{description}
 // \item[i]
 //  index of the domain
@@ -61,30 +58,28 @@ void FTN(registerroughnesssetup)(char *j,void (*func)(int*),int len)
 //  index of the greenness data source
 //  \end{description}
 //EOP
-{ 
-  int len1;
-  struct roughnesssetnode* current;
-  struct roughnesssetnode* pnode; 
-  // create node
-  
-  len1 = len + 1; // ensure that there is space for terminating null
-  pnode=(struct roughnesssetnode*) malloc(sizeof(struct roughnesssetnode));
-  pnode->name=(char*) calloc(len1,sizeof(char));
-  strncpy(pnode->name,j,len);
-  pnode->func = func;
-  pnode->next = NULL; 
+{
+    int len1;
+    struct roughnesssetnode* current;
+    struct roughnesssetnode* pnode;
+    // create node
 
-  if(roughnessset_table == NULL){
-    roughnessset_table = pnode;
-  }
-  else{
-    current = roughnessset_table; 
-    while(current->next!=NULL){
-      current = current->next;
+    len1 = len + 1; // ensure that there is space for terminating null
+    pnode = (struct roughnesssetnode*) malloc(sizeof(struct roughnesssetnode));
+    pnode->name = (char*) calloc(len1, sizeof(char));
+    strncpy(pnode->name, j, len);
+    pnode->func = func;
+    pnode->next = NULL;
+
+    if (roughnessset_table == NULL) {
+        roughnessset_table = pnode;
+    } else {
+        current = roughnessset_table;
+        while (current->next != NULL ) {
+            current = current->next;
+        }
+        current->next = pnode;
     }
-    current->next = pnode; 
-  }
-
 }
 
 //BOP
@@ -93,12 +88,12 @@ void FTN(registerroughnesssetup)(char *j,void (*func)(int*),int len)
 //
 // !INTERFACE:
 void FTN(roughnesssetup)(char *j,int *n, int len)
-//  
+//
 // !DESCRIPTION:
-// Invokes the routine from the registry to 
+// Invokes the routine from the registry to
 // setup roughness data reading
-// 
-// The arguments are: 
+//
+// The arguments are:
 // \begin{description}
 //  \item[n]
 //   index of the nest
@@ -106,33 +101,36 @@ void FTN(roughnesssetup)(char *j,int *n, int len)
 //  index of the greenness data source
 //  \end{description}
 //EOP
-{ 
-  struct roughnesssetnode* current;
-  
-  current = roughnessset_table;
-  while(strcmp(current->name,j)!=0){
-    current = current->next;
-    if(current==NULL) {
-      printf("****************Error****************************\n"); 
-      printf("roughnesssetup routine for runmode %s is not defined\n",j); 
-      printf("program will seg fault.....\n"); 
-      printf("****************Error****************************\n"); 
+{
+    struct roughnesssetnode* current;
+
+    current = roughnessset_table;
+    while (strcmp(current->name, j) != 0) {
+        current = current->next;
+        if (current == NULL) {
+            printf("****************Error****************************\n");
+            printf("roughnesssetup routine for runmode %s is not defined\n",
+                   j);
+            printf("program will seg fault.....\n");
+            printf("****************Error****************************\n");
+        }
     }
-  }
-  current->func(n); 
+    current->func(n);
 }
 
 //BOP
 // !ROUTINE: registerreadroughness
 // \label{registerreadroughness}
-// 
+//
 // !INTERFACE:
-void FTN(registerreadroughness)(char *j,void (*func)(int*, void*, void*, float*, float*),int len)
-// !DESCRIPTION: 
-// Makes an entry in the registry for the routine to 
+void FTN(registerreadroughness)(char *j,
+                           void (*func)(int*, float*, float*, float*, float*),
+                                int len)
+// !DESCRIPTION:
+// Makes an entry in the registry for the routine to
 // read roughness data
 //
-// The arguments are: 
+// The arguments are:
 // \begin{description}
 // \item[i]
 //  index of the domain
@@ -140,30 +138,29 @@ void FTN(registerreadroughness)(char *j,void (*func)(int*, void*, void*, float*,
 //  index of the greenness data source
 //  \end{description}
 //EOP
-{ 
-  int len1;
-  struct roughnessreadnode* current;
-  struct roughnessreadnode* pnode; 
-  // create node
-  
-  len1 = len + 1; // ensure that there is space for terminating null
-  pnode=(struct roughnessreadnode*) malloc(sizeof(struct roughnessreadnode));
-  pnode->name=(char*) calloc(len1,sizeof(char));
-  strncpy(pnode->name,j,len);
-  pnode->func = func;
-  pnode->next = NULL; 
+{
+    int len1;
+    struct roughnessreadnode* current;
+    struct roughnessreadnode* pnode;
+    // create node
 
-  if(roughnessread_table == NULL){
-    roughnessread_table = pnode;
-  }
-  else{
-    current = roughnessread_table; 
-    while(current->next!=NULL){
-      current = current->next;
+    len1 = len + 1; // ensure that there is space for terminating null
+    pnode = (struct roughnessreadnode*)
+        malloc(sizeof(struct roughnessreadnode));
+    pnode->name = (char*) calloc(len1, sizeof(char));
+    strncpy(pnode->name, j, len);
+    pnode->func = func;
+    pnode->next = NULL;
+
+    if (roughnessread_table == NULL) {
+        roughnessread_table = pnode;
+    } else {
+        current = roughnessread_table;
+        while (current->next != NULL) {
+            current = current->next;
+        }
+        current->next = pnode;
     }
-    current->next = pnode; 
-  }
-
 }
 
 //BOP
@@ -171,38 +168,40 @@ void FTN(registerreadroughness)(char *j,void (*func)(int*, void*, void*, float*,
 // \label{readroughness}
 //
 // !INTERFACE:
-void FTN(readroughness)(char *j,int *n, void *time1, void *time2, float *array1, float *array2, int len)
-//  
+//EMK Fixed argument list
+void FTN(readroughness)(char *j, int *n, float *wt1, float *wt2,
+                        float *array1, float *array2)
+//
 // !DESCRIPTION:
-// Invokes the routine from the registry to 
-// reading roughness data 
-// 
-// The arguments are: 
+// Invokes the routine from the registry to
+// reading roughness data
+//
+// The arguments are:
 // \begin{description}
 //  \item[n]
 //   index of the nest
 //  \item[j]
 //  index of the greenness data source
 //  \item[time]
-//  month 
+//  month
 //  \item[array]
 //  pointer to the greenness data
 //  \end{description}
 //EOP
-{ 
-  struct roughnessreadnode* current;
-  
-  current = roughnessread_table;
-  while(strcmp(current->name,j)!=0){
-    current = current->next;
-    if(current==NULL) {
-      printf("****************Error****************************\n"); 
-      printf("readroughness routine for runmode %s is not defined\n",j); 
-      printf("program will seg fault.....\n"); 
-      printf("****************Error****************************\n"); 
+{
+    struct roughnessreadnode* current;
+
+    current = roughnessread_table;
+    while (strcmp(current->name, j) != 0) {
+        current = current->next;
+        if (current == NULL) {
+            printf("****************Error****************************\n");
+            printf("readroughness routine for runmode %s is not defined\n",j);
+            printf("program will seg fault.....\n");
+            printf("****************Error****************************\n");
+        }
     }
-  }
-  current->func(n,time1,time2, array1,array2); 
+    current->func(n, wt1, wt2, array1, array2);
 }
 
 

--- a/lis/core/LIS_roughness_FTable.c
+++ b/lis/core/LIS_roughness_FTable.c
@@ -170,7 +170,7 @@ void FTN(registerreadroughness)(char *j,
 // !INTERFACE:
 //EMK Fixed argument list
 void FTN(readroughness)(char *j, int *n, float *wt1, float *wt2,
-                        float *array1, float *array2)
+                        float *array1, float *array2, int len)
 //
 // !DESCRIPTION:
 // Invokes the routine from the registry to

--- a/lis/core/LIS_vegDataMod.F90
+++ b/lis/core/LIS_vegDataMod.F90
@@ -23,12 +23,12 @@ module LIS_vegDataMod
 !
 ! !DESCRIPTION:
 !  The code in this file implements routines to read various vegetation
-!  datasets. 
+!  datasets.
 !
 !  \subsubsection{Overview}
-!  This routines in this module provides routines to read the 
+!  This routines in this module provides routines to read the
 !  greenness fraction, LAI, SAI and roughness data. Both real-time
-!  and climatological datasets are supported. The climatological 
+!  and climatological datasets are supported. The climatological
 !  data is expected to be provided in the parameter input file (from LPT)
 !
 ! !REVISION HISTORY:
@@ -64,8 +64,8 @@ module LIS_vegDataMod
 
   public :: LIS_roughness_setup   !allocates memory for required structures
   public :: LIS_read_roughness    !reads the roughness data
-  public :: LIS_diagnoseroughness !maps the roughness data to the history writer
-  public :: LIS_roughness_finalize !cleanup allocated structures 
+  public :: LIS_diagnoseroughness !maps the roughness data to history writer
+  public :: LIS_roughness_finalize !cleanup allocated structures
   public :: LIS_roughness_reset    !resets datastructures
 
   public :: LIS_lai_setup ! allocates memory for required structures
@@ -85,10 +85,10 @@ module LIS_vegDataMod
 !------------------------------------------------------------------------------
 ! !PUBLIC TYPES:
 !------------------------------------------------------------------------------
-  public :: LIS_gfrac !data structure containing greenness fraction data. 
-  public :: LIS_roughness !data structure containing roughness data. 
-  public :: LIS_lai ! data structure containing LAI data. 
-  public :: LIS_sai ! data structure containing SAI data. 
+  public :: LIS_gfrac !data structure containing greenness fraction data.
+  public :: LIS_roughness !data structure containing roughness data.
+  public :: LIS_lai ! data structure containing LAI data.
+  public :: LIS_sai ! data structure containing SAI data.
 !EOP
   type, public :: gfrac_type_dec
      integer       :: realtimemode
@@ -156,39 +156,40 @@ module LIS_vegDataMod
 contains
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_greenness_setup
 ! \label{LIS_greenness_setup}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_greenness_setup
 ! !USES:
 
 ! !DESCRIPTION:
 !
-! Allocates memory for data structures for reading 
-! the greenness fraction datasets. This routine also 
-! reads the greenness datasets as initial values. 
-! 
-!  The routines invoked are: 
+! Allocates memory for data structures for reading
+! the greenness fraction datasets. This routine also
+! reads the greenness datasets as initial values.
+!
+!  The routines invoked are:
 !  \begin{description}
 !   \item[gfracsetup](\ref{gfracsetup}) \newline
-!    calls the registry to invoke the gfrac setup methods. 
+!    calls the registry to invoke the gfrac setup methods.
 !   \item[LIS\_registerAlarm](\ref{LIS_registerAlarm}) \newline
 !    registers the alarm for reading greenness datasets
-!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights}) \newline
+!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights})
+!      \newline
 !    computes the interpolation weights
 !   \item[read\_gfracclimo](\ref{read_gfracclimo}) \newline
 !    reads the greenness climatology data from the LIS parameter data file.
 !   \item[readgfrac](\ref{readgfrac}) \newline
 !    invokes the method from the registry to read the real-time (time-varying)
-!    greenness data. 
+!    greenness data.
 !  \end{description}
 !
 !EOP
     implicit none
     integer   :: n
-    integer   :: ndoms 
+    integer   :: ndoms
     integer   :: rc,ios,nid
     integer :: i
     real :: wt1, wt2
@@ -198,18 +199,18 @@ contains
     logical   :: file_exists
 
     TRACE_ENTER("green_setup")
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
-       if(LIS_rc%usegreennessmap(n).ne."none") then 
+       if(LIS_rc%usegreennessmap(n).ne."none") then
           ndoms = ndoms+1
        endif
     enddo
-    
-    if(ndoms.gt.0) then 
+
+    if(ndoms.gt.0) then
        allocate(LIS_gfrac(LIS_rc%nnest))
        do n=1,LIS_rc%nnest
-          LIS_gfrac(n)%firstInstance = .true. 
-          LIS_gfrac(n)%realtimemode = 0 
+          LIS_gfrac(n)%firstInstance = .true.
+          LIS_gfrac(n)%realtimemode = 0
        enddo
 
        do n=1,LIS_rc%nnest
@@ -220,51 +221,54 @@ contains
           LIS_gfrac(n)%vegmp2 = 0.0
           LIS_gfrac(n)%greenness = 0.0
 
-          if(LIS_rc%usegreennessmap(n).eq."LDT") then 
+          if(LIS_rc%usegreennessmap(n).eq."LDT") then
 
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-             
+
              inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-             if(file_exists) then 
-                
+             if(file_exists) then
+
                 ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
                      mode=NF90_NOWRITE,ncid=nid)
                 call LIS_verify(ios,'Error in nf90_open in read_gfracclimo')
-                
-                ios = nf90_get_att(nid, NF90_GLOBAL, 'GREENNESS_DATA_INTERVAL', &
+
+                ios = nf90_get_att(nid, NF90_GLOBAL, &
+                     'GREENNESS_DATA_INTERVAL', &
                      LIS_gfrac(n)%gfracIntervalType)
-                call LIS_verify(ios,'Error in nf90_get_att in read_gfracclimo')       
-                
+                call LIS_verify(ios, &
+                     'Error in nf90_get_att in read_gfracclimo')
+
                 ios = nf90_close(nid)
                 call LIS_verify(ios,'Error in nf90_close in read_gfracclimo')
              else
-                write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), ' does not exist'
+                write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), &
+                     ' does not exist'
                 write(LIS_logunit,*) '[ERR] program stopping ...'
                 call LIS_endrun
              endif
 #endif
-             if(LIS_gfrac(n)%gfracIntervalType.eq."monthly") then 
+             if(LIS_gfrac(n)%gfracIntervalType.eq."monthly") then
                 LIS_gfrac(n)%gfracInterval = 2592000
              endif
 !The intervaltype and interval is set in the plugin, now
-!register the alarm.          
+!register the alarm.
              call LIS_registerAlarm("LIS gfrac read alarm",LIS_rc%ts, &
                   LIS_gfrac(n)%gfracInterval,&
-                  intervalType=LIS_gfrac(n)%gfracIntervalType) 
-             
+                  intervalType=LIS_gfrac(n)%gfracIntervalType)
+
              call LIS_computeTemporalWeights(LIS_rc,&
                   LIS_gfrac(n)%gfracIntervalType, &
                   t1,t2,wt1,wt2,"LIS gfrac read alarm")
-             
+
              allocate(value1(LIS_rc%ntiles(n)))
              allocate(value2(LIS_rc%ntiles(n)))
-             
+
              value1 = LIS_rc%udef
              value2 = LIS_rc%udef
-             
+
              call read_gfracclimo(n,t1,value1)
              call read_gfracclimo(n,t2,value2)
-             
+
              do i=1,LIS_rc%ntiles(n)
                 LIS_gfrac(n)%vegmp1(i) = value1(i)
                 LIS_gfrac(n)%vegmp2(i) = value2(i)
@@ -278,7 +282,7 @@ contains
                   n,wt1,wt2,LIS_gfrac(n)%vegmp1,LIS_gfrac(n)%vegmp2)
 
           endif
-          do i=1,LIS_rc%ntiles(n)  
+          do i=1,LIS_rc%ntiles(n)
              LIS_gfrac(n)%greenness(i) = (wt1*LIS_gfrac(n)%vegmp1(i))+&
                   (wt2*LIS_gfrac(n)%vegmp2(i))
           enddo
@@ -289,38 +293,39 @@ contains
   end subroutine LIS_greenness_setup
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_read_greenness
 ! \label{LIS_read_greenness}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_read_greenness(n)
-! !USES:    
+! !USES:
 
     implicit none
-! !ARGUMENTS:    
+! !ARGUMENTS:
     integer, intent(in) :: n
-! 
+!
 ! !DESCRIPTION:
 !
 !  Reads the greenness fraction climalotogy and temporally interpolates
-!  it to the current day. 
-! 
-!  The arguments are: 
+!  it to the current day.
+!
+!  The arguments are:
 !  \begin{description}
 !   \item [n]
 !     index of the domain or nest.
 !  \end{description}
 !
-!  The routines invoked are: 
+!  The routines invoked are:
 !  \begin{description}
-!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights}) \newline
+!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights})
+!     \newline
 !    computes the interpolation weights
 !   \item[read\_gfracclimo](\ref{read_gfracclimo}) \newline
 !    reads the greenness climatology data from the LIS parameter data file.
 !   \item[readgfrac](\ref{readgfrac}) \newline
 !    invokes the method from the registry to read the real-time (time-varying)
-!    greenness data. 
+!    greenness data.
 !  \end{description}
 !
 !EOP
@@ -336,16 +341,16 @@ contains
     allocate(value1(LIS_rc%ntiles(n)))
     allocate(value2(LIS_rc%ntiles(n)))
 
-    if(LIS_rc%usegreennessmap(n).ne."none") then 
-       if(LIS_rc%usegreennessmap(n).eq."LDT") then 
+    if(LIS_rc%usegreennessmap(n).ne."none") then
+       if(LIS_rc%usegreennessmap(n).eq."LDT") then
           gfracAlarmCheck = LIS_isAlarmRinging(LIS_rc,&
-               "LIS gfrac read alarm",&           
+               "LIS gfrac read alarm",&
                LIS_gfrac(n)%gfracIntervalType)
-!move the tindex to computetemporalweights? 
+!move the tindex to computetemporalweights?
           call LIS_computeTemporalWeights(LIS_rc,&
                LIS_gfrac(n)%gfracIntervalType, &
                t1,t2,wt1,wt2, "LIS gfrac read alarm")
-          if(gfracAlarmCheck) then   
+          if(gfracAlarmCheck) then
 
              value1 = LIS_rc%udef
              value2 = LIS_rc%udef
@@ -359,7 +364,7 @@ contains
              enddo
           endif
        else
-          
+
           call readgfrac(trim(LIS_rc%usegreennessmap(n))//char(0),&
                n,wt1,wt2,LIS_gfrac(n)%vegmp1,LIS_gfrac(n)%vegmp2)
        endif
@@ -374,17 +379,17 @@ contains
     TRACE_EXIT("green_read")
 
   end subroutine LIS_read_greenness
-  
+
 !BOP
-! 
+!
 ! !ROUTINE: LIS_greenness_finalize
 ! \label{LIS_greenness_finalize}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_greenness_finalize
 ! !USES:
 
-! 
+!
 ! !DESCRIPTION:
 !
 ! Deallocates objects created in this module
@@ -393,13 +398,13 @@ contains
     implicit none
     integer :: n
     integer :: ndoms
-    
-    ndoms = 0 
+
+    ndoms = 0
     do n=1,LIS_rc%nnest
        if(LIS_rc%usegreennessmap(n).ne."none") ndoms = ndoms+1
     enddo
-    
-    if(ndoms.gt.0) then 
+
+    if(ndoms.gt.0) then
        do n=1,LIS_rc%nnest
           deallocate(LIS_gfrac(n)%greenness)
           deallocate(LIS_gfrac(n)%vegmp1)
@@ -410,27 +415,27 @@ contains
   end subroutine LIS_greenness_finalize
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_diagnosegfrac
 ! \label{LIS_diagnosegfrac}
-! 
-! !INTERFACE: 
+!
+! !INTERFACE:
   subroutine LIS_diagnosegfrac(n)
-! !USES: 
+! !USES:
 
 ! !ARGUMENTS:
     implicit none
-    integer, intent(in)   :: n 
+    integer, intent(in)   :: n
 
-! !DESCRIPTION: 
-!  This routine maps the greenness data to the LIS history writer. 
-! 
-!  The arguments are: 
+! !DESCRIPTION:
+!  This routine maps the greenness data to the LIS history writer.
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[n] index of the nest \newline
 !  \end{description}
-! 
-!  The routines called are: 
+!
+!  The routines called are:
 !  \begin{description}
 !  \item[LIS\_diagnoseOutputVar](\ref{LIS_diagnoseSurfaceOutputVar}) \newline
 !    maps the greenness data to the LIS history writer
@@ -456,14 +461,16 @@ contains
         (LIS_rc%lsm.ne."Noah-MP.4.0.1")) then
        temp = LIS_rc%udef
        do t=1,LIS_rc%ntiles(n)
-          if(LIS_domain(n)%tile(t)%index.ne.-1) then 
+          if(LIS_domain(n)%tile(t)%index.ne.-1) then
              temp(t) = LIS_gfrac(n)%greenness(t)
           endif
           call LIS_diagnoseSurfaceOutputVar(n,t,LIS_MOC_GREENNESS,vlevel=1,&
-                                           value=temp(t),unit="-",direction="-")
+               value=temp(t),unit="-", &
+               direction="-")
           call LIS_diagnoseSurfaceOutputVar(n,t,LIS_MOC_GREENNESS,vlevel=1,&
-                                           value=temp(t)*100.0,unit="%",direction="-")
-       enddo       
+               value=temp(t)*100.0,unit="%", &
+               direction="-")
+       enddo
     endif
     deallocate(temp)
     TRACE_EXIT("green_diag")
@@ -471,36 +478,37 @@ contains
   end subroutine LIS_diagnosegfrac
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_greenness_reset
 ! \label{LIS_greenness_reset}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_greenness_reset
 ! !USES:
 
 ! !DESCRIPTION:
 !
-! Resets the data structures for reading 
-! the greenness fraction datasets 
-! 
-!  The routines invoked are: 
+! Resets the data structures for reading
+! the greenness fraction datasets
+!
+!  The routines invoked are:
 !  \begin{description}
 !   \item[gfracsetup](\ref{gfracsetup}) \newline
-!    calls the registry to invoke the gfrac data reading methods. 
-!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights}) \newline
+!    calls the registry to invoke the gfrac data reading methods.
+!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights})
+!       \newline
 !    computes the interpolation weights
 !   \item[read\_gfracclimo](\ref{read_gfracclimo}) \newline
 !    reads the greenness climatology data from the LIS parameter data file.
 !   \item[readgfrac](\ref{readgfrac}) \newline
 !    invokes the method from the registry to read the real-time (time-varying)
-!    greenness data. 
+!    greenness data.
 !  \end{description}
 !
 !EOP
     implicit none
     integer   :: n
-    integer   :: ndoms 
+    integer   :: ndoms
     integer   :: rc
     integer :: i
     real :: wt1, wt2
@@ -509,36 +517,36 @@ contains
     integer       :: t1, t2
 
     TRACE_ENTER("green_reset")
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
-       if(LIS_rc%usegreennessmap(n).ne."none") then 
+       if(LIS_rc%usegreennessmap(n).ne."none") then
           ndoms = ndoms+1
        endif
     enddo
-    
-    if(ndoms.gt.0) then 
+
+    if(ndoms.gt.0) then
 
        do n=1,LIS_rc%nnest
-          LIS_gfrac(n)%firstInstance = .true. 
+          LIS_gfrac(n)%firstInstance = .true.
           LIS_gfrac(n)%vegmp1 = 0.0
           LIS_gfrac(n)%vegmp2 = 0.0
           LIS_gfrac(n)%greenness = 0.0
 
-          if(LIS_rc%usegreennessmap(n).eq."LDT") then 
-             
+          if(LIS_rc%usegreennessmap(n).eq."LDT") then
+
              call LIS_computeTemporalWeights(LIS_rc,&
                   LIS_gfrac(n)%gfracIntervalType, &
                   t1,t2,wt1,wt2,"LIS gfrac read alarm")
-             
+
              allocate(value1(LIS_rc%ntiles(n)))
              allocate(value2(LIS_rc%ntiles(n)))
-             
+
              value1 = LIS_rc%udef
              value2 = LIS_rc%udef
-             
+
              call read_gfracclimo(n,t1,value1)
              call read_gfracclimo(n,t2,value2)
-             
+
              do i=1,LIS_rc%ntiles(n)
                 LIS_gfrac(n)%vegmp1(i) = value1(i)
                 LIS_gfrac(n)%vegmp2(i) = value2(i)
@@ -553,7 +561,7 @@ contains
 
           endif
 
-          do i=1,LIS_rc%ntiles(n)  
+          do i=1,LIS_rc%ntiles(n)
              LIS_gfrac(n)%greenness(i) = (wt1*LIS_gfrac(n)%vegmp1(i))+&
                   (wt2*LIS_gfrac(n)%vegmp2(i))
           enddo
@@ -575,16 +583,16 @@ contains
 ! !INTERFACE:
   subroutine read_gfracclimo(n,time,array)
 ! !USES:
-    
+
     implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
     integer, intent(in)         :: n
     integer, intent(in)         :: time
-    real, intent(inout)         :: array(LIS_rc%ntiles(n))    
+    real, intent(inout)         :: array(LIS_rc%ntiles(n))
 ! !DESCRIPTION:
 !  This subroutine reads the greenness data climatology from the LIS
 !  parameter data file
-!  
+!
 !  The arguments are:
 !  \begin{description}
 !   \item[n]
@@ -595,7 +603,7 @@ contains
 !    array containing the greenness values
 !   \end{description}
 !
-!EOP      
+!EOP
 
     integer :: ios1
     integer :: ios,nid,gfracid,ncId, nrId,mid
@@ -604,12 +612,12 @@ contains
     real, allocatable :: gfrac(:,:,:)
     real    :: localgfrac(LIS_rc%lnc(n),LIS_rc%lnr(n))
     logical :: file_exists
-    
+
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-    mo = time 
+    mo = time
 
     inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-    if(file_exists) then 
+    if(file_exists) then
 
        write(LIS_logunit,*)'[INFO] Reading greenness map for month ', mo,&
             'from ',trim(LIS_rc%paramfile(n))
@@ -617,38 +625,41 @@ contains
        ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
             mode=NF90_NOWRITE,ncid=nid)
        call LIS_verify(ios,'Error in nf90_open in read_gfracclimo')
-       
+
        ios = nf90_inq_dimid(nid,"east_west",ncId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_gfracclimo')
-       
+
        ios = nf90_inq_dimid(nid,"north_south",nrId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_gfracclimo')
 
        ios = nf90_inq_dimid(nid,"month",mId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_gfracclimo')
-       
+
        ios = nf90_inquire_dimension(nid,ncId, len=nc)
-       call LIS_verify(ios,'Error in nf90_inquire_dimension in read_gfracclimo')
-       
+       call LIS_verify(ios, &
+            'Error in nf90_inquire_dimension in read_gfracclimo')
+
        ios = nf90_inquire_dimension(nid,nrId, len=nr)
-       call LIS_verify(ios,'Error in nf90_inquire_dimension in read_gfracclimo')
+       call LIS_verify(ios, &
+            'Error in nf90_inquire_dimension in read_gfracclimo')
 
        ios = nf90_inquire_dimension(nid,mId, len=months)
-       call LIS_verify(ios,'Error in nf90_inquire_dimension in read_gfracclimo')
-       
+       call LIS_verify(ios, &
+            'Error in nf90_inquire_dimension in read_gfracclimo')
+
        allocate(gfrac(LIS_rc%gnc(n),LIS_rc%gnr(n),months))
-       
+
        ios = nf90_inq_varid(nid,'GREENNESS',gfracid)
        call LIS_verify(ios,'GREENNESS field not found in the LIS param file')
-       
+
        ios = nf90_get_var(nid,gfracid,gfrac)
        call LIS_verify(ios,'Error in nf90_get_var in read_gfracclimo')
-       
+
        ios = nf90_close(nid)
        call LIS_verify(ios,'Error in nf90_close in read_gfracclimo')
-       
+
        localgfrac(:,:) = &
-            gfrac(LIS_ews_halo_ind(n,LIS_localPet+1):&         
+            gfrac(LIS_ews_halo_ind(n,LIS_localPet+1):&
             LIS_ewe_halo_ind(n,LIS_localPet+1), &
             LIS_nss_halo_ind(n,LIS_localPet+1): &
             LIS_nse_halo_ind(n,LIS_localPet+1),mo)
@@ -660,7 +671,8 @@ contains
                LIS_domain(n)%tile(t)%row)
        enddo
     else
-       write(LIS_logunit,*) '[ERR] gfrac map: ',LIS_rc%paramfile(n), ' does not exist'
+       write(LIS_logunit,*) '[ERR] gfrac map: ',LIS_rc%paramfile(n), &
+            ' does not exist'
        write(LIS_logunit,*) '[ERR] program stopping ...'
        call LIS_endrun
     endif
@@ -668,23 +680,23 @@ contains
   end subroutine read_gfracclimo
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_read_shdmin
 ! \label{LIS_read_shdmin}
 !
 ! !INTERFACE:
   subroutine LIS_read_shdmin(n,array)
-! !USES: 
+! !USES:
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in)    :: n
   real,    intent(inout) :: array(LIS_rc%lnc(n),LIS_rc%lnr(n))
-! 
+!
 ! !DESCRIPTION:
-!  Reads the static albedo upper bound over deep snow 
-!  for each domain. 
-!  
+!  Reads the static albedo upper bound over deep snow
+!  for each domain.
+!
 !  The arguments are:
 !  \begin{description}
 !   \item[n]
@@ -693,7 +705,7 @@ contains
 !    shdmin for the region of interest
 !   \end{description}
 !
-!EOP      
+!EOP
 
   integer :: ios1
   integer :: ios,nid,shdminid,ncId, nrId
@@ -704,7 +716,7 @@ contains
   TRACE_ENTER("green_readmin")
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
   inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-  if(file_exists) then 
+  if(file_exists) then
 
      write(LIS_logunit,*)'[INFO] Reading SHDMIN map from ',&
           trim(LIS_rc%paramfile(n))
@@ -712,7 +724,7 @@ contains
      ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
           mode=NF90_NOWRITE,ncid=nid)
      call LIS_verify(ios,'Error in nf90_open in LIS_read_shdmin')
-     
+
      ios = nf90_inq_dimid(nid,"east_west",ncId)
      call LIS_verify(ios,'Error in nf90_inq_dimid in LIS_read_shdmin')
 
@@ -730,12 +742,12 @@ contains
 
      ios = nf90_get_var(nid,shdminid,shdmin)
      call LIS_verify(ios,'Error in nf90_get_var in LIS_read_shdmin')
-     
+
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in LIS_read_shdmin')
 
      array(:,:) = &
-          shdmin(LIS_ews_halo_ind(n,LIS_localPet+1):&         
+          shdmin(LIS_ews_halo_ind(n,LIS_localPet+1):&
           LIS_ewe_halo_ind(n,LIS_localPet+1), &
           LIS_nss_halo_ind(n,LIS_localPet+1): &
           LIS_nse_halo_ind(n,LIS_localPet+1))
@@ -753,23 +765,23 @@ contains
   end subroutine LIS_read_shdmin
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_read_shdmax
 ! \label{LIS_read_shdmax}
 !
 ! !INTERFACE:
   subroutine LIS_read_shdmax(n,array)
-! !USES: 
+! !USES:
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in)    :: n
   real,    intent(inout) :: array(LIS_rc%lnc(n),LIS_rc%lnr(n))
-! 
+!
 ! !DESCRIPTION:
-!  Reads the static albedo upper bound over deep snow 
-!  for each domain. 
-!  
+!  Reads the static albedo upper bound over deep snow
+!  for each domain.
+!
 !  The arguments are:
 !  \begin{description}
 !   \item[n]
@@ -778,7 +790,7 @@ contains
 !    shdmax for the region of interest
 !   \end{description}
 !
-!EOP      
+!EOP
 
   integer :: ios1
   integer :: ios,nid,shdmaxid,ncId, nrId
@@ -789,7 +801,7 @@ contains
   TRACE_ENTER("green_readmax")
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
   inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-  if(file_exists) then 
+  if(file_exists) then
 
      write(LIS_logunit,*)'[INFO] Reading SHDMAX map from ',&
           trim(LIS_rc%paramfile(n))
@@ -797,7 +809,7 @@ contains
      ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
           mode=NF90_NOWRITE,ncid=nid)
      call LIS_verify(ios,'Error in nf90_open in LIS_read_shdmax')
-     
+
      ios = nf90_inq_dimid(nid,"east_west",ncId)
      call LIS_verify(ios,'Error in nf90_inq_dimid in LIS_read_shdmax')
 
@@ -815,12 +827,12 @@ contains
 
      ios = nf90_get_var(nid,shdmaxid,shdmax)
      call LIS_verify(ios,'Error in nf90_get_var in LIS_read_shdmax')
-     
+
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in LIS_read_shdmax')
 
      array(:,:) = &
-          shdmax(LIS_ews_halo_ind(n,LIS_localPet+1):&         
+          shdmax(LIS_ews_halo_ind(n,LIS_localPet+1):&
           LIS_ewe_halo_ind(n,LIS_localPet+1), &
           LIS_nss_halo_ind(n,LIS_localPet+1): &
           LIS_nse_halo_ind(n,LIS_localPet+1))
@@ -838,23 +850,23 @@ contains
   end subroutine LIS_read_shdmax
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_read_laimin
 ! \label{LIS_read_laimin}
 !
 ! !INTERFACE:
   subroutine LIS_read_laimin(n,array)
-! !USES: 
+! !USES:
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in)    :: n
   real,    intent(inout) :: array(LIS_rc%lnc(n),LIS_rc%lnr(n))
-! 
+!
 ! !DESCRIPTION:
-!  Reads the static albedo upper bound over deep snow 
-!  for each domain. 
-!  
+!  Reads the static albedo upper bound over deep snow
+!  for each domain.
+!
 !  The arguments are:
 !  \begin{description}
 !   \item[n]
@@ -863,7 +875,7 @@ contains
 !    laimin for the region of interest
 !   \end{description}
 !
-!EOP      
+!EOP
 
   integer :: ios1
   integer :: ios,nid,laiminid,ncId, nrId
@@ -874,7 +886,7 @@ contains
   TRACE_ENTER("lai_readmin")
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
   inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-  if(file_exists) then 
+  if(file_exists) then
 
      write(LIS_logunit,*)'[INFO] Reading LAIMIN map from ',&
           trim(LIS_rc%paramfile(n))
@@ -882,7 +894,7 @@ contains
      ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
           mode=NF90_NOWRITE,ncid=nid)
      call LIS_verify(ios,'Error in nf90_open in LIS_read_laimin')
-     
+
      ios = nf90_inq_dimid(nid,"east_west",ncId)
      call LIS_verify(ios,'Error in nf90_inq_dimid in LIS_read_laimin')
 
@@ -900,12 +912,12 @@ contains
 
      ios = nf90_get_var(nid,laiminid,laimin)
      call LIS_verify(ios,'Error in nf90_get_var in LIS_read_laimin')
-     
+
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in LIS_read_laimin')
 
      array(:,:) = &
-          laimin(LIS_ews_halo_ind(n,LIS_localPet+1):&         
+          laimin(LIS_ews_halo_ind(n,LIS_localPet+1):&
           LIS_ewe_halo_ind(n,LIS_localPet+1), &
           LIS_nss_halo_ind(n,LIS_localPet+1): &
           LIS_nse_halo_ind(n,LIS_localPet+1))
@@ -923,23 +935,23 @@ contains
   end subroutine LIS_read_laimin
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_read_laimax
 ! \label{LIS_read_laimax}
 !
 ! !INTERFACE:
   subroutine LIS_read_laimax(n,array)
-! !USES: 
+! !USES:
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in)    :: n
   real,    intent(inout) :: array(LIS_rc%lnc(n),LIS_rc%lnr(n))
-! 
+!
 ! !DESCRIPTION:
-!  Reads the static albedo upper bound over deep snow 
-!  for each domain. 
-!  
+!  Reads the static albedo upper bound over deep snow
+!  for each domain.
+!
 !  The arguments are:
 !  \begin{description}
 !   \item[n]
@@ -948,7 +960,7 @@ contains
 !    laimax for the region of interest
 !   \end{description}
 !
-!EOP      
+!EOP
 
   integer :: ios1
   integer :: ios,nid,laimaxid,ncId, nrId
@@ -959,7 +971,7 @@ contains
   TRACE_ENTER("lai_readmax")
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
   inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-  if(file_exists) then 
+  if(file_exists) then
 
      write(LIS_logunit,*)'[INFO] Reading LAIMAX map from ',&
           trim(LIS_rc%paramfile(n))
@@ -967,7 +979,7 @@ contains
      ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
           mode=NF90_NOWRITE,ncid=nid)
      call LIS_verify(ios,'Error in nf90_open in LIS_read_laimax')
-     
+
      ios = nf90_inq_dimid(nid,"east_west",ncId)
      call LIS_verify(ios,'Error in nf90_inq_dimid in LIS_read_laimax')
 
@@ -985,12 +997,12 @@ contains
 
      ios = nf90_get_var(nid,laimaxid,laimax)
      call LIS_verify(ios,'Error in nf90_get_var in LIS_read_laimax')
-     
+
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in LIS_read_laimax')
 
      array(:,:) = &
-          laimax(LIS_ews_halo_ind(n,LIS_localPet+1):&         
+          laimax(LIS_ews_halo_ind(n,LIS_localPet+1):&
           LIS_ewe_halo_ind(n,LIS_localPet+1), &
           LIS_nss_halo_ind(n,LIS_localPet+1): &
           LIS_nse_halo_ind(n,LIS_localPet+1))
@@ -1008,29 +1020,29 @@ contains
   end subroutine LIS_read_laimax
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_roughness_setup
 ! \label{LIS_roughness_setup}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_roughness_setup
 ! !USES:
 
 ! !DESCRIPTION:
 !
-! Allocates memory for data structures for reading 
-! the roughness fraction datasets 
-! 
-!  The routines invoked are: 
+! Allocates memory for data structures for reading
+! the roughness fraction datasets
+!
+!  The routines invoked are:
 !  \begin{description}
 !   \item[gfracsetup](\ref{gfracsetup}) \newline
-!    calls the registry to invoke the gfrac setup methods. 
+!    calls the registry to invoke the gfrac setup methods.
 !  \end{description}
 !
 !EOP
     implicit none
     integer   :: n
-    integer   :: ndoms 
+    integer   :: ndoms
     integer   :: rc,ios,nid
     integer :: i
     real :: wt1, wt2
@@ -1040,18 +1052,18 @@ contains
     logical   :: file_exists
 
     TRACE_ENTER("rough_setup")
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
-       if(LIS_rc%useroughnessmap(n).ne."none") then 
+       if(LIS_rc%useroughnessmap(n).ne."none") then
           ndoms = ndoms+1
        endif
     enddo
-    
-    if(ndoms.gt.0) then 
+
+    if(ndoms.gt.0) then
        allocate(LIS_roughness(LIS_rc%nnest))
 
        do n=1,LIS_rc%nnest
-          LIS_roughness(n)%firstInstance = .true. 
+          LIS_roughness(n)%firstInstance = .true.
        enddo
 
        do n=1,LIS_rc%nnest
@@ -1061,67 +1073,68 @@ contains
           LIS_roughness(n)%z0v1 = 0.0
           LIS_roughness(n)%z0v2 = 0.0
           LIS_roughness(n)%roughness = 0.0
-          
-          if(LIS_rc%useroughnessmap(n).eq."LDT") then 
+
+          if(LIS_rc%useroughnessmap(n).eq."LDT") then
 
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-             
+
              inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-             if(file_exists) then 
-                
+             if(file_exists) then
+
                 ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
                      mode=NF90_NOWRITE,ncid=nid)
-                call LIS_verify(ios,'Error in nf90_open in read_roughnessclimo')
-                
+                call LIS_verify(ios, &
+                     'Error in nf90_open in read_roughnessclimo')
+
                 ios = nf90_get_att(nid, NF90_GLOBAL, &
                      'ROUGHNESS_DATA_INTERVAL', &
                      LIS_roughness(n)%roughnessIntervalType)
                 call LIS_verify(ios,&
-                     'Error in nf90_get_att in read_roughnessclimo')       
-                
+                     'Error in nf90_get_att in read_roughnessclimo')
+
                 ios = nf90_close(nid)
                 call LIS_verify(ios,&
                      'Error in nf90_close in read_roughnessclimo')
              else
-                write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), ' does not exist'
+                write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), &
+                     ' does not exist'
                 write(LIS_logunit,*) '[ERR] program stopping ...'
                 call LIS_endrun
              endif
 #endif
-             if(LIS_roughness(n)%roughnessIntervalType.eq."monthly") then 
+             if(LIS_roughness(n)%roughnessIntervalType.eq."monthly") then
                 LIS_roughness(n)%roughnessInterval = 2592000
              endif
 !The intervaltype and interval is set in the plugin, now
-!register the alarm.          
+!register the alarm.
              call LIS_registerAlarm("LIS roughness read alarm",LIS_rc%ts, &
                   LIS_roughness(n)%roughnessInterval,&
-                  intervalType=LIS_roughness(n)%roughnessIntervalType) 
-             
+                  intervalType=LIS_roughness(n)%roughnessIntervalType)
+
              call LIS_computeTemporalWeights(LIS_rc,&
                   LIS_roughness(n)%roughnessIntervalType, &
                   t1,t2,wt1,wt2,"LIS roughness read alarm")
-             
+
              allocate(value1(LIS_rc%ntiles(n)))
              allocate(value2(LIS_rc%ntiles(n)))
-             
+
              value1 = LIS_rc%udef
              value2 = LIS_rc%udef
-             
-             
+
              call read_roughnessclimo(n,t1,value1)
              call read_roughnessclimo(n,t2,value2)
-             
+
              do i=1,LIS_rc%ntiles(n)
                 LIS_roughness(n)%z0v1(i) = value1(i)
                 LIS_roughness(n)%z0v2(i) = value2(i)
              enddo
           else
              call roughnesssetup(trim(LIS_rc%useroughnessmap(n))//char(0),n)
-             call readroughness(trim(LIS_rc%useroughnessmap(n))//char(0),&
-                  n,wt1,wt2,LIS_roughness(n)%z0v1,LIS_roughness(n)%z0v2)
+             call readroughness(trim(LIS_rc%useroughnessmap(n))//char(0), &
+                  n, wt1, wt2, LIS_roughness(n)%z0v1, LIS_roughness(n)%z0v2)
           endif
-          
-          do i=1,LIS_rc%ntiles(n)  
+
+          do i=1,LIS_rc%ntiles(n)
              LIS_roughness(n)%roughness(i) = (wt1*LIS_roughness(n)%z0v1(i))+&
                   (wt2*LIS_roughness(n)%z0v2(i))
           enddo
@@ -1132,37 +1145,38 @@ contains
   end subroutine LIS_roughness_setup
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_read_roughness
 ! \label{LIS_read_roughness}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_read_roughness(n)
-! !USES:    
+! !USES:
     use LIS_coreMod,    only : LIS_rc, LIS_domain
     use LIS_timeMgrMod, only : LIS_isAlarmRinging, LIS_computeTemporalWeights
 
     implicit none
-! !ARGUMENTS:    
+! !ARGUMENTS:
     integer, intent(in) :: n
-! 
+!
 ! !DESCRIPTION:
 !
 !  Reads the roughness fraction climalotogy and temporally interpolates
-!  it to the current day. 
-! 
-!  The arguments are: 
+!  it to the current day.
+!
+!  The arguments are:
 !  \begin{description}
 !   \item [n]
 !     index of the domain or nest.
 !  \end{description}
 !
-!  The routines invoked are: 
+!  The routines invoked are:
 !  \begin{description}
-!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights}) \newline
+!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights})
+!      \newline
 !    computes the interpolation weights
 !   \item[readroughness](\ref{readroughness}) \newline
-!    invokes the generic method in the registry to read the 
+!    invokes the generic method in the registry to read the
 !    roughness climatology data
 !  \end{description}
 !
@@ -1176,17 +1190,17 @@ contains
     real, allocatable   :: value2(:) ! temporary value holder for t2
 
     TRACE_ENTER("rough_setup")
-    if(LIS_rc%useroughnessmap(n).ne."none") then 
-       if(LIS_rc%useroughnessmap(n).eq."LDT") then 
+    if(LIS_rc%useroughnessmap(n).ne."none") then
+       if(LIS_rc%useroughnessmap(n).eq."LDT") then
           roughnessAlarmCheck = LIS_isAlarmRinging(LIS_rc,&
-               "LIS roughness read alarm",&           
+               "LIS roughness read alarm",&
                LIS_roughness(n)%roughnessIntervalType)
-          
+
           call LIS_computeTemporalWeights(LIS_rc,&
                LIS_roughness(n)%roughnessIntervalType, &
                t1,t2,wt1,wt2)
-          if(roughnessAlarmCheck) then   
-             
+          if(roughnessAlarmCheck) then
+
              value1 = LIS_rc%udef
              value2 = LIS_rc%udef
 
@@ -1199,10 +1213,10 @@ contains
              enddo
           endif
        else
-          call readroughness(trim(LIS_rc%useroughnessmap(n))//char(0),&
-               n,wt1,wt2,LIS_roughness(n)%z0v1, LIS_roughness(n)%z0v2)
+          call readroughness(trim(LIS_rc%useroughnessmap(n))//char(0), &
+               n, wt1, wt2, LIS_roughness(n)%z0v1, LIS_roughness(n)%z0v2)
        endif
-          
+
        do i=1,LIS_rc%ntiles(n)
           LIS_roughness(n)%roughness(i) = (wt1*LIS_roughness(n)%z0v1(i))+&
                (wt2*LIS_roughness(n)%z0v2(i))
@@ -1210,17 +1224,17 @@ contains
     endif
     TRACE_EXIT("rough_setup")
   end subroutine LIS_read_roughness
-  
+
 !BOP
-! 
+!
 ! !ROUTINE: LIS_roughness_finalize
 ! \label{LIS_roughness_finalize}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_roughness_finalize
 ! !USES:
     use LIS_coreMod, only : LIS_rc
-! 
+!
 ! !DESCRIPTION:
 !
 ! Deallocates objects created in this module
@@ -1229,13 +1243,13 @@ contains
     implicit none
     integer :: n
     integer :: ndoms
-    
-    ndoms = 0 
+
+    ndoms = 0
     do n=1,LIS_rc%nnest
        if(LIS_rc%useroughnessmap(n).ne."none") ndoms = ndoms+1
     enddo
-    
-    if(ndoms.gt.0) then 
+
+    if(ndoms.gt.0) then
        do n=1,LIS_rc%nnest
           deallocate(LIS_roughness(n)%roughness)
           deallocate(LIS_roughness(n)%z0v1)
@@ -1246,31 +1260,31 @@ contains
   end subroutine LIS_roughness_finalize
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_diagnoseroughness
 ! \label{LIS_diagnoseroughness}
-! 
-! !INTERFACE: 
+!
+! !INTERFACE:
   subroutine LIS_diagnoseroughness(n)
-! !USES: 
+! !USES:
     use LIS_coreMod,     only : LIS_rc, LIS_domain
     use LIS_histDataMod, only : LIS_diagnoseSurfaceOutputVar, LIS_MOC_ROUGHNESS
 ! !ARGUMENTS:
     implicit none
-    integer, intent(in)   :: n 
+    integer, intent(in)   :: n
 
-! !DESCRIPTION: 
-!  This routine maps the roughness data to the LIS history writer. 
-! 
-!  The arguments are: 
+! !DESCRIPTION:
+!  This routine maps the roughness data to the LIS history writer.
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[n] index of the nest \newline
 !  \end{description}
-! 
-!  The routines called are: 
+!
+!  The routines called are:
 !  \begin{description}
 !  \item[LIS\_diagnoseOutputVar](\ref{LIS_diagnoseSurfaceOutputVar}) \newline
-!    generic routine to map a single variable to the LIS 
+!    generic routine to map a single variable to the LIS
 !    history writer
 !  \end{description}
 !EOP
@@ -1280,15 +1294,16 @@ contains
     TRACE_ENTER("rough_diag")
     allocate(temp(LIS_rc%ntiles(n)))
 
-    if(LIS_rc%useroughnessmap(n).ne."none") then 
+    if(LIS_rc%useroughnessmap(n).ne."none") then
        temp = LIS_rc%udef
        do t=1,LIS_rc%ntiles(n)
-          if(LIS_domain(n)%tile(t)%index.ne.-1) then 
+          if(LIS_domain(n)%tile(t)%index.ne.-1) then
              temp(t) = LIS_roughness(n)%roughness(t)
           endif
           call LIS_diagnoseSurfaceOutputVar(n,t,LIS_MOC_ROUGHNESS,vlevel=1,&
-                                           value=temp(t),unit="m",direction="-")
-       enddo       
+               value=temp(t),unit="m", &
+               direction="-")
+       enddo
     endif
     deallocate(temp)
     TRACE_EXIT("rough_diag")
@@ -1296,10 +1311,10 @@ contains
   end subroutine LIS_diagnoseroughness
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_roughness_reset
 ! \label{LIS_roughness_reset}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_roughness_reset
 ! !USES:
@@ -1308,19 +1323,19 @@ contains
     use LIS_timeMgrMod, only : LIS_computeTemporalWeights
 ! !DESCRIPTION:
 !
-! Resets the data structures for reading 
-! the roughness fraction datasets 
-! 
-!  The routines invoked are: 
+! Resets the data structures for reading
+! the roughness fraction datasets
+!
+!  The routines invoked are:
 !  \begin{description}
 !   \item[roughnesssetup](\ref{roughnesssetup}) \newline
-!    calls the registry to invoke the roughness data reading methods. 
+!    calls the registry to invoke the roughness data reading methods.
 !  \end{description}
 !
 !EOP
     implicit none
     integer   :: n
-    integer   :: ndoms 
+    integer   :: ndoms
     integer   :: rc
     integer :: i
     real :: wt1, wt2
@@ -1329,14 +1344,14 @@ contains
     integer       :: t1, t2
 
     TRACE_ENTER("rough_reset")
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
-       if(LIS_rc%useroughnessmap(n).ne."none") then 
+       if(LIS_rc%useroughnessmap(n).ne."none") then
           ndoms = ndoms+1
        endif
     enddo
-    
-    if(ndoms.gt.0) then 
+
+    if(ndoms.gt.0) then
 
        do n=1,LIS_rc%nnest
 
@@ -1344,12 +1359,12 @@ contains
           LIS_roughness(n)%z0v2 = 0.0
           LIS_roughness(n)%roughness = 0.0
 
-          if(LIS_rc%useroughnessmap(n).ne."LDT") then 
+          if(LIS_rc%useroughnessmap(n).ne."LDT") then
              call roughnesssetup(trim(LIS_rc%useroughnessmap(n))//char(0),n)
           else
  !            LIS_roughness(n)%roughnessIntervalType = "monthly"
           endif
-                   
+
           !Read the data for the first time
           call LIS_computeTemporalWeights(LIS_rc,&
                LIS_roughness(n)%roughnessIntervalType, &
@@ -1357,17 +1372,20 @@ contains
 
           allocate(value1(LIS_rc%ntiles(n)))
           allocate(value2(LIS_rc%ntiles(n)))
-          
-          if(LIS_rc%useroughnessmap(n).eq."LDT") then 
+
+          if(LIS_rc%useroughnessmap(n).eq."LDT") then
              call read_roughnessclimo(n,t1,value1)
              call read_roughnessclimo(n,t2,value2)
           else
-             call readroughness(trim(LIS_rc%useroughnessmap(n))//char(0),&
-                  n,t1,value1)
-             call readroughness(trim(LIS_rc%useroughnessmap(n))//char(0),&
-                  n,t2,value2)
+             !EMK Fixed argument list
+             !call readroughness(trim(LIS_rc%useroughnessmap(n))//char(0),&
+             !     n,t1,value1)
+             !call readroughness(trim(LIS_rc%useroughnessmap(n))//char(0),&
+             !     n,t2,value2)
+             call readroughness(trim(LIS_rc%useroughnessmap(n))//char(0), &
+                  n, wt1, wt2, value1, value2)
           endif
-          
+
           do i=1,LIS_rc%ntiles(n)
              LIS_roughness(n)%z0v1(i) = value1(i)
              LIS_roughness(n)%z0v2(i) = value2(i)
@@ -1402,22 +1420,22 @@ contains
          LIS_nss_halo_ind, LIS_nse_halo_ind
     use LIS_logMod,         only : LIS_logunit, LIS_getNextUnitNumber, &
          LIS_releaseUnitNumber, LIS_endrun, LIS_verify
-    
+
     implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
     integer, intent(in)         :: n
     integer, intent(in)         :: time
-    real, intent(inout)         :: array(LIS_rc%ntiles(n))    
+    real, intent(inout)         :: array(LIS_rc%ntiles(n))
 ! !DESCRIPTION:
 !  This subroutine reads the greenness data climatology
-!  
+!
 !  The arguments are:
 !  \begin{description}
 !   \item[n]
 !    index of n
 !   \end{description}
 !
-!EOP      
+!EOP
 
     integer :: ios1
     integer :: ios,nid,roughnessid,ncId, nrId,mid
@@ -1426,12 +1444,12 @@ contains
     real, allocatable :: roughness(:,:,:)
     real    :: localroughness(LIS_rc%lnc(n),LIS_rc%lnr(n))
     logical :: file_exists
-    
+
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-    mo = time 
+    mo = time
 
     inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-    if(file_exists) then 
+    if(file_exists) then
 
        write(LIS_logunit,*)'[INFO] Reading roughness map for month ', mo, &
             'from ',trim(LIS_rc%paramfile(n))
@@ -1439,38 +1457,41 @@ contains
        ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
             mode=NF90_NOWRITE,ncid=nid)
        call LIS_verify(ios,'Error in nf90_open in read_roughnessclimo')
-       
+
        ios = nf90_inq_dimid(nid,"east_west",ncId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_roughnessclimo')
-       
+
        ios = nf90_inq_dimid(nid,"north_south",nrId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_roughnessclimo')
 
        ios = nf90_inq_dimid(nid,"month",mId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_roughnessclimo')
-       
+
        ios = nf90_inquire_dimension(nid,ncId, len=nc)
-       call LIS_verify(ios,'Error in nf90_inquire_dimension in read_roughnessclimo')
-       
+       call LIS_verify(ios, &
+            'Error in nf90_inquire_dimension in read_roughnessclimo')
+
        ios = nf90_inquire_dimension(nid,nrId, len=nr)
-       call LIS_verify(ios,'Error in nf90_inquire_dimension in read_roughnessclimo')
+       call LIS_verify(ios, &
+            'Error in nf90_inquire_dimension in read_roughnessclimo')
 
        ios = nf90_inquire_dimension(nid,mId, len=months)
-       call LIS_verify(ios,'Error in nf90_inquire_dimension in read_roughnessclimo')
-              
+       call LIS_verify(ios, &
+            'Error in nf90_inquire_dimension in read_roughnessclimo')
+
        allocate(roughness(LIS_rc%gnc(n),LIS_rc%gnr(n),months))
 
        ios = nf90_inq_varid(nid,'ROUGHNESS',roughnessid)
        call LIS_verify(ios,'ROUGHNESS field not found in the LIS param file')
-       
+
        ios = nf90_get_var(nid,roughnessid,roughness)
        call LIS_verify(ios,'Error in nf90_get_var in read_roughnessclimo')
-       
+
        ios = nf90_close(nid)
        call LIS_verify(ios,'Error in nf90_close in read_roughnessclimo')
-       
+
        localroughness(:,:) = &
-            roughness(LIS_ews_halo_ind(n,LIS_localPet+1):&         
+            roughness(LIS_ews_halo_ind(n,LIS_localPet+1):&
             LIS_ewe_halo_ind(n,LIS_localPet+1), &
             LIS_nss_halo_ind(n,LIS_localPet+1): &
             LIS_nse_halo_ind(n,LIS_localPet+1),mo)
@@ -1482,19 +1503,20 @@ contains
                LIS_domain(n)%tile(t)%row)
        enddo
     else
-       write(LIS_logunit,*) '[ERR] roughness map: ',LIS_rc%paramfile(n), ' does not exist'
+       write(LIS_logunit,*) '[ERR] roughness map: ',LIS_rc%paramfile(n), &
+            ' does not exist'
        write(LIS_logunit,*) '[ERR] program stopping ...'
        call LIS_endrun
     endif
 #endif
   end subroutine read_roughnessclimo
 
-#if 0 
+#if 0
 !BOP
-! 
+!
 ! !ROUTINE: LIS_lai_setup
 ! \label{LIS_lai_setup_old}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_lai_setup
 ! !USES:
@@ -1505,14 +1527,15 @@ contains
 
 ! !DESCRIPTION:
 !
-! Allocates memory and other structures for reading 
+! Allocates memory and other structures for reading
 ! LAI datasets
-! 
-!  The routines invoked are: 
+!
+!  The routines invoked are:
 !  \begin{description}
 !   \item[LIS\_registerAlarm](\ref{LIS_registerAlarm}) \newline
 !    registers the alarm for reading LAI datasets
-!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights}) \newline
+!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights})
+!     \newline
 !    computes the interpolation weights
 !   \item[read\_laiclimo](\ref{read_laiclimo}) \newline
 !    reads the climatological lai data
@@ -1521,8 +1544,8 @@ contains
 !   \item[readlai](\ref{readlai}) \newline
 !    reads the realtime lai data
 !  \end{description}
-!EOP    
-    implicit none    
+!EOP
+    implicit none
     integer :: n, i
     integer :: rc
     integer :: ndoms
@@ -1536,18 +1559,18 @@ contains
     integer :: status
 
     TRACE_ENTER("lai_setup")
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
-       if(LIS_rc%uselaimap(n).ne."none") then 
+       if(LIS_rc%uselaimap(n).ne."none") then
           ndoms = ndoms+1
        endif
     enddo
-    
+
     if(ndoms.gt.0) then !at least one nest requires lai to be supplied
        allocate(LIS_lai(LIS_rc%nnest))
-                 
+
        do n=1,LIS_rc%nnest
-          LIS_lai(n)%firstInstance = .true. 
+          LIS_lai(n)%firstInstance = .true.
        enddo
        !initialize variables/alarms
        do n=1,LIS_rc%nnest
@@ -1558,32 +1581,32 @@ contains
           LIS_lai(n)%lai1 = 0
           LIS_lai(n)%lai2 = 0
           LIS_lai(n)%tlai = 0
-          
+
           !set alarms
           select case (LIS_rc%uselaimap(n))
           case ("LDT")
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-             
+
              inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-             if(file_exists) then 
-                
+             if(file_exists) then
+
                 ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
                      mode=NF90_NOWRITE,ncid=nid)
                 call LIS_verify(ios,'Error in nf90_open in read_laiclimo')
-                
+
                 ios = nf90_get_att(nid, NF90_GLOBAL, 'LAISAI_DATA_INTERVAL', &
                      LIS_lai(n)%laiIntervalType)
-                call LIS_verify(ios,'Error in nf90_get_att in read_laiclimo')       
-                
+                call LIS_verify(ios,'Error in nf90_get_att in read_laiclimo')
                 ios = nf90_close(nid)
                 call LIS_verify(ios,'Error in nf90_close in read_laiclimo')
              else
-                write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), ' does not exist'
+                write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), &
+                     ' does not exist'
                 write(LIS_logunit,*) '[ERR] program stopping ...'
                 call LIS_endrun
              endif
 #endif
-             if(LIS_lai(n)%laiIntervalType.eq."monthly") then 
+             if(LIS_lai(n)%laiIntervalType.eq."monthly") then
                 LIS_lai(n)%laiInterval = 2592000  ! 30 days
              endif
 
@@ -1603,22 +1626,26 @@ contains
              enddo
              deallocate(value1)
              deallocate(value2)
-             
 
           case default ! is some kind of real-time
 !             !presume for now that files no more frequent than daily
-!             call LIS_registerAlarm("LIS LAI real-time read alarm", LIS_rc%ts, &
+!             call LIS_registerAlarm("LIS LAI real-time read alarm", &
+!                  LIS_rc%ts, &
 !                  86400)
              call laisetup(trim(LIS_rc%uselaimap(n))//char(0),n)
 
-             call readlai(trim(LIS_rc%uselaimap(n))//char(0),n,&
-                  wt1,wt2,LIS_lai(n)%lai1,LIS_lai(n)%time1)
+             ! EMK Fixed argument list.
+             !call readlai(trim(LIS_rc%uselaimap(n))//char(0), n,&
+             !     wt1, wt2, LIS_lai(n)%lai1, LIS_lai(n)%time1)
+             call readlai(trim(LIS_rc%uselaimap(n))//char(0), n,&
+                  wt1, wt2, LIS_lai(n)%lai1, LIS_lai(n)%lai2)
+
           end select
           do i=1,LIS_rc%ntiles(n)
              LIS_lai(n)%tlai(i)=wt1*LIS_lai(n)%lai1(i)+wt2*LIS_lai(n)%lai2(i)
           enddo
        end do
-#if 0 
+#if 0
 !read in initial values
        do n=1,LIS_rc%nnest
           select case (LIS_rc%uselaimap(n))
@@ -1636,7 +1663,7 @@ contains
              enddo
              deallocate(value1)
              deallocate(value2)
-             
+
              do i=1,LIS_rc%ntiles(n)
                 LIS_lai(n)%tlai(i) = wt1* LIS_lai(n)%lai1(i)+ &
                      wt2*LIS_lai(n)%lai2(i)
@@ -1651,7 +1678,7 @@ contains
              forward_search=.true.
              call readlai(trim(LIS_rc%uselaimap(n))//char(0),n,&
                   forward_search,LIS_lai(n)%lai2,LIS_lai(n)%time2)
- 
+
              call ESMF_TimeSet(time, yy=LIS_rc%yr, &
                   mm=LIS_rc%mo, &
                   dd=LIS_rc%da, &
@@ -1662,24 +1689,25 @@ contains
                   rc = status)
              deltaT=time-LIS_lai(n)%time1
              deltaTinterval=LIS_lai(n)%time2-LIS_lai(n)%time1
-             
+
              call ESMF_TimeIntervalGet(deltaT, s=t_delta)
              call ESMF_TimeIntervalGet(deltaTinterval, s=t_delta_interval)
-             
+
              !get current values from linear interpolation
              wt1=real(t_delta_interval-t_delta)/real(t_delta_interval)
              wt2=real(t_delta)/real(t_delta_interval)
              do i=1,LIS_rc%ntiles(n)
-                LIS_lai(n)%tlai(i)=wt1*LIS_lai(n)%lai1(i)+wt2*LIS_lai(n)%lai2(i)
+                LIS_lai(n)%tlai(i)= &
+                     wt1*LIS_lai(n)%lai1(i)+wt2*LIS_lai(n)%lai2(i)
              enddo
-             
+
              if (time >= LIS_lai(n)%time2) then
                 LIS_lai(n)%lai1=LIS_lai(n)%lai2
                 LIS_lai(n)%time1=LIS_lai(n)%time2
-                
+
                 forward_search=.true.
                 call readlai(trim(LIS_rc%uselaimap(n))//char(0),n,&
-                     forward_search,LIS_lai(n)%lai2,LIS_lai(n)%time2) 
+                     forward_search,LIS_lai(n)%lai2,LIS_lai(n)%time2)
              end if
           end select
        enddo
@@ -1689,36 +1717,37 @@ contains
   end subroutine LIS_lai_setup
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_read_lai
 ! \label{LIS_read_lai_old}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_read_lai(n)
-! !USES:    
+! !USES:
     use LIS_coreMod,    only : LIS_rc, LIS_domain
-    use LIS_timeMgrMod, only : LIS_isAlarmRinging,LIS_computeTemporalWeights, LIS_calendar
+    use LIS_timeMgrMod, only : LIS_isAlarmRinging,LIS_computeTemporalWeights, &
+         LIS_calendar
     use LIS_logMod,     only : LIS_verify, LIS_logunit
 
     implicit none
 ! !ARGUMENTS:
     integer, intent(in) :: n
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !
-!  Reads the LAI climatology and temporally interpolates it to the 
-!  current day. 
-! 
-!  The arguments are: 
+!  Reads the LAI climatology and temporally interpolates it to the
+!  current day.
+!
+!  The arguments are:
 !  \begin{description}
 !   \item [n]
 !     index of the domain or nest.
 !  \end{description}
 !
-!  The routines invoked are: 
+!  The routines invoked are:
 !  \begin{description}
 !   \item[readlai](\ref{readlai}) \newline
-!    invokes the generic method in the registry to read the 
+!    invokes the generic method in the registry to read the
 !    LAI climatology data
 !  \end{description}
 !
@@ -1747,14 +1776,14 @@ contains
 
        call LIS_computeTemporalWeights(LIS_rc,&
             LIS_lai(n)%laiIntervalType, t1,t2,wt1,wt2)
-          
-       if(laiAlarmCheckclimo) then 
+
+       if(laiAlarmCheckclimo) then
           allocate(value1(LIS_rc%ntiles(n)))
           allocate(value2(LIS_rc%ntiles(n)))
-          
+
           call read_LAIclimo(n,t1,value1)
           call read_LAIclimo(n,t2,value2)
-          
+
           do i=1,LIS_rc%ntiles(n)
              LIS_lai(n)%lai1(i) = value1(i)
              LIS_lai(n)%lai2(i) = value2(i)
@@ -1768,15 +1797,15 @@ contains
                wt2*LIS_lai(n)%lai2(i)
        end do
     case default ! is some kind of real-time
-       call readlai(trim(LIS_rc%uselaimap(n))//char(0),n,&
-            wt1,wt2,LIS_lai(n)%lai1,LIS_lai(n)%lai2) 
+       call readlai(trim(LIS_rc%uselaimap(n))//char(0), n, &
+            wt1, wt2, LIS_lai(n)%lai1, LIS_lai(n)%lai2)
        do i=1,LIS_rc%ntiles(n)
           LIS_lai(n)%tlai(i) = wt1* LIS_lai(n)%lai1(i)+ &
                wt2*LIS_lai(n)%lai2(i)
        enddo
     end select
 
-#if 0 
+#if 0
           call ESMF_TimeSet(time, yy=LIS_rc%yr, &
                mm=LIS_rc%mo, &
                dd=LIS_rc%da, &
@@ -1804,7 +1833,7 @@ contains
 
              forward_search=.true.
              call readlai(trim(LIS_rc%uselaimap(n))//char(0),n,&
-                  forward_search,LIS_lai(n)%lai2,LIS_lai(n)%time2) 
+                  forward_search,LIS_lai(n)%lai2,LIS_lai(n)%time2)
           end if
 #endif
 !       endif
@@ -1815,10 +1844,10 @@ contains
 #endif
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_lai_setup
 ! \label{LIS_lai_setup}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_lai_setup
 ! !USES:
@@ -1829,44 +1858,45 @@ contains
 
 ! !DESCRIPTION:
 !
-! Allocates memory and other structures for reading 
+! Allocates memory and other structures for reading
 ! LAI datasets
-! 
-!  The routines invoked are: 
+!
+!  The routines invoked are:
 !  \begin{description}
 !   \item[laisetup](\ref{laisetup}) \newline
 !    initializes the realtime lai reader
 !   \item[LIS\_registerAlarm](\ref{LIS_registerAlarm}) \newline
 !    registers the alarm for reading LAI datasets
-!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights}) \newline
+!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights})
+!      \newline
 !    computes the interpolation weights
 !   \item[read\_LAIclimo](\ref{read_laiclimo}) \newline
 !    reads the climatological lai data
 !   \item[readlai](\ref{readlai}) \newline
 !    reads the realtime lai data
 !  \end{description}
-!EOP    
-    implicit none    
+!EOP
+    implicit none
     integer :: n, i
     integer :: rc
     integer :: ndoms
     real, allocatable :: value1(:) ! temporary value holder for mo1
     real, allocatable :: value2(:) ! temporary value holder for mo2
     real          :: wt1,wt2
-    integer       :: t1,t2    
-    
+    integer       :: t1,t2
+
     TRACE_ENTER("lai_setup")
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
-       if(LIS_rc%uselaimap(n).ne."none") then 
+       if(LIS_rc%uselaimap(n).ne."none") then
           ndoms = ndoms+1
        endif
     enddo
-    
+
     if(ndoms.gt.0) then
-       allocate(LIS_lai(LIS_rc%nnest))      
+       allocate(LIS_lai(LIS_rc%nnest))
        do n=1,LIS_rc%nnest
-          LIS_lai(n)%firstInstance = .true. 
+          LIS_lai(n)%firstInstance = .true.
        enddo
 
        do n=1,LIS_rc%nnest
@@ -1878,22 +1908,21 @@ contains
           LIS_lai(n)%tlai = 0
 
           if(LIS_rc%uselaimap(n).ne."none".and.&
-               LIS_rc%uselaimap(n).ne."LDT") then 
+               LIS_rc%uselaimap(n).ne."LDT") then
              call laisetup(trim(LIS_rc%uselaimap(n))//char(0),n)
           else
              LIS_lai(n)%laiInterval = 2592000
              LIS_lai(n)%laiIntervalType = "monthly"
           endif
-          
+
           call LIS_registerAlarm("LIS LAI read alarm",&
                LIS_rc%ts, LIS_lai(n)%laiInterval, &
                intervalType = LIS_lai(n)%laiIntervalType)
 
           call LIS_computeTemporalWeights(LIS_rc,&
                LIS_lai(n)%laiIntervalType, t1,t2,wt1,wt2)
-          
-          
-          if(LIS_rc%uselaimap(n).eq."LDT") then 
+
+          if(LIS_rc%uselaimap(n).eq."LDT") then
              allocate(value1(LIS_rc%ntiles(n)))
              allocate(value2(LIS_rc%ntiles(n)))
 
@@ -1906,17 +1935,16 @@ contains
              enddo
              deallocate(value1)
              deallocate(value2)
-             
+
           else
-             call readlai(trim(LIS_rc%uselaimap(n))//char(0),n,&
-                  wt1,wt2,LIS_lai(n)%lai1,LIS_lai(n)%lai2)
+             call readlai(trim(LIS_rc%uselaimap(n))//char(0), n, &
+                  wt1, wt2, LIS_lai(n)%lai1, LIS_lai(n)%lai2)
           endif
 
-          
           do i=1,LIS_rc%ntiles(n)
              LIS_lai(n)%tlai(i) = wt1* LIS_lai(n)%lai1(i)+ &
                   wt2*LIS_lai(n)%lai2(i)
-#if 0 
+#if 0
 !SVK : Should be cleaned up -- hardcoding checks for LSM is not clean
 !  YDT: 10/18/2011 added a check for minimal lai values
 !    Otherwise noah will crash in CANRES()
@@ -1925,12 +1953,12 @@ contains
 !  YDT: 10/20/2011 more "elegant" solution: compute greenness from lai if lai is MODIS-RT (src=3).
              if ( LIS_rc%uselaimap(n) .eq. "MODIS" ) then !??
                 LIS_gfrac(n)%greenness(i) = 1.0 - exp(-0.52 * LIS_lai(n)%tlai(i) )
-                ! for Urban LC, Noah will assign gfrac=0.05. So need to set a min lai to not crash 
+                ! for Urban LC, Noah will assign gfrac=0.05. So need to set a min lai to not crash
                 ! CNARES()
                 if (LIS_domain(n)%tile(i)%vegt .eq. LIS_rc%urbanclass .and. LIS_rc%lsm .eq. "NOAH32" ) &
                    LIS_lai(n)%tlai(i) = max(LIS_lai(n)%tlai(i), 0.1)
              end if
-#endif             
+#endif
           end do
        enddo
     endif
@@ -1939,13 +1967,13 @@ contains
   end subroutine LIS_lai_setup
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_read_lai
 ! \label{LIS_read_lai}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_read_lai(n)
-! !USES:    
+! !USES:
     use LIS_coreMod,    only : LIS_rc, LIS_domain
     use LIS_timeMgrMod, only : LIS_isAlarmRinging,LIS_computeTemporalWeights
     use LIS_logMod,     only : LIS_verify, LIS_logunit
@@ -1954,21 +1982,21 @@ contains
 ! !ARGUMENTS:
     integer, intent(in) :: n
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !
-!  Reads the LAI climatology and temporally interpolates it to the 
-!  current day. 
-! 
-!  The arguments are: 
+!  Reads the LAI climatology and temporally interpolates it to the
+!  current day.
+!
+!  The arguments are:
 !  \begin{description}
 !   \item [n]
 !     index of the domain or nest.
 !  \end{description}
 !
-!  The routines invoked are: 
+!  The routines invoked are:
 !  \begin{description}
 !   \item[readlai](\ref{readlai}) \newline
-!    invokes the generic method in the registry to read the 
+!    invokes the generic method in the registry to read the
 !    LAI climatology data
 !  \end{description}
 !
@@ -1981,16 +2009,16 @@ contains
     logical           :: laiAlarmCheck
 
     TRACE_ENTER("lai_read")
-    if(LIS_rc%uselaimap(n).ne."none") then 
+    if(LIS_rc%uselaimap(n).ne."none") then
        laiAlarmCheck = LIS_isAlarmRinging(LIS_rc,&
             "LIS LAI read alarm",&
             LIS_lai(n)%laiIntervalType)
        call LIS_computeTemporalWeights(LIS_rc,&
             LIS_lai(n)%laiIntervalType, t1,t2,wt1,wt2)
 
-       if(laiAlarmCheck) then 
+       if(laiAlarmCheck) then
 
-          if(LIS_rc%uselaimap(n).eq."LDT") then 
+          if(LIS_rc%uselaimap(n).eq."LDT") then
              allocate(value1(LIS_rc%ntiles(n)))
              allocate(value2(LIS_rc%ntiles(n)))
 
@@ -2003,10 +2031,9 @@ contains
              enddo
              deallocate(value1)
              deallocate(value2)
-             
           else
-             call readlai(trim(LIS_rc%uselaimap(n))//char(0),n,&
-                  wt1,wt2,LIS_lai(n)%lai1,LIS_lai(n)%lai2)
+             call readlai(trim(LIS_rc%uselaimap(n))//char(0), n, &
+                  wt1, wt2, LIS_lai(n)%lai1, LIS_lai(n)%lai2)
           endif
 
 
@@ -2014,7 +2041,7 @@ contains
        do i=1,LIS_rc%ntiles(n)
           LIS_lai(n)%tlai(i) = wt1* LIS_lai(n)%lai1(i)+ &
                wt2*LIS_lai(n)%lai2(i)
-#if 0 
+#if 0
 !  YDT: 10/18/2011 added a check for minimal lai values
 !    Otherwise noah will crash in CANRES()
 !             if ( LIS_rc%gfracsrc(n) .gt. 0 .and. LIS_gfrac(n)%greenness(i) .gt. 0) &
@@ -2034,33 +2061,33 @@ contains
   end subroutine LIS_read_lai
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_lai_finalize
 ! \label{LIS_lai_finalize}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_lai_finalize
-! !USES: 
+! !USES:
     use LIS_coreMod, only : LIS_rc
-! 
+!
 ! !DESCRIPTION:
 !
 ! Deallocates objects created in this module
 !
 !EOP
     implicit none
-    
+
     integer :: n
     integer :: ndoms
-    
-    ndoms = 0 
+
+    ndoms = 0
     do n=1,LIS_rc%nnest
-       if(LIS_rc%uselaimap(n).ne."none") then 
+       if(LIS_rc%uselaimap(n).ne."none") then
           ndoms = ndoms+1
        endif
     enddo
 
-    if(ndoms.gt.0) then 
+    if(ndoms.gt.0) then
        do n=1,LIS_rc%nnest
           deallocate(LIS_lai(n)%lai1)
           deallocate(LIS_lai(n)%lai2)
@@ -2072,33 +2099,34 @@ contains
   end subroutine LIS_lai_finalize
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_diagnoseLAI
 ! \label{LIS_diagnoseLAI}
-! 
-! !INTERFACE: 
+!
+! !INTERFACE:
   subroutine LIS_diagnoseLAI(n)
-! !USES: 
+! !USES:
     use LIS_coreMod,    only : LIS_rc, LIS_domain
     use LIS_histDataMod, only : LIS_diagnoseSurfaceOutputVar, LIS_MOC_LAI
 
 ! !ARGUMENTS:
     implicit none
-    integer, intent(in)   :: n 
+    integer, intent(in)   :: n
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine writes the LIS LAI to the parameter
-!  output file. 
-! 
-!  The arguments are: 
+!  output file.
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[n] index of the nest \newline
 !  \item[ftn] file unit number to be used \newline
 !  \end{description}
-! 
-!  The routines called are: 
+!
+!  The routines called are:
 !  \begin{description}
-!  \item[LIS\_diagnoseOutputVar] (\ref{LIS_diagnoseSurfaceOutputVar})  \newline
+!  \item[LIS\_diagnoseOutputVar] (\ref{LIS_diagnoseSurfaceOutputVar})
+!     \newline
 !   This routine maps a variable to the history writing routines
 !  \end{description}
 !EOP
@@ -2106,24 +2134,25 @@ contains
     integer :: t
 
     TRACE_ENTER("lai_diag")
-    if(LIS_rc%uselaimap(n).ne."none") then 
+    if(LIS_rc%uselaimap(n).ne."none") then
        temp = LIS_rc%udef
        do t=1,LIS_rc%ntiles(n)
-          if(LIS_domain(n)%tile(t)%index.ne.-1) then 
+          if(LIS_domain(n)%tile(t)%index.ne.-1) then
              temp(t) = LIS_lai(n)%tlai(t)
           endif
           call LIS_diagnoseSurfaceOutputVar(n,t,LIS_MOC_LAI, vlevel=1,&
-                                           value=temp(t),unit="-",direction="-")
+               value=temp(t),unit="-", &
+               direction="-")
        enddo
     endif
     TRACE_EXIT("lai_diag")
   end subroutine LIS_diagnoseLAI
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_lai_reset
 ! \label{LIS_lai_reset}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_lai_reset
 ! !USES:
@@ -2133,24 +2162,25 @@ contains
     use LIS_logMod,     only : LIS_verify, LIS_logunit
 ! !DESCRIPTION:
 !
-! Resets data structures for reading 
+! Resets data structures for reading
 ! LAI datasets
-! 
-!  The routines invoked are: 
+!
+!  The routines invoked are:
 !  \begin{description}
 !   \item[laisetup](\ref{laisetup}) \newline
 !    initializes the realtime lai reader
 !   \item[LIS\_registerAlarm](\ref{LIS_registerAlarm}) \newline
 !    registers the alarm for reading LAI datasets
-!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights}) \newline
+!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights})
+!      \newline
 !    computes the interpolation weights
 !   \item[read\_LAIclimo](\ref{read_laiclimo}) \newline
 !    reads the climatological lai data
 !   \item[readlai](\ref{readlai}) \newline
 !    reads the realtime lai data
 !  \end{description}
-!EOP    
-    implicit none    
+!EOP
+    implicit none
     integer :: n, i
     integer :: rc,ios,nid
     logical :: file_exists
@@ -2165,66 +2195,69 @@ contains
     integer :: status
 
     TRACE_ENTER("lai_reset")
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
-       if(LIS_rc%uselaimap(n).ne."none") then 
+       if(LIS_rc%uselaimap(n).ne."none") then
           ndoms = ndoms+1
        endif
     enddo
-    
+
     if(ndoms.gt.0) then
-       
+
        do n=1,LIS_rc%nnest
 
           LIS_lai(n)%lai1 = 0
           LIS_lai(n)%lai2 = 0
           LIS_lai(n)%tlai = 0
 
-          if(LIS_rc%uselaimap(n).ne."LDT") then 
+          if(LIS_rc%uselaimap(n).ne."LDT") then
              call laisetup(trim(LIS_rc%uselaimap(n))//char(0),n)
           else
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-             
+
              inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-             if(file_exists) then 
-                
+             if(file_exists) then
+
                 ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
                      mode=NF90_NOWRITE,ncid=nid)
                 call LIS_verify(ios,'Error in nf90_open in read_laiclimo')
-                
+
                 ios = nf90_get_att(nid, NF90_GLOBAL, 'LAISAI_DATA_INTERVAL', &
                      LIS_lai(n)%laiIntervalType)
-                call LIS_verify(ios,'Error in nf90_get_att in read_laiclimo')       
-                
+                call LIS_verify(ios,'Error in nf90_get_att in read_laiclimo')
                 ios = nf90_close(nid)
                 call LIS_verify(ios,'Error in nf90_close in read_laiclimo')
              else
-                write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), ' does not exist'
+                write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), &
+                     ' does not exist'
                 write(LIS_logunit,*) '[ERR] program stopping ...'
                 call LIS_endrun
              endif
 #endif
-             if(LIS_lai(n)%laiIntervalType.eq."monthly") then 
+             if(LIS_lai(n)%laiIntervalType.eq."monthly") then
                 LIS_lai(n)%laiInterval = 2592000  ! 30 days
              endif
           endif
-          
+
           call LIS_registerAlarm("LIS LAI read alarm",&
                LIS_rc%ts, LIS_lai(n)%laiInterval, &
                intervalType = LIS_lai(n)%laiIntervalType)
 
           call LIS_computeTemporalWeights(LIS_rc,&
                LIS_lai(n)%laiIntervalType, t1,t2,wt1,wt2)
-          
+
           allocate(value1(LIS_rc%ntiles(n)))
           allocate(value2(LIS_rc%ntiles(n)))
-          
+
           if(LIS_rc%uselaimap(n).eq."LDT") then
              call read_LAIclimo(n,t1,value1)
              call read_LAIclimo(n,t2,value2)
           else
-             call readlai(trim(LIS_rc%uselaimap(n))//char(0),n,t1,value1)
-             call readlai(trim(LIS_rc%uselaimap(n))//char(0),n,t2,value2)
+             !EMK Corrected function call.
+             !call readlai(trim(LIS_rc%uselaimap(n))//char(0),n,t1,value1)
+             !call readlai(trim(LIS_rc%uselaimap(n))//char(0),n,t2,value2)
+             call readlai(trim(LIS_rc%uselaimap(n))//char(0), &
+                  n, wt1, wt2, value1, value2)
           endif
 
           do i=1,LIS_rc%ntiles(n)
@@ -2233,7 +2266,7 @@ contains
           enddo
           deallocate(value1)
           deallocate(value2)
-          
+
           do i=1,LIS_rc%ntiles(n)
              LIS_lai(n)%tlai(i) = wt1* LIS_lai(n)%lai1(i)+ &
                   wt2*LIS_lai(n)%lai2(i)
@@ -2244,10 +2277,10 @@ contains
   end subroutine LIS_lai_reset
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_sai_setup
 ! \label{LIS_sai_setup}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_sai_setup
 ! !USES:
@@ -2257,24 +2290,25 @@ contains
     use LIS_logMod,     only : LIS_verify
 ! !DESCRIPTION:
 !
-! Allocates memory and other structures for reading 
+! Allocates memory and other structures for reading
 ! SAI datasets
-! 
-!  The routines invoked are: 
+!
+!  The routines invoked are:
 !  \begin{description}
 !   \item[saisetup](\ref{saisetup}) \newline
 !    initializes the realtime sai reader
 !   \item[LIS\_registerAlarm](\ref{LIS_registerAlarm}) \newline
 !    registers the alarm for reading SAI datasets
-!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights}) \newline
+!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights})
+!      \newline
 !    computes the interpolation weights
 !   \item[read\_saiclimo](\ref{read_saiclimo}) \newline
 !    reads the climatological sai data
 !   \item[readsai](\ref{readsai}) \newline
 !    reads the realtime sai data
 !  \end{description}
-!EOP    
-    implicit none    
+!EOP
+    implicit none
     integer :: n, i
     integer :: rc,ios,nid
     logical :: file_exists
@@ -2285,13 +2319,13 @@ contains
     integer           :: t1,t2
 
     TRACE_ENTER("sai_setup")
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
-       if(LIS_rc%usesaimap(n).ne."none") then 
+       if(LIS_rc%usesaimap(n).ne."none") then
           ndoms = ndoms+1
        endif
     enddo
-    
+
     if(ndoms.gt.0) then
        allocate(LIS_sai(LIS_rc%nnest))
 
@@ -2303,46 +2337,47 @@ contains
           LIS_sai(n)%sai2 = 0
           LIS_sai(n)%tsai = 0
 
-          if(LIS_rc%usesaimap(n).ne."LDT") then 
+          if(LIS_rc%usesaimap(n).ne."LDT") then
              call saisetup(trim(LIS_rc%usesaimap(n))//char(0),n)
           else
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-             
+
              inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-             if(file_exists) then 
-                
+             if(file_exists) then
+
                 ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
                      mode=NF90_NOWRITE,ncid=nid)
                 call LIS_verify(ios,'Error in nf90_open in read_saiclimo')
-                
+
                 ios = nf90_get_att(nid, NF90_GLOBAL, 'LAISAI_DATA_INTERVAL', &
                      LIS_sai(n)%saiIntervalType)
-                call LIS_verify(ios,'Error in nf90_get_att in read_saiclimo')       
-                
+                call LIS_verify(ios,'Error in nf90_get_att in read_saiclimo')
+
                 ios = nf90_close(nid)
                 call LIS_verify(ios,'Error in nf90_close in read_saiclimo')
              else
-                write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), ' does not exist'
+                write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), &
+                     ' does not exist'
                 write(LIS_logunit,*) '[ERR] program stopping ...'
                 call LIS_endrun
              endif
 #endif
-             if(LIS_sai(n)%saiIntervalType.eq."monthly") then 
+             if(LIS_sai(n)%saiIntervalType.eq."monthly") then
                 LIS_sai(n)%saiInterval = 2592000  ! 30 days
              endif
           endif
-          
+
           call LIS_registerAlarm("LIS SAI read alarm",&
                LIS_rc%ts, LIS_sai(n)%saiInterval, &
                intervalType = LIS_sai(n)%saiIntervalType)
 
           call LIS_computeTemporalWeights(LIS_rc,&
                LIS_sai(n)%saiIntervalType, t1,t2,wt1,wt2)
-          
+
           allocate(value1(LIS_rc%ntiles(n)))
           allocate(value2(LIS_rc%ntiles(n)))
-          
-          if(LIS_rc%usesaimap(n).eq."LDT") then 
+
+          if(LIS_rc%usesaimap(n).eq."LDT") then
              call read_saiclimo(n,t1,value1)
              call read_saiclimo(n,t2,value2)
           else
@@ -2356,7 +2391,7 @@ contains
           enddo
           deallocate(value1)
           deallocate(value2)
-          
+
           do i=1,LIS_rc%ntiles(n)
              LIS_sai(n)%tsai(i) = wt1* LIS_sai(n)%sai1(i)+ &
                   wt2*LIS_sai(n)%sai2(i)
@@ -2368,13 +2403,13 @@ contains
   end subroutine LIS_sai_setup
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_read_sai
 ! \label{LIS_read_sai}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_read_sai(n)
-! !USES:    
+! !USES:
     use LIS_coreMod,    only : LIS_rc, LIS_domain
     use LIS_timeMgrMod, only : LIS_computeTemporalWeights, &
          LIS_isAlarmRinging
@@ -2385,19 +2420,19 @@ contains
 !
 ! !DESCRIPTION:
 !
-!  Reads the SAI climatology and temporally interpolates it to the 
-!  current day. 
-! 
-!  The arguments are: 
+!  Reads the SAI climatology and temporally interpolates it to the
+!  current day.
+!
+!  The arguments are:
 !  \begin{description}
 !   \item [n]
 !     index of the domain or nest.
 !  \end{description}
 !
-!  The routines invoked are: 
+!  The routines invoked are:
 !  \begin{description}
 !   \item[readsai](\ref{readsai}) \newline
-!    invokes the generic method in the registry to read the 
+!    invokes the generic method in the registry to read the
 !    SAI climatology data
 !  \end{description}
 !
@@ -2410,19 +2445,19 @@ contains
     logical           :: saiAlarmCheck
 
     TRACE_ENTER("sai_read")
-    if(LIS_rc%usesaimap(n).ne."none") then 
+    if(LIS_rc%usesaimap(n).ne."none") then
        saiAlarmCheck = LIS_isAlarmRinging(LIS_rc,&
             "LIS SAI read alarm",&
             LIS_sai(n)%saiIntervalType)
 
        call LIS_computeTemporalWeights(LIS_rc,&
             LIS_sai(n)%saiIntervalType, t1,t2,wt1,wt2)
-       
-       if(saiAlarmCheck) then 
+
+       if(saiAlarmCheck) then
           allocate(value1(LIS_rc%ntiles(n)))
           allocate(value2(LIS_rc%ntiles(n)))
 
-          if(LIS_rc%usesaimap(n).eq."LDT") then 
+          if(LIS_rc%usesaimap(n).eq."LDT") then
              call read_SAIclimo(n,t1,value1)
              call read_SAIclimo(n,t2,value2)
           else
@@ -2447,33 +2482,33 @@ contains
   end subroutine LIS_read_sai
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_sai_finalize
 ! \label{LIS_sai_finalize}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_sai_finalize
-! !USES: 
+! !USES:
     use LIS_coreMod, only : LIS_rc
-! 
+!
 ! !DESCRIPTION:
 !
 ! Deallocates objects created in this module
 !
 !EOP
     implicit none
-    
+
     integer :: n
     integer :: ndoms
 
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
-       if(LIS_rc%usesaimap(n).ne."none") then 
+       if(LIS_rc%usesaimap(n).ne."none") then
           ndoms = ndoms+1
        endif
     enddo
 
-    if(ndoms.gt.0) then 
+    if(ndoms.gt.0) then
        do n=1,LIS_rc%nnest
           deallocate(LIS_sai(n)%sai1)
           deallocate(LIS_sai(n)%sai2)
@@ -2484,58 +2519,60 @@ contains
   end subroutine LIS_sai_finalize
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_diagnoseSAI
 ! \label{LIS_diagnoseSAI}
-! 
-! !INTERFACE: 
+!
+! !INTERFACE:
   subroutine LIS_diagnoseSAI(n)
-! !USES: 
+! !USES:
     use LIS_coreMod,     only : LIS_rc, LIS_domain
     use LIS_histDataMod, only : LIS_diagnoseSurfaceOutputVar, LIS_MOC_SAI
 
 ! !ARGUMENTS:
     implicit none
-    integer, intent(in)   :: n 
+    integer, intent(in)   :: n
 
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This routine diagnoses the LIS SAI to the parameter
-!  output file. 
-! 
-!  The arguments are: 
+!  output file.
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[n] index of the nest \newline
 !  \item[ftn] file unit number to be used \newline
 !  \end{description}
-! 
-!  The routines called are: 
+!
+!  The routines called are:
 !  \begin{description}
-!  \item[LIS\_diagnoseOutputVar] (\ref{LIS_diagnoseSurfaceOutputVar})  \newline
+!  \item[LIS\_diagnoseOutputVar] (\ref{LIS_diagnoseSurfaceOutputVar})
+!     \newline
 !   This routine maps a variable to the history writing routines
 !  \end{description}
 !EOP
     real    :: temp(LIS_rc%ntiles(n))
     integer :: t
     TRACE_ENTER("sai_diag")
-    if(LIS_rc%usesaimap(n).ne."none") then 
+    if(LIS_rc%usesaimap(n).ne."none") then
        temp = LIS_rc%udef
        do t=1,LIS_rc%ntiles(n)
-          if(LIS_domain(n)%tile(t)%index.ne.-1) then 
+          if(LIS_domain(n)%tile(t)%index.ne.-1) then
              temp(t) = LIS_sai(n)%tsai(t)
           endif
           call LIS_diagnoseSurfaceOutputVar(n,t,LIS_MOC_SAI,vlevel=1,&
-                                           value=temp(t),unit="-",direction="-")
+               value=temp(t),unit="-", &
+               direction="-")
        enddo
     endif
     TRACE_EXIT("sai_diag")
 
-  end subroutine LIS_diagnoseSAI    
+  end subroutine LIS_diagnoseSAI
 
 !BOP
-! 
+!
 ! !ROUTINE: LIS_sai_reset
 ! \label{LIS_sai_reset}
-! 
+!
 ! !INTERFACE:
   subroutine LIS_sai_reset
 ! !USES:
@@ -2547,20 +2584,21 @@ contains
 !
 ! resets the structures that hold
 ! SAI datasets
-! 
-!  The routines invoked are: 
+!
+!  The routines invoked are:
 !  \begin{description}
 !   \item[saisetup](\ref{saisetup}) \newline
 !    initializes the realtime sai reader
-!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights}) \newline
+!   \item[LIS\_computeTemporalWeights](\ref{LIS_computeTemporalWeights})
+!     \newline
 !    computes the interpolation weights
 !   \item[read\_saiclimo](\ref{read_saiclimo}) \newline
 !    reads the climatological sai data
 !   \item[readsai](\ref{readsai}) \newline
 !    reads the realtime sai data
 !  \end{description}
-!EOP    
-    implicit none    
+!EOP
+    implicit none
     integer :: n, i
     integer :: rc,ios,nid
     logical :: file_exists
@@ -2571,13 +2609,13 @@ contains
     integer           :: t1,t2
 
     TRACE_ENTER("sai_reset")
-    ndoms = 0 
+    ndoms = 0
     do n=1,LIS_rc%nnest
-       if(LIS_rc%usesaimap(n).ne."none") then 
+       if(LIS_rc%usesaimap(n).ne."none") then
           ndoms = ndoms+1
        endif
     enddo
-    
+
     if(ndoms.gt.0) then
        do n=1,LIS_rc%nnest
 
@@ -2585,31 +2623,32 @@ contains
           LIS_sai(n)%sai2 = 0
           LIS_sai(n)%tsai = 0
 
-          if(LIS_rc%usesaimap(n).ne."LDT") then 
+          if(LIS_rc%usesaimap(n).ne."LDT") then
              call saisetup(trim(LIS_rc%usesaimap(n))//char(0),n)
           else
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-             
+
              inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-             if(file_exists) then 
-                
+             if(file_exists) then
+
                 ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
                      mode=NF90_NOWRITE,ncid=nid)
                 call LIS_verify(ios,'Error in nf90_open in read_saiclimo')
-                
+
                 ios = nf90_get_att(nid, NF90_GLOBAL, 'LAISAI_DATA_INTERVAL', &
                      LIS_sai(n)%saiIntervalType)
-                call LIS_verify(ios,'Error in nf90_get_att in read_saiclimo')       
-                
+                call LIS_verify(ios,'Error in nf90_get_att in read_saiclimo')
+
                 ios = nf90_close(nid)
                 call LIS_verify(ios,'Error in nf90_close in read_saiclimo')
              else
-                write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), ' does not exist'
+                write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), &
+                     ' does not exist'
                 write(LIS_logunit,*) '[ERR] program stopping ...'
                 call LIS_endrun
              endif
 #endif
-             if(LIS_sai(n)%saiIntervalType.eq."monthly") then 
+             if(LIS_sai(n)%saiIntervalType.eq."monthly") then
                 LIS_sai(n)%saiInterval = 2592000  ! 30 days
              endif
 
@@ -2617,11 +2656,11 @@ contains
 
           call LIS_computeTemporalWeights(LIS_rc,&
                LIS_sai(n)%saiIntervalType, t1,t2,wt1,wt2)
-          
+
           allocate(value1(LIS_rc%ntiles(n)))
           allocate(value2(LIS_rc%ntiles(n)))
-          
-          if(LIS_rc%usesaimap(n).eq."LDT") then 
+
+          if(LIS_rc%usesaimap(n).eq."LDT") then
              call read_saiclimo(n,t1,value1)
              call read_saiclimo(n,t2,value2)
           else
@@ -2635,7 +2674,7 @@ contains
           enddo
           deallocate(value1)
           deallocate(value2)
-          
+
           do i=1,LIS_rc%ntiles(n)
              LIS_sai(n)%tsai(i) = wt1* LIS_sai(n)%sai1(i)+ &
                   wt2*LIS_sai(n)%sai2(i)
@@ -2664,22 +2703,22 @@ contains
          LIS_nss_halo_ind, LIS_nse_halo_ind
     use LIS_logMod,         only : LIS_logunit, LIS_getNextUnitNumber, &
          LIS_releaseUnitNumber, LIS_endrun, LIS_verify
-    
+
     implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
     integer, intent(in)         :: n
     integer, intent(in)         :: time
-    real, intent(inout)         :: array(LIS_rc%ntiles(n))    
+    real, intent(inout)         :: array(LIS_rc%ntiles(n))
 ! !DESCRIPTION:
 !  This subroutine reads the lai data climatology
-!  
+!
 !  The arguments are:
 !  \begin{description}
 !   \item[n]
 !    index of n
 !   \end{description}
 !
-!EOP      
+!EOP
 
     integer :: ios1
     integer :: ios,nid,laiid,ncId, nrId,mid
@@ -2688,12 +2727,12 @@ contains
     real, allocatable :: lai(:,:,:)
     real    :: locallai(LIS_rc%lnc(n),LIS_rc%lnr(n))
     logical :: file_exists
-    
+
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-    mo = time 
+    mo = time
 
     inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-    if(file_exists) then 
+    if(file_exists) then
 
        write(LIS_logunit,*)'[INFO] Reading LAI map for month ', mo, &
             'from ',trim(LIS_rc%paramfile(n))
@@ -2701,38 +2740,38 @@ contains
        ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
             mode=NF90_NOWRITE,ncid=nid)
        call LIS_verify(ios,'Error in nf90_open in read_laiclimo')
-       
+
        ios = nf90_inq_dimid(nid,"east_west",ncId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_laiclimo')
-       
+
        ios = nf90_inq_dimid(nid,"north_south",nrId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_laiclimo')
 
        ios = nf90_inq_dimid(nid,"month",mId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_laiclimo')
-       
+
        ios = nf90_inquire_dimension(nid,ncId, len=nc)
        call LIS_verify(ios,'Error in nf90_inquire_dimension in read_laiclimo')
-       
+
        ios = nf90_inquire_dimension(nid,nrId, len=nr)
        call LIS_verify(ios,'Error in nf90_inquire_dimension in read_laiclimo')
 
        ios = nf90_inquire_dimension(nid,mId, len=months)
        call LIS_verify(ios,'Error in nf90_inquire_dimension in read_laiclimo')
-       
+
        allocate(lai(LIS_rc%gnc(n),LIS_rc%gnr(n),months))
 
        ios = nf90_inq_varid(nid,'LAI',laiid)
        call LIS_verify(ios,'LAI field not found in the LIS param file')
-       
+
        ios = nf90_get_var(nid,laiid,lai)
        call LIS_verify(ios,'Error in nf90_get_var in read_laiclimo')
-       
+
        ios = nf90_close(nid)
        call LIS_verify(ios,'Error in nf90_close in read_laiclimo')
-       
+
        locallai(:,:) = &
-            lai(LIS_ews_halo_ind(n,LIS_localPet+1):&         
+            lai(LIS_ews_halo_ind(n,LIS_localPet+1):&
             LIS_ewe_halo_ind(n,LIS_localPet+1), &
             LIS_nss_halo_ind(n,LIS_localPet+1): &
             LIS_nse_halo_ind(n,LIS_localPet+1),mo)
@@ -2744,7 +2783,8 @@ contains
                LIS_domain(n)%tile(t)%row)
        enddo
     else
-       write(LIS_logunit,*) '[ERR] lai map: ',LIS_rc%paramfile(n), ' does not exist'
+       write(LIS_logunit,*) '[ERR] lai map: ',LIS_rc%paramfile(n), &
+            ' does not exist'
        write(LIS_logunit,*) '[ERR] program stopping ...'
        call LIS_endrun
     endif
@@ -2769,22 +2809,22 @@ contains
          LIS_nss_halo_ind, LIS_nse_halo_ind
     use LIS_logMod,         only : LIS_logunit, LIS_getNextUnitNumber, &
          LIS_releaseUnitNumber, LIS_endrun, LIS_verify
-    
+
     implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
     integer, intent(in)         :: n
     integer, intent(in)         :: time
-    real, intent(inout)         :: array(LIS_rc%ntiles(n))    
+    real, intent(inout)         :: array(LIS_rc%ntiles(n))
 ! !DESCRIPTION:
 !  This subroutine reads the greenness data climatology
-!  
+!
 !  The arguments are:
 !  \begin{description}
 !   \item[n]
 !    index of n
 !   \end{description}
 !
-!EOP      
+!EOP
 
     integer :: ios1
     integer :: ios,nid,saiid,ncId, nrId,mid
@@ -2793,12 +2833,12 @@ contains
     real, allocatable :: sai(:,:,:)
     real    :: localsai(LIS_rc%lnc(n),LIS_rc%lnr(n))
     logical :: file_exists
-    
+
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-    mo = time 
+    mo = time
 
     inquire(file=LIS_rc%paramfile(n), exist=file_exists)
-    if(file_exists) then 
+    if(file_exists) then
 
        write(LIS_logunit,*)'[INFO] Reading SAI map for month ', mo, &
             'from ',trim(LIS_rc%paramfile(n))
@@ -2806,38 +2846,38 @@ contains
        ios = nf90_open(path=trim(LIS_rc%paramfile(n)),&
             mode=NF90_NOWRITE,ncid=nid)
        call LIS_verify(ios,'Error in nf90_open in read_saiclimo')
-       
+
        ios = nf90_inq_dimid(nid,"east_west",ncId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_saiclimo')
-       
+
        ios = nf90_inq_dimid(nid,"north_south",nrId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_saiclimo')
 
        ios = nf90_inq_dimid(nid,"month",mId)
        call LIS_verify(ios,'Error in nf90_inq_dimid in read_saiclimo')
-       
+
        ios = nf90_inquire_dimension(nid,ncId, len=nc)
        call LIS_verify(ios,'Error in nf90_inquire_dimension in read_saiclimo')
-       
+
        ios = nf90_inquire_dimension(nid,nrId, len=nr)
        call LIS_verify(ios,'Error in nf90_inquire_dimension in read_saiclimo')
 
        ios = nf90_inquire_dimension(nid,mId, len=months)
        call LIS_verify(ios,'Error in nf90_inquire_dimension in read_saiclimo')
-              
+
        allocate(sai(LIS_rc%gnc(n),LIS_rc%gnr(n),months))
-       
+
        ios = nf90_inq_varid(nid,'SAI',saiid)
        call LIS_verify(ios,'SAI field not found in the LIS param file')
-       
+
        ios = nf90_get_var(nid,saiid,sai)
        call LIS_verify(ios,'Error in nf90_get_var in read_saiclimo')
-       
+
        ios = nf90_close(nid)
        call LIS_verify(ios,'Error in nf90_close in read_saiclimo')
 
        localsai(:,:) = &
-            sai(LIS_ews_halo_ind(n,LIS_localPet+1):&         
+            sai(LIS_ews_halo_ind(n,LIS_localPet+1):&
             LIS_ewe_halo_ind(n,LIS_localPet+1), &
             LIS_nss_halo_ind(n,LIS_localPet+1): &
             LIS_nse_halo_ind(n,LIS_localPet+1),mo)
@@ -2849,7 +2889,8 @@ contains
                LIS_domain(n)%tile(t)%row)
        enddo
     else
-       write(LIS_logunit,*) '[ERR] sai map: ',LIS_rc%paramfile(n), ' does not exist'
+       write(LIS_logunit,*) '[ERR] sai map: ',LIS_rc%paramfile(n), &
+            ' does not exist'
        write(LIS_logunit,*) '[ERR] program stopping ...'
        call LIS_endrun
     endif

--- a/lis/make/default.cfg
+++ b/lis/make/default.cfg
@@ -525,8 +525,10 @@ path: metforcing/mrms
 #
 # {{{
 
+#EMK...MODIS real-time LAI reader is broken.
 [MODIS real-time]
-enabled: True
+#enabled: True
+enabled: False
 macro: PARAM_MODIS_REAL_TIME
 path: params/lai/MODIS_RT
 

--- a/lis/make/default.cfg
+++ b/lis/make/default.cfg
@@ -527,7 +527,6 @@ path: metforcing/mrms
 
 #EMK...MODIS real-time LAI reader is broken.
 [MODIS real-time]
-#enabled: True
 enabled: False
 macro: PARAM_MODIS_REAL_TIME
 path: params/lai/MODIS_RT

--- a/lis/params/emissivity/ALMIPII/read_ALMIPIIemiss.F90
+++ b/lis/params/emissivity/ALMIPII/read_ALMIPIIemiss.F90
@@ -31,7 +31,7 @@ subroutine read_ALMIPIIemiss(n, wt1,wt2,array1,array2)
 #endif
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
 
   integer, intent(in) :: n
   real                :: wt1
@@ -40,9 +40,9 @@ subroutine read_ALMIPIIemiss(n, wt1,wt2,array1,array2)
   real, intent(inout) :: array2(LIS_rc%ntiles(n))
 
 ! !DESCRIPTION:
-!  This subroutine retrieves the greenness fraction climatology for the 
+!  This subroutine retrieves the greenness fraction climatology for the
 !  specified month and returns the values in the latlon projection
-!  
+!
 !  The arguments are:
 !  \begin{description}
 !  \item[n]
@@ -53,7 +53,7 @@ subroutine read_ALMIPIIemiss(n, wt1,wt2,array1,array2)
 !   output field with the retrieved greenness fraction
 !  \end{description}
 !
-!EOP      
+!EOP
   character*100               :: filename
   character*100               :: temp
   logical                     :: file_exists
@@ -74,8 +74,8 @@ subroutine read_ALMIPIIemiss(n, wt1,wt2,array1,array2)
   allocate(emiss_t(LIS_rc%gnc(n),LIS_rc%gnr(n)))
   allocate(localemiss(LIS_rc%lnc(n),LIS_rc%lnr(n)))
 
-  if(LIS_emiss(n)%firstInstance) then 
-     emissAlarmCheck = .true. 
+  if(LIS_emiss(n)%firstInstance) then
+     emissAlarmCheck = .true.
   else
      emissAlarmCheck = LIS_isAlarmRinging(LIS_rc,&
           "LIS emiss read alarm",&
@@ -85,108 +85,108 @@ subroutine read_ALMIPIIemiss(n, wt1,wt2,array1,array2)
   call LIS_computeTemporalWeights(LIS_rc,LIS_emiss(n)%emissIntervalType, &
        t1,t2,wt1,wt2)
 
-  if(emissAlarmCheck) then 
+  if(emissAlarmCheck) then
      if(LIS_emiss(n)%firstInstance) &
-          LIS_emiss(n)%firstInstance = .false. 
-     
+          LIS_emiss(n)%firstInstance = .false.
+
      array1 = LIS_rc%udef
      array2 = LIS_rc%udef
 
-#if (defined USE_NETCDF3 || defined USE_NETCDF4) 
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
      write(unit=temp,fmt='(I4)') LIS_rc%yr
      read(unit=temp,fmt='(4a1)') (fyr(i),i=1,4)
-     
+
      filename = trim(LIS_emiss(n)%emissfile)//&
           "/ALMIP2_ECOCLIMAP2_"//trim(fyr(3))//trim(fyr(4))&
           //'.nc'
-     
+
      inquire(file=trim(filename), exist=file_exists)
-     if(.not.file_exists) then 
+     if(.not.file_exists) then
         write(LIS_logunit,*) 'emissivity map ',trim(filename),' not found'
         write(LIS_logunit,*) 'Program stopping ...'
         call LIS_endrun
      endif
-     
+
      write(LIS_logunit,*) 'opening EMISS file ',trim(filename)
 
      call LIS_verify(nf90_open(path=trim(filename),mode=NF90_NOWRITE,&
           ncid=ftn), 'nf90_open failed in read_ALMIPIIemiss')
-     
+
      call LIS_verify(nf90_inq_varid(ftn,'emis',emissId),&
           'nf90_inq_varid failed in read_ALMIPIIemiss')
      call LIS_verify(nf90_get_var(ftn,emissId,emiss,&
           start=(/1,1,t1/),&
           count=(/LIS_rc%gnc(n),LIS_rc%gnr(n),1/)),&
           'nf90_get_var failed in read_ALMIPIIemiss')
-     
+
      do r=1,LIS_rc%gnr(n)
         do c=1,LIS_rc%gnc(n)
 !           emiss_t(c,r) = emiss(c,LIS_rc%gnr(n)-r+1)
            emiss_t(c,r) = emiss(c,r)
         enddo
      enddo
-     
+
      localemiss(:,:) = &
-          emiss_t(LIS_ews_halo_ind(n,LIS_localPet+1):&         
+          emiss_t(LIS_ews_halo_ind(n,LIS_localPet+1):&
           LIS_ewe_halo_ind(n,LIS_localPet+1), &
           LIS_nss_halo_ind(n,LIS_localPet+1): &
           LIS_nse_halo_ind(n,LIS_localPet+1))
-     
+
      do t=1,LIS_rc%ntiles(n)
         c = LIS_domain(n)%tile(t)%col
         r = LIS_domain(n)%tile(t)%row
         array1(t) = localemiss(c,r)
      enddo
-     
+
      call LIS_verify(nf90_close(ftn),'nf90_close failed in read_ALMIPIIemiss')
 
      write(unit=temp,fmt='(I4)') LIS_rc%yr
      read(unit=temp,fmt='(4a1)') (fyr(i),i=1,4)
-     
+
      filename = trim(LIS_emiss(n)%emissfile)//&
           "/ALMIP2_ECOCLIMAP2_"//trim(fyr(3))//trim(fyr(4))&
           //'.nc'
-     
+
      inquire(file=trim(filename), exist=file_exists)
-     if(.not.file_exists) then 
+     if(.not.file_exists) then
         write(LIS_logunit,*) 'emissivity map ',trim(filename),' not found'
         write(LIS_logunit,*) 'Program stopping ...'
         call LIS_endrun
      endif
-     
+
      write(LIS_logunit,*) 'opening EMISS file ',trim(filename)
 
      call LIS_verify(nf90_open(path=trim(filename),mode=NF90_NOWRITE,&
           ncid=ftn), 'nf90_open failed in read_ALMIPIIemiss')
-     
+
      call LIS_verify(nf90_inq_varid(ftn,'emis',emissId),&
           'nf90_inq_varid failed in read_ALMIPIIemiss')
      call LIS_verify(nf90_get_var(ftn,emissId,emiss,&
           start=(/1,1,t2/),&
           count=(/LIS_rc%gnc(n),LIS_rc%gnr(n),1/)),&
           'nf90_get_var failed in read_ALMIPIIemiss')
-     
+
      do r=1,LIS_rc%gnr(n)
         do c=1,LIS_rc%gnc(n)
 !           emiss_t(c,r) = emiss(c,LIS_rc%gnr(n)-r+1)
            emiss_t(c,r) = emiss(c,r)
         enddo
      enddo
-     
+
      localemiss(:,:) = &
-          emiss_t(LIS_ews_halo_ind(n,LIS_localPet+1):&         
+          emiss_t(LIS_ews_halo_ind(n,LIS_localPet+1): &
           LIS_ewe_halo_ind(n,LIS_localPet+1), &
           LIS_nss_halo_ind(n,LIS_localPet+1): &
           LIS_nse_halo_ind(n,LIS_localPet+1))
-     
+
      do t=1,LIS_rc%ntiles(n)
         c = LIS_domain(n)%tile(t)%col
         r = LIS_domain(n)%tile(t)%row
         array2(t) = localemiss(c,r)
      enddo
-     
+
      call LIS_verify(nf90_close(ftn),'nf90_close failed in read_ALMIPIIemiss')
-  
+
 #endif
   endif
 

--- a/lis/surfacemodels/land/rdhm.3.5.6/sachtet/htet_fland1.f
+++ b/lis/surfacemodels/land/rdhm.3.5.6/sachtet/htet_fland1.f
@@ -585,7 +585,7 @@ cvk convert precip into kg/(m**2 sec)
        pxvs=pxv/dtsec
 
        call penman_ohd(tak,sfcprs,ch,t2v,th2,pxvs,fdown,t24,ssoil,q2,
-     +              q2sat,etp,rch,epsca,rr,snowng,frzgra,dqsdt2,flx2) 
+     +              q2sat,etp,rch,epsca,rr,snowng,frzgra,dqsdt2,flx2)
        etp=etp*dtsec
 c         write(*,'(a,i5,5f10.5)') 'ch',iter,ch,sfcspd,etp,pc,rc
        if(etp .le. 0.0) then
@@ -643,8 +643,9 @@ c                       if other values, use them as adjustment factors
 cvk  5/10 wind effect correction to PET
         ediff=abs(sfcref-sfcspd)
         if(sfcref .gt. 0.0 .and. ediff .gt. 0.01) then
-         call sfcdif(ztmp,z0,thzv,thav,sfcref,czil,cmref,chref)
-         call penman_ohd(tak,sfcprs,chref,t2v,th2,pxvs,fdown,t24,ssoil,q2,
+          call sfcdif(ztmp,z0,thzv,thav,sfcref,czil,cmref,chref)
+       !EMK Fix indentation to prevent truncation 
+       call penman_ohd(tak,sfcprs,chref,t2v,th2,pxvs,fdown,t24,ssoil,q2,
      +              q2sat,etpref,rch,epsca,rr,snowng,frzgra,dqsdt2,flx2)
          etpref=etpref*dtsec
          if(etpref .le. 0.0) then

--- a/lis/surfacemodels/land/vic.4.1.1/vic411_f2t.F90
+++ b/lis/surfacemodels/land/vic.4.1.1/vic411_f2t.F90
@@ -158,9 +158,13 @@ subroutine vic411_f2t(n)
                 vic411_struc(n)%vic(t)%min_Tfactor ) < &
               vic411_struc(n)%MAX_SNOW_TEMP .and.      &
               rainf_temp(tid) > 0 ) then
-            call vic411_add_atmosdata(t, k, VAR, 1) ! TRUE
+            ! EMK...Last argument should be real
+            !call vic411_add_atmosdata(t, k, VAR, 1) ! TRUE
+            call vic411_add_atmosdata(t, k, VAR, 1.) ! TRUE
          else
-            call vic411_add_atmosdata(t, k, VAR, 0) ! FALSE
+            ! EMK...Last argument should be real
+            !call vic411_add_atmosdata(t, k, VAR, 0) ! FALSE
+            call vic411_add_atmosdata(t, k, VAR, 0.) ! FALSE
          endif
       enddo
    endif

--- a/lis/surfacemodels/land/vic.4.1.2.l/vic412_f2t.F90
+++ b/lis/surfacemodels/land/vic.4.1.2.l/vic412_f2t.F90
@@ -158,9 +158,13 @@ subroutine vic412_f2t(n)
                 vic412_struc(n)%vic(t)%min_Tfactor ) < &
               vic412_struc(n)%MAX_SNOW_TEMP .and.      &
               rainf_temp(tid) > 0 ) then
-            call vic412_add_atmosdata(t, k, VAR, 1) ! TRUE
+            !EMK...Fixed type of last argument.
+            !call vic412_add_atmosdata(t, k, VAR, 1) ! TRUE
+            call vic412_add_atmosdata(t, k, VAR, 1.) ! TRUE
          else
-            call vic412_add_atmosdata(t, k, VAR, 0) ! FALSE
+            !EMK...Fixed type of last argument.
+            !call vic412_add_atmosdata(t, k, VAR, 0) ! FALSE
+            call vic412_add_atmosdata(t, k, VAR, 0.) ! FALSE
          endif
       enddo
    endif


### PR DESCRIPTION

### Description

Issue #843 discusses a number of syntax errors found by gfortran 10 and 11, which were reproduced on Discover. Generally the bugs for LIS fall into three categories:

* Fortran 77 code for RDHM 3.5.6 has column truncations that affect two subroutine calls, effectively changing the argument lists passed to the underlying subroutine.
* The albedo, emissivity, LAISAI, and roughness functionality had inconsistent argument lists, which causes newer gfortran to give a cryptic syntax error.
* Several subroutine calls to VIC 4.1.1 and VIC 4.1.2.l had raw integers passed as arguments, when real arguments are expected.

In addition, per discussions with @dmocko, the MODIS real-time LAI reader is not working correctly and should be disabled by default.

This pull request addresses the errors found by gfortran 10+, and modifies the default.cfg to disable compilation for the MODIS real-time LAI reader.  Editorial changes were also made to some code for better readability. Test compilations were made with gfortran 10.1.0 and 11.1.0, plus existing official modules lisf_7_intel_19_1_3_304 and lisf_7_gnu_9.3.0_gmao_openmpi_4.0.4. No runtime tests were performed.

Note: Issue #843 also implicates LDT (and possibly LVT), but this pull request is restricted to LIS proper.

### Testcase

Recommend testing this code with existing unit test suite.


