### PR TITLE
Update LVT 7.3 to satisfy gfortran 11.1.0

### DIFF
--- a/lvt/datastreams/SMOPS/readSMOPSsmObs.F90
+++ b/lvt/datastreams/SMOPS/readSMOPSsmObs.F90
@@ -311,16 +311,20 @@ subroutine read_SMOPS_data(source, fname, smobs_ip)
    integer        :: param_AMSR2, param_AMSR2_qa
    integer        :: param_SMAP, param_SMAP_qa
    integer*1,parameter :: err_threshold = 5 ! in percent
-   integer*1,parameter :: AMSR2_accept = b'00000001'
-   integer*2,parameter :: SMOS_accept1 = b'0000000000000000'
-   integer*2,parameter :: SMOS_accept2 = b'0000000000000001'
-   integer*2,parameter :: SMOS_accept3 = b'0000000000001000'
-   integer*2,parameter :: SMOS_accept4 = b'0000000000001001'
-   integer*2,parameter :: SMOS_accept5 = b'0000000010000000'
-   integer*2,parameter :: SMOS_accept6 = b'0000000010000001'
-   integer*2,parameter :: SMOS_accept7 = b'0000000010001000'
-   integer*2,parameter :: SMOS_accept8 = b'0000000010001001'
-
+   ! EMK...ISO Fortran does not allow binary integer constants in PARAMETERS,
+   ! but does allow them in DATA statements.  So we edit the code below
+   ! accordingly to pacify gfortran 10+.
+   ! integer*1,parameter :: AMSR2_accept = b'00000001'
+   ! integer*2,parameter :: SMOS_accept1 = b'0000000000000000'
+   ! integer*2,parameter :: SMOS_accept2 = b'0000000000000001'
+   ! integer*2,parameter :: SMOS_accept3 = b'0000000000001000'
+   ! integer*2,parameter :: SMOS_accept4 = b'0000000000001001'
+   ! integer*2,parameter :: SMOS_accept5 = b'0000000010000000'
+   ! integer*2,parameter :: SMOS_accept6 = b'0000000010000001'
+   ! integer*2,parameter :: SMOS_accept7 = b'0000000010001000'
+   ! integer*2,parameter :: SMOS_accept8 = b'0000000010001001'
+   integer*1 :: AMSR2_accept(1)
+   integer*2 :: SMOS_accept(8)
 
 !  INTEGER*2, PARAMETER :: FF = 255
 !  real,    parameter  :: err_threshold = 5 ! in percent
@@ -417,6 +421,29 @@ subroutine read_SMOPS_data(source, fname, smobs_ip)
    logical        :: smDataNotAvailable
 
    integer        :: ix, jx,c_s, c_e, r_s, r_e
+
+   ! EMK...ISO Fortran does not allow binary integer constants in PARAMETERS,
+   ! but does allow them in DATA statements.  So we use DATA statements below
+   ! to pacify gfortran 10+
+   !integer*1,parameter :: AMSR2_accept = b'00000001'
+   !integer*2,parameter :: SMOS_accept1 = b'0000000000000000'
+   !integer*2,parameter :: SMOS_accept2 = b'0000000000000001'
+   !integer*2,parameter :: SMOS_accept3 = b'0000000000001000'
+   !integer*2,parameter :: SMOS_accept4 = b'0000000000001001'
+   !integer*2,parameter :: SMOS_accept5 = b'0000000010000000'
+   !integer*2,parameter :: SMOS_accept6 = b'0000000010000001'
+   !integer*2,parameter :: SMOS_accept7 = b'0000000010001000'
+   !integer*2,parameter :: SMOS_accept8 = b'0000000010001001'
+   data AMSR2_accept /b'00000001'/
+   data SMOS_accept /b'0000000000000000', &
+        b'0000000000000001', &
+        b'0000000000001000', &
+        b'0000000000001001', &
+        b'0000000010000000', &
+        b'0000000010000001', &
+        b'0000000010001000', &
+        b'0000000010001001' /
+
 
 #if (defined USE_GRIBAPI)
    smDataNotAvailable = .false.
@@ -1006,14 +1033,14 @@ subroutine read_SMOPS_data(source, fname, smobs_ip)
         do c=1, SMOPSsmobs(source)%smopsnc
            qavalue = sm_smos_qa_t(c+(r-1)*SMOPSsmobs(source)%smopsnc)
            if ( qavalue .ne. 9999 ) then
-              if ( qavalue == SMOS_accept1 .or. &
-                  qavalue == SMOS_accept2 .or. &
-                  qavalue == SMOS_accept3 .or. &
-                  qavalue == SMOS_accept4 .or. &
-                  qavalue == SMOS_accept5 .or. &
-                  qavalue == SMOS_accept6 .or. &
-                  qavalue == SMOS_accept7 .or. &
-                  qavalue == SMOS_accept8 ) then
+              if ( qavalue == SMOS_accept(1) .or. &
+                  qavalue == SMOS_accept(2) .or. &
+                  qavalue == SMOS_accept(3) .or. &
+                  qavalue == SMOS_accept(4) .or. &
+                  qavalue == SMOS_accept(5) .or. &
+                  qavalue == SMOS_accept(6) .or. &
+                  qavalue == SMOS_accept(7) .or. &
+                  qavalue == SMOS_accept(8) ) then
                   sm_data_b(c+(r-1)*SMOPSsmobs(source)%smopsnc) = .true.
               else
                  sm_data_b(c+(r-1)*SMOPSsmobs(source)%smopsnc) = .false.
@@ -1092,7 +1119,7 @@ subroutine read_SMOPS_data(source, fname, smobs_ip)
                qavalue = sm_amsr2_qa_t(c+(r-1)*SMOPSsmobs(source)%smopsnc)
                if ( qavalue .ne. 9999 ) then
                   qaflags = get_byte1(qavalue)
-                  if (qaflags == AMSR2_accept ) then
+                  if (qaflags == AMSR2_accept(1) ) then
                      sm_data_b(c+(r-1)*SMOPSsmobs(source)%smopsnc) = .true.
                   else
                      sm_data_b(c+(r-1)*SMOPSsmobs(source)%smopsnc) = .false.


### PR DESCRIPTION

### Description

ISO Fortran does not permit use of binary integer constants in PARAMETERS,
but does permit them with DATA statements.  Gfortran 10 and 11 treat use
of binary integer constants with PARAMETERS as syntax errors, so the relevant
code in LVT has been adjusted.

Test compilations were made with GFORTRAN 10 and 11, plus existing official modules lisf_7_intel_19_1_3_304 and lisf_7_gnu_9.3.0_gmao_openmpi_4.0.4. No runtime tests were performed.

Note: Issue #843 also implicates LIS and LDT, but this pull request is restricted to LVT.
