### PR TITLE
Fix documentation issue template (auto-label)

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -2,7 +2,7 @@
 name: Documentation
 about: Missing information? Broken formatting? Help us improve the docs!
 title: ''
-labels: documentation
+labels: Documentation
 assignees: ''
 
 ---


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

The documentation issue template is not auto-adding the documentation label. Change `documentation` 👉 `Documentation` to fix.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

