### PR TITLE
Update LIS documentation and error message

### DIFF
--- a/lis/configs/forcing_variables.adoc
+++ b/lis/configs/forcing_variables.adoc
@@ -58,7 +58,7 @@ SWdown:     1  1  W/m2    # Incident shortwave radiation (total)
 SWdirect:   0  1  W/m2    # Incident shortwave radiation (direct)
 SWdiffuse:  0  1  W/m2    # Incident shortwave radiation (diffuse)
 LWdown:     1  1  W/m2    # Incident longwave radiation
-Wind_E:     1  1  W/m2    # Eastward wind
+Wind_E:     1  1  m/s     # Eastward wind
 Wind_N:     1  1  m/s     # Northward wind
 Psurf:      1  1  Pa      # Surface pressure
 Rainf:      1  1  kg/m2s  # Rainfall rate

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -131,6 +131,7 @@ Acceptable values are:
 |LSM     | land surface model
 |Lake    | lake model
 |Glacier | glacier model
+!Openwater | open water surface type
 |====
 
 .Example _lis.config_ entry

--- a/lis/core/LIS_gridmappingMod.F90
+++ b/lis/core/LIS_gridmappingMod.F90
@@ -331,7 +331,7 @@ contains
 
   !- Double check subsetted and global parameter number of rows and columns:
      if( subparam_nc > glpnc .or. subparam_nr > glpnr ) then
-       write(LIS_logunit,*) "ERR MSG: The number of *subsetted* row or column points"
+       write(LIS_logunit,*) "[ERR]: The number of *subsetted* row or column points"
        write(LIS_logunit,*) "          EXCEEDS the total *global* row or column points "
        write(LIS_logunit,*) "          for the input parameter file, respectively."
        write(LIS_logunit,*) " "


### PR DESCRIPTION
- Fixed a wrong unit entry for the "forcing_variables.adoc" file
- Added "Openwater" option for surface model types (may have been forgotten in the past)
- Updated the start of an error message to '[ERR]'

Note: No issue was opened for this commit, since minor updates and easy to compare and merge.
