### PR TITLE
Add snow data assimilation quality control flags to NoahMP401

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/da_snow/noahmp401_qc_snowobs.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/da_snow/noahmp401_qc_snowobs.F90
@@ -65,6 +65,8 @@ subroutine noahmp401_qc_snowobs(n,k,OBS_State)
   real                     :: stc1_obs(LIS_rc%obs_ngrid(k))
   real                     :: vegt_obs(LIS_rc%obs_ngrid(k))
 
+  print *, 'Reading /da_snow/noahmp401_qc_snowobs'
+
   call ESMF_StateGet(OBS_State,"Observation01",obs_snow_field,rc=status)
   call LIS_verify(status,&
        "ESMF_StateGet failed in noahmp401_qc_snowobs")
@@ -88,6 +90,20 @@ subroutine noahmp401_qc_snowobs(n,k,OBS_State)
   call LIS_convertPatchSpaceToObsSpace(n,k,&
        LIS_rc%lsm_index,vegt,vegt_obs)
 
+  do t=1,LIS_rc%obs_ngrid(k)
+     if(snowobs(t).ne.LIS_rc%udef) then
+        if(fveg_obs(t).gt.0.7) then
+           snowobs(t) = LIS_rc%udef
+        elseif(vegt_obs(t).le.4) then !forest types
+           snowobs(t) = LIS_rc%udef
+!assume that snow will not form at 5 deg. celcius or higher ground temp. 
+       elseif(tv_obs(t).ge.278.15) then
+           snowobs(t) = LIS_rc%udef
+       elseif(stc1_obs(t).ge.278.15) then
+           snowobs(t) = LIS_rc%udef
+        endif
+     endif
+  enddo
 
 end subroutine noahmp401_qc_snowobs
 

--- a/lis/surfacemodels/land/noahmp.4.0.1/da_snow/noahmp401_qc_snowobs.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/da_snow/noahmp401_qc_snowobs.F90
@@ -65,8 +65,6 @@ subroutine noahmp401_qc_snowobs(n,k,OBS_State)
   real                     :: stc1_obs(LIS_rc%obs_ngrid(k))
   real                     :: vegt_obs(LIS_rc%obs_ngrid(k))
 
-  print *, 'Reading /da_snow/noahmp401_qc_snowobs'
-
   call ESMF_StateGet(OBS_State,"Observation01",obs_snow_field,rc=status)
   call LIS_verify(status,&
        "ESMF_StateGet failed in noahmp401_qc_snowobs")


### PR DESCRIPTION
### Description
NoahMP401 snow DA QC flags updated to match what has been done in previous versions of NoahMP and Noah. These checks were missing in noahmp401_qc_snowobs.F90. 

These checks prevent snow DA in dense vegetation, certain land categories, and above a certain temperature threshold.

### Testcase
Example test case at /discover/nobackup/projects/eis_freshwater/mwrzesie/testCase


