### PR TITLE
Fix for global domain HYMAP parameter setup where a boundary box of m…

### DIFF
--- a/ldt/params/HYMAP/HYMAP_parmsMod.F90
+++ b/ldt/params/HYMAP/HYMAP_parmsMod.F90
@@ -737,6 +737,8 @@ contains
     ! at HSL/GSFC/NASA
     ! ================================================   
     
+    use LDT_logmod, only : LDT_logunit
+
     implicit none       
   
     integer, intent(in)    :: nx                  ! number of grids in horizontal
@@ -764,7 +766,7 @@ contains
 !Hiroko: do not insert boundary if global domain
 !        this fix only works on single processor run
     if ( idx.eq.0 .and. idy.eq.0 ) then
-     print*,'HYMAP parameter global'
+     write(LDT_logunit,*) '[INFO] HYMAP parameter global'
      where(i2nextx<1.and.i2nextx/=imis.and.i2mask>0)
         i2nextx=ibound
         i2nexty=ibound

--- a/ldt/params/HYMAP/HYMAP_parmsMod.F90
+++ b/ldt/params/HYMAP/HYMAP_parmsMod.F90
@@ -23,6 +23,7 @@ module HYMAP_parmsMod
 !   2 Dec 2015: Augusto Getirana: Included drainage area and basin maps
 !   1 Nov 2017: Augusto Getirana: Included flow type maps, baseflow and surface runoff dwi maps
 !   9 Jun 2020: Yeosang Yoon: Support flexible grid setting (dx~=dy)
+!  24 Aug 2021: Hiroko Beaudoing: Fix boundary for global domain
 !
   use ESMF
   use LDT_coreMod
@@ -760,25 +761,39 @@ contains
     where(i2nextx>0)i2nextx=i2nextx-idx
     where(i2nexty>0)i2nexty=i2nexty-idy
 
-    i2nexty(1,:)=imis
-    i2nexty(nx,:)=imis
-    i2nexty(:,1)=imis
-    i2nexty(:,ny)=imis
+!Hiroko: do not insert boundary if global domain
+!        this fix only works on single processor run
+    if ( idx.eq.0 .and. idy.eq.0 ) then
+     print*,'HYMAP parameter global'
+     where(i2nextx<1.and.i2nextx/=imis.and.i2mask>0)
+        i2nextx=ibound
+        i2nexty=ibound
+     endwhere
+     where(i2nextx>nx.and.i2mask>0)
+        i2nextx=ibound
+        i2nexty=ibound
+     endwhere
+    else    ! local domain, insert boundary
+     i2nexty(1,:)=imis
+     i2nexty(nx,:)=imis
+     i2nexty(:,1)=imis
+     i2nexty(:,ny)=imis
     
-    i2nextx(1,:)=imis
-    i2nextx(nx,:)=imis
-    i2nextx(:,1)=imis
-    i2nextx(:,ny)=imis
-
-    where(i2nextx<=1.and.i2nextx/=imis.and.i2mask>0)
-       i2nextx=ibound
-       i2nexty=ibound
-    endwhere
+     i2nextx(1,:)=imis
+     i2nextx(nx,:)=imis
+     i2nextx(:,1)=imis
+     i2nextx(:,ny)=imis
+ 
+     where(i2nextx<=1.and.i2nextx/=imis.and.i2mask>0)
+        i2nextx=ibound
+        i2nexty=ibound
+     endwhere
     
-    where(i2nextx>=nx.and.i2mask>0)
-       i2nextx=ibound
-       i2nexty=ibound
-    endwhere
+     where(i2nextx>=nx.and.i2mask>0)
+        i2nextx=ibound
+        i2nexty=ibound
+     endwhere
+    endif    ! global
     
     where(i2nexty<=1.and.i2nexty/=imis.and.i2mask>0)
        i2nextx=ibound


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

HYMAP flow direction parameters (i.e. HYMAP_flow_direction_x and HYMAP_flow_direction_y) created in LDT for global domain have missing values in adjacent grid cells along 180W longitude, resulting in missing values for the HYMAP routing output fields simulated in LIS.  This issue applies only for global domain and appears over the northeastern edge of Russia.  The flow directions are designed to have outlet cells outlining the simulation domain to prevent flow in/out of the domain boundary, however, the boundary should not be applied in global domain simulations.  Two steps are required to fix this issue: 1) check the  HYMAP input parameters prepared by Augusto @agetiran --some of the parameters have missing values along 180W as well, however, the new input parameters based on MERIT data are corrected.  2) Add the fix made in ldt/params/HYMAP/HYMAP_parmsMod.F90

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->Resolves #886 
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->
path:/discover/nobackup/hkato/GLDAS/noahmp025run
ldt config file: ldt.config_noahmp401_gldas20_025d_hymap2
initial output with the problem: noahmp401_hymap2_gldas20_025d_gap_lisf.nc 
fixed output: noahmp401_hymap2new_gldas20_025d.nc
GrADS control files to view outputs : param_gldas2.0_noahmp401_gap.xdf and paramnew_gldas2.0_noahmp401.xdf


