### PR TITLE
Update revision history for LISF 557WW 7.4.5 release

### DIFF
--- a/docs/LDT_users_guide/LDT_usersguide.adoc
+++ b/docs/LDT_users_guide/LDT_usersguide.adoc
@@ -1,6 +1,6 @@
 = Land Data Toolkit (LDT): LDT {lisfrevision} Users' Guide
-:revnumber: 1.12
-:revdate: 4 Mar 2021
+:revnumber: 1.13
+:revdate: 28 Sep 2021
 :doctype: book
 :sectnums:
 :toc:

--- a/docs/LDT_users_guide/revision_table.adoc
+++ b/docs/LDT_users_guide/revision_table.adoc
@@ -2,6 +2,7 @@
 |====
 | Revision | Summary of Changes             | Date
 
+| 1.13     | LISF 557WW 7.4.5 release       | Sep 28, 2021
 | 1.12     | LISF 557WW 7.4.0 release       | Mar 4, 2021
 | 1.11     | LDT 557WW 7.3.3 release        | Jan 25, 2021
 | 1.10     | LISF Public 7.3.0 release      | Dec 21, 2020


### PR DESCRIPTION
### Description

Update revision history for LISF 557WW 7.4.5 release.

Note that only the LDT Users' Guide was updated since the LISF 557WW 7.4.4 release.




