### PR TITLE
Fix LIS compile failure when ecCodes disabled

### DIFF
--- a/lis/metforcing/gefs/read_gefs_reforecast.F90
+++ b/lis/metforcing/gefs/read_gefs_reforecast.F90
@@ -213,7 +213,6 @@ subroutine read_gefs_reforecast(n, m, findex, order, filename, varname, ferror)
         endif
       enddo
     endif
-#endif
 
 ! _______________________________________________________
 
@@ -378,6 +377,7 @@ subroutine read_gefs_reforecast(n, m, findex, order, filename, varname, ferror)
        '[ERR] Could not find file: ',trim(filename)
      ferror = 0
   endif
+#endif
 
 end subroutine read_gefs_reforecast
 


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Moves closing `#endif` to enclose hanging `else` block to allow LIS to compile when ecCodes is disabled. Compiles with Intel 19 and GNU9.
Fixes #587 

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->

I used the testcase below and reproduced the target output, but the reviewer of this PR may not need to test for such a small change.

Inputs and outputs are in `/discover/nobackup/projects/lis/PR_TESTCASES/packaged/ready_for_tcs/gefsforcingtest/`:
* Inputs: `gefsforcingtest_input_v73.tar.gz`
* Intel 19 outputs: `gefsforcingtest_output_v73-intel19.tar.gz`
* GNU outputs: `gefsforcingtest_output_v73-gnu4.tar.gz` (these outputs were generated with GNU 7.3. Rounding error differences are present in `SWdown_f_inst` in two files.)

Testcase files are in the repo at: `LISF/lis/testcases/metforcing/gefs`