### PR TITLE
Updates to PR 791 / smap anomaly support

### DIFF
--- a/lis/core/LIS_dataAssimMod.F90
+++ b/lis/core/LIS_dataAssimMod.F90
@@ -815,8 +815,7 @@ contains
 ! \end{description}
 !EOP
 
-    integer             :: t,i,kk
-    integer             :: binval
+    integer             :: t,kk
     integer             :: col,row
     real                :: obs_tmp
 

--- a/lis/dataassim/obs/NASA_SMAPsm/NASASMAPsm_Mod.F90
+++ b/lis/dataassim/obs/NASA_SMAPsm/NASASMAPsm_Mod.F90
@@ -1,7 +1,9 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
-! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
 !
-! Copyright (c) 2015 United States Government as represented by the
+! Copyright (c) 2020 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------

--- a/lis/dataassim/obs/NASA_SMAPsm/read_NASASMAPsm.F90
+++ b/lis/dataassim/obs/NASA_SMAPsm/read_NASASMAPsm.F90
@@ -1,7 +1,9 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
-! NASA Goddard Space Flight Center Land Information System (LIS) v7.2
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
 !
-! Copyright (c) 2015 United States Government as represented by the
+! Copyright (c) 2020 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------


### PR DESCRIPTION
### Description

Clean up as part of EIS Freshwater branch review.

I repurposed the "NASA SMAP ENKF NOAH36" testcase to read SMAP L2 observations to test replacing the system call to `ls` with our create_filelist function.  The before and after runs processed the SMAP L2 obs the same way.

Related to PR #791.

