### PR TITLE
Cleanup PR 845 and fix the write_UAsnowobs routine

### DIFF
--- a/lis/optUE/type/paramestim/obs/UAsnow/UAsnow_obsMod.F90
+++ b/lis/optUE/type/paramestim/obs/UAsnow/UAsnow_obsMod.F90
@@ -111,7 +111,7 @@ contains
 
     call ESMF_ArraySpecSet(realarrspec,rank=1,typekind=ESMF_TYPEKIND_R4,&
          rc=status)
-    call LIS_verify(status)
+    call LIS_verify(status, 'Error in ESMF_ArraySpecSet')
     
     call ESMF_ConfigFindLabel(LIS_config,"UA snow data directory:",&
          rc=status)
@@ -123,11 +123,11 @@ contains
 
        call ESMF_AttributeSet(Obs_State(n),"Data Directory",&
             obsdir, rc=status)
-       call LIS_verify(status)
+       call LIS_verify(status, 'Error in ESMF_AttributeSet: Data Directory')
 
        call ESMF_AttributeSet(Obs_State(n),"Data Update Status",&
             .false., rc=status)
-       call LIS_verify(status)
+       call LIS_verify(status, 'Error in ESMF_AttributeSet: Data Update Status')
     enddo
 
     do n=1,LIS_rc%nnest
@@ -182,22 +182,22 @@ contains
        obsField1 = ESMF_FieldCreate(arrayspec=realarrspec, &
             grid=LIS_vecGrid(n), &
             name="UA_SWE", rc=status)
-       call LIS_verify(status)
+       call LIS_verify(status, 'Error in ESMF_FieldCreate: UA_SWE ')
 
        obsField2 = ESMF_FieldCreate(arrayspec=realarrspec, &
             grid=LIS_vecGrid(n), &
             name="UA_SNOD", rc=status)
-       call LIS_verify(status)       
+       call LIS_verify(status, 'Error in ESMF_FieldCreate: UA_SNOD')
 
        call ESMF_StateAdd(Obs_State(n),(/obsField1/),rc=status)
-       call LIS_verify(status)
+       call LIS_verify(status, 'Error in ESMF_StateAdd: obsField1')
 
        call ESMF_StateAdd(Obs_State(n),(/obsField2/),rc=status)
-       call LIS_verify(status)
+       call LIS_verify(status, 'Error in ESMF_StateAdd: obsField2')
 
        call ESMF_TimeIntervalSet(UAsnow_obs_struc(n)%timestep, &
             s=86400,rc=status)
-       call LIS_verify(status, 'Error in ESMF_TimeIntervalSet (UA snowobs)')
+       call LIS_verify(status, 'Error in ESMF_TimeIntervalSet: UAsnow_obs_struc(n)%timestep')
     enddo
 
     write(LIS_logunit,*) '[INFO] created the States to hold the UA snow data'

--- a/lis/optUE/type/paramestim/obs/UAsnow/read_UAsnowobs.F90
+++ b/lis/optUE/type/paramestim/obs/UAsnow/read_UAsnowobs.F90
@@ -73,10 +73,10 @@ subroutine read_UAsnowobs(Obj_Space)
 
   call ESMF_AttributeGet(Obj_Space,"Data Directory",&
        obsdir, rc=status)
-  call LIS_verify(status)
+  call LIS_verify(status, 'Error in ESMF_AttributeGet: Data Directory')
   call ESMF_AttributeGet(Obj_Space,"Data Update Status",&
        data_update, rc=status)
-  call LIS_verify(status)
+  call LIS_verify(status, 'Error in ESMF_AttributeGet: Data Update Status')
 
   allocate(snwd_out(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
   allocate(swe_out(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
@@ -224,17 +224,17 @@ subroutine read_UAsnowobs(Obj_Space)
   endif
   call ESMF_StateGet(Obj_Space,"UA_SNOD",snodField,&
        rc=status)
-  call LIS_verify(status)
+  call LIS_verify(status, 'Error in ESMF_StateGet: UA_SNOD')
 
   call ESMF_FieldGet(snodField,localDE=0,farrayPtr=snod,rc=status)
-  call LIS_verify(status)
+  call LIS_verify(status, 'Error in ESMF_FieldGet: snodField')
 
   call ESMF_StateGet(Obj_Space,"UA_SWE",sweField,&
        rc=status)
-  call LIS_verify(status)
+  call LIS_verify(status, 'Error in ESMF_StateGet: UA_SWE')
 
   call ESMF_FieldGet(sweField,localDE=0,farrayPtr=swe,rc=status)
-  call LIS_verify(status)
+  call LIS_verify(status, 'Error in ESMF_FieldGet: sweField')
 
   snod = LIS_rc%udef
   swe = LIS_rc%udef
@@ -261,7 +261,7 @@ subroutine read_UAsnowobs(Obj_Space)
 
   call ESMF_AttributeSet(Obj_Space,"Data Update Status",&
        .true., rc=status)
-  call LIS_verify(status)
+  call LIS_verify(status, 'Error in ESMF_AttributeSet: Data Update Status')
 
 end subroutine read_UAsnowobs
 

--- a/lis/testcases/paramest/ua_snow/NOAHMP_OUTPUT_LIST.TBL
+++ b/lis/testcases/paramest/ua_snow/NOAHMP_OUTPUT_LIST.TBL
@@ -1,0 +1,134 @@
+#short_name select? units signconv timeavg? min/max? std? vert.levels grib_id grib_scalefactor longname
+
+#Energy balance components
+Swnet:        0  W/m2    DN   1 0 0 1 111 10      # Net Shortwave Radiation (W/m2)
+Lwnet:        0  W/m2    DN   1 0 0 1 112 10      # Net Longwave Radiation (W/m2)
+Qle:          0  W/m2    UP   1 0 0 1 121 10      # Latent Heat Flux (W/m2)
+Qh:           0  W/m2    UP   1 0 0 1 122 10      # Sensible Heat Flux (W/m2)
+Qg:           0  W/m2    DN   1 0 0 1 155 10      # Ground Heat Flux (W/m2)
+Qf:           0  W/m2    S2L  1 0 0 1 229 10      # Energy of fusion (W/m2)
+Qv:           0  W/m2    S2V  1 0 0 1 134 10      # Energy of sublimation (W/m2)
+Qa:           0  W/m2    DN   1 0 0 1 136 10      # Advective Energy (W/m2)
+Qtau:         0  N/m2    DN   1 0 0 1 135 10      # Momentum flux (N/m2)
+DelSurfHeat:  0  J/m2    INC  1 0 0 1 137 10      # Change in surface heat storage (J/m2)
+DelColdCont:  0  J/m2    INC  1 0 0 1 138 10      # Change in snow cold content (J/m2)
+BR:           0  -       -    1 0 1 1 256 10      # Bowen ratio
+EF:           0  -       -    1 0 1 1 256 10      # Evaporative fraction
+
+#Water balance components
+Snowf:        1  kg/m2s  DN   1 0 0 1 161 10000   # Snowfall rate (kg/m2s)
+Rainf:        1  kg/m2s  DN   1 0 0 1 162 10000   # Rainfall rate (kg/m2s)
+RainfConv:    0  kg/m2s  DN   1 0 0 1 163 10000   # Convective Rainfall rate (kg/m2s)
+TotalPrecip:  1  kg/m2s  DN   1 0 0 1 164 10000   # Total Precipitation rate (kg/m2s)
+Evap:         0  kg/m2s  UP   1 0 0 1  57 10000   # Total Evapotranspiration (kg/m2s)
+Qs:           1  kg/m2s  OUT  1 0 0 1 235 10000   # Surface runoff (kg/m2s)
+Qrec:         0  kg/m2s  IN   1 0 0 1 143 10000   # Recharge (kg/m2s)
+Qsb:          1  kg/m2s  OUT  1 0 0 1 254 10000   # Subsurface runoff (kg/m2s)
+Qsm:          0  kg/m2s  S2L  1 0 0 1  99 10000   # Snowmelt (kg/m2s)
+Qfz:          0  kg/m2s  L2S  1 0 0 1 146 10000   # Refreezing of water in the snowpack (kg/m2s)
+Qst:          0  kg/m2s  -    1 0 0 1 147 10000   # Snow throughfall (kg/m2s)
+DelSoilMoist: 0  kg/m2   INC  0 0 0 1 148 10000   # Change in soil moisture (kg/m2)
+DelSWE:       0  kg/m2   INC  0 0 0 1 149 1000    # Change in snow water equivalent (kg/m2)
+DelSurfStor:  0  kg/m2   INC  1 0 0 1 150 1000    # Change in surface water storage (kg/m2)
+DelIntercept: 0  kg/m2   INC  1 0 0 1 151 1000    # Change in interception storage (kg/m2)
+RHMin:        0   -      -    0 0 0 1  51 10      # Minimum 2 meter relative humidity (-)
+
+#Surface state variables
+SnowT:        0  K       -    1 0 0 1 152 10      # Snow surface temperature (K)
+VegT:         0  K       -    1 0 0 1 153 10      # Vegetation canopy temperature (K)
+BareSoilT:    0  K       -    1 0 0 1 154 10      # Temperature of bare soil (K)
+AvgSurfT:     0  K       -    1 0 0 1 148 10      # Average surface temperature (K)
+RadT:         0  K       -    1 0 0 1 156 10      # Surface Radiative Temperature (K)
+Albedo:       0  -       -    1 0 0 1  84 100     # Surface Albedo (-)
+SWE:          1  kg/m2   -    1 0 0 1  65 1000    # Snow Water Equivalent (kg/m2)
+SWEVeg:       0  kg/m2   -    1 0 0 1 159 1000    # SWE intercepted by vegetation (kg/m2)
+SurfStor:     0  kg/m2   -    1 0 0 1 160 1000    # Surface water storage (kg/m2)
+TWS:     0  mm   -    1 0 0 1 160 1000    #
+
+#Subsurface state variables
+SoilMoist:    1  m3/m3   -    1 0 0 4  86 1000    # Average layer soil moisture (kg/m2)
+SoilTemp:     0  K       -    1 0 0 4  85 1000    # Average layer soil temperature (K)
+SmLiqFrac:    0  -       -    1 0 0 4  85 100     # Average layer fraction of liquid moisture (-)
+SmFrozFrac:   0  -       -    1 0 0 4  85 100     # Average layer fraction of frozen moisture (-)
+SoilWet:      0  -       -    0 0 0 1  85 100     # Total soil wetness (-)
+RelSMC:       0  m3/m3   -    0 0 0 1  86 1000    # Relative soil moisture
+RootTemp:     0  K       -    0 0 0 1  85 1000    # Rootzone temperature (K)
+
+#Evaporation components
+PotEvap:      0  kg/m2s  UP   1 0 0 1 166 1       # Potential Evapotranspiration (kg/m2s)
+ECanop:       0  kg/m2s  UP   1 0 0 1 200 1       # Interception evaporation (kg/m2s)
+TVeg:         0  kg/m2s  UP   1 0 0 1 210 1       # Vegetation transpiration (kg/m2s)
+ESoil:        0  kg/m2s  UP   1 0 0 1 199 1       # Bare soil evaporation (kg/m2s)
+EWater:       0  kg/m2s  UP   1 0 0 1 170 1       # Open water evaporation (kg/m2s)
+RootMoist:    0  kg/m2   -    0 0 0 1 171 1       # Root zone soil moisture (kg/m2)
+CanopInt:     0  kg/m2   -    1 0 0 1 223 1000    # Total canopy water storage (kg/m2)
+EvapSnow:     0  kg/m2s  -    1 0 0 1 173 1000    # Snow evaporation (kg/m2s)
+SubSnow:      0  kg/m2s  -    1 0 0 1 198 1000    # Snow sublimation (kg/m2s)
+SubSurf:      0  kg/m2s  -    1 0 0 1 175 1000    # Sublimation of the snow free area (kg/m2s)
+ACond:        0  m/s     -    1 0 0 1 179 100000  # Aerodynamic conductance
+CCond:        0  m/s     -    1 0 0 1 179 1000000 # Canopy conductance
+
+#Cold season processes
+Snowcover:    0  -       -    1 0 0 1  66 100     # Snow Cover (-)
+SnowDepth:    1  m       -    1 0 0 1  66 1000    # Snow Depth (m)
+SLiqFrac:     0  -       -    0 0 0 1  65 1000    # Fraction of SWE in the liquid phase
+
+#Forcings
+Wind_f:       0  m/s     -    1 0 0 1 177 10      # Near Surface Wind (m/s)
+Rainf_f:      0  kg/m2s  DN   1 0 0 1 162 1000    # Average rainfall rate
+Snowf_f:      0  kg/m2s  DN   1 0 0 1 161 1000    # Average snowfall rate
+Tair_f:       0  K       -    1 1 0 1  11 10      # Near surface air temperature
+Qair_f:       0  kg/kg   -    1 0 0 1  51 1000    # Near surface specific humidity
+Psurf_f:      0  Pa      -    1 0 0 1   1 10      # Surface pressure
+SWdown_f:     0  W/m2    DN   1 0 0 1 204 10      # Surface incident shortwave radiation
+LWdown_f:     0  W/m2    DN   1 0 0 1 205 10      # Surface incident longwave radiation
+
+#Additional forcings
+DirectSW_f:   0  W/m2    -    0 0 0 1 256 10      # Surface direct incident shortwave radiation
+DiffuseSW_f:  0  W/m2    -    0 0 0 1 256 10      # Surface diffuse incident shortwave radiation
+NWind_f:      0  m/s     N    0 0 0 1 256 10      # Northward wind
+EWind_f:      0  m/s     E    0 0 0 1 256 10      # Eastward wind
+FHeight_f:    0  m       -    0 0 0 1 256 10      # Height of forcing variables
+CH_f:         0  -       -    0 0 0 1 256 10      # Surface exchange coefficient for heat
+CM_f:         0  -       -    0 0 0 1 256 10      # Surface Exchange Coefficient for momentum
+Emiss_f:      0  -       -    0 0 0 1 256 10      # Surface emissivity
+MixRatio_f:   0  kg/kg   -    0 0 0 1 256 10      # Surface mixing ration
+CosZenith_f:  0  -       -    0 0 0 1 256 10      # Cosine of zenith angle
+Albedo_f:     0  -       -    0 0 0 1 256 10      # Surface albedo
+
+#Parameters
+Landmask:     0  -       -    0 0 0 1  81 1       # Land Mask (0 - Water, 1- Land)
+Landcover:    0  -       -    0 0 0 1 186 1       # Land cover
+Soiltype:     0  -       -    0 0 0 1 187 1       # Soil type
+SandFrac:     0  -       -    0 0 0 1 999 1       # Sand fraction
+ClayFrac:     0  -       -    0 0 0 1 999 1       # Clay fraction
+SiltFrac:     0  -       -    0 0 0 1 999 1       # Silt fraction
+Porosity:     0  -       -    3 0 0 1 999 1       # Porosity
+Soilcolor:    0  -       -    0 0 0 1 188 1       # Soil color
+Elevation:    0  m       -    0 0 0 1 189 10      # Elevation
+Slope:        0  -       -    0 0 0 1 999 10      # Slope
+LAI:          0  -       -    0 0 0 1 190 100     # LAI
+SAI:          0  -       -    0 0 0 1 191 100     # SAI
+Snfralbedo:   0  -       -    0 0 0 1 192 100     # Snow fraction albedo
+Mxsnalbedo:   0  -       -    0 0 0 1 192 100     # Maximum snow albedo
+Greenness:    0  -       -    0 0 0 1  87 100     # Greenness
+Tempbot:      0  -       -    0 0 0 1 194 10      # Bottom soil temperature
+
+#Routing
+Streamflow:   1 m3/s    -     1 0 0 1 333 10      #Streamflow
+RiverStor:       0 m3      -     1 0 0 1 333 10      #RiverStorage
+RiverDepth:      0 m       -     1 0 0 1 333 10      #RiverDepth
+RiverVelocity:   0 m/s       -     1 0 0 1 333 10      #RiverVelocity
+FloodQ:          0 m3/s       -     1 0 0 1 333 10      #FloodDischarge
+FloodEvap:       0 m3       -     1 0 0 1 333 10      #FloodEvap
+FloodStor:       0 m3       -     1 0 0 1 333 10      #FloodStorage
+FloodDepth:      0 m       -     1 0 0 1 333 10      #FloodDepth
+FloodVelocity:   0 m/s       -     1 0 0 1 333 10      #FloodVelocity
+FloodedFrac:     1 -       -     1 0 0 1 333 10      #FloodedFrac
+FloodedArea:     1 m2       -     1 0 0 1 333 10      #FloodedArea
+SurfElev:        0 m       -     1 0 0 1 333 10      #SurfElev
+RunoffStor:      0 m3       -     1 0 0 1 333 10      #RunoffStor
+BaseflowStor:    0 m3       -     1 0 0 1 333 10      #BaseflowStor
+
+#Irrigation
+Irrigated water:   1 kg/m2s    -     1 0 0 1 333 10      #Irrigation amount

--- a/lis/testcases/paramest/ua_snow/lis.config
+++ b/lis/testcases/paramest/ua_snow/lis.config
@@ -1,0 +1,281 @@
+#Overall driver options
+LIS domain and parameter data file:     ./lis_input.d01.nc
+Output model restart files:             0
+Running mode:                   "parameter estimation"
+Number of model types subject to parameter estimation:    1
+Model types subject to parameter estimation:      "LSM"
+Number of model types with observation predictors for parameter estimation:  1
+Model types with observation predictors for parameter estimation:  "LSM"
+Optimization/Uncertainty Estimation Algorithm:   "Genetic algorithm"
+Least Squares objective function mode:    1 
+Objective Function Method:               "Least squares"
+Least Squares objective function minimum number of obs:   30
+Initialize decision space with default values:  1
+LSM Decision space attributes file:      ./noahmp401_dec_space_No0s.txt
+Write PE Observations:  1 
+
+Least Squares objective function weights file: ./LS_weights.txt
+
+Optimization/Uncertainty Estimation Set:  "UA snow"
+
+UA snow data directory:  ./input/STN_DATA/UA_SNOW
+
+GA number of generations:           2 #200 
+GA restart file:                  ./OUTPUT/GA/GA.0009.GArst
+GA start mode:                   coldstart
+GA number of children per parent:   1
+GA crossover scheme:                1   # 1=two pt crossover; 2=uniform
+GA crossover probability:          0.90
+GA mutation scheme:                 0
+GA creep mutation probability:     0.04
+GA jump mutation probability:      0.02
+GA use elitism:                     1
+
+Calibration period start year:   2007
+Calibration period start month:    1
+Calibration period start day:      1
+Calibration period start hour:     0
+Calibration period start minutes:  0
+Calibration period start seconds:  0
+
+Map projection of the LIS domain:       latlon
+Number of nests:                        1
+Number of surface model types:          1
+Surface model types:                    LSM
+Surface model output interval:          1da
+Land surface model:                     "Noah-MP.4.0.1"
+Number of met forcing sources:          1
+Blending method for forcings:           overlay
+Met forcing sources:                    "NLDAS2"
+Met forcing chosen ensemble member:     1
+Topographic correction method (met forcing): "none"  "lapse-rate and slope-aspect" "lapse-rate and slope-aspect"
+Enable spatial downscaling of precipitation:  0 0
+Spatial upscaling method (met forcing):       none none
+Spatial interpolation method (met forcing):   bilinear bilinear
+Temporal interpolation method (met forcing):  linear linear
+
+#Runtime options
+Forcing variables list file:            ./forcing_variables.txt
+Output methodology:                     "2d gridspace"
+Output model restart files:             0
+Output data format:                     netcdf
+Output naming style:                    "3 level hierarchy"
+Start mode:                             coldstart
+Starting year:                          2007
+Starting month:                            1 
+Starting day:                              1
+Starting hour:                             0
+Starting minute:                           0
+Starting second:                           0
+Ending year:                            2007
+Ending month:                              1 
+Ending day:                                5
+Ending hour:                               0
+Ending minute:                             0
+Ending second:                             0
+Undefined value:                       -9999
+Output directory:                       "OUTPUT"
+Diagnostic output file:                 "OUTPUT/lislog"
+Number of ensembles per tile:           30
+
+#The following options are used for subgrid tiling based on vegetation
+Maximum number of surface type tiles per grid:    1
+Minimum cutoff percentage (surface type tiles):   0.05
+Maximum number of soil texture tiles per grid:    1
+Minimum cutoff percentage (soil texture tiles):   0.05
+Maximum number of soil fraction tiles per grid:   1
+Minimum cutoff percentage (soil fraction tiles):  0.05
+Maximum number of elevation bands per grid:       1
+Minimum cutoff percentage (elevation bands):      0.05
+Maximum number of slope bands per grid:           1
+Minimum cutoff percentage (slope bands):          0.05
+Maximum number of aspect bands per grid:          1
+Minimum cutoff percentage (aspect bands):         0.05
+
+#Processor layout
+#Should match the total number of processors used
+Number of processors along x:           28
+Number of processors along y:           19 
+Halo size along x:                      0
+Halo size along y:                      0
+
+#Sub-models
+#Routing model:  "none"
+Routing model:                          "none"
+Radiative transfer model:               none
+Number of application models:           0
+
+HYMAP2 routing model time step:               "15mn"
+TEMPLATE model timestep:                      "15mn"
+HYMAP2 routing model output interval:         "1da"
+HYMAP2 routing model restart interval:        "1mo"
+
+# method:                         enter "kinematic", "diffusive" or "local inertia"
+# linear reservoir flag:          enter 1 - use; or 0 - do not use linear reservoirs
+# evaporation option:             enter "penman" - compute; or "none" - do not compute evapotation in floodplains;
+# floodplain dynamics option:     enter 1 - compute floodplain dynamics; or 0 - do not compute floodplain dynamics
+# time step method:      enter "constant" or "adaptive"
+# if "adaptive" time step, provide alfa coefficient value
+#
+#
+HYMAP2 routing method:                            "local inertia" # "kinematic" #
+HYMAP2 routing model time step method:       "constant" # "constant" #
+HYMAP2 routing model adaptive time step alfa coefficient: 1.0
+HYMAP2 run in ensemble mode:                 0
+HYMAP2 routing model linear reservoir flag:  0
+HYMAP2 routing model evaporation option:     none # "penman"
+HYMAP2 routing model start mode:      coldstart
+HYMAP2 routing model restart file:  LIS_RST_HYMAP2_router_200104302345.d01.nc
+HYMAP2 floodplain dynamics: 1
+
+HYMAP2 reservoir operation option: 0
+HYMAP2 number of reservoirs: 1
+HYMAP2 reservoir operation input time series size: 2
+HYMAP2 reservoir operation input directory: ./
+HYMAP2 reservoir operation header filename: ./header_test.txt
+HYMAP2 reservoir operation input data type: "water level" # "streamflow" #
+
+HYMAP2 routing model dwi flag: 0
+HYMAP2 enable 2-way coupling: 0
+
+#---------------------DATA ASSIMILATION ----------------------------------
+#Data Assimilation Options
+Number of data assimilation instances:               0
+Data assimilation algorithm:                         "Direct insertion"
+Data assimilation set:                               "GLASS LAI"
+Data assimilation exclude analysis increments:       0
+Data assimilation output interval for diagnostics:   "1da"
+Data assimilation number of observation types:       1
+Data assimilation output ensemble spread:            0
+Data assimilation scaling strategy:                  "none"
+Data assimilation output processed observations:     0
+Data assimilation output innovations:                0
+Number of state variables:                           1
+
+Data assimilation observation domain file: ./lis_input.d01.nc
+
+Data assimilation use a trained forward model: 0
+Data assimilation trained forward model output file: none
+
+Apply perturbation bias correction:        0
+Bias estimation algorithm:                "none"
+Bias estimation attributes file:          "none"
+Bias estimation restart output frequency:
+Bias estimation start mode:
+Bias estimation restart file:
+
+#Perturbation options
+Perturbations start mode:                 "coldstart"
+Perturbations restart output interval:    "1mo"
+Perturbations restart filename:           "none"
+
+Forcing perturbation algorithm:           "none"  #"GMAO scheme"
+Forcing perturbation frequency:           "1hr"
+Forcing attributes file:                  "none" #./config/forcing_attribs.txt
+Forcing perturbation attributes file:     "none" #./config/forcing_pert_attribs.txt
+
+State perturbation algorithm:             "none" #"GMAO scheme"
+State perturbation frequency:             "3hr"
+State attributes file:                    ./noah_lai_attribs.txt
+State perturbation attributes file:       ./noah_lai_pert_attribs.txt
+
+Observation perturbation algorithm:       "none"
+Observation perturbation frequency:       "1da"
+Observation attributes file:              ./GLASSLAI_attribs.txt
+Observation perturbation attributes file: ./GLASSLAI_pertattribs.txt
+
+GLASS LAI data directory:           ./GLASSLAIdata
+
+#------------------------DOMAIN SPECIFICATION--------------------------
+#Definition of Running Domain
+
+#The following options list the choice of parameter maps to be used
+LIS domain and parameter data file:     ./lis_input.d01.nc
+Landmask data source:                   LDT
+Landcover data source:                  LDT
+Soil texture data source:               LDT
+Soil fraction data source:              none
+Soil color data source:                 none
+Elevation data source:                  LDT
+Slope data source:                      LDT
+Aspect data source:                     LDT
+Curvature data source:                  none
+LAI data source:                        none
+SAI data source:                        none
+Albedo data source:                     LDT
+Max snow albedo data source:            LDT
+Greenness data source:                  LDT
+Roughness data source:                  none
+Porosity data source:                   none
+Ksat data source:                       none
+B parameter data source:                none
+Quartz data source:                     none
+Emissivity data source:                 none
+
+#--------------------------------FORCINGS----------------------------------
+NLDAS2 forcing directory:               ./input/MET_FORCING/NLDAS2.FORCING
+NLDAS2 data center source:              "GES-DISC"
+NLDAS2 use model level data:            0
+NLDAS2 use model based swdown:          0
+NLDAS2 use model based precip:          0
+NLDAS2 use model based pressure:        0
+
+MERRA2 forcing directory:       ./input/MET_FORCING/MERRA2/
+MERRA2 use lowest model level forcing:     1
+MERRA2 use corrected total precipitation:  1
+
+
+#-----------------------LAND SURFACE MODELS--------------------------
+
+Noah-MP.4.0.1 model timestep:                15mn
+Noah-MP.4.0.1 restart output interval:       1da
+Noah-MP.4.0.1 restart file:                  LIS_RST_NOAHMP401_200501190000.d01.nc
+Noah-MP.4.0.1 restart file format:           netcdf
+Noah-MP.4.0.1 soil parameter table:          ./input/LS_PARAMETERS/noahmp401_parms/SOILPARM.TBL
+Noah-MP.4.0.1 general parameter table:       ./input/LS_PARAMETERS/noahmp401_parms/GENPARM.TBL
+Noah-MP.4.0.1 MP parameter table:            ./input/LS_PARAMETERS/noahmp401_parms/MPTABLE.TBL
+Noah-MP.4.0.1 number of soil layers:         4
+Noah-MP.4.0.1 thickness of soil layers:      0.05  0.3  0.6  1.0
+Noah-MP.4.0.1 dynamic vegetation option:                      2  # Up to 10 different options
+Noah-MP.4.0.1 canopy stomatal resistance option:              1  # 1=Ball-Berry; 2=Jarvis
+Noah-MP.4.0.1 soil moisture factor for stomatal resistance:   1  # 1=Noah; 2=CLM; 3=SSiB
+Noah-MP.4.0.1 runoff and groundwater option:                  1  # 1=SIMGM; 2=SIMTOP; 3=Schaake96; 4=BATS; 5=Miguez-Mach
+o&Fan
+Noah-MP.4.0.1 surface layer drag coefficient option:          1  # 1=M-O; 2=Chen97
+Noah-MP.4.0.1 supercooled liquid water option:                1  # 1=NY06; 2=Koren99
+Noah-MP.4.0.1 frozen soil permeability option:                1  # 1=NY06; 2=Koren99
+Noah-MP.4.0.1 radiation transfer option:                      3  # 1=gap=F(3D;cosz); 2=gap=0; 3=gap=1-Fveg
+Noah-MP.4.0.1 snow surface albedo option:                     2  # 1=BATS; 2=CLASS
+Noah-MP.4.0.1 rainfall & snowfall option:                     1  # 1=Jordan91; 2=BATS; 3=Noah
+Noah-MP.4.0.1 lower boundary of soil temperature option:      2  # 1=zero-flux; 2=Noah
+Noah-MP.4.0.1 snow&soil temperature time scheme option:       1  # 1=semi-implicit; 2=fully implicit; 3=FSNO for TS
+Noah-MP.4.0.1 glacier option:                                 1  # 1=include phase change; 2=slab ice (Noah)
+Noah-MP.4.0.1 surface resistance option:                      1  # 1=Sakaguchi and Zeng 2009; 2=Sellers (1992); 3=adjusted Sellers; 4=option1 for non-snow and rsurf_snow for snow
+Noah-MP.4.0.1 soil configuration option:                      1  # 1=input dominant soil texture; 2=input soil texture varies that varies with depth; 3=soil composition and pedotransfer; 4=input soil properties
+Noah-MP.4.0.1 soil pedotransfer function option:              1  # 1=Saxton and Rawls (2006) (used when soil_opt=3)
+Noah-MP.4.0.1 crop model option:                              0  # 0=No crop model; 1=Liu et al. 2016; 2=Gecros
+Noah-MP.4.0.1 urban physics option:                           0  # 0=No; 1=Single-layer; 2=Multi-layer BEP scheme; 3=Multi-layer BEM scheme
+Noah-MP.4.0.1 reference height of temperature and humidity: 6.0
+Noah-MP.4.0.1 initial surface skin temperature:           263.7
+Noah-MP.4.0.1 initial snow water equivalent:                1.0
+Noah-MP.4.0.1 initial snow depth:                          0.01
+Noah-MP.4.0.1 initial total canopy surface water:          0.01
+Noah-MP.4.0.1 initial soil temperatures:                  266.1  274.0  276.9  279.9
+Noah-MP.4.0.1 initial total soil moistures:               0.298  0.294  0.271  0.307
+Noah-MP.4.0.1 initial leaf area index:                      2.0
+Noah-MP.4.0.1 initial water table depth:                    2.5
+Noah-MP.4.0.1 initial water in the aquifer:                 4900.0
+Noah-MP.4.0.1 initial water in aquifer and saturated soil:  4900.0
+
+#---------------------------MODEL OUTPUT CONFIGURATION-----------------------
+#Specify the list of ALMA variables that need to be featured in the
+#LSM model output
+Output start year:
+Output start month:
+Output start day:
+Output start hour:
+Output start minutes:
+Output start seconds:
+
+Model output attributes file:           './NOAHMP_OUTPUT_LIST.TBL'
+

--- a/lis/testcases/paramest/ua_snow/output.ctl
+++ b/lis/testcases/paramest/ua_snow/output.ctl
@@ -1,0 +1,24 @@
+dset ^OUTPUT/SURFACEMODEL/%y4%m2/LIS_HIST_%y4%m2%d20000.d01.nc
+dtype netcdf
+options template
+undef -9999
+xdef 355 linear -108.565 0.01
+ydef 320 linear 37.525 0.01
+zdef 1 linear 1 1
+* dummy tdef
+tdef 4 linear 0z02jan2007 1dy
+vars 13
+lat=>lat 1 y,x description
+lon=>lon 1 y,x description
+Snowf_tavg=>Snowf_tavg 1 y,x description
+Rainf_tavg=>Rainf_tavg 1 y,x description
+Qs_tavg=>Qs_tavg 1 y,x description
+Qsb_tavg=>Qsb_tavg 1 y,x description
+SWE_tavg=>SWE_tavg 1 y,x description
+SnowDepth_tavg=>SnowDepth_tavg 1 y,x description
+SoilMoist_tavg=>SoilMoist_tavg1 0 0,y,x description
+SoilMoist_tavg=>SoilMoist_tavg2 0 1,y,x description
+SoilMoist_tavg=>SoilMoist_tavg3 0 2,y,x description
+SoilMoist_tavg=>SoilMoist_tavg4 0 3,y,x description
+TotalPrecip_tavg=>TotalPrecip_tavg 1 y,x description
+endvars

--- a/lis/testcases/paramest/ua_snow/snod_obs_output.ctl
+++ b/lis/testcases/paramest/ua_snow/snod_obs_output.ctl
@@ -1,0 +1,13 @@
+DSET ^OUTPUT/PEOBS/UA_SNOD_%y4%m2%d2%h2%n2.1gs4r 
+options template
+options sequential
+options big_endian
+TITLE UA Snowdepth PEOBS
+UNDEF -9999.0
+XDEF     355 LINEAR  -108.565 0.01
+YDEF     320 LINEAR   37.525 0.01
+ZDEF 1 LINEAR 1 1
+TDEF 8 LINEAR 12Z01jan2007 1dy
+VARS 1
+UA_SNOD        1  99  ** snowdepth  [m]                
+ENDVARS

--- a/lis/testcases/paramest/ua_snow/swe_obs_output.ctl
+++ b/lis/testcases/paramest/ua_snow/swe_obs_output.ctl
@@ -1,0 +1,13 @@
+DSET ^OUTPUT/PEOBS/UA_SWE_%y4%m2%d2%h2%n2.1gs4r 
+options template
+options sequential
+options big_endian
+TITLE UA SWE PEOBS
+UNDEF -9999.0
+XDEF     355 LINEAR  -108.565 0.01
+YDEF     320 LINEAR   37.525 0.01
+ZDEF 1 LINEAR 1 1
+TDEF 8 LINEAR 12Z01jan2007 1dy
+VARS 1
+UA_SWE        1  99  ** snow water equivalent  [mm]                
+ENDVARS

--- a/lis/testcases/paramest/ua_snow/testcase.ctl
+++ b/lis/testcases/paramest/ua_snow/testcase.ctl
@@ -1,0 +1,24 @@
+dset ^TARGET_OUTPUT/SURFACEMODEL/%y4%m2/LIS_HIST_%y4%m2%d20000.d01.nc
+dtype netcdf
+options template
+undef -9999
+xdef 355 linear -108.565 0.01
+ydef 320 linear 37.525 0.01
+zdef 1 linear 1 1
+* dummy tdef
+tdef 4 linear 0z02jan2007 1dy
+vars 13
+lat=>lat 1 y,x description
+lon=>lon 1 y,x description
+Snowf_tavg=>Snowf_tavg 1 y,x description
+Rainf_tavg=>Rainf_tavg 1 y,x description
+Qs_tavg=>Qs_tavg 1 y,x description
+Qsb_tavg=>Qsb_tavg 1 y,x description
+SWE_tavg=>SWE_tavg 1 y,x description
+SnowDepth_tavg=>SnowDepth_tavg 1 y,x description
+SoilMoist_tavg=>SoilMoist_tavg1 0 0,y,x description
+SoilMoist_tavg=>SoilMoist_tavg2 0 1,y,x description
+SoilMoist_tavg=>SoilMoist_tavg3 0 2,y,x description
+SoilMoist_tavg=>SoilMoist_tavg4 0 3,y,x description
+TotalPrecip_tavg=>TotalPrecip_tavg 1 y,x description
+endvars


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

This pull request cleans up changes made in #845. Changes here include:

1. Addition of error messages to calls to `LIS_verify`
2. Fixes the `write_UAsnowobs` routine in `write_UAsnowobs.F90`

    This fix ensures the write routine correctly retrieves the renamed states (`UA_SNOD` and `UA_SWE`) and writes them to disk as described in [this comment](https://github.com/NASA-LIS/LISF/pull/845#issuecomment-962230617).

    Note: obs are written to OUTPUT/PEOBS at the model timestep, but only the 12Z files contain data (the snow data is daily). It may be possible to fix this by adjusting the data update status flag so that obs are only written out when they are read in so that this directory isn't filled with "empty" files. We will revisit this later as it appears to affect other PE obs readers.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->
Files for a short testcase are available here: /discover/nobackup/projects/eis_freshwater/bmcandr/for/share/pr_845_cleanup

To run, first create a symbolic link to the LIS project directory called `input/`. I didn't package the input files as this just a shorter testcase based on the one supplied for #845