### PR TITLE
Expand length of paths in LIS metforcing readers

### DIFF
--- a/lis/core/LIS_constantsMod.F90
+++ b/lis/core/LIS_constantsMod.F90
@@ -13,7 +13,7 @@ module LIS_constantsMod
 !  !MODULE: LIS_constantsMod
 ! 
 !  !DESCRIPTION: 
-!   The code in this file provides values of physical constants for
+!   The code in this file provides values of named constants for
 !   consistent use across different components. 
 !   
 !  !REVISION HISTORY: 
@@ -21,10 +21,15 @@ module LIS_constantsMod
 !
 !EOP
 !BOC
+   public
+!----------------------------------------------------------------------------
+! software constants
+!----------------------------------------------------------------------------
+   integer,parameter :: LIS_CONST_PATH_LEN  = 500    ! max path length (in char)
+
 !----------------------------------------------------------------------------
 ! physical constants (all data public)
 !----------------------------------------------------------------------------
-   public
 !   real,parameter :: CONST_PI     = 3.14159265358979323846  ! pi
    real,parameter :: LIS_CONST_PI     = 3.14159265   ! pi
    real,parameter :: LIS_CONST_CDAY   = 86400.0      ! sec in calendar day ~ sec

--- a/lis/metforcing/3B42RT/TRMM3B42RT_forcingMod.F90
+++ b/lis/metforcing/3B42RT/TRMM3B42RT_forcingMod.F90
@@ -55,6 +55,7 @@ module TRMM3B42RT_forcingMod
 
 ! !USES:
   use ESMF
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
   PRIVATE
@@ -74,7 +75,7 @@ module TRMM3B42RT_forcingMod
      real                     :: ts
      integer                  :: ncold
      integer                  :: nrold  
-     character*40             :: TRMM3B42RTdir  
+     character(len=LIS_CONST_PATH_LEN) :: TRMM3B42RTdir
      !real*8                   :: TRMM3B42RTtime ! SY
      real*8                   :: TRMM3B42RTtime_TStepStart ! SY
      integer                  :: TRMM3B42RTyr_TStepStart ! SY

--- a/lis/metforcing/3B42RT/get_TRMM3B42RT.F90
+++ b/lis/metforcing/3B42RT/get_TRMM3B42RT.F90
@@ -26,6 +26,7 @@ subroutine get_TRMM3B42RT(n,findex)
   use LIS_logMod, only            : LIS_logunit, LIS_endrun
   use TRMM3B42RT_forcingMod, only : TRMM3B42RT_struc
   use LIS_metforcingMod,  only    : LIS_forc ! SY
+  use LIS_constantsMod,      only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -64,7 +65,7 @@ subroutine get_TRMM3B42RT(n,findex)
   integer :: doy2, yr2, mo2, da2, hr2, mn2, ss2, ts2    ! SY: Time parameters for TRMM data time nearest to start of model time step
   integer :: doy3, yr3, mo3, da3, hr3, mn3, ss3, ts3    ! SY: Time parameters for TRMM data time nearest to end of model time step
   real    :: gmt1, gmt2, gmt3
-  character*120 :: name                    ! Filename variables for precip data sources
+  character(len=LIS_CONST_PATH_LEN) :: name                    ! Filename variables for precip data sources
   real*8  :: LIS_timeAtTStepStart_add90min 
   real*8  :: LIS_timeAtTStepEnd_add90min   
   integer :: order
@@ -179,7 +180,7 @@ subroutine get_TRMM3B42RT(n,findex)
                           TRMM3B42RT_struc(n)%TRMM3B42RTmo_TStepStart, &
                           TRMM3B42RT_struc(n)%TRMM3B42RTda_TStepStart, &
                           TRMM3B42RT_struc(n)%TRMM3B42RThr_TStepStart )
-     write(LIS_logunit, *)'Getting new TRMM 3B42RT satellite precip data:', name
+     write(LIS_logunit, *)'Getting new TRMM 3B42RT satellite precip data:', trim(name)
      order = 1
      call read_TRMM3B42RT(n, name, findex, order, ferror_TRMM3B42RT)
    elseif (.NOT. ((TRMM3B42RT_struc(n)%TRMM3B42RTyr_TStepStart .EQ. &
@@ -220,7 +221,7 @@ subroutine get_TRMM3B42RT(n,findex)
                           TRMM3B42RT_struc(n)%TRMM3B42RTmo_TStepEnd, &
                           TRMM3B42RT_struc(n)%TRMM3B42RTda_TStepEnd, &
                           TRMM3B42RT_struc(n)%TRMM3B42RThr_TStepEnd )
-     write(LIS_logunit, *)'Getting new TRMM 3B42RT satellite precip data:', name
+     write(LIS_logunit, *)'Getting new TRMM 3B42RT satellite precip data:', trim(name)
      order = 2
      call read_TRMM3B42RT(n, name, findex, order, ferror_TRMM3B42RT)
    endif
@@ -289,7 +290,6 @@ subroutine TRMM3B42RTfile( name, TRMM3B42RTdir, yr, mo, da, hr)
 !
 !EOP
 
-  character*120 temp
   integer :: i, c
   integer :: uyr, umo, uda, uhr, umn, uss, ts1, udoy
   real    :: ugmt

--- a/lis/metforcing/3B42RT/read_TRMM3B42RT.F90
+++ b/lis/metforcing/3B42RT/read_TRMM3B42RT.F90
@@ -26,11 +26,12 @@ subroutine read_TRMM3B42RT (n, name_TRMM3B42RT, findex, order, ferror_TRMM3B42RT
                                    LIS_releaseUnitNumber
  use LIS_metforcingMod, only     : LIS_forc
  use TRMM3B42RT_forcingMod, only : TRMM3B42RT_struc
+ use LIS_constantsMod,      only : LIS_CONST_PATH_LEN
  
   implicit none
 ! !ARGUMENTS:
   integer, intent(in) :: n
-  character(len=120)  :: name_TRMM3B42RT
+  character(len=*)    :: name_TRMM3B42RT
   integer, intent(in) :: findex
   integer, intent(in) :: order
   integer             :: ferror_TRMM3B42RT
@@ -67,8 +68,8 @@ subroutine read_TRMM3B42RT (n, name_TRMM3B42RT, findex, order, ferror_TRMM3B42RT
 
  real :: precip(xd,yd), tmp(xd, yd)   
  real, allocatable :: precip_regrid(:,:)        ! Interpolated precipitation array
- character(len=120) :: fname                ! Filename variables
- character*200 :: dfile 
+ character(len=LIS_CONST_PATH_LEN) :: fname                ! Filename variables
+ character(len=LIS_CONST_PATH_LEN) :: dfile 
  integer             ::  ftn
  logical :: file_exists
 
@@ -182,7 +183,7 @@ subroutine rd3B42RT1gd4r(dfile, precip, xd, yd)
 
  integer :: i,j,xd,yd, ftn
  real :: precip(xd,yd)
- character*200 :: dfile 
+ character(len=*) :: dfile 
 
  ftn = LIS_getNextUnitNumber()
  open(unit=ftn,file=dfile, status='old', &
@@ -202,7 +203,7 @@ subroutine rd3B42RTbin(dfile, precip, xd, yd)
  integer, parameter :: nc=1440, nr=480
  integer :: i,j,xd,yd, ftn
  real :: precip(xd,yd), output(nc, nr)
- character*200 :: dfile
+ character(len=*) :: dfile
  integer*2 :: rr(nc, nr)
 
  ftn = LIS_getNextUnitNumber()
@@ -239,7 +240,7 @@ subroutine rd3B42RTgz(zipfile, output, xd, yd)
         integer, parameter :: nc=1440, nr=480
         integer :: xd, yd
         real output(xd, yd)
-        character*200 zipfile
+        character(len=*) zipfile
         integer*2 input(nc, nr), itmp(nc, nr+1), rtmp(nc)  ! tmp includes header
         character*1 array(nc*(nr+1)*2), ct    ! buffer space
         equivalence (itmp, array)

--- a/lis/metforcing/3B42RT/readcrd_TRMM3B42RT.F90
+++ b/lis/metforcing/3B42RT/readcrd_TRMM3B42RT.F90
@@ -42,7 +42,7 @@ subroutine readcrd_TRMM3B42RT()
 
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*)'Using TRMM 3B42RT forcing'
-     write(LIS_logunit,*) 'TRMM 3B42RT forcing directory :',TRMM3B42RT_struc(n)%TRMM3B42RTDIR
+     write(LIS_logunit,*) 'TRMM 3B42RT forcing directory :',trim(TRMM3B42RT_struc(n)%TRMM3B42RTDIR)
 !------------------------------------------------------------------------
 ! Setting global observed precip times to zero to ensure 
 ! data is read in during first time step

--- a/lis/metforcing/3B42RTV7/TRMM3B42RTV7_forcingMod.F90
+++ b/lis/metforcing/3B42RTV7/TRMM3B42RTV7_forcingMod.F90
@@ -57,6 +57,7 @@ module TRMM3B42RTV7_forcingMod
 
 ! !USES:
   use ESMF
+  use LIS_constantsMod, only: LIS_CONST_PATH_LEN
 
   implicit none
   PRIVATE
@@ -76,7 +77,7 @@ module TRMM3B42RTV7_forcingMod
      real                     :: ts
      integer                  :: nc
      integer                  :: nr
-     character*40             :: directory  
+     character(len=LIS_CONST_PATH_LEN) :: directory  
      real*8                   :: time_TStepStart ! SY
      integer                  :: yr_TStepStart ! SY
      integer                  :: mo_TStepStart ! SY

--- a/lis/metforcing/3B42RTV7/get_TRMM3B42RTV7.F90
+++ b/lis/metforcing/3B42RTV7/get_TRMM3B42RTV7.F90
@@ -27,6 +27,7 @@ subroutine get_TRMM3B42RTV7(n,findex)
                                     LIS_isAlarmRinging 
   use LIS_logMod, only            : LIS_logunit, LIS_endrun
   use TRMM3B42RTV7_forcingMod, only : TRMM3B42RTV7_struc
+  use LIS_constantsMod,        only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -69,7 +70,7 @@ subroutine get_TRMM3B42RTV7(n,findex)
   integer :: doy3, yr3, mo3, da3, hr3, mn3, ss3, ts3    
   real    :: gmt1, gmt2, gmt3             
 
-  character*120 :: filename                ! Filename variables for precip data sources
+  character(len=LIS_CONST_PATH_LEN) :: filename                ! Filename variables for precip data sources
   real*8  :: LIS_timeAtTStepStart_add90min ! SY
   real*8  :: LIS_timeAtTStepEnd_add90min   ! SY
   logical :: alarmCheck  

--- a/lis/metforcing/3B42RTV7/read_TRMM3B42RTV7.F90
+++ b/lis/metforcing/3B42RTV7/read_TRMM3B42RTV7.F90
@@ -27,12 +27,13 @@ subroutine read_TRMM3B42RTV7 (n, kk, filename_TRMM3B42RT, findex, &
                                LIS_releaseUnitNumber
  use LIS_metforcingMod, only : LIS_forc
  use TRMM3B42RTV7_forcingMod, only : TRMM3B42RTV7_struc
+ use LIS_constantsMod,        only : LIS_CONST_PATH_LEN
  
   implicit none
 ! !ARGUMENTS:
   integer, intent(in) :: n
   integer, intent(in) :: kk     ! Forecast ensemble member
-  character(len=120)  :: filename_TRMM3B42RT
+  character(len=*)  :: filename_TRMM3B42RT
   integer, intent(in) :: findex
   integer, intent(in) :: order
   integer             :: ferror_TRMM3B42RT
@@ -69,8 +70,8 @@ subroutine read_TRMM3B42RTV7 (n, kk, filename_TRMM3B42RT, findex, &
   real    :: tmp(TRMM3B42RTV7_struc(n)%nc, TRMM3B42RTV7_struc(n)%nr)   
   real, allocatable  :: precip_regrid(:,:)   ! Interpolated precipitation array
  
-  character(len=120) :: filename             ! Filename variables
-  character*200      :: dirfile 
+  character(len=LIS_CONST_PATH_LEN) :: filename             ! Filename variables
+  character(len=LIS_CONST_PATH_LEN) :: dirfile 
   integer            :: ftn
   logical            :: file_exists
  
@@ -179,7 +180,7 @@ subroutine read_TRMM3B42RTV7 (n, kk, filename_TRMM3B42RT, findex, &
   use LIS_coreMod, only : LIS_rc
 
    implicit none
-   character*200, intent(in) :: dirfile
+   character(len=*), intent(in) :: dirfile
    integer,       intent(in) :: xd, yd 
    real,       intent(inout) :: precip(xd,yd)
 
@@ -227,7 +228,7 @@ subroutine read_TRMM3B42RTV7 (n, kk, filename_TRMM3B42RT, findex, &
 
   use LIS_coreMod, only : LIS_rc
 
-  character*200, intent(in) :: zipfile
+  character(len=*), intent(in) :: zipfile
   integer, intent(in) :: xd, yd
   real, intent(inout) :: output(xd, yd)
 
@@ -282,7 +283,7 @@ end subroutine read_3B42RTV7_gzip
   use LIS_logMod, only : LIS_logunit, LIS_getNextUnitNumber, &
                          LIS_releaseUnitNumber
 
-  character*200, intent(in) :: dirfile
+  character(len=*), intent(in) :: dirfile
   integer, intent(in)       :: xd,yd
   real,    intent(inout)    :: precip(xd,yd)
 

--- a/lis/metforcing/3B42V6/TRMM3B42V6_forcingMod.F90
+++ b/lis/metforcing/3B42V6/TRMM3B42V6_forcingMod.F90
@@ -52,6 +52,8 @@ module TRMM3B42V6_forcingMod
 !  \end{description}
 !
 ! !USES:
+    USE LIS_constantsMod, only: LIS_CONST_PATH_LEN
+
     implicit none
     PRIVATE
 !-----------------------------------------------------------------------------
@@ -70,7 +72,7 @@ module TRMM3B42V6_forcingMod
      real                     :: ts 
      integer                  :: ncold
      integer                  :: nrold
-     character*40             :: TRMM3B42V6dir
+     character(len=LIS_CONST_PATH_LEN) :: TRMM3B42V6dir
      real*8                   :: TRMM3B42V6time_TStepStart 
      integer                  :: TRMM3B42V6yr_TStepStart ! SY
      integer                  :: TRMM3B42V6mo_TStepStart ! SY

--- a/lis/metforcing/3B42V6/get_TRMM3B42V6.F90
+++ b/lis/metforcing/3B42V6/get_TRMM3B42V6.F90
@@ -28,6 +28,7 @@ subroutine get_TRMM3B42V6(n, findex)
   use LIS_logMod, only            : LIS_logunit, LIS_endrun
   use TRMM3B42V6_forcingMod, only : TRMM3B42V6_struc
   use LIS_metforcingMod, only     : LIS_forc ! SY
+  use LIS_constantsMod,      only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS:
@@ -65,7 +66,7 @@ subroutine get_TRMM3B42V6(n, findex)
   integer :: doy2, yr2, mo2, da2, hr2, mn2, ss2, ts2               ! SY: Time parameters for TRMM data time nearest to start of model time step
   integer :: doy3, yr3, mo3, da3, hr3, mn3, ss3, ts3               ! SY: Time parameters for TRMM data time nearest to end of model time step
   real    :: gmt1, gmt2, gmt3 ! SY ,kgmt3, mgmt3
-  character(len=80) :: name ! Filename variables for precip data sources
+  character(len=LIS_CONST_PATH_LEN) :: name ! Filename variables for precip data sources
   real*8 :: LIS_timeAtTStepStart_add90min ! SY
   real*8 :: LIS_timeAtTStepEnd_add90min ! SY
   integer :: order
@@ -179,7 +180,7 @@ subroutine get_TRMM3B42V6(n, findex)
                           TRMM3B42V6_struc(n)%TRMM3B42V6mo_TStepStart, &
                           TRMM3B42V6_struc(n)%TRMM3B42V6da_TStepStart, &
                           TRMM3B42V6_struc(n)%TRMM3B42V6hr_TStepStart )
-     write(LIS_logunit, *)'Getting new TRMM 3B42V6 satellite precip data:', name
+     write(LIS_logunit, *)'Getting new TRMM 3B42V6 satellite precip data:', trim(name)
      order = 1
      call read_TRMM3B42V6(n, name, findex, order, ferror_TRMM3B42V6)
    elseif (.NOT. ((TRMM3B42V6_struc(n)%TRMM3B42V6yr_TStepStart .EQ. &
@@ -218,7 +219,7 @@ subroutine get_TRMM3B42V6(n, findex)
                           TRMM3B42V6_struc(n)%TRMM3B42V6mo_TStepEnd, &
                           TRMM3B42V6_struc(n)%TRMM3B42V6da_TStepEnd, &
                           TRMM3B42V6_struc(n)%TRMM3B42V6hr_TStepEnd )
-     write(LIS_logunit, *)'Getting new TRMM 3B42V6 satellite precip data:', name
+     write(LIS_logunit, *)'Getting new TRMM 3B42V6 satellite precip data:', trim(name)
      order = 2
      call read_TRMM3B42V6(n, name, findex, order, ferror_TRMM3B42V6)
    endif
@@ -267,6 +268,7 @@ end subroutine get_TRMM3B42V6
 subroutine TRMM3B42V6file( name, n, yr, mo, da, hr)
 
   use TRMM3B42V6_forcingMod, only : TRMM3B42V6_struc
+  use LIS_constantsMod,      only : LIS_CONST_PATH_LEN
 
 !EOP
   implicit none
@@ -275,8 +277,8 @@ subroutine TRMM3B42V6file( name, n, yr, mo, da, hr)
 
 !==== Local Variables=======================
 
-  character(len=80) :: name, TRMM3B42V6dir
-  character*160 temp
+  character(len=*) :: name
+  character(len=LIS_CONST_PATH_LEN) :: temp, TRMM3B42V6dir
   integer :: yr, mo, da, hr
   integer :: i, j
   integer :: uyr, umo, uda, uhr, umn, uss
@@ -296,20 +298,14 @@ subroutine TRMM3B42V6file( name, n, yr, mo, da, hr)
 
    original = 2
    if (original .eq. 1) then     !  1. original: /abc/3B42.980131.12.6.precipitation
-     write(temp, '(a, a, I4, I2.2, a, 3I2.2, a, I2, a)') TRMM3B42V6dir, '/', yr, mo, '/3B42.', uyr, umo, uda, '.', &
+     write(temp, '(a, a, I4, I2.2, a, 3I2.2, a, I2, a)') trim(TRMM3B42V6dir), '/', yr, mo, '/3B42.', uyr, umo, uda, '.', &
           uhr,  '.6.precipitation'
    else                          !  2. renamed: TRMM3B42V6.2005110809
-     write(temp, '(a, a, I4, I2.2, a, I4, 3I2.2)') TRMM3B42V6dir, '/', yr, mo, '/3B42V6.', yr, umo, uda, uhr
+     write(temp, '(a, a, I4, I2.2, a, I4, 3I2.2)') trim(TRMM3B42V6dir), '/', yr, mo, '/3B42V6.', yr, umo, uda, uhr
    end if
 
   !strip off the spaces
-  j = 1
-  Do i=1, len(temp)
-   if( temp(i:i) .ne. ' ' ) then
-      name(j:j)=temp(i:i)
-      j=j+1
-   end if
-  End Do
+  name = trim(temp)
 
 end subroutine TRMM3B42V6file
 

--- a/lis/metforcing/3B42V6/read_TRMM3B42V6.F90
+++ b/lis/metforcing/3B42V6/read_TRMM3B42V6.F90
@@ -38,7 +38,7 @@ subroutine read_TRMM3B42V6 (n, fname, findex, order, ferror_TRMM3B42V6)
   implicit none
 ! !ARGUMENTS:
   integer, intent(in) :: n
-  character(len=80)   :: fname
+  character(len=*)   :: fname
   integer, intent(in) :: findex
   integer, intent(in) :: order
   integer             :: ferror_TRMM3B42V6

--- a/lis/metforcing/3B42V6/readcrd_TRMM3B42V6.F90
+++ b/lis/metforcing/3B42V6/readcrd_TRMM3B42V6.F90
@@ -43,7 +43,7 @@ subroutine readcrd_TRMM3B42V6()
 
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*)'Using TRMM 3B42V6 forcing'
-     write(LIS_logunit,*) 'TRMM 3B42V6 forcing directory :',TRMM3B42V6_struc(n)%TRMM3B42V6DIR
+     write(LIS_logunit,*) 'TRMM 3B42V6 forcing directory :',trim(TRMM3B42V6_struc(n)%TRMM3B42V6DIR)
 !------------------------------------------------------------------------
 ! Setting global observed precip times to zero to ensure
 ! data is read in during first time step

--- a/lis/metforcing/3B42V7/TRMM3B42V7_forcingMod.F90
+++ b/lis/metforcing/3B42V7/TRMM3B42V7_forcingMod.F90
@@ -55,6 +55,7 @@ module TRMM3B42V7_forcingMod
 !  \end{description}
 !
 ! !USES:
+    use LIS_constantsMod, only : LIS_CONST_PATH_LEN
     implicit none
     PRIVATE
 !-----------------------------------------------------------------------------
@@ -72,7 +73,7 @@ module TRMM3B42V7_forcingMod
      real                     :: ts 
      integer                  :: ncold
      integer                  :: nrold
-     character*40             :: TRMM3B42V7dir
+     character(len=LIS_CONST_PATH_LEN) :: TRMM3B42V7dir
      real*8                   :: TRMM3B42V7time_TStepStart ! SY
      integer                  :: TRMM3B42V7yr_TStepStart ! SY
      integer                  :: TRMM3B42V7mo_TStepStart ! SY

--- a/lis/metforcing/3B42V7/get_TRMM3B42V7.F90
+++ b/lis/metforcing/3B42V7/get_TRMM3B42V7.F90
@@ -26,6 +26,7 @@ subroutine get_TRMM3B42V7(n, findex)
                                     LIS_isAlarmRinging ! SY
   use LIS_logMod, only            : LIS_logunit, LIS_endrun
   use TRMM3B42V7_forcingMod, only : TRMM3B42V7_struc
+  use LIS_constantsMod,      only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS:
@@ -63,7 +64,7 @@ subroutine get_TRMM3B42V7(n, findex)
   integer :: doy2, yr2, mo2, da2, hr2, mn2, ss2, ts2   ! SY: Time parameters for TRMM data time nearest to start of model time step
   integer :: doy3, yr3, mo3, da3, hr3, mn3, ss3, ts3   ! SY: Time parameters for TRMM data time nearest to end of model time step
   real    :: gmt1, gmt2, gmt3       
-  character(len=80) :: filename     ! Filename variables for precip data sources
+  character(len=LIS_CONST_PATH_LEN) :: filename     ! Filename variables for precip data sources
   real*8  :: LIS_timeAtTStepStart_add90min ! SY
   real*8  :: LIS_timeAtTStepEnd_add90min   ! SY
   logical :: alarmCheck 
@@ -271,20 +272,19 @@ subroutine TRMM3B42V7file( filename, n, kk, findex, yr, mo, da, hr)
   use LIS_coreMod
   use LIS_forecastMod
   use TRMM3B42V7_forcingMod, only : TRMM3B42V7_struc
-
+  use LIS_constantsMod,      only : LIS_CONST_PATH_LEN
 !EOP
   implicit none
 
   integer, intent(in) :: n
   integer, intent(in) :: kk        ! Forecast member
   integer, intent(in) :: findex
-  character(80)       :: filename
+  character(len=*)       :: filename
   integer             :: yr, mo, da, hr
 
 !==== Local Variables=======================
 
-   character(80)  :: TRMM3B42V7dir
-   character(160) :: temp
+   character(len=LIS_CONST_PATH_LEN)  :: TRMM3B42V7dir, temp
    integer :: i, j
    integer :: uyr, umo, uda, uhr, umn, uss
    integer :: original
@@ -304,19 +304,14 @@ subroutine TRMM3B42V7file( filename, n, kk, findex, yr, mo, da, hr)
 
      original = 2
      if (original .eq. 1) then     !  1. original: /abc/3B42.980131.12.6.precipitation
-       write(temp, '(a, a, I4, I2.2, a, 3I2.2, a, I2, a)') TRMM3B42V7dir, '/', yr, mo, '/3B42.', uyr, umo, uda, '.', &
+       write(temp, '(a, a, I4, I2.2, a, 3I2.2, a, I2, a)') trim(TRMM3B42V7dir), '/', yr, mo, '/3B42.', uyr, umo, uda, '.', &
             uhr,  '.6.precipitation'
      else                          !  2. renamed: TRMM3B42V7.2005110809
-       write(temp, '(a, a, I4, I2.2, a, I4, 3I2.2)') TRMM3B42V7dir, '/', yr, mo, '/3B42V7.', yr, umo, uda, uhr
+       write(temp, '(a, a, I4, I2.2, a, I4, 3I2.2)') trim(TRMM3B42V7dir), '/', yr, mo, '/3B42V7.', yr, umo, uda, uhr
      end if
+     
      ! strip off the spaces
-     j = 1
-     Do i=1, len(temp)
-       if( temp(i:i) .ne. ' ' ) then
-         filename(j:j)=temp(i:i)
-         j=j+1
-       end if
-     End Do
+     filename = trim(temp)
 
    else !forecast mode
 
@@ -330,19 +325,14 @@ subroutine TRMM3B42V7file( filename, n, kk, findex, yr, mo, da, hr)
      uss = 0
      original = 2
      if (original .eq. 1) then     !  1. original: /abc/3B42.980131.12.6.precipitation
-       write(temp, '(a, a, I4, I2.2, a, 3I2.2, a, I2, a)') TRMM3B42V7dir, '/', yr, mo, '/3B42.', uyr, umo, uda, '.', &
+       write(temp, '(a, a, I4, I2.2, a, 3I2.2, a, I2, a)') trim(TRMM3B42V7dir), '/', yr, mo, '/3B42.', uyr, umo, uda, '.', &
             uhr,  '.6.precipitation'
      else                          !  2. renamed: TRMM3B42V7.2005110809
-       write(temp, '(a, a, I4, I2.2, a, I4, 3I2.2)') TRMM3B42V7dir, '/', yr, mo, '/3B42V7.', yr, umo, uda, uhr
+       write(temp, '(a, a, I4, I2.2, a, I4, 3I2.2)') trim(TRMM3B42V7dir), '/', yr, mo, '/3B42V7.', yr, umo, uda, uhr
      end if
+
      ! strip off the spaces
-     j = 1
-     Do i=1, len(temp)
-       if( temp(i:i) .ne. ' ' ) then
-         filename(j:j)=temp(i:i)
-         j=j+1
-       end if
-     End Do
+     filename = trim(temp)
 
    endif   ! End forecast mode
 

--- a/lis/metforcing/3B42V7/read_TRMM3B42V7.F90
+++ b/lis/metforcing/3B42V7/read_TRMM3B42V7.F90
@@ -32,7 +32,7 @@ subroutine read_TRMM3B42V7 (n, kk, fname, findex, order, ferror_TRMM3B42V7)
 ! !ARGUMENTS:
   integer, intent(in) :: n
   integer, intent(in) :: kk
-  character(len=80)   :: fname
+  character(len=*)   :: fname
   integer, intent(in) :: findex
   integer, intent(in) :: order
   integer             :: ferror_TRMM3B42V7

--- a/lis/metforcing/3B42V7/readcrd_TRMM3B42V7.F90
+++ b/lis/metforcing/3B42V7/readcrd_TRMM3B42V7.F90
@@ -44,7 +44,7 @@ subroutine readcrd_TRMM3B42V7()
 
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*)'Using TRMM 3B42V7 forcing'
-     write(LIS_logunit,*) 'TRMM 3B42V7 forcing directory :',TRMM3B42V7_struc(n)%TRMM3B42V7DIR
+     write(LIS_logunit,*) 'TRMM 3B42V7 forcing directory :',trim(TRMM3B42V7_struc(n)%TRMM3B42V7DIR)
 !------------------------------------------------------------------------
 ! Setting global observed precip times to zero to ensure
 ! data is read in during first time step

--- a/lis/metforcing/ALMIPII/ALMIPII_forcingMod.F90
+++ b/lis/metforcing/ALMIPII/ALMIPII_forcingMod.F90
@@ -16,6 +16,7 @@ module ALMIPII_forcingMod
 !
 ! !USES: 
   use ESMF
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
   
@@ -37,7 +38,7 @@ module ALMIPII_forcingMod
   type, public ::  ALMIPII_type_dec 
      real               :: ts
      integer            :: nc, nr
-     character*100      :: dir   !ALMIPII Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: dir   !ALMIPII Forcing Directory
      character*100      :: filename_prefix   !ALMIPII filename prefix
      integer            :: mi
      integer            :: ncid

--- a/lis/metforcing/ALMIPII/get_ALMIPII.F90
+++ b/lis/metforcing/ALMIPII/get_ALMIPII.F90
@@ -27,6 +27,7 @@ subroutine get_ALMIPII(n, findex)
   use LIS_timeMgrMod,     only : LIS_calendar
   use LIS_metforcingMod,  only : LIS_forc
   use LIS_logMod,         only : LIS_logunit, LIS_endrun, LIS_verify
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
   use ALMIPII_forcingMod,   only : ALMIPII_struc
 
   implicit none
@@ -40,7 +41,7 @@ subroutine get_ALMIPII(n, findex)
 !EOP
 
   character*4           :: fyr
-  character*100         :: ALMIPIIfile
+  character(len=LIS_CONST_PATH_LEN) :: ALMIPIIfile
   integer               :: lonid, latid
   integer               :: tair_id, qair_id, swd_id, lwd_id, u_id,v_id
   integer               :: psurf_id, rainf_id, snowf_id

--- a/lis/metforcing/AWAP/AWAP_forcingMod.F90
+++ b/lis/metforcing/AWAP/AWAP_forcingMod.F90
@@ -51,6 +51,8 @@ module AWAP_forcingMod
 ! 30 Jan 2017: Sujay Kumar, Initial version
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
 
   PRIVATE
@@ -70,7 +72,7 @@ module AWAP_forcingMod
      real               :: ts
      integer            :: ncol                 ! Number of cols
      integer            :: nrow                 ! Number of rows
-     character*40       :: AWAPdir              ! STAGE IV Directory
+     character(len=LIS_CONST_PATH_LEN) :: AWAPdir ! STAGE IV Directory
      real*8             :: AWAPtime             ! Nearest hourly instance of incoming file
      integer            :: mi                   ! Number of points in the input grid
      logical            :: interp_flag

--- a/lis/metforcing/AWAP/AWAPfile.F90
+++ b/lis/metforcing/AWAP/AWAPfile.F90
@@ -38,8 +38,8 @@ subroutine AWAPfile( name, AWAPdir, yr, doy)
 ! !ARGUMENTS: 
   integer :: yr, doy
 
-  character(80) :: name
-  character(40) :: AWAPdir
+  character(len=*) :: name
+  character(len=*) :: AWAPdir
   character(4) :: cyear
   character(3) :: cdoy
 

--- a/lis/metforcing/AWAP/get_AWAP.F90
+++ b/lis/metforcing/AWAP/get_AWAP.F90
@@ -23,6 +23,7 @@ subroutine get_AWAP(n, findex)
   use LIS_timeMgrMod, only  : LIS_tick, LIS_get_nstep
   use LIS_logMod,      only : LIS_logunit, LIS_endrun
   use AWAP_forcingMod, only : AWAP_struc
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -62,7 +63,7 @@ subroutine get_AWAP(n, findex)
     real*8  :: timenext
     real*8  :: AWAP_file_time1       ! End boundary time for STAGEIV file
     real*8  :: AWAP_file_time2       ! End boundary time for STAGEIV file
-    character(80) :: file_name       ! Filename variables for precip data sources
+    character(len=LIS_CONST_PATH_LEN) :: file_name ! Filename variables for precip data sources
 
     integer :: doy1, yr1, mo1, da1, hr1, mn1, ss1
     integer :: doy2, yr2, mo2, da2, hr2, mn2, ss2
@@ -114,7 +115,7 @@ subroutine get_AWAP(n, findex)
       if ( LIS_rc%time > AWAP_struc(n)%AWAPtime ) then
       ! Determine and return filename of AWAP file 
         call AWAPfile( file_name, AWAP_struc(n)%AWAPdir, yr2, doy2)
-        write(LIS_logunit,*) '[INFO] Getting new AWAP precip data:: ', file_name
+        write(LIS_logunit,*) '[INFO] Getting new AWAP precip data:: ', trim(file_name)
       ! Open, read, and reinterpolate AWAP field to LIS-defined grid
         call read_AWAP ( n, file_name, findex, order, ferror_AWAP )
       ! Assign latest AWAP file time to stored AWAP time variable
@@ -126,7 +127,7 @@ subroutine get_AWAP(n, findex)
 
      ! Determine and return filename of AWAP file 
        call AWAPfile( file_name, AWAP_struc(n)%AWAPdir, yr1, doy1 )
-       write(LIS_logunit,*) '[INFO] Getting new AWAP precip data:: ', file_name
+       write(LIS_logunit,*) '[INFO] Getting new AWAP precip data:: ', trim(file_name)
      ! Open, read, and reinterpolate AWAP field to LIS-defined grid
        call read_AWAP ( n, file_name, findex, order, ferror_AWAP )
      ! Assign latest AWAP file time to stored AWAP time variable

--- a/lis/metforcing/AWAP/read_AWAP.F90
+++ b/lis/metforcing/AWAP/read_AWAP.F90
@@ -32,7 +32,7 @@ subroutine read_AWAP( n, fname,findex,order, ferror_AWAP )
   implicit none
 ! !ARGUMENTS:
   integer, intent(in) :: n
-  character(len=80)   :: fname          
+  character(len=*)   :: fname          
   integer, intent(in) :: findex
   integer, intent(in) :: order
   integer             :: ferror_AWAP

--- a/lis/metforcing/AWAP/readcrd_AWAP.F90
+++ b/lis/metforcing/AWAP/readcrd_AWAP.F90
@@ -42,7 +42,7 @@ subroutine readcrd_AWAP()
        call ESMF_ConfigGetAttribute(LIS_config, AWAP_struc(n)%AWAPdir,rc=rc)
 
        write(LIS_logunit,*) '[INFO] Using AWAP forcing'
-       write(LIS_logunit,*) '[INFO] AWAP forcing directory :', AWAP_struc(n)%AWAPDIR
+       write(LIS_logunit,*) '[INFO] AWAP forcing directory :', trim(AWAP_struc(n)%AWAPDIR)
 
     !- Setting observed precip times to zero to ensure data is read in
     !   at first time step

--- a/lis/metforcing/AWRAL/AWRAL_forcingMod.F90
+++ b/lis/metforcing/AWRAL/AWRAL_forcingMod.F90
@@ -51,6 +51,8 @@ module AWRAL_forcingMod
 ! 30 Jan 2017: Sujay Kumar, Initial version
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
 
   PRIVATE
@@ -71,7 +73,7 @@ module AWRAL_forcingMod
      integer            :: ncol                 ! Number of cols
      integer            :: nrow                 ! Number of rows
      real 		:: gridDesci(50)
-     character*100      :: AWRALdir              ! STAGE IV Directory
+     character(len=LIS_CONST_PATH_LEN) :: AWRALdir ! STAGE IV Directory
      real*8             :: AWRALtime             ! Nearest daily instance of incoming file
      integer            :: mi                   ! Number of points in the input grid
      logical            :: interp_flag

--- a/lis/metforcing/AWRAL/get_AWRAL.F90
+++ b/lis/metforcing/AWRAL/get_AWRAL.F90
@@ -62,7 +62,6 @@ subroutine get_AWRAL(n, findex)
     real*8  :: timenext
     real*8  :: AWRAL_file_timep       ! End boundary time for STAGEIV file
     real*8  :: AWRAL_file_timec       ! End boundary time for STAGEIV file
-    character(80) :: file_name       ! Filename variables for precip data sources
 
     integer :: doyp, yrp, mop, dap, hrp, mnp, ssp
     integer :: doyc, yrc, moc, dac, hrc, mnc, ssc

--- a/lis/metforcing/AWRAL/read_AWRAL.F90
+++ b/lis/metforcing/AWRAL/read_AWRAL.F90
@@ -25,6 +25,7 @@ subroutine read_AWRAL( order, n, findex, year, doy, ferror_AWRAL )
   use LIS_logMod,         only : LIS_logunit, LIS_verify, LIS_endrun
   use LIS_metforcingMod,  only : LIS_forc
   use AWRAL_forcingMod,    only : AWRAL_struc
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
 
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
@@ -35,7 +36,6 @@ subroutine read_AWRAL( order, n, findex, year, doy, ferror_AWRAL )
   integer, intent(in)    :: order     ! lower(1) or upper(2) time interval bdry
   integer, intent(in)    :: n         ! nest
   integer, intent(in)    :: findex    ! forcing index
-  character(len=255)   :: fname          
   integer, intent(in) :: year,doy
   character(4) :: cyear
   integer             :: ferror_AWRAL
@@ -48,8 +48,6 @@ subroutine read_AWRAL( order, n, findex, year, doy, ferror_AWRAL )
 !  \begin{description}
 !  \item[n]
 !    index of the nest
-!  \item[fname]
-!    name of the AWRAL file : file naming convention is currently: AWRALdir/var_year.nc'
 !  \item[ferror\_AWRAL]
 !    flag to indicate success of the call (=0 indicates success)
 !  \item[filehr]
@@ -75,7 +73,7 @@ subroutine read_AWRAL( order, n, findex, year, doy, ferror_AWRAL )
        'pt        '     /)
 
 
-  character*255 :: var_fname
+  character(len=LIS_CONST_PATH_LEN) :: var_fname
   real,allocatable  :: datain(:,:) ! input data (lat,lon)
   logical            :: file_exists            
 ! netcdf variables
@@ -106,7 +104,7 @@ subroutine read_AWRAL( order, n, findex, year, doy, ferror_AWRAL )
     var_fname = trim(AWRAL_struc(n)%AWRALdir)//'/'//trim(awral_fv(v))//'_'//trim(cyear)//'.nc'
     inquire (file=trim(var_fname), exist=file_exists ) ! Check if file exists
      if (.not. file_exists)  then 
-       write(LIS_logunit,*)"[ERR] Missing AWRAL file: ", var_fname
+       write(LIS_logunit,*)"[ERR] Missing AWRAL file: ", trim(var_fname)
        ferror_AWRAL = 1
        return
     endif
@@ -129,7 +127,7 @@ subroutine read_AWRAL( order, n, findex, year, doy, ferror_AWRAL )
     ndata = AWRAL_struc(n)%ncol * AWRAL_struc(n)%nrow
     datain = 0.0
     var_fname = trim(AWRAL_struc(n)%AWRALdir)//'/'//trim(awral_fv(v))//'_'//trim(cyear)//'.nc'
-    write(LIS_logunit,*)"[INFO] Attempting to read file: ", var_fname 
+    write(LIS_logunit,*)"[INFO] Attempting to read file: ", trim(var_fname)
     !-- netcdf reader --!
     ! Open netCDF file.
     status = nf90_open(var_fname, nf90_NoWrite, ncid)
@@ -137,13 +135,13 @@ subroutine read_AWRAL( order, n, findex, year, doy, ferror_AWRAL )
   
     if(status/=0) then
        if(LIS_masterproc) then
-            write(LIS_logunit,*)'[ERR] Problem opening file: ',var_fname,status
+            write(LIS_logunit,*)'[ERR] Problem opening file: ',trim(var_fname),status
             write(LIS_logunit,*)'[ERR]  Stopping...'
             call LIS_endrun
        endif
          call LIS_endrun
     else
-       if(LIS_masterproc) write(LIS_logunit,*)'[INFO] Opened file: ',var_fname
+       if(LIS_masterproc) write(LIS_logunit,*)'[INFO] Opened file: ',trim(var_fname)
     endif
 
     status = nf90_get_var(ncid, varid, datain, &

--- a/lis/metforcing/AWRAL/readcrd_AWRAL.F90
+++ b/lis/metforcing/AWRAL/readcrd_AWRAL.F90
@@ -42,7 +42,7 @@ subroutine readcrd_AWRAL()
        call ESMF_ConfigGetAttribute(LIS_config, AWRAL_struc(n)%AWRALdir,rc=rc)
 
        write(LIS_logunit,*) '[INFO] Using AWRAL forcing'
-       write(LIS_logunit,*) '[INFO] AWRAL forcing directory :', AWRAL_struc(n)%AWRALDIR
+       write(LIS_logunit,*) '[INFO] AWRAL forcing directory :', trim(AWRAL_struc(n)%AWRALDIR)
 
     !- Setting observed forcing times to zero to ensure data is read in
     !   at first time step

--- a/lis/metforcing/Bondville/Bondville_forcingMod.F90
+++ b/lis/metforcing/Bondville/Bondville_forcingMod.F90
@@ -26,6 +26,8 @@ module Bondville_forcingMod
 ! 05 Oct 2010: David Mocko, Updated for Bondville test case
 ! 26 Oct 2018: David Mocko, Updated for Noah-MP-4.0.1 HRLDAS test case
 ! 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
   PRIVATE
 !-----------------------------------------------------------------------------
@@ -41,7 +43,7 @@ module Bondville_forcingMod
 
   type, public         :: Bondville_type_dec
      real                 :: ts
-     character*80         :: Bondvillefile
+     character(len=LIS_CONST_PATH_LEN) :: Bondvillefile
      integer              :: mp
      real                 :: undef
      real*8               :: starttime,Bondvilletime1,Bondvilletime2

--- a/lis/metforcing/Bondville/read_Bondville.F90
+++ b/lis/metforcing/Bondville/read_Bondville.F90
@@ -23,7 +23,8 @@ subroutine read_Bondville(n,ftn,findex,order,itime)
   use LIS_coreMod, only           : LIS_rc,LIS_domain
   use LIS_metforcingMod,     only : LIS_forc
   use LIS_timeMgrMod, only        : LIS_date2time,LIS_tick
-  use Bondville_forcingMod, only : Bondville_struc
+  use Bondville_forcingMod,  only : Bondville_struc
+  use LIS_constantsMod,      only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS:
@@ -75,7 +76,7 @@ subroutine read_Bondville(n,ftn,findex,order,itime)
   integer :: bonyr,bonmon,bonday,bonhr,bonmin,bonsec
   real    :: bontick
   logical :: file_exists
-  character*80       :: Bondville_filename
+  character(len=LIS_CONST_PATH_LEN) :: Bondville_filename
   character(len=500) :: line
 
   ! write(LIS_logunit,*) 'starting read_Bondville'

--- a/lis/metforcing/CaPA/capa_forcingMod.F90
+++ b/lis/metforcing/CaPA/capa_forcingMod.F90
@@ -43,6 +43,8 @@ module capa_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
   
   PRIVATE
@@ -62,7 +64,7 @@ module capa_forcingMod
      real             :: ts
      integer          :: ncold
      integer          :: nrold
-     character*40     :: capadir
+     character(len=LIS_CONST_PATH_LEN) :: capadir
      real*8           :: capatime
      integer          :: mi
      integer, allocatable :: n112(:,:)

--- a/lis/metforcing/CaPA/get_capa.F90
+++ b/lis/metforcing/CaPA/get_capa.F90
@@ -21,6 +21,7 @@ subroutine get_capa(n, findex)
   use LIS_coreMod,     only : LIS_rc
   use LIS_timeMgrMod,  only : LIS_tick, LIS_get_nstep
   use LIS_logMod,      only : LIS_logunit
+  use LIS_constantsMod, only: LIS_CONST_PATH_LEN
   use capa_forcingMod, only : capa_struc
 
   implicit none
@@ -62,7 +63,7 @@ subroutine get_capa(n, findex)
   real    :: ts1, ts5
   real*8  :: ctime,ftime_capa
   real    :: gmt1,gmt5       
-  character*80 :: name 
+  character(len=LIS_CONST_PATH_LEN) :: name
 
 !------------------------------------------------------------------------
 ! Determine required observed precip data times 
@@ -106,7 +107,7 @@ subroutine get_capa(n, findex)
    if ( endtime_capa == 1 ) then  !get new time2 data
         ferror_capa = 0
         call capafile( name, capa_struc(n)%capadir, yr5, mo5, da5, hr5 )
-        write(LIS_logunit,*) 'Getting new CAPA CPC precip data',name
+        write(LIS_logunit,*) 'Getting new CAPA CPC precip data',trim(name)
         call read_capa( n, findex, name, ferror_capa, hr5 )
         capa_struc(n)%capatime = ftime_capa
    endif  !need new time2

--- a/lis/metforcing/CaPA/read_capa.F90
+++ b/lis/metforcing/CaPA/read_capa.F90
@@ -32,7 +32,7 @@ subroutine read_capa(n, findex, fname, ferror_capa)
 ! !ARGUMENTS:
   integer, intent(in) :: n
   integer, intent(in) :: findex
-  character(len=80)   :: fname          
+  character(len=*)   :: fname
   integer             :: ferror_capa
 !
 ! !DESCRIPTION:

--- a/lis/metforcing/CaPA/readcrd_capa.F90
+++ b/lis/metforcing/CaPA/readcrd_capa.F90
@@ -41,7 +41,7 @@ subroutine readcrd_capa()
 
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*)'Using CAPA forcing'
-     write(LIS_logunit,*) 'CAPA forcing directory :',capa_struc(n)%CAPADIR
+     write(LIS_logunit,*) 'CAPA forcing directory :',trim(capa_struc(n)%CAPADIR)
 !------------------------------------------------------------------------
 ! Setting global observed precip times to zero to ensure 
 ! data is read in during first time step

--- a/lis/metforcing/FASSTsingle/FASSTsingle_forcingMod.F90
+++ b/lis/metforcing/FASSTsingle/FASSTsingle_forcingMod.F90
@@ -26,6 +26,7 @@ module FASSTsingle_forcingMod
 ! 13 Apr 2007: Bailing Li, Initial Specification
 ! 05 Oct 2010: David Mocko, Updated for FASST single-point test case
 ! 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
   PRIVATE
 !-----------------------------------------------------------------------------
@@ -40,7 +41,7 @@ module FASSTsingle_forcingMod
 !EOP
 
   type, public         :: FASSTsingle_type_dec
-     character*40         :: FASSTsinglefile
+     character(len=LIS_CONST_PATH_LEN) :: FASSTsinglefile
      real                 :: undef
      real*8               :: starttime,FASSTsingletime1,FASSTsingletime2
      integer              :: findtime1,findtime2,nstns

--- a/lis/metforcing/FASSTsingle/read_FASSTsingle.F90
+++ b/lis/metforcing/FASSTsingle/read_FASSTsingle.F90
@@ -22,6 +22,7 @@ subroutine read_FASSTsingle(n,ftn,findex,metdata,itime)
   use LIS_logMod, only            : LIS_logunit,LIS_endrun
   use LIS_coreMod, only           : LIS_rc,LIS_domain
   use LIS_timeMgrMod, only        : LIS_date2time,LIS_doy2date
+  use LIS_constantsMod, only      : LIS_CONST_PATH_LEN
   use FASSTsingle_forcingMod, only : FASSTsingle_struc
 
   implicit none
@@ -75,7 +76,7 @@ subroutine read_FASSTsingle(n,ftn,findex,metdata,itime)
   integer :: lisdoy,fasstdoy
   integer :: fasstyr,fasstmon,fasstday,fassthr,fasstmin,fasstsec
   logical :: file_exists
-  character*80       :: FASSTsingle_filename
+  character(len=LIS_CONST_PATH_LEN) :: FASSTsingle_filename
   character(len=500) :: line
 
   !      write(LIS_logunit,*) 'starting read_FASSTsingle'

--- a/lis/metforcing/HiMAT_GMU/HiMATGMU_forcingMod.F90
+++ b/lis/metforcing/HiMAT_GMU/HiMATGMU_forcingMod.F90
@@ -49,6 +49,7 @@ module HiMATGMU_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
 
   PRIVATE
@@ -68,7 +69,7 @@ module HiMATGMU_forcingMod
      real               :: ts
      integer            :: ncol                 ! Number of cols
      integer            :: nrow                 ! Number of rows
-     character*40       :: HiMATGMUdir              ! STAGE IV Directory
+     character(len=LIS_CONST_PATH_LEN) :: HiMATGMUdir ! STAGE IV Directory
      real*8             :: HiMATGMUtime             ! Nearest hourly instance of incoming file
      integer            :: mi                   ! Number of points in the input grid
 

--- a/lis/metforcing/HiMAT_GMU/HiMATGMUfile.F90
+++ b/lis/metforcing/HiMAT_GMU/HiMATGMUfile.F90
@@ -42,8 +42,8 @@ subroutine HiMATGMUfile( name, HiMATGMUdir, yr, mo, da, hr)
 ! !ARGUMENTS: 
   integer :: yr, mo, da, hr
 
-  character(80) :: name
-  character(40) :: HiMATGMUdir
+  character(len=*) :: name
+  character(len=*) :: HiMATGMUdir
   character(4) :: cyear
   character(2) :: cmon, cday, chour
 

--- a/lis/metforcing/HiMAT_GMU/get_HiMATGMU.F90
+++ b/lis/metforcing/HiMAT_GMU/get_HiMATGMU.F90
@@ -23,6 +23,7 @@ subroutine get_HiMATGMU(n, findex)
   use LIS_timeMgrMod, only  : LIS_tick, LIS_get_nstep
   use LIS_logMod,      only : LIS_logunit, LIS_endrun
   use HiMATGMU_forcingMod, only : HiMATGMU_struc
+  use LIS_constantsMod,    only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -71,7 +72,7 @@ subroutine get_HiMATGMU(n, findex)
 
     real*8  :: HiMATGMU_file_time1  
     real*8  :: HiMATGMU_file_time2  
-    character(80) :: file_name      
+    character(len=LIS_CONST_PATH_LEN) :: file_name      
 
     integer :: doy1, yr1, mo1, da1, hr1, mn1, ss1
     integer :: doy2, yr2, mo2, da2, hr2, mn2, ss2
@@ -115,7 +116,7 @@ subroutine get_HiMATGMU(n, findex)
       if ( LIS_rc%time > HiMATGMU_struc(n)%HiMATGMUtime ) then
 
         call HiMATGMUfile( file_name, HiMATGMU_struc(n)%HiMATGMUdir, yr2, mo2, da2, hr2 )
-        write(LIS_logunit,*) '[INFO] Getting new HiMAT GMU precip data: ', file_name
+        write(LIS_logunit,*) '[INFO] Getting new HiMAT GMU precip data: ', trim(file_name)
         call read_HiMATGMU ( n, file_name, findex, order, ferror_HiMATGMU )
         HiMATGMU_struc(n)%HiMATGMUtime = HiMATGMU_file_time2
       endif
@@ -123,7 +124,7 @@ subroutine get_HiMATGMU(n, findex)
     elseif( LIS_rc%ts == HiMATGMU_struc(n)%ts ) then
 
        call HiMATGMUfile( file_name, HiMATGMU_struc(n)%HiMATGMUdir, yr1, mo1, da1, hr1 )
-       write(LIS_logunit,*) '[INFO] Getting new HiMAT GMU precip data: ', file_name
+       write(LIS_logunit,*) '[INFO] Getting new HiMAT GMU precip data: ', trim(file_name)
        call read_HiMATGMU ( n, file_name, findex, order, ferror_HiMATGMU )
        HiMATGMU_struc(n)%HiMATGMUtime = HiMATGMU_file_time1
 

--- a/lis/metforcing/HiMAT_GMU/read_HiMATGMU.F90
+++ b/lis/metforcing/HiMAT_GMU/read_HiMATGMU.F90
@@ -32,7 +32,7 @@ subroutine read_HiMATGMU( n, fname,findex,order, ferror_HiMATGMU )
   implicit none
 ! !ARGUMENTS:
   integer, intent(in) :: n
-  character(len=80)   :: fname          
+  character(len=*)   :: fname          
   integer, intent(in) :: findex
   integer, intent(in) :: order
   integer             :: ferror_HiMATGMU

--- a/lis/metforcing/HiMAT_GMU/readcrd_HiMATGMU.F90
+++ b/lis/metforcing/HiMAT_GMU/readcrd_HiMATGMU.F90
@@ -42,7 +42,7 @@ subroutine readcrd_HiMATGMU()
        call ESMF_ConfigGetAttribute(LIS_config, HiMATGMU_struc(n)%HiMATGMUdir,rc=rc)
 
        write(LIS_logunit,*) '[INFO] Using HiMAT GMU forcing'
-       write(LIS_logunit,*) '[INFO] HiMAT GMU forcing directory :', HiMATGMU_struc(n)%HIMATGMUDIR
+       write(LIS_logunit,*) '[INFO] HiMAT GMU forcing directory :', trim(HiMATGMU_struc(n)%HIMATGMUDIR)
 
     !- Setting observed precip times to zero to ensure data is read in
     !   at first time step

--- a/lis/metforcing/Loobos/Loobos_forcingMod.F90
+++ b/lis/metforcing/Loobos/Loobos_forcingMod.F90
@@ -25,6 +25,8 @@ module Loobos_forcingMod
 ! !REVISION HISTORY: 
 ! 05 Oct 2010: David Mocko, Updated for Loobos test case
 ! 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
   PRIVATE
 !-----------------------------------------------------------------------------
@@ -40,7 +42,7 @@ module Loobos_forcingMod
 
   type, public         :: Loobos_type_dec
      real                 :: ts
-     character*80         :: Loobosfile
+     character(len=LIS_CONST_PATH_LEN) :: Loobosfile
      real                 :: undef
      real*8               :: starttime,Loobostime1,Loobostime2
      integer              :: findtime1,findtime2,nstns

--- a/lis/metforcing/Loobos/read_Loobos.F90
+++ b/lis/metforcing/Loobos/read_Loobos.F90
@@ -24,6 +24,7 @@ subroutine read_Loobos(n,ftn,findex,order,itime)
   use LIS_metforcingMod,     only : LIS_forc
   use LIS_timeMgrMod, only        : LIS_date2time,LIS_tick
   use Loobos_forcingMod, only : Loobos_struc
+  use LIS_constantsMod,  only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS:
@@ -77,7 +78,7 @@ subroutine read_Loobos(n,ftn,findex,order,itime)
   integer :: loobos_yr,loobos_mon,loobos_day,loobos_hr,loobos_min,loobos_sec
   real    :: loobos_tick
   logical :: file_exists
-  character*80       :: Loobos_filename
+  character(len=LIS_CONST_PATH_LEN) :: Loobos_filename
   character(len=500) :: line
 
   !      write(LIS_logunit,*) 'starting read_Loobos'

--- a/lis/metforcing/PALSmetdata/PALSmetdata_forcingMod.F90
+++ b/lis/metforcing/PALSmetdata/PALSmetdata_forcingMod.F90
@@ -22,6 +22,7 @@ module PALSmetdata_forcingMod
 !
 ! !USES: 
   use ESMF
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 
@@ -40,7 +41,7 @@ module PALSmetdata_forcingMod
   type, public ::  PALSmetdata_type_dec 
 
      real                       :: ts
-     character*80               :: PALSmetdatadir     
+     character(len=LIS_CONST_PATH_LEN) :: PALSmetdatadir     
      character*80               :: stn_name
      real*8                     :: fcsttime1,fcsttime2
      integer                    :: findtime1, findtime2

--- a/lis/metforcing/PALSmetdata/get_PALSmetdata.F90
+++ b/lis/metforcing/PALSmetdata/get_PALSmetdata.F90
@@ -32,6 +32,7 @@ subroutine get_PALSmetdata(n,findex)
   use LIS_metforcingMod,  only : LIS_forc
   use LIS_logMod
   use PALSmetdata_forcingMod,  only : PALSmetdata_struc
+  use LIS_constantsMod,        only : LIS_CONST_PATH_LEN
 #if (defined USE_NETCDF3 || defined USE_NETCDF4) 
   use netcdf
 #endif
@@ -69,7 +70,7 @@ subroutine get_PALSmetdata(n,findex)
 !  \end{description}
 !
 !EOP
-  character*100                 :: name
+  character(len=LIS_CONST_PATH_LEN) :: name
   logical                       :: file_exists
   integer                       :: ftn
   integer                       :: t

--- a/lis/metforcing/PALSmetdata/readcrd_PALSmetdata.F90
+++ b/lis/metforcing/PALSmetdata/readcrd_PALSmetdata.F90
@@ -101,7 +101,7 @@ subroutine readcrd_PALSmetdata()
 
   do n=1,LIS_rc%nnest
      write(unit=LIS_logunit,fmt=*) 'PALS met forcing directory :',&
-          PALSmetdata_struc(n)%PALSmetdatadir
+          trim(PALSmetdata_struc(n)%PALSmetdatadir)
 
      PALSmetdata_struc(n)%fcsttime1 = 3000.0
      PALSmetdata_struc(n)%fcsttime2 = 0.0

--- a/lis/metforcing/PILDAS/get_pildas.F90
+++ b/lis/metforcing/PILDAS/get_pildas.F90
@@ -24,6 +24,7 @@ subroutine get_pildas(n,findex)
   use LIS_timeMgrMod
   use LIS_logMod
   use LIS_metforcingMod
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   use pildas_forcingMod
 
   implicit none
@@ -63,7 +64,7 @@ subroutine get_pildas(n,findex)
   real*8  :: dtime1, dtime2
   integer :: yr1,mo1,da1,hr1,mn1,ss1,doy1
   integer :: yr2,mo2,da2,hr2,mn2,ss2,doy2
-  character*80 :: name
+  character(len=LIS_CONST_PATH_LEN) :: name
   real :: gmt1,gmt2,ts1,ts2
   integer:: movetime     ! 1=move time 2 data into time 1  
 
@@ -172,7 +173,7 @@ subroutine get_pildas(n,findex)
              pildas_struc(n)%version,&
              yr1,mo1,da1,hr1,mn1)
         
-        write(unit=LIS_logunit,fmt=*)'getting file1.. ',name
+        write(unit=LIS_logunit,fmt=*)'getting file1.. ',trim(name)
         order = 1
         call read_pildas(n,findex,order,name,ferror)
         if(ferror.ge.1) then
@@ -201,7 +202,7 @@ subroutine get_pildas(n,findex)
              pildas_struc(n)%version,&
              yr2,mo2,da2,hr2,mn2)
         
-        write(unit=LIS_logunit,fmt=*)'getting file2.. ',name
+        write(unit=LIS_logunit,fmt=*)'getting file2.. ',trim(name)
         order = 2
         call read_pildas(n,findex,order,name,ferror)
         if(ferror.ge.1) then

--- a/lis/metforcing/PILDAS/pildas_forcingMod.F90
+++ b/lis/metforcing/PILDAS/pildas_forcingMod.F90
@@ -55,6 +55,8 @@ module pildas_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
 
   PRIVATE
@@ -74,7 +76,7 @@ module pildas_forcingMod
      integer :: nc, nr
      integer :: version
      integer :: uselml
-     character*40 :: pildasdir
+     character(len=LIS_CONST_PATH_LEN) :: pildasdir
      real*8 :: pildastime1,pildastime2
      real   :: gmt1, gmt2
 

--- a/lis/metforcing/PILDAS/read_pildas.F90
+++ b/lis/metforcing/PILDAS/read_pildas.F90
@@ -31,7 +31,7 @@ subroutine read_pildas(n, findex, order, name,ferror)
   integer, intent(in)      :: findex
   integer, intent(in)      :: n
   integer, intent(in)      :: order
-  character*80, intent(in) :: name
+  character(len=*), intent(in) :: name
   integer, intent(out)     :: ferror
 !
 ! !DESCRIPTION:

--- a/lis/metforcing/PILDAS/readcrd_pildas.F90
+++ b/lis/metforcing/PILDAS/readcrd_pildas.F90
@@ -61,7 +61,7 @@ subroutine readcrd_pildas()
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*) 'Using PILDAS forcing'
      write(LIS_logunit,*) 'PILDAS forcing directory: ',&
-          pildas_struc(n)%PILDASDIR
+          trim(pildas_struc(n)%PILDASDIR)
 
      pildas_struc(n)%nc = 70
      pildas_struc(n)%nr = 50

--- a/lis/metforcing/RFE2Daily/RFE2Daily_forcingMod.F90
+++ b/lis/metforcing/RFE2Daily/RFE2Daily_forcingMod.F90
@@ -65,6 +65,7 @@ module RFE2Daily_forcingMod
 !
 ! !USES:
   use ESMF
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 
@@ -83,7 +84,7 @@ module RFE2Daily_forcingMod
 
   type, public :: RFE2Daily_type_dec
      real                    :: ts
-     character*40            :: RFE2DailyDir
+     character(len=LIS_CONST_PATH_LEN) :: RFE2DailyDir
      real*8                  :: RFE2DailyEndTime
      type(ESMF_Time)         :: startTime
      real*8                  :: st_real

--- a/lis/metforcing/RFE2Daily/get_RFE2Daily.F90
+++ b/lis/metforcing/RFE2Daily/get_RFE2Daily.F90
@@ -24,6 +24,7 @@ subroutine get_RFE2Daily(n, findex)
   use LIS_timeMgrMod,        only : LIS_calendar, LIS_get_nstep, &
                                     LIS_tick, LIS_date2time, LIS_time2date
   use LIS_logMod,            only : LIS_logunit, LIS_endrun, LIS_verify
+  use LIS_constantsMod,      only : LIS_CONST_PATH_LEN
   use RFE2Daily_forcingMod,  only : RFE2Daily_struc
 
   implicit none
@@ -91,7 +92,7 @@ subroutine get_RFE2Daily(n, findex)
   real    :: gmtNow, gmt1, gmt2
 
   integer :: ferror_RFE2Daily ! Error flags for precip data sources
-  character*80 :: filename    ! Filename variables for precip data sources
+  character(len=LIS_CONST_PATH_LEN) :: filename    ! Filename variables for precip data sources
   integer      :: order
   integer      :: kk          ! Forecast index
 

--- a/lis/metforcing/RFE2Daily/readcrd_RFE2Daily.F90
+++ b/lis/metforcing/RFE2Daily/readcrd_RFE2Daily.F90
@@ -51,7 +51,7 @@ subroutine readcrd_RFE2Daily()
      call ESMF_ConfigGetAttribute(LIS_config,RFE2Daily_struc(n)%RFE2DailyDir,rc=rc)
      call LIS_verify(rc,"LISconfig: RFE2Daily forcing dir value not correct/given")
      write(LIS_logunit,*) 'For nest ', n, ', RFE2Daily forcing directory: ', &
-                             RFE2Daily_struc(n)%RFE2DailyDir
+                             trim(RFE2Daily_struc(n)%RFE2DailyDir)
   enddo
   write(LIS_logunit,*) 'Using RFE2Daily forcing'
 

--- a/lis/metforcing/RFE2Daily/readprecip_RFE2Daily.F90
+++ b/lis/metforcing/RFE2Daily/readprecip_RFE2Daily.F90
@@ -31,7 +31,7 @@ subroutine readprecip_RFE2Daily( n, kk, findex, fname, order, ferror_RFE2Daily)
   integer, intent(in) :: n
   integer, intent(in) :: kk
   integer, intent(in) :: findex
-  character(len=80)   :: fname
+  character(len=*)   :: fname
   integer, intent(in) :: order
   integer             :: ferror_RFE2Daily
 ! 
@@ -65,7 +65,6 @@ subroutine readprecip_RFE2Daily( n, kk, findex, fname, order, ferror_RFE2Daily)
   real, allocatable     :: rain1d(:)
   REAL, ALLOCATABLE     :: rain2d(:,:)
   integer               :: ftn, ios, ftn2, ftn3
-  character(len=84)     :: fnametemp
   LOGICAL               :: file_exists
   real, dimension(LIS_rc%lnc(n), LIS_rc%lnr(n)) :: varfield ! reprojected arrray
 

--- a/lis/metforcing/RFE2gdas/RFE2gdas_forcingMod.F90
+++ b/lis/metforcing/RFE2gdas/RFE2gdas_forcingMod.F90
@@ -77,6 +77,7 @@ module RFE2gdas_forcingMod
 !
 ! !USES:
   use ESMF
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 
@@ -95,7 +96,7 @@ module RFE2gdas_forcingMod
 
   type, public :: RFE2gdas_type_dec
 
-     character*80             :: RFE2gdasDir
+     character(len=LIS_CONST_PATH_LEN) :: RFE2gdasDir
      real*8                   :: RFE2gdasEndTime
      type(ESMF_Time)          :: startTime
      real*8                   :: st_real

--- a/lis/metforcing/RFE2gdas/get_RFE2gdas.F90
+++ b/lis/metforcing/RFE2gdas/get_RFE2gdas.F90
@@ -24,6 +24,7 @@ subroutine get_RFE2gdas(n, findex)
   use LIS_coreMod,         only : LIS_rc
   use LIS_timeMgrMod,      only : LIS_calendar, LIS_get_nstep, LIS_tick
   use LIS_logMod,          only : LIS_logunit, LIS_endrun, LIS_verify
+  use LIS_constantsMod,    only : LIS_CONST_PATH_LEN
   use RFE2gdas_forcingMod, only : RFE2gdas_struc
 
   implicit none
@@ -77,7 +78,7 @@ subroutine get_RFE2gdas(n, findex)
   real*8  :: ctime,EndTime_RFE2gdas       ! Current LDAS time and end boundary time for precip data source
   real    :: gmtNow,gmt1,gmt2             ! GMT times for current LDAS time and begin and end boundary times for precip data sources
   integer :: ferror_RFE2gdas              ! Error flags for precip data sources
-  character*140:: filename                ! Filename variables for precip data sources
+  character(len=LIS_CONST_PATH_LEN):: filename                ! Filename variables for precip data sources
   integer      :: order,kk
 
 !=== End Variable Definition =======================

--- a/lis/metforcing/RFE2gdas/readprecip_RFE2gdas.F90
+++ b/lis/metforcing/RFE2gdas/readprecip_RFE2gdas.F90
@@ -28,7 +28,7 @@ subroutine readprecip_RFE2gdas( n, kk,fname, month, findex, order, ferror_RFE2gd
 ! !ARGUMENTS:
   integer, intent(in) :: n
   integer, intent(in) :: kk
-  character(len=80)   :: fname
+  character(len=*)    :: fname
   integer, intent(in) :: month
   integer, intent(in) :: findex
   integer, intent(in) :: order
@@ -69,7 +69,6 @@ subroutine readprecip_RFE2gdas( n, kk,fname, month, findex, order, ferror_RFE2gd
   REAL, ALLOCATABLE     :: rain2d(:,:)
   real, dimension(LIS_rc%lnc(n), LIS_rc%lnr(n)) :: varfield ! reprojected arrray
   integer               ::  ftn, ios, ftn2, ftn3
-  character(len=84)     :: fnametemp
 
 !=== End Variable Definition =======================
 

--- a/lis/metforcing/WRFout/WRFout_forcingMod.F90
+++ b/lis/metforcing/WRFout/WRFout_forcingMod.F90
@@ -38,6 +38,7 @@ module WRFout_forcingMod
 !  \end{description}
 
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
 
   PRIVATE
@@ -54,7 +55,7 @@ module WRFout_forcingMod
 
   type, public    :: WRFout_type_dec
      integer      :: nest_id
-     character*80 :: WRFoutdir
+     character(len=LIS_CONST_PATH_LEN) :: WRFoutdir
      real         :: ts
      real*8       :: WRFouttime1,WRFouttime2
      integer      :: findtime1,findtime2

--- a/lis/metforcing/WRFout/get_WRFout.F90
+++ b/lis/metforcing/WRFout/get_WRFout.F90
@@ -22,6 +22,7 @@ subroutine get_WRFout(n, findex)
   use LIS_metforcingMod, only : LIS_forc
   use LIS_timeMgrMod,    only : LIS_tick
   use LIS_logMod,        only : LIS_logunit, LIS_endrun
+  use LIS_constantsMod,  only : LIS_CONST_PATH_LEN
   use WRFout_forcingMod, only : WRFout_struc
 
   implicit none
@@ -56,7 +57,7 @@ subroutine get_WRFout(n, findex)
   integer      :: yr1,mo1,da1,hr1,mn1,ss1,doy1
   integer      :: yr2,mo2,da2,hr2,mn2,ss2,doy2
   real         :: ts1, ts2
-  character*80 :: fname
+  character(len=LIS_CONST_PATH_LEN) :: fname
   real         :: gmt1,gmt2
   integer      :: movetime     ! 1=move time 2 data into time 1
 
@@ -159,7 +160,7 @@ subroutine get_WRFout(n, findex)
         call WRFoutfile(fname,WRFout_struc(n)%WRFoutdir,&
              WRFout_struc(n)%nest_id, yr1,mo1,da1,hr1,mn1,ss1)
 
-        write(unit=LIS_logunit,fmt=*)'[INFO] getting file1.. ',fname
+        write(unit=LIS_logunit,fmt=*)'[INFO] getting file1.. ',trim(fname)
         call read_WRFout(n,findex,1,fname,ferror)
 
         if(ferror.ge.1) WRFout_struc(n)%WRFouttime1=time1
@@ -186,7 +187,7 @@ subroutine get_WRFout(n, findex)
         call WRFoutfile(fname,WRFout_struc(n)%WRFoutdir,&
              WRFout_struc(n)%nest_id, yr2,mo2,da2,hr2,mn2,ss2)
 
-        write(unit=LIS_logunit,fmt=*)'[INFO] getting file2.. ',fname
+        write(unit=LIS_logunit,fmt=*)'[INFO] getting file2.. ',trim(fname)
         call read_WRFout(n,findex,2,fname,ferror)
 
         if(ferror.ge.1) then
@@ -215,8 +216,8 @@ end subroutine get_WRFout
 
    implicit none
 ! !ARGUMENTS: 
-   character*80, intent(out) :: filename
-   character*40, intent(in)  :: wrfdir
+   character(len=*), intent(out) :: filename
+   character(len=*), intent(in)  :: wrfdir
    integer, intent(in)       :: nest
    integer, intent(in)       :: yr,mo,da,hr,mn,ss
 

--- a/lis/metforcing/WRFout/readcrd_WRFout.F90
+++ b/lis/metforcing/WRFout/readcrd_WRFout.F90
@@ -49,7 +49,7 @@ subroutine readcrd_WRFout()
   write(unit=LIS_logunit,fmt=*)'[INFO] Using WRF output forcing'
 
   do n=1,LIS_rc%nnest
-     write(unit=LIS_logunit,fmt=*) '[INFO] WRF output forcing directory :',WRFout_struc(n)%WRFoutdir
+     write(unit=LIS_logunit,fmt=*) '[INFO] WRF output forcing directory :',trim(WRFout_struc(n)%WRFoutdir)
 
      WRFout_struc(n)%WRFouttime1 = 3000.0
      WRFout_struc(n)%WRFouttime2 = 0.0

--- a/lis/metforcing/agrrad/agrrad_forcingMod.F90
+++ b/lis/metforcing/agrrad/agrrad_forcingMod.F90
@@ -53,6 +53,7 @@ module agrrad_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
   PRIVATE
 !-----------------------------------------------------------------------------
@@ -72,7 +73,7 @@ module agrrad_forcingMod
      real*8           :: agrtime1,agrtime2
      real*8           :: changetime1,changetime2
      integer          :: findtime1,findtime2
-     character*40     :: agrdir
+     character(len=LIS_CONST_PATH_LEN) :: agrdir
      integer, allocatable :: n111(:)
      integer, allocatable :: n121(:)
      integer, allocatable :: n211(:)

--- a/lis/metforcing/agrrad/read_agrrad.F90
+++ b/lis/metforcing/agrrad/read_agrrad.F90
@@ -22,6 +22,7 @@ subroutine read_agrrad(n,findex,order,yr,mo,da,hr)
   use LIS_coreMod,        only : LIS_rc,LIS_domain
   use LIS_logMod,         only : LIS_logunit, LIS_endrun
   use LIS_timeMgrMod,     only : LIS_tick
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
   use LIS_metforcingMod,  only : LIS_forc
   use agrrad_forcingMod,  only : agrrad_struc
 
@@ -67,7 +68,7 @@ subroutine read_agrrad(n,findex,order,yr,mo,da,hr)
 !EOP
 
   integer,   parameter     :: nc = 720, nr=361
-  character*100            :: agrradfile
+  character(len=LIS_CONST_PATH_LEN) :: agrradfile
   real                     :: var(nc,nr)
   real                     :: swd(nc*nr)
   logical*1                :: lb(nc*nr)
@@ -370,7 +371,7 @@ subroutine retrieve_agrrad_variables(fname, error, vindex, var)
   implicit none
   integer, parameter             :: nc=720, nr=361
 ! !ARGUMENTS:
-  character(len=100), intent(in) :: fname
+  character(len=*), intent(in) :: fname
   integer, intent(out)           :: error
   integer, intent(in)            :: vindex
   real, intent(out)              :: var(nc,nr)

--- a/lis/metforcing/agrrad/readcrd_agrrad.F90
+++ b/lis/metforcing/agrrad/readcrd_agrrad.F90
@@ -39,7 +39,7 @@ subroutine readcrd_agrrad()
   do n=1,LIS_rc%nnest
      call ESMF_ConfigGetAttribute(LIS_config,agrrad_struc(n)%agrdir,rc=rc)
      write(LIS_logunit,*) 'AGRRAD forcing directory :',&
-                          agrrad_struc(n)%agrdir
+                          trim(agrrad_struc(n)%agrdir)
   enddo
 
 end subroutine readcrd_agrrad

--- a/lis/metforcing/agrradps/agrradps_forcingMod.F90
+++ b/lis/metforcing/agrradps/agrradps_forcingMod.F90
@@ -102,6 +102,7 @@ module agrradps_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
   
 !-----------------------------------------------------------------------------
@@ -119,7 +120,7 @@ module agrradps_forcingMod
   type agrradps_type_dec
      real                 :: ts
      real*8               :: agrtime1,agrtime2
-     character*40         :: agrpsdir
+     character(len=LIS_CONST_PATH_LEN) :: agrpsdir
      integer              :: gridspan
      integer              :: mo1
      integer              :: mo2

--- a/lis/metforcing/agrradps/read_agrradps.F90
+++ b/lis/metforcing/agrradps/read_agrradps.F90
@@ -25,6 +25,7 @@ subroutine read_agrradps(n,m,order,yr,mo,da,hr)
   use LIS_logMod,          only : LIS_logunit, LIS_verify
   use LIS_FORC_AttributesMod 
   use LIS_metforcingMod,  only : LIS_FORC_Base_State
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -63,8 +64,7 @@ subroutine read_agrradps(n,m,order,yr,mo,da,hr)
 !  \end{description}
 !EOP
 
-  character*100            :: agrradpsfileNH
-  character*100            :: agrradpsfileSH
+  character(len=LIS_CONST_PATH_LEN) :: agrradpsfileNH,  agrradpsfileSH
   logical                  :: exists1,exists2,exists3,exists4
   integer                  :: c,r
   integer                  :: t

--- a/lis/metforcing/agrradps/readcrd_agrradps.F90
+++ b/lis/metforcing/agrradps/readcrd_agrradps.F90
@@ -39,7 +39,7 @@ subroutine readcrd_agrradps()
   do n=1,LIS_rc%nnest
     call ESMF_ConfigGetAttribute(LIS_config,agrradps_struc(n)%agrpsdir,rc=rc)
     write(LIS_logunit,*) 'AGRRADPS forcing directory :',&
-                         agrradps_struc(n)%agrpsdir
+                         trim(agrradps_struc(n)%agrpsdir)
   enddo
 
 

--- a/lis/metforcing/arms/arms_forcingMod.F90
+++ b/lis/metforcing/arms/arms_forcingMod.F90
@@ -27,6 +27,7 @@ module arms_forcingMod
 ! 28 Jun 2009: Sujay Kumar: Reengineered for LIS version 6
 ! 
   use ESMF
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
   PRIVATE
@@ -43,9 +44,7 @@ module arms_forcingMod
 
   type, public :: arms_type_dec
      real          :: ts 
-     character*40  :: armsfile
-     character*40  :: armspcpfile
-     character*40  :: mdatafile
+     character(len=LIS_CONST_PATH_LEN) :: armsfile,  armspcpfile, mdatafile
      real          :: undef
      real*8        :: starttime,armstime1,armstime2
      logical       :: startRead

--- a/lis/metforcing/arms/readcrd_arms.F90
+++ b/lis/metforcing/arms/readcrd_arms.F90
@@ -51,7 +51,7 @@ subroutine readcrd_arms()
 
   do n=1, LIS_rc%nnest
      write(LIS_logunit,*)'Using ARMS forcing'
-     write(LIS_logunit,*) 'ARMS forcing directory :',arms_struc(n)%armsfile
+     write(LIS_logunit,*) 'ARMS forcing directory :',trim(arms_struc(n)%armsfile)
      arms_struc(n)%startRead = .true.
 
      arms_struc(n)%armstime1 = 3000.0

--- a/lis/metforcing/ceop/ceop_forcingMod.F90
+++ b/lis/metforcing/ceop/ceop_forcingMod.F90
@@ -25,6 +25,8 @@ module ceop_forcingMod
 ! !REVISION HISTORY: 
 ! 08Dec2004: Sujay Kumar; Initial Specification
 ! 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
   PRIVATE
 !-----------------------------------------------------------------------------
@@ -40,8 +42,7 @@ module ceop_forcingMod
 
   type, public :: ceop_type_dec
      real          :: ts
-     character*40  :: ceopdir 
-     character*40  :: metadata 
+     character(len=LIS_CONST_PATH_LEN) :: ceopdir, metadata 
      real          :: undef
      real*8        :: starttime,ceoptime1,ceoptime2
      integer       :: findtime1,findtime2,nstns

--- a/lis/metforcing/ceop/readcrd_ceop.F90
+++ b/lis/metforcing/ceop/readcrd_ceop.F90
@@ -50,8 +50,8 @@ subroutine readcrd_ceop()
   enddo
   do n=1, LIS_rc%nnest
      write(LIS_logunit,*)'Using CEOP forcing'
-     write(LIS_logunit,*) 'CEOP forcing directory :',ceop_struc(n)%ceopdir
-     write(LIS_logunit,*) 'CEOP metadata file : ',ceop_struc(n)%metadata
+     write(LIS_logunit,*) 'CEOP forcing directory :',trim(ceop_struc(n)%ceopdir)
+     write(LIS_logunit,*) 'CEOP metadata file : ',trim(ceop_struc(n)%metadata)
      ceop_struc(n)%ceoptime2  = 3000.0
      ceop_struc(n)%ceoptime1  = 0.0
      ceop_struc(n)%startRead = .false.

--- a/lis/metforcing/chirps2/chirps2_forcingMod.F90
+++ b/lis/metforcing/chirps2/chirps2_forcingMod.F90
@@ -48,6 +48,7 @@ module chirps2_forcingMod
 
 ! !USES:
   use ESMF
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
   PRIVATE
@@ -69,7 +70,7 @@ module chirps2_forcingMod
      integer            :: nc
      integer            :: nr
      integer            :: mi
-     character*80       :: directory  
+     character(len=LIS_CONST_PATH_LEN) :: directory  
      real*8             :: chirpstime1, chirpstime2
      logical            :: reset_flag
      integer            :: start_nc, start_nr

--- a/lis/metforcing/chirps2/get_chirps2.F90
+++ b/lis/metforcing/chirps2/get_chirps2.F90
@@ -23,6 +23,7 @@ subroutine get_chirps2(n,findex)
   use LIS_timeMgrMod,      only : LIS_get_nstep, LIS_tick
   use LIS_logMod,          only : LIS_logunit, LIS_endrun
   use chirps2_forcingMod,  only : chirps2_struc
+  use LIS_constantsMod,    only : LIS_CONST_PATH_LEN
 
   implicit none
 
@@ -64,7 +65,7 @@ subroutine get_chirps2(n,findex)
   real    :: gmt1,gmt2,ts1,ts2
   integer :: kk
 
-  character*120 :: chirps2_filename
+  character(len=LIS_CONST_PATH_LEN) :: chirps2_filename
   logical :: file_exists
 
 ! ___________________________________________________________________

--- a/lis/metforcing/chirps2/read_chirps2.F90
+++ b/lis/metforcing/chirps2/read_chirps2.F90
@@ -40,7 +40,7 @@ subroutine read_chirps2( n, kk, findex, chirps_filename, year, mon, day, ferror 
   integer, intent(in)    :: mon
   integer, intent(in)    :: day
   integer, intent(inout) :: ferror   ! set to non-zero if there's an error
-  character(120), intent(in) :: chirps_filename
+  character(len=*), intent(in) :: chirps_filename
 
 ! !DESCRIPTION:
 !  For the given time, reads the CHIRPS 2.0 precipitation data, 

--- a/lis/metforcing/climatology/climatology_VariablesMod.F90
+++ b/lis/metforcing/climatology/climatology_VariablesMod.F90
@@ -302,7 +302,7 @@ contains
 !
 ! !ARGUMENTS: 
    integer, intent(in) :: findex          ! Forcing index
-   character(140), intent(in) :: filename ! Forcing filename path
+   character(len=*), intent(in) :: filename ! Forcing filename path
    integer, intent(in) :: inc, inr        ! Input forcing cols, rows
    integer, intent(in) :: ntimes          ! Input number of daily time pts 
 !

--- a/lis/metforcing/climatology/climatology_forcingMod.F90
+++ b/lis/metforcing/climatology/climatology_forcingMod.F90
@@ -25,7 +25,9 @@ module climatology_forcingMod
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
 #endif
-!
+
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
 
 !-----------------------------------------------------------------------------
@@ -48,7 +50,7 @@ module climatology_forcingMod
      real*8         :: findtime1, metforc_time1
      real*8         :: findtime2, metforc_time2
 
-     character(120) :: directory
+     character(len=LIS_CONST_PATH_LEN) :: directory
      character(50)  :: proj_name
      integer        :: proj_index
  
@@ -93,7 +95,7 @@ contains
     integer  :: varid
     real     :: gridDesci(50)
     logical  :: file_exists
-    character(140) :: fullfilename
+    character(len=LIS_CONST_PATH_LEN) :: fullfilename
 
     integer  :: da, hr, mn, ss
     character*50 :: timeInc

--- a/lis/metforcing/climatology/get_climatology.F90
+++ b/lis/metforcing/climatology/get_climatology.F90
@@ -24,6 +24,7 @@ subroutine get_climatology(n, findex)
   use LIS_timeMgrMod,   only : LIS_tick, LIS_get_nstep
   use climatology_forcingMod,  only : clim_struc
   use climatology_VariablesMod
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -55,7 +56,7 @@ subroutine get_climatology(n, findex)
   integer        :: c, r
   integer        :: metforc_hrts
   integer        :: metforc_mnts
-  character(140) :: fullfilename
+  character(len=LIS_CONST_PATH_LEN) :: fullfilename
   logical        :: file_exists
 
 ! Date/time parameters for file get/read:

--- a/lis/metforcing/climatology/get_climatology_filename.F90
+++ b/lis/metforcing/climatology/get_climatology_filename.F90
@@ -20,8 +20,8 @@
    implicit none
 ! !ARGUMENTS: 
    integer, intent(in)        :: doy             ! File day of year (DOY)
-   character*100, intent(in)  :: directory       ! File directory
-   character*140, intent(out) :: filename  
+   character(len=*), intent(in)  :: directory       ! File directory
+   character(len=*), intent(out) :: filename  
 !
 ! !DESCRIPTION:
 !   This subroutine puts together LDT generated forcing

--- a/lis/metforcing/cmap/cmap_forcingMod.F90
+++ b/lis/metforcing/cmap/cmap_forcingMod.F90
@@ -62,6 +62,7 @@ module cmap_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
   
@@ -82,7 +83,7 @@ module cmap_forcingMod
      real                   :: ts
      integer                :: ncold
      integer                :: nrold  
-     character*40           :: cmapdir  
+     character(len=LIS_CONST_PATH_LEN) :: cmapdir  
      character*50           :: met_interp
      real*8                 :: cmaptime
      real*8                 :: griduptime1

--- a/lis/metforcing/cmap/get_cmap.F90
+++ b/lis/metforcing/cmap/get_cmap.F90
@@ -27,6 +27,7 @@ subroutine get_cmap(n,findex)
   use LIS_timeMgrMod,  only : LIS_tick, LIS_get_nstep
   use LIS_logMod,      only : LIS_logunit, LIS_endrun
   use cmap_forcingMod, only : cmap_struc
+  use LIS_constantsMod, only: LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -76,7 +77,7 @@ subroutine get_cmap(n,findex)
   integer :: order
   real    :: gmt1,gmt5,ts1,ts5   ! GMT times for current LDAS time and end boundary times for precip data sources
   real    :: gridDesci(50)
-  character*80 :: filename ! Filename variables for precip data sources
+  character(len=LIS_CONST_PATH_LEN) :: filename ! Filename variables for precip data sources
 !=== End Variable Definition =======================
 
 !------------------------------------------------------------------------
@@ -291,12 +292,10 @@ end subroutine get_cmap
 !
 ! !INTERFACE:
 subroutine cmapfile( filename, cmapdir, yr, mo, da, hr)
-
   implicit none
 ! !ARGUMENTS: 
   character(len=*)   :: filename
   character(len=*)   :: cmapdir
-  character(len=100) :: temp
   integer            :: yr, mo, da, hr
 ! !DESCRIPTION:
 !   This subroutine puts together CMAP file name for 
@@ -320,9 +319,11 @@ subroutine cmapfile( filename, cmapdir, yr, mo, da, hr)
 !
 !EOP
 
-  integer :: i, c
   integer :: uyr, umo, uda, uhr, umn, uss, ts1
-  character*1 :: fbase(80), fdir(8), ftime(10), fsubs(10), fsubs2(4)
+  character(len=6)  :: fdir
+  character(len=10) :: ftime
+  character(len=10), parameter :: fprefix = 'cmap_gdas_'
+  character(len=4),  parameter :: fext = '.grb'
 
 !=== End Variable Definition ===============
 
@@ -340,42 +341,10 @@ subroutine cmapfile( filename, cmapdir, yr, mo, da, hr)
 
   filename = ''
 
-  write(UNIT=temp, fmt='(a40)') cmapdir
-  read(UNIT=temp, fmt='(80a1)') (fbase(i), i=1,80)
+  write(UNIT=fdir,  fmt='(i4, i2.2)')  uyr, umo
+  write(UNIT=ftime, fmt='(i4, i2.2, i2.2, i2.2)') uyr, umo, uda, uhr
 
-  write(UNIT=temp, fmt='(a1, i4, i2, a1)') '/', uyr, umo, '/'
-  read(UNIT=temp, fmt='(8a1)') fdir
-  do i = 1, 8
-     if ( fdir(i) == ' ' ) fdir(i) = '0'
-  end do
-
-  write(UNIT=temp, fmt='(a10)') 'cmap_gdas_'
-  read (UNIT=temp, fmt='(10a1)') (fsubs(i), i=1,10)
-
-  write(UNIT=temp, fmt='(i4, i2, i2, i2)') uyr, umo, uda, uhr
-  read(UNIT=temp, fmt='(10a1)') ftime
-  do i = 1, 10
-     if ( ftime(i) == ' ' ) ftime(i) = '0'
-  end do
-
-  write(UNIT=temp, fmt='(i4, i2, i2, i2)') uyr, umo, uda, uhr
-  read(UNIT=temp, fmt='(10a1)') ftime
-  do i = 1, 10
-     if ( ftime(i) == ' ' ) ftime(i) = '0'
-  end do
-
-  write(UNIT=temp, fmt='(a4)') '.grb'
-  read (UNIT=temp, fmt='(4a1)') (fsubs2(i), i=1,4)
-  c = 0
-  do i = 1, 80
-     if ( (fbase(i) == ' ') .and. (c == 0) ) c = i-1
-  end do
-
-  write(UNIT=temp, fmt='(80a1)') (fbase(i), i=1,c), (fdir(i), i=1,8),  &
-                       (fsubs(i), i=1,10),(ftime(i), i=1,10), &
-                       (fsubs2(i), i=1,4)
-
-  read(UNIT=temp, fmt='(a80)') filename
+  filename = trim(cmapdir) // '/' // fdir // '/' // fprefix // ftime // fext
 
   return
 end subroutine cmapfile

--- a/lis/metforcing/cmap/read_cmap.F90
+++ b/lis/metforcing/cmap/read_cmap.F90
@@ -32,7 +32,7 @@ subroutine read_cmap( n, fname, findex, order, ferror_cmap, filehr)
   implicit none
 ! !ARGUMENTS:
   integer, intent(in) :: n
-  character(len=80)   :: fname          
+  character(len=*)   :: fname          
   integer, intent(in) :: findex
   integer, intent(in) :: order
   integer             :: ferror_cmap

--- a/lis/metforcing/cmorph/cmorph_forcingMod.F90
+++ b/lis/metforcing/cmorph/cmorph_forcingMod.F90
@@ -49,6 +49,8 @@ module cmorph_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
   PRIVATE
 !-----------------------------------------------------------------------------
@@ -65,7 +67,7 @@ module cmorph_forcingMod
   type, public :: cmorph_type_dec
      real    :: ts
      integer :: ncold, nrold   !AWIPS 212 dimensions
-     character*100 :: cmorphdir   !CMOR Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: cmorphdir   !CMOR Forcing Directory
      real*8  :: cmorphtime
      real*8  :: griduptime1
      logical :: gridchange1

--- a/lis/metforcing/cmorph/get_cmorph.F90
+++ b/lis/metforcing/cmorph/get_cmorph.F90
@@ -27,6 +27,7 @@ subroutine get_cmorph(n, findex)
   use LIS_timeMgrMod, only : LIS_tick, LIS_get_nstep
   use cmorph_forcingMod, only :cmorph_struc
   use LIS_logMod, only : LIS_logunit
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -66,7 +67,7 @@ subroutine get_cmorph(n, findex)
   real*8  :: datatime, breaktime, fnametime                    ! Times used in HUFFMAN to determine data and filename boundaries (see below)
   integer :: order
   real    :: gmt1,gmt4,ts1,ts4
-  character(len=99) :: filename ! Filename variables for precip data sources
+  character(len=LIS_CONST_PATH_LEN) :: filename ! Filename variables for precip data sources
   integer :: kk
 
 !=== End Variable Definition =======================
@@ -133,10 +134,10 @@ subroutine get_cmorph(n, findex)
        if(LIS_masterproc) then
          if (sectionofcmorph .EQ. 1) then
            write(LIS_logunit,*) '[INFO] Getting new CMORPH precip data first 30 minutes:'
-           write(LIS_logunit,*) filename
+           write(LIS_logunit,*) trim(filename)
          else
            write(LIS_logunit,*) '[INFO] Getting new CMORPH precip data second 30 minutes:'
-           write(LIS_logunit,*) filename
+           write(LIS_logunit,*) trim(filename)
          endif
        end if
        order = 2
@@ -191,12 +192,11 @@ subroutine cmorphfile( n, kk, findex, filename, cmorphdir, yr, mo, da, hr)
 !EOP
 
   integer, parameter :: T2008060100 = 1212292800
-  character(len=120) :: temp
   integer :: i, c
   integer :: uyr, umo, uda, uhr, umn, uss, ts1
   integer :: tout(9), fmktime, it, ih, irec
 
-  character*100 :: fbase, ftimedir, fstem 
+  character*100 :: fstem 
   character*4   :: cyr
   character*2   :: cmo, cda, chr 
 

--- a/lis/metforcing/cmorph/read_cmorph.F90
+++ b/lis/metforcing/cmorph/read_cmorph.F90
@@ -26,6 +26,7 @@ subroutine read_cmorph (n, kk, name_cmorph, findex, order, ferror_cmorph, iflg )
                           LIS_releaseUnitNumber
   use LIS_metforcingMod, only : LIS_forc
   use cmorph_forcingMod, only : cmorph_struc
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS:   
@@ -75,7 +76,7 @@ subroutine read_cmorph (n, kk, name_cmorph, findex, order, ferror_cmorph, iflg )
   real     :: realprecip(xd,yd)
   real     :: testout(xd,yd)
   real, allocatable :: precip_regrid(:,:)    ! Interpolated precip array
-  character(len=99) :: fname, zname          ! Filename variables
+  character(len=LIS_CONST_PATH_LEN) :: fname, zname          ! Filename variables
   logical           :: file_exists
   integer           :: ftn
 
@@ -231,7 +232,7 @@ subroutine read_cmorph (n, kk, name_cmorph, findex, order, ferror_cmorph, iflg )
 
   integer :: xd, yd, iflg
   character*1 ::  precip(xd,yd)
-  character*99 :: zname
+  character(len=*) :: zname
   character*1, allocatable :: buff(:, :, :)
   integer :: readzipf, dlen, rdlen 
   

--- a/lis/metforcing/cmorph/readcrd_cmorph.F90
+++ b/lis/metforcing/cmorph/readcrd_cmorph.F90
@@ -47,7 +47,7 @@ subroutine readcrd_cmorph()
      call ESMF_ConfigGetAttribute(LIS_config,cmorph_struc(n)%nrold,rc=rc)
      
      write(LIS_logunit,*)'Using CMORPH forcing'
-     write(LIS_logunit,*) 'CMORPH forcing directory :',cmorph_struc(n)%CMORPHDIR
+     write(LIS_logunit,*) 'CMORPH forcing directory :',trim(cmorph_struc(n)%CMORPHDIR)
 !------------------------------------------------------------------------
 ! Setting global observed precip times to zero to ensure 
 ! data is read in during first time step

--- a/lis/metforcing/coop/coop_forcingMod.F90
+++ b/lis/metforcing/coop/coop_forcingMod.F90
@@ -25,6 +25,7 @@ module coop_forcingMod
 ! !REVISION HISTORY: 
 ! 13Jul2011: Yuqiong Liu:  Initial Specification
 ! 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
   PRIVATE
 !-----------------------------------------------------------------------------
@@ -40,9 +41,7 @@ module coop_forcingMod
 
   type, public ::  coop_type_dec
      real           :: ts
-     character*100  :: coopdir 
-     character*100  :: metadata 
-     character*100  :: coorddata 
+     character(len=LIS_CONST_PATH_LEN) :: coopdir, metadata, coorddata 
      real          :: undef
      real*8        :: starttime,cooptime1,cooptime2
      integer       :: findtime1,findtime2,nstns

--- a/lis/metforcing/coop/read_coop.F90
+++ b/lis/metforcing/coop/read_coop.F90
@@ -22,6 +22,7 @@ subroutine read_coop(n,ftn,findex,order)
   use LIS_logMod, only         : LIS_logunit, LIS_endrun
   use LIS_coreMod, only        : LIS_rc,LIS_domain
   use LIS_metforcingMod,  only : LIS_forc
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
   use coop_forcingMod,    only : coop_struc
   use map_utils,    only : latlon_to_ij
 
@@ -66,7 +67,7 @@ subroutine read_coop(n,ftn,findex,order)
 !  real :: varfield(LIS_rc%lnc(n)*LIS_rc%lnr(n))
   real :: varfield1(LIS_rc%lnc(n),LIS_rc%lnr(n))
   integer :: npcp(LIS_rc%lnc(n),LIS_rc%lnr(n))
-  character*80 :: coop_filename
+  character(len=LIS_CONST_PATH_LEN) :: coop_filename
 !  character(len=500) :: line
   integer :: yr,mo
   logical :: file_exists, readflag
@@ -99,7 +100,7 @@ subroutine read_coop(n,ftn,findex,order)
 
      inquire(file=coop_filename,exist=file_exists)
      if(file_exists) then 
-        write(LIS_logunit,*) 'Reading COOP file ',coop_filename
+        write(LIS_logunit,*) 'Reading COOP file ',trim(coop_filename)
         open(ftn,file=coop_filename,form='formatted',status='old')
         read(ftn,*)
         read(ftn,*) ! skip the two header line

--- a/lis/metforcing/ecmwf/ecmwf_forcingMod.F90
+++ b/lis/metforcing/ecmwf/ecmwf_forcingMod.F90
@@ -70,6 +70,8 @@ module ecmwf_forcingMod
 !  \end{description}
 !
 ! !USES:
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
 
   PRIVATE
@@ -89,7 +91,7 @@ module ecmwf_forcingMod
   type, public     :: ecmwf_type_dec
      real          :: ts
      integer       :: ncold, nrold    ! AWIPS 212 dimensions
-     character*145 :: ecmwfdir        ! ecmwf Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: ecmwfdir ! ecmwf Forcing Directory
      !character*45 :: elevfileifs23r4  ! elevation for 2001-2002
      !character*45 :: elevfileifs25r1  ! elevation for 2003-2006
      !character*45 :: elevfileifs30r1  ! elevation for 2006 - jun 2008

--- a/lis/metforcing/ecmwf/get_ecmwf.F90
+++ b/lis/metforcing/ecmwf/get_ecmwf.F90
@@ -23,6 +23,7 @@ subroutine get_ecmwf(n,findex)
   use LIS_logMod,         only : LIS_logunit
   use LIS_timeMgrMod,     only : LIS_get_nstep, LIS_tick
   use ecmwf_forcingMod,   only : ecmwf_struc
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
 
   implicit none
 
@@ -62,7 +63,7 @@ subroutine get_ecmwf(n,findex)
   integer :: yr1,mo1,da1,hr1,mn1,ss1,doy1
   integer :: yr2,mo2,da2,hr2,mn2,ss2,doy2
   real*8  :: time1,time2,dumbtime1,dumbtime2
-  character*200 :: avgfilename1, instfilename, avgfilename2
+  character(len=LIS_CONST_PATH_LEN) :: avgfilename1, instfilename, avgfilename2
   real    :: gmt1,gmt2,ts1,ts2
   integer :: movetime      ! 1=move time 2 data into time 1
   integer :: nforce  ! # forcing variables
@@ -259,6 +260,7 @@ subroutine create_ecmwf_filename(dir,avgfilename1, avgfilename2, instfilename,&
      yr,mo,da,hr)
 ! !USES: 
   use LIS_timeMgrMod, only : LIS_tick
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -279,7 +281,8 @@ subroutine create_ecmwf_filename(dir,avgfilename1, avgfilename2, instfilename,&
   real*8 :: itime
   real :: igmt
   integer :: iyr,imo,ida,ihr,imn,iss,ts,idoy
-  character(200) :: filename, file1, file2
+  character(len=LIS_CONST_PATH_LEN) :: filename
+  character(200)                    :: file1, file2
 
 
   !instantaneous files 

--- a/lis/metforcing/ecmwf/read_ecmwf_elev.F90
+++ b/lis/metforcing/ecmwf/read_ecmwf_elev.F90
@@ -22,6 +22,7 @@ subroutine read_ecmwf_elev(n, findex, change)
   use LIS_metforcingMod, only : LIS_forc
   use LIS_fileIOMod,     only : LIS_read_param
   use LIS_logMod,         only : LIS_logunit, LIS_endrun
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
   use ecmwf_forcingMod,   only : ecmwf_struc
 
   implicit none
@@ -45,10 +46,10 @@ subroutine read_ecmwf_elev(n, findex, change)
   integer :: c,r,line1,line2,nc_dom,line
   integer :: glnc, glnr
   real :: go(LIS_rc%lnc(n),LIS_rc%lnr(n))
-  character(len=45) :: filename
+  character(len=LIS_CONST_PATH_LEN) :: filename
 
   if ( trim(LIS_rc%met_ecor(findex)) .ne."none" ) then 
-     write(LIS_logunit,*) 'Reading the ECMWF elevation ',filename
+     write(LIS_logunit,*) 'Reading the ECMWF elevation ',trim(filename)
      if ( change == 0 ) then ! period 2001-2002
         call LIS_read_param(n,"ELEV_ECMWF_S23R4",go)
      elseif ( change == 1 ) then ! period 04/2002-02/2006

--- a/lis/metforcing/ecmwf/readcrd_ecmwf.F90
+++ b/lis/metforcing/ecmwf/readcrd_ecmwf.F90
@@ -73,7 +73,7 @@ subroutine readcrd_ecmwf()
 
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*)'Using ECMWF forcing'
-     write(LIS_logunit,*) 'ECMWF forcing directory :',ecmwf_struc(n)%ecmwfDIR
+     write(LIS_logunit,*) 'ECMWF forcing directory :',trim(ecmwf_struc(n)%ecmwfDIR)
 #if 0
      write(LIS_logunit,*) 'ECMWF IFS23R4 elevation map :',ecmwf_struc(n)%elevfileifs23r4
      write(LIS_logunit,*) 'ECMWF IFS25R1 elevation map :',ecmwf_struc(n)%elevfileifs25r1

--- a/lis/metforcing/ecmwfreanal/ecmwfreanal_forcingMod.F90
+++ b/lis/metforcing/ecmwfreanal/ecmwfreanal_forcingMod.F90
@@ -64,6 +64,8 @@ module ecmwfreanal_forcingMod
 !  Geophysical Research, 108, 4490, DOI: 10.1029/2002JD003334. \newline
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
   
   PRIVATE
@@ -84,9 +86,8 @@ module ecmwfreanal_forcingMod
      integer                :: ncold, nrold   !AWIPS 212 dimensions
      real*8                 :: fmodeltime1,fmodeltime2
      integer                :: remask1d(720*360)
-     character*100          :: ecmwfreanaldir
-     character*100           :: emaskfile !1/2deg ECMWFREANAL Land-Sea Mask File
-     character*100          :: elevfile
+     character(len=LIS_CONST_PATH_LEN) :: ecmwfreanaldir, elevfile
+     character(len=LIS_CONST_PATH_LEN) :: emaskfile !1/2deg ECMWFREANAL Land-Sea Mask File
      integer                :: mi
      integer, allocatable   :: n111(:)
      integer, allocatable   :: n121(:)

--- a/lis/metforcing/ecmwfreanal/read_ecmwfreanal.F90
+++ b/lis/metforcing/ecmwfreanal/read_ecmwfreanal.F90
@@ -26,6 +26,7 @@ subroutine read_ecmwfreanal(order, n, findex, yr, mon, da, hr, ferror)
   use LIS_coreMod,        only : LIS_rc,LIS_domain, LIS_localPet, LIS_masterproc
   use LIS_metforcingMod, only : LIS_forc
   use LIS_logMod,         only : LIS_logunit, LIS_endrun
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
   use ecmwfreanal_forcingMod, only : ecmwfreanal_struc
 
 
@@ -115,7 +116,7 @@ subroutine read_ecmwfreanal(order, n, findex, yr, mon, da, hr, ferror)
   integer, dimension(N_EF), parameter :: fnum = (/ &
        31, 33, 34, 35, 36, 37, 38, 39 /) 
 
-  character*200 :: infile
+  character(len=LIS_CONST_PATH_LEN) :: infile
 
   real :: tempecmwf(ecmwfreanal_struc(n)%ncold,ecmwfreanal_struc(n)%nrold,N_EF)
   real :: temp2ecmwf(ecmwfreanal_struc(n)%ncold,ecmwfreanal_struc(n)%nrold,NF)

--- a/lis/metforcing/ecmwfreanal/read_ecmwfreanal_elev.F90
+++ b/lis/metforcing/ecmwfreanal/read_ecmwfreanal_elev.F90
@@ -57,7 +57,7 @@ subroutine read_ecmwfreanal_elev(n,findex)
   allocate(LIS_forc(n,findex)%modelelev(LIS_rc%ngrid(n)))
   
   write(LIS_logunit,*) 'Reading the ECMWF Reanalysis elevation ',&
-       ecmwfreanal_struc(n)%elevfile
+       trim(ecmwfreanal_struc(n)%elevfile)
 !  ftn = LIS_getNextUnitNumber()
 !  open(ftn,file=ecmwfreanal_struc(n)%elevfile,form='unformatted',&
 !       access='direct',recl=4)

--- a/lis/metforcing/era5/era5_forcingMod.F90
+++ b/lis/metforcing/era5/era5_forcingMod.F90
@@ -59,6 +59,9 @@ module era5_forcingMod
 !  \end{description}
 !
 ! !USES:
+
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
 
   PRIVATE
@@ -78,8 +81,8 @@ module era5_forcingMod
      integer      :: npts
      real         :: ts
      integer      :: ncold, nrold
-     character*40 :: era5dir   !ERA5 Forcing Directory
-     character*40 :: mapfile
+     character(len=LIS_CONST_PATH_LEN) :: era5dir   !ERA5 Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: mapfile
      real*8       :: era5time1,era5time2
      logical      :: reset_flag
      integer      :: mo1,mo2

--- a/lis/metforcing/era5/get_era5.F90
+++ b/lis/metforcing/era5/get_era5.F90
@@ -24,6 +24,7 @@ subroutine get_era5(n, findex)
   use LIS_logMod
   use LIS_metforcingMod
   use era5_forcingMod
+  use LIS_constantsMod, only: LIS_CONST_PATH_LEN
 
   implicit none
 
@@ -63,7 +64,7 @@ subroutine get_era5(n, findex)
 !EOP
   integer           :: order
   integer           :: ferror
-  character*100     :: fname
+  character(len=LIS_CONST_PATH_LEN) :: fname
   integer           :: c, r,kk,f,try
   integer           :: yr1, mo1, da1, hr1, mn1, ss1, doy1
   integer           :: yr2, mo2, da2, hr2, mn2, ss2, doy2
@@ -270,7 +271,6 @@ subroutine era5files(n, kk, findex, era5dir, yr, mo, da, fname)
   character*4  :: cyear
   character*2  :: cmonth
   character*8  :: cdate
-  character*20 :: dir
   integer      :: hr, mn, ss
   real*8       :: time
   integer      :: doy

--- a/lis/metforcing/era5/readcrd_era5.F90
+++ b/lis/metforcing/era5/readcrd_era5.F90
@@ -52,7 +52,7 @@ subroutine readcrd_era5()
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*) '[INFO] Using ERA5 forcing'
      write(LIS_logunit,*) '[INFO] ERA5 forcing directory: ',&
-          era5_struc(n)%era5DIR
+          trim(era5_struc(n)%era5DIR)
 
      era5_struc(n)%era5time1 = 3000.0
      era5_struc(n)%era5time2 = 0.0

--- a/lis/metforcing/gdas/gdas_forcingMod.F90
+++ b/lis/metforcing/gdas/gdas_forcingMod.F90
@@ -89,6 +89,7 @@ module gdas_forcingMod
 !  \end{description}
 !
 ! !USES:
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 
@@ -108,7 +109,7 @@ module gdas_forcingMod
      real          :: ts
      integer       :: ncold, nrold   !AWIPS 212 dimensions
      integer       :: nmif
-     character*100 :: gdasdir   !GDAS Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: gdasdir   !GDAS Forcing Directory
      character*50  :: met_interp
 
      real*8        :: gdastime1, gdastime2

--- a/lis/metforcing/gdas/get_gdas.F90
+++ b/lis/metforcing/gdas/get_gdas.F90
@@ -35,6 +35,7 @@ subroutine get_gdas(n, findex)
   use LIS_timeMgrMod,     only : LIS_tick, LIS_get_nstep
   use LIS_logMod,         only : LIS_logunit, LIS_endrun
   use gdas_forcingMod,    only : gdas_struc
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -92,7 +93,7 @@ subroutine get_gdas(n, findex)
   real*8  :: timenow, time1, time2
   real*8  :: dumbtime1, dumbtime2
   real    :: gmt1, gmt2
-  character(len=80) :: name00, name03, name06
+  character(len=LIS_CONST_PATH_LEN) :: name00, name03, name06
   logical :: file_exists1, file_exists2, file_exists3
   real :: gridDesci(50)
   integer :: nstep

--- a/lis/metforcing/gdas/read_gdas.F90
+++ b/lis/metforcing/gdas/read_gdas.F90
@@ -40,6 +40,7 @@ subroutine read_gdas( order, n, findex, &
   use gdas_forcingMod,    only : gdas_struc
   use LIS_logMod,         only : LIS_logunit, LIS_endrun
   use LIS_surfaceModelDataMod
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS:
@@ -87,7 +88,7 @@ subroutine read_gdas( order, n, findex, &
 !EOP
 !==== Local Variables=======================
   
-  character(len=80) :: fname
+  character(len=LIS_CONST_PATH_LEN) :: fname
   integer :: iv, c,r,t
   integer :: ferror1, ferror2, ferror3
   integer :: nforce

--- a/lis/metforcing/gdas3d/gdas3d_forcingMod.F90
+++ b/lis/metforcing/gdas3d/gdas3d_forcingMod.F90
@@ -15,6 +15,7 @@ module gdas3d_forcingMod
 !  
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
   
   PRIVATE
@@ -32,7 +33,7 @@ module gdas3d_forcingMod
   type, public :: gdas3d_type_dec
      real             :: ts
      real*8           :: gdastime1,gdastime2
-     character*100    :: gdasdir
+     character(len=LIS_CONST_PATH_LEN) :: gdasdir
      integer          :: nc,nr
      integer          :: nlayer
 

--- a/lis/metforcing/gdas3d/get_gdas3d.F90
+++ b/lis/metforcing/gdas3d/get_gdas3d.F90
@@ -21,6 +21,7 @@ subroutine get_gdas3d(n, findex)
   use LIS_coreMod,        only : LIS_rc
   use LIS_timeMgrMod,     only : LIS_get_nstep, LIS_tick
   use LIS_logMod,         only : LIS_logunit
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
   use gdas3d_forcingMod,  only : gdas3d_struc
 
   implicit none
@@ -39,7 +40,7 @@ subroutine get_gdas3d(n, findex)
   integer             :: doy1, doy2
   real                :: gmt1, gmt2,ts1,ts2
   integer             :: nstep
-  character*100       :: sanlfile
+  character(len=LIS_CONST_PATH_LEN) :: sanlfile
 
   gdas3d_struc(n)%findtime1 = 0 
   gdas3d_struc(n)%findtime2 = 0 

--- a/lis/metforcing/gdas3d/readcrd_gdas3d.F90
+++ b/lis/metforcing/gdas3d/readcrd_gdas3d.F90
@@ -60,7 +60,7 @@ subroutine readcrd_gdas3d()
   do n=1,LIS_rc%nnest
 
      write(LIS_logunit,*) 'Using GDAS3D forcing'
-     write(LIS_logunit,*) 'GDAS3D forcing directory :',gdas3d_struc(n)%GDASDIR
+     write(LIS_logunit,*) 'GDAS3D forcing directory :',trim(gdas3d_struc(n)%GDASDIR)
      gdas3d_struc(n)%GDASTIME1  = 3000.0
      gdas3d_struc(n)%GDASTIME2  = 0.0
   enddo

--- a/lis/metforcing/gdasLSWG/gdasLSWG_forcingMod.F90
+++ b/lis/metforcing/gdasLSWG/gdasLSWG_forcingMod.F90
@@ -18,6 +18,7 @@ module gdasLSWG_forcingMod
 !
 ! !USES: 
   use ESMF
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
   
@@ -37,7 +38,7 @@ module gdasLSWG_forcingMod
 
      real                     :: ts
      real*8                   :: time1, time2
-     character*100            :: gdasLSWGfile
+     character(len=LIS_CONST_PATH_LEN) :: gdasLSWGfile
      integer                  :: mi
      logical                  :: startRead
      real, allocatable        :: rlat3(:)

--- a/lis/metforcing/gdasLSWG/get_gdasLSWG.F90
+++ b/lis/metforcing/gdasLSWG/get_gdasLSWG.F90
@@ -23,6 +23,7 @@ subroutine get_gdasLSWG(n, findex, metdata1, metdata2)
   use LIS_metforcingMod, only : LIS_forc
   use LIS_timeMgrMod,     only : LIS_calendar, LIS_get_nstep, LIS_tick
   use LIS_logMod,         only : LIS_logunit, LIS_endrun, LIS_verify
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
   use gdasLSWG_forcingMod,  only : gdasLSWG_struc
 
   implicit none
@@ -47,7 +48,7 @@ subroutine get_gdasLSWG(n, findex, metdata1, metdata2)
   real                :: gmt1, gmt2,ts1,ts2
   integer             :: status
   integer             :: nstep
-  character*100       :: narrfile
+  character(len=LIS_CONST_PATH_LEN) :: narrfile
 
   gdasLSWG_struc(n)%findtime1 = 0 
   gdasLSWG_struc(n)%findtime2 = 0 

--- a/lis/metforcing/gdasT1534/create_gdasT1534filename.F90
+++ b/lis/metforcing/gdasT1534/create_gdasT1534filename.F90
@@ -41,20 +41,10 @@ subroutine create_gdasT1534filename(name, gdasdir, yr, mo, da, hr)
   real    :: gmt
   real*8  :: dumbtime
   character(len=2) :: initcode, fcstcode
-  character*1 :: fbase(80), fdir(15), ftime(10), fsubs(22)
-  character(LEN=100) :: temp
+  character(len=13) :: fdir
+  character(len=22) :: fsubs
 !=== End Variable Definition ===============
 
-!=== formats for filename segments
-!BOC
-92 format (80a1)
-93 format (a80)
-94 format (i4, i2, i2, a2)
-95 format (10a1)
-96 format (a40)
-97 format (a16, a2, a3)
-98 format (a1, i4, i2, a1)
-99 format (8a1)
 !-----------------------------------------------------------------
 !  Make variables for the time used to create the file
 !  We don't want these variables being passed out
@@ -83,29 +73,10 @@ subroutine create_gdasT1534filename(name, gdasdir, yr, mo, da, hr)
   write(initcode,'(i2.2)') ghh
   write(fcstcode,'(i2.2)') gff
 
-  write(UNIT=temp, fmt='(a40)') gdasdir  
-  read(UNIT=temp, fmt='(80a1)') (fbase(i), i=1,80)
-  c = 0
-  do i = 1, 80
-     if ( fbase(i) .NE. ' ' ) c = c + 1
-  end do
+  write(UNIT=fdir, fmt='(a5, i4, i2.2, i2.2)') 'gdas.', uyr, umo, uda
 
-  write(UNIT=temp, fmt='(a6, i4, i2, i2, a1)') '/gdas.',uyr,umo,uda,'/'
-  read(UNIT=temp, fmt='(15a1)') fdir
-  do i = 1, 15
-     if ( fdir(i) == ' ' ) fdir(i) = '0'
-  end do
+  fsubs = 'gdas1.t' // initcode // 'z.sfluxgrbf' // fcstcode
 
-  write(UNIT=temp, fmt='(a7,a2,a11,a2)') &
-        'gdas1.t',initcode,'z.sfluxgrbf',fcstcode
-
-  read(UNIT=temp, fmt='(22a1)') fsubs
-
-  write(UNIT=temp, fmt='(80a1)') &
-        (fbase(i),i=1,c), (fdir(i),i=1,15), (fsubs(i),i=1,22)
-
-  read(UNIT=temp, fmt='(a80)') name
+  name = trim(gdasdir) // '/' // fdir // '/' // fsubs
 
 end subroutine create_gdasT1534filename
-
-

--- a/lis/metforcing/gdasT1534/gdasT1534_forcingMod.F90
+++ b/lis/metforcing/gdasT1534/gdasT1534_forcingMod.F90
@@ -52,6 +52,7 @@ module gdasT1534_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
   
@@ -71,7 +72,7 @@ module gdasT1534_forcingMod
      real          :: ts
      integer       :: ncold, nrold   !AWIPS 212 dimensions
      integer       :: nmif
-     character*100 :: gdasT1534dir   !GDAST1534 Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: gdasT1534dir !GDAST1534 Forcing Directory
      real*8        :: gdasT1534time1,gdasT1534time2
      integer       :: mi
      integer       :: findtime1, findtime2

--- a/lis/metforcing/gdasT1534/read_gdasT1534.F90
+++ b/lis/metforcing/gdasT1534/read_gdasT1534.F90
@@ -67,7 +67,6 @@ subroutine read_gdasT1534( order, n, findex, &
 !EOP
 !==== Local Variables=======================
   
-  character(len=80) :: fname
   integer :: iv, c,r,t
   integer :: ferror1, ferror2, ferror3
   integer :: ngdasT1534
@@ -93,8 +92,7 @@ subroutine read_gdasT1534( order, n, findex, &
 !--------------------------------------------------------------------------
 ! Set up to open file and retrieve specified field 
 !--------------------------------------------------------------------------
-  fname = name
-  call retrieve_gdasT1534_variables(n, findex, fname,glbdata, ferror)
+  call retrieve_gdasT1534_variables(n, findex, name,glbdata, ferror)
 
 !--------------------------------------------------------------------------
 ! Place the interpolated data into the LIS arrays

--- a/lis/metforcing/gdasT1534/readcrd_gdasT1534.F90
+++ b/lis/metforcing/gdasT1534/readcrd_gdasT1534.F90
@@ -42,7 +42,7 @@ subroutine readcrd_gdasT1534()
   do n=1,LIS_rc%nnest
      gdasT1534_struc(n)%nmif = 16 
      write(LIS_logunit,*) 'Using GDAS T1534 forcing'
-     write(LIS_logunit,*) 'GDAS T1534 forcing directory :',gdasT1534_struc(n)%GDAST1534DIR
+     write(LIS_logunit,*) 'GDAS T1534 forcing directory :',trim(gdasT1534_struc(n)%GDAST1534DIR)
      gdasT1534_struc(n)%GDAST1534TIME1  = 3000.0
      gdasT1534_struc(n)%GDAST1534TIME2  = 0.0
   enddo

--- a/lis/metforcing/gefs/gefs_forcingMod.F90
+++ b/lis/metforcing/gefs/gefs_forcingMod.F90
@@ -18,6 +18,7 @@
 !  within LIS. 
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
 
   PRIVATE
@@ -35,7 +36,7 @@
   type, public ::  gefs_type_dec
 
     integer            :: max_ens_members
-    character*100      :: gefs_dir
+    character(len=LIS_CONST_PATH_LEN) :: gefs_dir
     character*20       :: gefs_fcsttype
     character*20       :: gefs_runmode
     character*20       :: gefs_proj

--- a/lis/metforcing/gefs/get_gefs.F90
+++ b/lis/metforcing/gefs/get_gefs.F90
@@ -24,6 +24,7 @@ subroutine get_gefs(n,findex)
   use LIS_metforcingMod,    only : LIS_forc
   use LIS_logMod,           only : LIS_logunit, LIS_endrun
   use gefs_forcingMod,      only : gefs_struc
+  use LIS_constantsMod,     only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -67,7 +68,7 @@ subroutine get_gefs(n,findex)
   integer       :: yr1,mo1,da1,hr1,mn1,ss1,doy1
   integer       :: yr2,mo2,da2,hr2,mn2,ss2,doy2
   integer       :: openfile
-  character*140 :: filename
+  character(len=LIS_CONST_PATH_LEN) :: filename
 
 !  character(10), dimension(LIS_rc%met_nf(findex)), parameter :: gefs_vars = (/ &
   character(10), dimension(8), parameter :: gefs_vars = (/ &
@@ -192,7 +193,7 @@ subroutine get_gefs(n,findex)
                  gefs_struc(n)%gefs_proj, gefs_vars(v),&
                  yr1,mo1,da1,m)
           endif
-          write(LIS_logunit,*)'[INFO] Getting GEFS file ... ',filename
+          write(LIS_logunit,*)'[INFO] Getting GEFS file ... ',trim(filename)
 
           ! Read in file contents:
           if( LIS_rc%tscount(n) == 1 ) then  ! Read in first two book-ends
@@ -279,7 +280,7 @@ subroutine get_gefs(n,findex)
         call get_operational_filename(filename,gefs_struc(n)%gefs_dir,&
                 yr1,mo1,da1,hr1,mn1,m)
 
-        write(LIS_logunit,*)'[INFO] getting file1.. ',filename
+        write(LIS_logunit,*)'[INFO] getting file1.. ',trim(filename)
         order = 1
         call read_gefs(n,m,findex,order,filename,ferror)
         if(ferror.ge.1) then 

--- a/lis/metforcing/gefs/read_gefs_reforecast.F90
+++ b/lis/metforcing/gefs/read_gefs_reforecast.F90
@@ -34,7 +34,7 @@ subroutine read_gefs_reforecast(n, m, findex, order, filename, varname, ferror)
   integer, intent(in)       :: n
   integer, intent(in)       :: m
   integer, intent(in)       :: order
-  character*140, intent(in) :: filename
+  character(len=*), intent(in) :: filename
   character*10, intent(in)  :: varname
   integer, intent(out)      :: ferror
 !

--- a/lis/metforcing/genEnsFcst/genEnsFcst_VariablesMod.F90
+++ b/lis/metforcing/genEnsFcst/genEnsFcst_VariablesMod.F90
@@ -312,7 +312,7 @@ contains
 !
 ! !ARGUMENTS: 
    integer, intent(in) :: findex          ! Forcing index
-   character(140), intent(in) :: filename ! Forcing filename path
+   character(len=*), intent(in) :: filename ! Forcing filename path
    integer, intent(in) :: inc, inr        ! Input forcing cols, rows
 !   integer, intent(in) :: start_inc, start_inr  ! Initial col / row points of subsetted domain 
    integer, intent(in) :: tindex          ! Index of daily time pt

--- a/lis/metforcing/genEnsFcst/genEnsFcst_forcingMod.F90
+++ b/lis/metforcing/genEnsFcst/genEnsFcst_forcingMod.F90
@@ -25,6 +25,8 @@ module genEnsFcst_forcingMod
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
 #endif
+  
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 !
   implicit none
 
@@ -50,7 +52,7 @@ module genEnsFcst_forcingMod
      real*8         :: findtime1, metforc_time1   ! File 1 flag and time (LIS)
      real*8         :: findtime2, metforc_time2   ! File 2 flag and time (LIS)
 
-     character(120) :: directory        ! Directory path of where files reside
+     character(len=LIS_CONST_PATH_LEN) :: directory        ! Directory path of where files reside
      character(50)  :: proj_name        ! Projection name
      integer        :: proj_index       ! Projection type index
  
@@ -98,7 +100,7 @@ contains
   integer  :: varid
   real     :: gridDesci(50)
   logical  :: file_exists
-  character(140) :: fullfilename
+  character(len=LIS_CONST_PATH_LEN) :: fullfilename
 
   integer  :: da, hr, mn, ss
   character*50 :: timeInc

--- a/lis/metforcing/genEnsFcst/get_genEnsFcst_filename.F90
+++ b/lis/metforcing/genEnsFcst/get_genEnsFcst_filename.F90
@@ -28,8 +28,8 @@
    integer,       intent(in)  :: fcstmo          ! Forecast month - Need to convert to "3-letter month"
    integer,       intent(in)  :: ensnum          ! Forecast ensemble number
    integer,       intent(in)  :: yr, mo          ! Lead-time year, month
-   character*100, intent(in)  :: directory       ! Dataset Directory
-   character*140, intent(out) :: filename        
+   character(len=*), intent(in)  :: directory       ! Dataset Directory
+   character(len=*), intent(out) :: filename        
 !
 ! !DESCRIPTION:
 !   This subroutine puts together ensemble forecast 

--- a/lis/metforcing/genMetForc/get_metForcGen_filename.F90
+++ b/lis/metforcing/genMetForc/get_metForcGen_filename.F90
@@ -29,8 +29,8 @@
    integer, intent(in)        :: kk              ! Forecast index
    integer, intent(in)        :: findex          ! Forcing index
    integer, intent(in)        :: yr,mo,da,hr,mn  ! File timestamp
-   character*100, intent(in)  :: directory       ! File directory
-   character*140, intent(out) :: filename  
+   character(len=*), intent(in)  :: directory       ! File directory
+   character(len=*), intent(out) :: filename  
 !
 ! !DESCRIPTION:
 !   This subroutine puts together LDT generated forcing

--- a/lis/metforcing/genMetForc/get_metForcGenerated.F90
+++ b/lis/metforcing/genMetForc/get_metForcGenerated.F90
@@ -24,6 +24,7 @@ subroutine get_metForcGenerated(n, findex)
   use LIS_timeMgrMod,   only : LIS_tick, LIS_get_nstep
   use metForcGenerated_forcingMod, only : metForcGen_struc
   use metForcGen_VariablesMod
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -56,7 +57,7 @@ subroutine get_metForcGenerated(n, findex)
   integer        :: kk      ! Forecast index
   integer        :: metforc_hrts
   integer        :: metforc_mnts
-  character(140) :: fullfilename
+  character(len=LIS_CONST_PATH_LEN) :: fullfilename
   logical        :: file_exists
 
 ! Date/time parameters for file get/read:

--- a/lis/metforcing/genMetForc/metForcGen_VariablesMod.F90
+++ b/lis/metforcing/genMetForc/metForcGen_VariablesMod.F90
@@ -315,7 +315,7 @@ contains
 !   integer, intent(in) :: n               ! Nest index
    integer, intent(in) :: kk              ! Forecast index
    integer, intent(in) :: findex          ! Forcing index
-   character(140), intent(in) :: filename ! Forcing filename path
+   character(len=*), intent(in) :: filename ! Forcing filename path
    integer, intent(in) :: inc, inr        ! Input forcing cols, rows
 !
 ! !DESCRIPTION: 

--- a/lis/metforcing/genMetForc/metForcGenerated_forcingMod.F90
+++ b/lis/metforcing/genMetForc/metForcGenerated_forcingMod.F90
@@ -23,6 +23,8 @@ module metForcGenerated_forcingMod
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
 #endif
+  
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 !
   implicit none
 
@@ -45,7 +47,7 @@ module metForcGenerated_forcingMod
      real*8         :: metforc_time1
      real*8         :: metforc_time2
 
-     character(100) :: directory
+     character(len=LIS_CONST_PATH_LEN) :: directory
      character(50)  :: proj_name
      integer        :: proj_index
  
@@ -92,7 +94,7 @@ contains
     integer  :: varid
     real     :: gridDesci(50)
     logical  :: file_exists
-    character(140) :: fullfilename
+    character(len=LIS_CONST_PATH_LEN) :: fullfilename
 
     integer  :: seconds, da, hr, mn, ss, icount
     character*50 :: timeInc

--- a/lis/metforcing/geos/geos_forcingMod.F90
+++ b/lis/metforcing/geos/geos_forcingMod.F90
@@ -57,6 +57,8 @@ module geos_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
 
   PRIVATE
@@ -75,7 +77,7 @@ module geos_forcingMod
      real    :: ts
      integer :: ncold, nrold   !AWIPS 212 dimensions
      integer :: nmif
-     character*40 :: geosdir   !GEOS Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: geosdir   !GEOS Forcing Directory
      real*8  :: geostime1,geostime2
      real*8  :: griduptime1, griduptime2
      logical :: gridchange1, gridchange2

--- a/lis/metforcing/geos/get_geos.F90
+++ b/lis/metforcing/geos/get_geos.F90
@@ -29,6 +29,7 @@ subroutine get_geos(n, findex)
   use LIS_coreMod,        only  : LIS_rc, LIS_domain
   use LIS_timeMgrMod,     only  : LIS_get_nstep, LIS_tick
   use LIS_logMod,         only  : LIS_logunit, LIS_endrun
+  use LIS_constantsMod,   only  : LIS_CONST_PATH_LEN
   use geos_forcingMod,    only  : geos_struc
 
   implicit none
@@ -72,7 +73,7 @@ subroutine get_geos(n, findex)
   integer :: yr2,mo2,da2,hr2,mn2,ss2,doy2
   real*8  :: time1,time2,dumbtime1,dumbtime2
   real*8  :: timenow
-  character*80 :: name
+  character(len=LIS_CONST_PATH_LEN) :: name
   character*40 :: elevfile, fpart1, fpart2
   real :: gmt1,gmt2,ts1,ts2
   integer :: movetime      ! 1=move time 2 data into time 1
@@ -317,7 +318,8 @@ end subroutine get_geos
 !
 ! !INTERFACE:
 subroutine geosfile(name,geosdir,yr,mo,da,hr,ncold)
-  
+ 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
 ! !ARGUMENTS: 
   character(len=*), intent(in)  :: geosdir
@@ -348,10 +350,10 @@ subroutine geosfile(name,geosdir,yr,mo,da,hr,ncold)
 !EOP
   integer uyr,umo,uda,uhr,i,c,ii,jj
   character(len=2) :: initcode
-  character*1 fbase(80),fsubs(80)
-  character*1 ftime(10),fdir(8)
+  character(len=6)  :: fdir
+  character(len=8)  :: fsubs
+  character(len=10) :: ftime
   
-  character(LEN=100) :: temp
   ii = ncold
   jj = 181
 
@@ -386,46 +388,21 @@ subroutine geosfile(name,geosdir,yr,mo,da,hr,ncold)
   elseif(uhr<24)then
      initcode = '21'
   endif
-  
-  write(UNIT=temp,FMT='(A40)') geosdir 
-  read(UNIT=temp,FMT='(80A1)') (fbase(i),i=1,80)
-  
-  write(UNIT=temp,FMT='(a1,i4,i2,a1)') '/',uyr,umo,'/'
-  read(UNIT=temp,FMT='(8A1)') fdir
-  do i=1,8
-     if(fdir(i).eq.(' ')) fdir(i)='0'
-  enddo
-  
-  write(UNIT=temp,FMT='(i4,i2,i2,a2)') uyr,umo,uda,initcode
-  read(UNIT=temp,FMT='(10A1)') ftime
-  do i=1,10
-     if(ftime(i).eq.(' ')) ftime(i)='0'
-  enddo
-  
+
+  write(UNIT=fdir,FMT='(i4,i2.2)') uyr, umo
+
+  write(UNIT=ftime,FMT='(i4,i2.2,i2.2,a2)') uyr, umo, uda, initcode
+
   if(ncold==360) then 
-     write(UNIT=temp,FMT='(A8)') '.GEOS323'
-     read(UNIT=temp,FMT='(80A1)') (fsubs(i),i=1,8)
+     fsubs = '.GEOS323'
   elseif(ncold==288) then 
-     write(UNIT=temp,FMT='(A6)') '.GEOS4'
-     read(UNIT=temp,FMT='(80A1)') (fsubs(i),i=1,6)
+     fsubs = '.GEOS4'
   else if(ncold==540) then 
-     write(UNIT=temp,FMT='(A6)') '.GEOS5'
-     read(UNIT=temp,FMT='(80A1)') (fsubs(i),i=1,6)
+     fsubs = '.GEOS5'
   endif
-  c=0
-  do i=1,80
-     if(fbase(i).eq.(' ').and.c.eq.0) c=i-1 
-  enddo
+
+  name = trim(geosdir) // '/' // fdir // '/' // ftime // trim(fsubs)
   
-  if (ncold==360) then       
-     write(UNIT=temp,FMT='(80a1)') (fbase(i),i=1,c),(fdir(i),i=1,8), &
-          (ftime(i),i=1,10),(fsubs(i),i=1,8)
-  else !covers both GEOS4 and GEOS5
-     write(UNIT=temp,FMT='(80a1)') (fbase(i),i=1,c),(fdir(i),i=1,8), &
-          (ftime(i),i=1,10),(fsubs(i),i=1,6)
-  endif
-  
-  read(UNIT=temp, FMT='(a80)') name
   return
 
 end subroutine geosfile

--- a/lis/metforcing/geos/readcrd_geos.F90
+++ b/lis/metforcing/geos/readcrd_geos.F90
@@ -40,7 +40,7 @@ subroutine readcrd_geos()
 
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*) 'Using GEOS forcing'
-     write(LIS_logunit,*) 'GEOS forcing directory :',geos_struc(n)%GEOSDIR
+     write(LIS_logunit,*) 'GEOS forcing directory :',trim(geos_struc(n)%GEOSDIR)
      geos_struc(n)%geostime1 = 3000.0
      geos_struc(n)%geostime2 = 0.0
 

--- a/lis/metforcing/geos5fcst/geos5fcst_forcingMod.F90
+++ b/lis/metforcing/geos5fcst/geos5fcst_forcingMod.F90
@@ -19,6 +19,8 @@ module geos5fcst_forcingMod
 !  GEOS5 forecast output or the full ensemble. 
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
 
   PRIVATE
@@ -38,7 +40,7 @@ module geos5fcst_forcingMod
      real               :: ts
      integer            :: nc, nr
      integer            :: max_ens_members
-     character*80       :: geos5fcstdir
+     character(len=LIS_CONST_PATH_LEN) :: geos5fcstdir
      real*8             :: fcsttime1,fcsttime2
      
      real               :: gridDesc(50)

--- a/lis/metforcing/geos5fcst/get_geos5fcst.F90
+++ b/lis/metforcing/geos5fcst/get_geos5fcst.F90
@@ -22,6 +22,7 @@ subroutine get_geos5fcst(n,findex)
   use LIS_timeMgrMod,       only : LIS_tick
   use LIS_metforcingMod,    only : LIS_forc
   use LIS_logMod,           only : LIS_logunit, LIS_endrun
+  use LIS_constantsMod,     only : LIS_CONST_PATH_LEN
   use geos5fcst_forcingMod, only : geos5fcst_struc
 
   implicit none
@@ -64,7 +65,7 @@ subroutine get_geos5fcst(n,findex)
   real*8        :: dtime1, dtime2
   integer       :: yr1,mo1,da1,hr1,mn1,ss1,doy1
   integer       :: yr2,mo2,da2,hr2,mn2,ss2,doy2
-  character*100 :: name
+  character(len=LIS_CONST_PATH_LEN) :: name
   real          :: gmt1,gmt2,ts1,ts2
   integer       :: movetime     ! 1=move time 2 data into time 1
 
@@ -166,7 +167,7 @@ subroutine get_geos5fcst(n,findex)
            call geos5fcstfile(name,geos5fcst_struc(n)%geos5fcstdir,&
                 yr1,mo1,da1,hr1,mn1,m)
         
-           write(LIS_logunit,*)'[INFO] getting file1.. ',name
+           write(LIS_logunit,*)'[INFO] getting file1.. ',trim(name)
            order = 1
            call read_geos5fcst(n,m,findex,order,name,ferror)
            if(ferror.ge.1) &
@@ -194,7 +195,7 @@ subroutine get_geos5fcst(n,findex)
            call geos5fcstfile(name,geos5fcst_struc(n)%geos5fcstdir,&
                 yr2,mo2,da2,hr2,mn2,m)
         
-           write(LIS_logunit,*)'[INFO] getting file2.. ',name
+           write(LIS_logunit,*)'[INFO] getting file2.. ',trim(name)
            order = 2
            call read_geos5fcst(n,m,findex,order,name,ferror)
            if(ferror.ge.1) then

--- a/lis/metforcing/geos5fcst/read_geos5fcst.F90
+++ b/lis/metforcing/geos5fcst/read_geos5fcst.F90
@@ -22,6 +22,7 @@ subroutine read_geos5fcst(n, m, findex, order, name, ferror)
   use LIS_logMod,           only : LIS_logunit, LIS_verify, LIS_warning
   use LIS_metforcingMod,    only : LIS_forc
   use geos5fcst_forcingMod, only : geos5fcst_struc
+  use LIS_constantsMod,     only : LIS_CONST_PATH_LEN
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
 #endif
@@ -31,7 +32,7 @@ subroutine read_geos5fcst(n, m, findex, order, name, ferror)
   integer, intent(in)       :: n
   integer, intent(in)       :: m
   integer, intent(in)       :: order
-  character*100, intent(in) :: name
+  character(len=LIS_CONST_PATH_LEN), intent(in) :: name
   integer, intent(out)      :: ferror
 !
 ! !DESCRIPTION:

--- a/lis/metforcing/geos5fcst/readcrd_geos5fcst.F90
+++ b/lis/metforcing/geos5fcst/readcrd_geos5fcst.F90
@@ -51,7 +51,7 @@ subroutine readcrd_geos5fcst()
 
   do n=1,LIS_rc%nnest
      write(unit=LIS_logunit,fmt=*) '[INFO] GEOS5 forecast forcing directory :',&
-          geos5fcst_struc(n)%geos5fcstdir
+          trim(geos5fcst_struc(n)%geos5fcstdir)
 
      geos5fcst_struc(n)%fcsttime1 = 3000.0
      geos5fcst_struc(n)%fcsttime2 = 0.0

--- a/lis/metforcing/gfs/create_gfs_f0backup_filename.F90
+++ b/lis/metforcing/gfs/create_gfs_f0backup_filename.F90
@@ -52,8 +52,11 @@ subroutine create_gfs_f0backup_filename(option, name00, gfsdir, yr, mo, da, hr, 
   integer :: uyr0, umo0, uda0, uhr0, umn0, uss0
   integer :: remainder
   character(len=2) :: initcode0, initcode1, fcstcode0, fcstcode1, fcstcode2
-  character*1 :: fbase(80), fdir(8), ftime(10), fsubs(21)
-  character(LEN=100) :: temp1,temp2
+  character(len=6)  :: fdir
+  character(len=10) :: ftime
+  character(len=21) :: fsubs
+  character(len=14), parameter :: fsubsprefix = '.gfs.sfluxgrbf'
+  character(len=3),  parameter :: fsubsext = '.sg'
   real*8      :: time1,dumbtime
   integer     :: doy1,doy
   real        :: gmt1,gmt
@@ -117,34 +120,14 @@ subroutine create_gfs_f0backup_filename(option, name00, gfsdir, yr, mo, da, hr, 
   fcstcode1 = '06'
    
   !name 00
-  write(UNIT=temp1, fmt='(a40)') gfsdir  
-  read(UNIT=temp1, fmt='(80a1)') (fbase(i), i=1,80)
 
-  write(UNIT=temp1, fmt='(a1, i4, i2, a1)') '/', uyr0, umo0, '/'
-  read(UNIT=temp1, fmt='(8a1)') fdir
-  do i = 1, 8
-     if ( fdir(i) == ' ' ) fdir(i) = '0'
-  end do
+  write(UNIT=fdir, fmt='(i4, i2.2)') uyr0, umo0
 
-  write(UNIT=temp1, fmt='(i4, i2, i2, a2)') uyr0, umo0, uda0, initcode1
-  read(UNIT=temp1, fmt='(10a1)') ftime
-  do i = 1, 10
-     if ( ftime(i) == ' ' ) ftime(i) = '0'
-  end do
+  write(UNIT=ftime, fmt='(i4, i2.2, i2.2, a2)') uyr0, umo0, uda0, initcode1
 
-  write(UNIT=temp1, fmt='(a14, a2, a3)') '.gfs.sfluxgrbf', fcstcode1, '.sg'
-  read (UNIT=temp1, fmt='(80a1)') (fsubs(i), i=1,21)
+  fsubs = fsubsprefix // fcstcode1 // fsubsext
 
-  c = 0
-  do i = 1, 80
-     if ( (fbase(i) == ' ') .and. (c == 0) ) c = i-1
-  end do
-
-  write(UNIT=temp1, fmt='(80a1)') (fbase(i), i=1,c), (fdir(i), i=1,8),  &
-                       (ftime(i), i=1,10), (fsubs(i), i=1,21)
-
-  read(UNIT=temp1, fmt='(a80)') name00
-
+  name00 = trim(gfsdir) // '/' // fdir // '/' // ftime // fsubs
 
   return
 

--- a/lis/metforcing/gfs/create_gfsfilename.F90
+++ b/lis/metforcing/gfs/create_gfsfilename.F90
@@ -63,8 +63,11 @@ subroutine create_gfsfilename(option, name00, name03, name06, &
   integer :: uyr0, umo0, uda0, uhr0, umn0, uss0
   integer :: remainder
   character(len=2) :: initcode0, initcode1, fcstcode0, fcstcode1, fcstcode2
-  character*1 :: fbase(80), fdir(8), ftime(10), fsubs(21)
-  character(LEN=100) :: temp1,temp2
+  character(len=6)  :: fdir
+  character(len=10) :: ftime
+  character(len=21) :: fsubs
+  character(len=14), parameter :: fsubsprefix = '.gfs.sfluxgrbf'
+  character(len=3),  parameter :: fsubsext    = '.sg'
   real*8      :: time1,dumbtime
   integer     :: doy1,doy
   real        :: gmt1,gmt
@@ -169,91 +172,34 @@ subroutine create_gfsfilename(option, name00, name03, name06, &
   fcstcode2 = '06'
   
   !name00
-  write(UNIT=temp1, fmt='(a40)') gfsdir  
-  read(UNIT=temp1, fmt='(80a1)') (fbase(i), i=1,80)
 
-  write(UNIT=temp1, fmt='(a1, i4, i2, a1)') '/', uyr, umo, '/'
-  read(UNIT=temp1, fmt='(8a1)') fdir
-  do i = 1, 8
-     if ( fdir(i) == ' ' ) fdir(i) = '0'
-  end do
+  write(UNIT=fdir, fmt='(i4, i2.2)') uyr, umo
 
-  write(UNIT=temp1, fmt='(i4, i2, i2, a2)') uyr, umo, uda, initcode0
-  read(UNIT=temp1, fmt='(10a1)') ftime
-  do i = 1, 10
-     if ( ftime(i) == ' ' ) ftime(i) = '0'
-  end do
+  write(UNIT=ftime, fmt='(i4, i2.2, i2.2, a2)') uyr, umo, uda, initcode0
 
-  write(UNIT=temp1, fmt='(a14, a2, a3)') '.gfs.sfluxgrbf', fcstcode0, '.sg'
-  read (UNIT=temp1, fmt='(80a1)') (fsubs(i), i=1,21)
+  fsubs = fsubsprefix // fcstcode0 // fsubsext
 
-  c = 0
-  do i = 1, 80
-     if ( (fbase(i) == ' ') .and. (c == 0) ) c = i-1
-  end do
-
-  write(UNIT=temp1, fmt='(80a1)') (fbase(i), i=1,c), (fdir(i), i=1,8),  &
-                       (ftime(i), i=1,10), (fsubs(i), i=1,21)
-
-  read(UNIT=temp1, fmt='(a80)') name00
+  name00 = trim(gfsdir) // '/' // fdir // '/' // ftime // fsubs
   
   !name 03
-  write(UNIT=temp1, fmt='(a40)') gfsdir  
-  read(UNIT=temp1, fmt='(80a1)') (fbase(i), i=1,80)
 
-  write(UNIT=temp1, fmt='(a1, i4, i2, a1)') '/', uyr0, umo0, '/'
-  read(UNIT=temp1, fmt='(8a1)') fdir
-  do i = 1, 8
-     if ( fdir(i) == ' ' ) fdir(i) = '0'
-  end do
+  write(UNIT=fdir, fmt='(i4, i2.2)') uyr, umo
 
-  write(UNIT=temp1, fmt='(i4, i2, i2, a2)') uyr0, umo0, uda0, initcode1
-  read(UNIT=temp1, fmt='(10a1)') ftime
-  do i = 1, 10
-     if ( ftime(i) == ' ' ) ftime(i) = '0'
-  end do
+  write(UNIT=ftime, fmt='(i4, i2.2, i2.2, a2)') uyr0, umo0, uda0, initcode1
 
-  write(UNIT=temp1, fmt='(a14, a2, a3)') '.gfs.sfluxgrbf', fcstcode1, '.sg'
-  read (UNIT=temp1, fmt='(80a1)') (fsubs(i), i=1,21)
+  fsubs = fsubsprefix // fcstcode1 // fsubsext
 
-  c = 0
-  do i = 1, 80
-     if ( (fbase(i) == ' ') .and. (c == 0) ) c = i-1
-  end do
-
-  write(UNIT=temp1, fmt='(80a1)') (fbase(i), i=1,c), (fdir(i), i=1,8),  &
-                       (ftime(i), i=1,10), (fsubs(i), i=1,21)
-
-  read(UNIT=temp1, fmt='(a80)') name03
+  name03 = trim(gfsdir) // '/' // fdir // '/' // ftime // fsubs
 
   !namef06
-  write(UNIT=temp2, fmt='(a40)') gfsdir  
-  read(UNIT=temp2, fmt='(80a1)') (fbase(i), i=1,80)
 
-  write(UNIT=temp2, fmt='(a1, i4, i2, a1)') '/', uyr0, umo0, '/'
-  read(UNIT=temp2, fmt='(8a1)') fdir
-  do i = 1, 8
-     if ( fdir(i) == ' ' ) fdir(i) = '0'
-  end do
+  write(UNIT=fdir, fmt='(i4, i2.2)') uyr, umo
 
-  write(UNIT=temp2, fmt='(i4, i2, i2, a2)') uyr0, umo0, uda0, initcode1
-  read(UNIT=temp2, fmt='(10a1)') ftime
-  do i = 1, 10
-     if ( ftime(i) == ' ' ) ftime(i) = '0'
-  end do
+  write(UNIT=ftime, fmt='(i4, i2.2, i2.2, a2)') uyr0, umo0, uda0, initcode1
 
-  write(UNIT=temp2, fmt='(a14, a2, a3)') '.gfs.sfluxgrbf', fcstcode2, '.sg'
-  read (UNIT=temp2, fmt='(80a1)') (fsubs(i), i=1,21)
+  fsubs = fsubsprefix // fcstcode2 // fsubsext
 
-  c = 0
-  do i = 1, 80
-     if ( (fbase(i) == ' ') .and. (c == 0) ) c = i-1
-  end do
-
-  write(UNIT=temp2, fmt='(80a1)') (fbase(i), i=1,c), (fdir(i), i=1,8),  &
-                       (ftime(i), i=1,10), (fsubs(i), i=1,21)
-
-  read(UNIT=temp2, fmt='(a80)') name06
+  name06 = trim(gfsdir) // '/' // fdir // '/' // ftime // fsubs
 
   return
 

--- a/lis/metforcing/gfs/get_gfs.F90
+++ b/lis/metforcing/gfs/get_gfs.F90
@@ -488,10 +488,10 @@ subroutine get_gfs(n,findex)
         endif
                
         if(status.eq.0) then 
-           write(LIS_logunit,*) 'Reading GFS file1 (I) ',name00
-           write(LIS_logunit,*) 'Reading GFS file1 (A) ',name03
+           write(LIS_logunit,*) 'Reading GFS file1 (I) ',trim(name00)
+           write(LIS_logunit,*) 'Reading GFS file1 (A) ',trim(name03)
            if(F06flag) then 
-              write(LIS_logunit,*) 'Reading GFS file1 (A)',name06
+              write(LIS_logunit,*) 'Reading GFS file1 (A)',trim(name06)
            endif
            call read_gfs( order, n, findex, name00, name03, name06, F06flag, ferror, try)
            if ( ferror == 1 ) then  
@@ -560,14 +560,14 @@ subroutine get_gfs(n,findex)
         
         if(file_exists1.and.file_exists2) then 
            status = 0 
-           write(LIS_logunit,*) 'Reading GFS file2 (I) ',name00
-           write(LIS_logunit,*) 'Reading GFS file2 (A) ',name03
+           write(LIS_logunit,*) 'Reading GFS file2 (I) ',trim(name00)
+           write(LIS_logunit,*) 'Reading GFS file2 (A) ',trim(name03)
         else
            status = 1
         endif
 
         if(F06flag) then 
-           write(LIS_logunit,*) 'Reading GFS file2 (A)',name06
+           write(LIS_logunit,*) 'Reading GFS file2 (A)',trim(name06)
         endif       
         call read_gfs( order, n, findex, name00, name03, name06, F06flag, ferror, try)    
         if ( ferror == 1 ) then  

--- a/lis/metforcing/gfs/gfs_forcingMod.F90
+++ b/lis/metforcing/gfs/gfs_forcingMod.F90
@@ -80,6 +80,8 @@ module gfs_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
   
   PRIVATE
@@ -98,14 +100,14 @@ module gfs_forcingMod
      real         :: ts
      integer      :: ncold, nrold   !AWIPS 212 dimensions
      integer      :: nmif
-     character*100 :: gfsdir   !GFS Forcing Directory
-     character*100 :: elevfile
-     character*100 :: t126elevfile
-     character*100 :: t170elevfile
-     character*100 :: t254elevfile
-     character*100 :: t382elevfile
-     character*100 :: t574elevfile
-     character*100 :: t1534elevfile
+     character(len=LIS_CONST_PATH_LEN) :: gfsdir  !GFS Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: elevfile
+     character(len=LIS_CONST_PATH_LEN) :: t126elevfile
+     character(len=LIS_CONST_PATH_LEN) :: t170elevfile
+     character(len=LIS_CONST_PATH_LEN) :: t254elevfile
+     character(len=LIS_CONST_PATH_LEN) :: t382elevfile
+     character(len=LIS_CONST_PATH_LEN) :: t574elevfile
+     character(len=LIS_CONST_PATH_LEN) :: t1534elevfile
      real*8       :: gfstime1,gfstime2
      real*8       :: griduptime1,griduptime2,griduptime3,griduptime4,griduptime5,griduptime6
      logical      :: gridchange1,gridchange2,gridchange3,gridchange4,gridchange5,gridchange6

--- a/lis/metforcing/gfs/read_gfs.F90
+++ b/lis/metforcing/gfs/read_gfs.F90
@@ -24,6 +24,7 @@ subroutine read_gfs( order, n, findex, name00, name03, name06, F06flag, ferror,t
   use LIS_metforcingMod, only : LIS_forc
   use LIS_logMod,         only : LIS_logunit
   use gfs_forcingMod,    only : gfs_struc
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS:
@@ -71,7 +72,7 @@ subroutine read_gfs( order, n, findex, name00, name03, name06, F06flag, ferror,t
 !EOP
 !==== Local Variables=======================
 
-  character(len=80) :: fname
+  character(len=LIS_CONST_PATH_LEN) :: fname
   integer :: iv, c,r,t
   integer :: ferror1, ferror2, ferror3
   integer :: nforce

--- a/lis/metforcing/gfs/read_gfs_elev.F90
+++ b/lis/metforcing/gfs/read_gfs_elev.F90
@@ -80,7 +80,7 @@ subroutine read_gfs_elev(n, findex, change)
         call LIS_endrun
      endif
 
-     write(LIS_logunit,*) 'Reading the GFS elevation ',gfs_struc(n)%elevfile
+     write(LIS_logunit,*) 'Reading the GFS elevation ',trim(gfs_struc(n)%elevfile)
      
      ftn = LIS_getNextUnitNumber()
      open(ftn,file=trim(gfs_struc(n)%elevfile),&

--- a/lis/metforcing/gfs/readcrd_gfs.F90
+++ b/lis/metforcing/gfs/readcrd_gfs.F90
@@ -83,7 +83,7 @@ subroutine readcrd_gfs()
      call ESMF_ConfigGetAttribute(LIS_config,gfs_struc(n)%nmif,rc=rc)
 
      write(LIS_logunit,*) 'Using GFS forcing'
-     write(LIS_logunit,*) 'GFS forcing directory :',gfs_struc(n)%GFSDIR
+     write(LIS_logunit,*) 'GFS forcing directory :',trim(gfs_struc(n)%GFSDIR)
      gfs_struc(n)%GFSTIME1  = 3000.0
      gfs_struc(n)%GFSTIME2  = 0.0
   enddo

--- a/lis/metforcing/gldas/get_gldas.F90
+++ b/lis/metforcing/gldas/get_gldas.F90
@@ -208,7 +208,7 @@ end subroutine get_gldas
 ! \label{gldasfile}
 !
 ! !INTERFACE:
-subroutine gldasfile(name,gldasdir,yr,mo,da,hr,ncold)
+subroutine gldasfile(name, gldasdir, yr, mo, da, hr, ncold)
   
   implicit none
 ! !ARGUMENTS: 
@@ -239,11 +239,11 @@ subroutine gldasfile(name,gldasdir,yr,mo,da,hr,ncold)
 !
 !EOP
   integer uyr,umo,uda,uhr,i,c,ii,jj
-  character(len=2) :: initcode
-  character*1 fbase(80),fsubs(80)
-  character*1 ftime(10),fdir(6)
+  character(len=2)  :: initcode
+  character(len=10) :: ftime
+  character(len=4)  :: fdir
+  character(len=17), parameter :: fsuffix = '.force.mosaic.grb'
   
-  character(LEN=100) :: temp
   ii = ncold
   jj = 181
 
@@ -279,34 +279,12 @@ subroutine gldasfile(name,gldasdir,yr,mo,da,hr,ncold)
      initcode = '21'
   endif
   
-  write(UNIT=temp,FMT='(A40)') gldasdir 
-  read(UNIT=temp,FMT='(80A1)') (fbase(i),i=1,80)
+  write(UNIT=fdir,FMT='(i4)') uyr
   
-  write(UNIT=temp,FMT='(a1,i4,a1)') '/',uyr,'/'
-  read(UNIT=temp,FMT='(6A1)') fdir
-  do i=1,6
-     if(fdir(i).eq.(' ')) fdir(i)='0'
-  enddo
+  write(UNIT=ftime,FMT='(i4, i2.2, i2.2, a2)') uyr, umo, uda, initcode
+
+  name = trim(gldasdir) // '/' // fdir // '/' // ftime // fsuffix
   
-  write(UNIT=temp,FMT='(i4,i2,i2,a2)') uyr,umo,uda,initcode
-  read(UNIT=temp,FMT='(10A1)') ftime
-  do i=1,10
-     if(ftime(i).eq.(' ')) ftime(i)='0'
-  enddo
-  
-  write(UNIT=temp,FMT='(A17)') '.force.mosaic.grb'
-  read(UNIT=temp,FMT='(80A1)') (fsubs(i),i=1,17)
-  
-  c=0
-  do i=1,80
-     if(fbase(i).eq.(' ').and.c.eq.0) c=i-1 
-  enddo
-  
-  write(UNIT=temp,FMT='(80a1)') (fbase(i),i=1,c),(fdir(i),i=1,6), &
-       (ftime(i),i=1,10),(fsubs(i),i=1,17)
-  
-  
-  read(UNIT=temp, FMT='(a80)') name
   return
 
 end subroutine gldasfile

--- a/lis/metforcing/gldas/gldas_forcingMod.F90
+++ b/lis/metforcing/gldas/gldas_forcingMod.F90
@@ -31,6 +31,8 @@ module gldas_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
   
   PRIVATE
@@ -48,7 +50,7 @@ module gldas_forcingMod
   type, public :: gldas_type_dec
      real         :: ts
      integer      :: ncold, nrold   !AWIPS 212 dimensions
-     character*40 :: gldasdir       !GLDAS Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: gldasdir       !GLDAS Forcing Directory
      real*8       :: gldastime1,gldastime2
      integer      :: mi
 

--- a/lis/metforcing/gldas/readcrd_gldas.F90
+++ b/lis/metforcing/gldas/readcrd_gldas.F90
@@ -40,7 +40,7 @@ subroutine readcrd_gldas()
 
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*) 'Using GLDAS forcing'
-     write(LIS_logunit,*) 'GLDAS forcing directory :',gldas_struc(n)%GLDASDIR
+     write(LIS_logunit,*) 'GLDAS forcing directory :',trim(gldas_struc(n)%GLDASDIR)
      gldas_struc(n)%GLDASTIME1  = 3000.0
      gldas_struc(n)%GLDASTIME2  = 0.0
   enddo

--- a/lis/metforcing/gswp1/get_gswp1.F90
+++ b/lis/metforcing/gswp1/get_gswp1.F90
@@ -22,7 +22,7 @@ subroutine get_gswp1(n, findex)
   use LIS_timeMgrMod,      only : LIS_get_nstep, LIS_tick
   use LIS_logMod,          only : LIS_logunit, LIS_endrun
   use gswp1_forcingMod,    only : gswp1_struc
-
+  use LIS_constantsMod,    only : LIS_CONST_PATH_LEN
   implicit none
 ! !ARGUMENTS: 
   integer, intent(in)  :: n 
@@ -60,7 +60,7 @@ subroutine get_gswp1(n, findex)
   integer :: yr2,mo2,da2,hr2,mn2,ss2,doy2
   real*8 :: time1,time2,dumbtime1,dumbtime2
   real*8 :: timenow
-  character*80 :: name
+  character(len=LIS_CONST_PATH_LEN) :: name
   real :: gmt1,gmt2,ts1,ts2
   integer :: movetime       ! 1=move time 2 data into time 1
   integer :: nforce         ! GSWP-1 forcing file time, # forcing variables
@@ -222,9 +222,8 @@ subroutine gswp1file(name,gswp1dir,yr,mo,da,hr,ncold)
 !EOP
   integer uyr,umo,uda,uhr,i,c,ii,jj
   character(len=2) :: initcode
-  character*1 fbase(80),fsubs(80)
-  character*1 ftime(10),fdir(8)
-  character(LEN=100) :: temp
+  character(len=6) :: fdir, fsubs
+  character(len=10) :: ftime
   character*2 hrstr(24)
   data hrstr /'01','02','03','04','05','06','07','08','09','10',   &
        '11','12','13','14','15','16','17','18','19','20',   &
@@ -247,43 +246,15 @@ subroutine gswp1file(name,gswp1dir,yr,mo,da,hr,ncold)
 !  with the next day.  So check for that first
 !-----------------------------------------------------------------------
   initcode = hrstr(uhr)
+
+  write(UNIT=fdir, FMT='(i4, i2.2)') uyr, umo
+
+  write(UNIT=ftime, FMT='(i4, i2.2, i2.2, a2)') uyr, umo, uda, initcode
+
+  fsubs = '.GSWP1'
+
+  name = trim(gswp1dir) // '/' // fdir // '/' // ftime // fsubs
   
-  write(UNIT=temp,FMT='(A40)') gswp1dir
-  read(UNIT=temp,FMT='(80A1)') (fbase(i),i=1,80)
-  
-  write(UNIT=temp,FMT='(a1,i4,i2,a1)') '/',uyr,umo,'/'
-  read(UNIT=temp,FMT='(8A1)') fdir
-  do i=1,8
-     if (fdir(i).eq.(' ')) fdir(i)='0'
-  enddo
-  
-  write(UNIT=temp,FMT='(i4,i2,i2,a2)') uyr,umo,uda,initcode
-  read(UNIT=temp,FMT='(10A1)') ftime
-  do i=1,10
-     if (ftime(i).eq.(' ')) ftime(i)='0'
-  enddo
-  
-  if (ncold.eq.360) then
-     write(UNIT=temp,FMT='(A6)') '.GSWP1'
-     read(UNIT=temp,FMT='(80A1)') (fsubs(i),i=1,6)
-  else
-     write(UNIT=temp,FMT='(A6)') '.GSWP1'
-     read(UNIT=temp,FMT='(80A1)') (fsubs(i),i=1,6)
-  endif
-  c=0
-  do i=1,80
-     if ((fbase(i).eq.(' ')).and.(c.eq.0)) c=i-1
-  enddo
-  
-  if (ncold.eq.360) then
-     write(UNIT=temp,FMT='(80a1)')(fbase(i),i=1,c),(fdir(i),i=1,8),&
-          (ftime(i),i=1,10),(fsubs(i),i=1,6)
-  else
-     write(UNIT=temp,FMT='(80a1)')(fbase(i),i=1,c),(fdir(i),i=1,8),&
-          (ftime(i),i=1,10),(fsubs(i),i=1,6)
-  endif
-  
-  read(UNIT=temp,FMT='(a80)') name
   return
 
 end subroutine gswp1file

--- a/lis/metforcing/gswp1/gswp1_forcingMod.F90
+++ b/lis/metforcing/gswp1/gswp1_forcingMod.F90
@@ -56,6 +56,8 @@
 !EOP
 module gswp1_forcingMod
 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN 
+
   implicit none
 
   PRIVATE 
@@ -74,7 +76,7 @@ module gswp1_forcingMod
      integer       :: mi 
      integer       :: ncold
      integer       :: nrold
-     character*100 :: gswp1dir
+     character(len=LIS_CONST_PATH_LEN) :: gswp1dir
      real*8        :: gswp1time1
      real*8        :: gswp1time2
 

--- a/lis/metforcing/gswp1/readcrd_gswp1.F90
+++ b/lis/metforcing/gswp1/readcrd_gswp1.F90
@@ -40,7 +40,7 @@ subroutine readcrd_gswp1()
 
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*)'Using GSWP1 forcing'
-     write(LIS_logunit,*)'GSWP1 forcing directory: ',gswp1_struc(n)%GSWP1DIR
+     write(LIS_logunit,*)'GSWP1 forcing directory: ',trim(gswp1_struc(n)%GSWP1DIR)
   enddo
 
 end subroutine readcrd_gswp1

--- a/lis/metforcing/gswp2/gswp2_forcingMod.F90
+++ b/lis/metforcing/gswp2/gswp2_forcingMod.F90
@@ -55,6 +55,7 @@ module gswp2_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
   
   PRIVATE
@@ -73,16 +74,16 @@ module gswp2_forcingMod
      real     :: ts
      integer  :: ncold, nrold, vector_len   !AWIPS 212 dimensions
      real*8   :: gswp2time1,gswp2time2
-     character*100 :: mfile
-     character*100 :: tair
-     character*100 :: qair
-     character*100 :: psurf
-     character*100 :: wind
-     character*100 :: rainf
-     character*100 :: snowf
-     character*100 :: swdown
-     character*100 :: lwdown
-     character*100 :: rainf_c
+     character(len=LIS_CONST_PATH_LEN) :: mfile
+     character(len=LIS_CONST_PATH_LEN) :: tair
+     character(len=LIS_CONST_PATH_LEN) :: qair
+     character(len=LIS_CONST_PATH_LEN) :: psurf
+     character(len=LIS_CONST_PATH_LEN) :: wind
+     character(len=LIS_CONST_PATH_LEN) :: rainf
+     character(len=LIS_CONST_PATH_LEN) :: snowf
+     character(len=LIS_CONST_PATH_LEN) :: swdown
+     character(len=LIS_CONST_PATH_LEN) :: lwdown
+     character(len=LIS_CONST_PATH_LEN) :: rainf_c
 
      integer, allocatable   :: gindex(:,:)
 

--- a/lis/metforcing/gswp2/read_gswp2.F90
+++ b/lis/metforcing/gswp2/read_gswp2.F90
@@ -28,6 +28,7 @@ subroutine read_gswp2(order,n, findex, yr,mo,da,hr,mn,ss)
   use LIS_logMod, only : LIS_logunit
   use LIS_gswpMod, only : getgswp_timeindex
   use gswp2_forcingMod, only : gswp2_struc
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -76,7 +77,7 @@ subroutine read_gswp2(order,n, findex, yr,mo,da,hr,mn,ss)
   integer :: tmp_yr, tmp_mo
   integer :: index1,c,r,order
   character*8 :: cyear,cmo
-  character*100 :: ffile
+  character(len=LIS_CONST_PATH_LEN) :: ffile
   real :: fvar(LIS_rc%lnc(n),LIS_rc%lnr(n))
   real, allocatable, dimension(:) :: fvar1
   real :: tempgswp2(LIS_rc%ngrid(n))
@@ -134,7 +135,7 @@ subroutine read_gswp2(order,n, findex, yr,mo,da,hr,mn,ss)
   write(cyear, '(I4)') tmp_yr
   write(cmo, '(I2.2)') tmp_mo
   ffile = trim(gswp2_struc(n)%tair)//trim(adjustl(cyear))//trim(adjustl(cmo))//".nc"
-  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading tair ',ffile
+  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading tair ',trim(ffile)
 
 #if ( defined USE_NETCDF3 || defined USE_NETCDF4 )
   status = nf90_open(path=ffile,mode= nf90_nowrite,&
@@ -213,7 +214,7 @@ subroutine read_gswp2(order,n, findex, yr,mo,da,hr,mn,ss)
   close(30)
 #else
   ffile = trim(gswp2_struc(n)%qair)//trim(adjustl(cyear))//trim(adjustl(cmo))//".nc"
-  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading qair ',ffile
+  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading qair ',trim(ffile)
 
 #if ( defined USE_NETCDF3 ||  defined USE_NETCDF4 )
   status = nf90_open(path=ffile,mode= nf90_nowrite,&
@@ -275,7 +276,7 @@ subroutine read_gswp2(order,n, findex, yr,mo,da,hr,mn,ss)
   close(30)
 #else
   ffile = trim(gswp2_struc(n)%swdown)//trim(adjustl(cyear))//trim(adjustl(cmo))//".nc"
-  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading swdown ',ffile
+  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading swdown ',trim(ffile)
 
 #if ( defined USE_NETCDF3 ||  defined USE_NETCDF4 )
   status = nf90_open(path=ffile,mode= nf90_nowrite,&
@@ -337,7 +338,7 @@ subroutine read_gswp2(order,n, findex, yr,mo,da,hr,mn,ss)
   close(30)
 #else
   ffile = trim(gswp2_struc(n)%lwdown)//trim(adjustl(cyear))//trim(adjustl(cmo))//".nc"
-  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading LWdown ',ffile
+  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading LWdown ',trim(ffile)
 
 #if ( defined USE_NETCDF3 ||  defined USE_NETCDF4 )
   status = nf90_open(path=ffile,mode= nf90_nowrite,&
@@ -399,7 +400,7 @@ subroutine read_gswp2(order,n, findex, yr,mo,da,hr,mn,ss)
   close(30)
 #else
   ffile = trim(gswp2_struc(n)%wind)//trim(adjustl(cyear))//trim(adjustl(cmo))//".nc"
-  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading Wind ',ffile
+  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading Wind ',trim(ffile)
 
 #if ( defined USE_NETCDF3 ||  defined USE_NETCDF4 )
   status = nf90_open(path=ffile,mode= nf90_nowrite,&
@@ -462,7 +463,7 @@ subroutine read_gswp2(order,n, findex, yr,mo,da,hr,mn,ss)
   close(30)
 #else
   ffile = trim(gswp2_struc(n)%psurf)//trim(adjustl(cyear))//trim(adjustl(cmo))//".nc"
-  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading psurf ',ffile
+  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading psurf ',trim(ffile)
 
 #if ( defined USE_NETCDF3 ||  defined USE_NETCDF4 )
   status = nf90_open(path=ffile,mode= nf90_nowrite,&
@@ -524,7 +525,7 @@ subroutine read_gswp2(order,n, findex, yr,mo,da,hr,mn,ss)
   close(30)
 #else
   ffile = trim(gswp2_struc(n)%rainf)//trim(adjustl(cyear))//trim(adjustl(cmo))//".nc"
-  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading Rainf ',ffile
+  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading Rainf ',trim(ffile)
 
 #if ( defined USE_NETCDF3 ||  defined USE_NETCDF4 )
   status = nf90_open(path=ffile,mode= nf90_nowrite,&
@@ -578,7 +579,7 @@ subroutine read_gswp2(order,n, findex, yr,mo,da,hr,mn,ss)
 #if ( defined GSWP2_OPENDAP )
 #else
   ffile = trim(gswp2_struc(n)%snowf)//trim(adjustl(cyear))//trim(adjustl(cmo))//".nc"
-  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading Snowf ',ffile
+  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading Snowf ',trim(ffile)
 
 #if ( defined USE_NETCDF3 ||  defined USE_NETCDF4 )
   status = nf90_open(path=ffile,mode= nf90_nowrite,&
@@ -640,7 +641,7 @@ subroutine read_gswp2(order,n, findex, yr,mo,da,hr,mn,ss)
   close(30)
 #else
   ffile = trim(gswp2_struc(n)%rainf_c)//trim(adjustl(cyear))//trim(adjustl(cmo))//".nc"
-  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading Rainf_C ',ffile
+  write(LIS_logunit,*)'MSG: GSWP2 forcing -- Reading Rainf_C ',trim(ffile)
 
 #if ( defined USE_NETCDF3 ||  defined USE_NETCDF4 )
   status = nf90_open(path=ffile,mode= nf90_nowrite,&

--- a/lis/metforcing/imerg/get_imerg.F90
+++ b/lis/metforcing/imerg/get_imerg.F90
@@ -24,6 +24,7 @@ subroutine get_imerg(n, findex)
   use LIS_timeMgrMod, only : LIS_tick, LIS_get_nstep
   use imerg_forcingMod, only :imerg_struc
   use LIS_logMod, only : LIS_logunit, LIS_endrun
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -63,7 +64,7 @@ subroutine get_imerg(n, findex)
   real*8  :: ctime,ftime_imerg       ! Current LIS time and end boundary times for precip data sources 
   integer :: order
   real    :: gmt1,gmt4,ts1,ts4
-  character(len=99) :: filename ! Filename variables for precip data sources
+  character(len=LIS_CONST_PATH_LEN) :: filename ! Filename variables for precip data sources
 
 !=== End Variable Definition =======================
 
@@ -160,11 +161,10 @@ subroutine imergfile(n, kk, findex, imergdir, &
 !  \end{description}
 !
 !EOP
-  character(len=120) :: temp
   integer :: i, c
   integer :: uyr, umo, uda, uhr, umn, umnadd, umnday, uss !, ts1
 
-  character*100 :: fbase, ftimedir, fstem, fext
+  character*100 :: fstem, fext
   character*4   :: cyr, cmnday, imVer
   character*2   :: cmo, cda, chr, cmn, cmnadd 
 

--- a/lis/metforcing/imerg/imerg_forcingMod.F90
+++ b/lis/metforcing/imerg/imerg_forcingMod.F90
@@ -50,6 +50,8 @@ module imerg_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
   PRIVATE
 !-----------------------------------------------------------------------------
@@ -66,7 +68,7 @@ module imerg_forcingMod
   type, public :: imerg_type_dec
      real    :: ts
      integer :: ncold, nrold     ! IMERG dimensions
-     character*100 :: imergdir   ! IMERG Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: imergdir   ! IMERG Forcing Directory
      character*5 :: imergver     ! IMERG version (V06B set as default)
      character*5 :: imergprd     ! IMERG product (early, late, final)
      real*8  :: imergtime

--- a/lis/metforcing/imerg/read_imerg.F90
+++ b/lis/metforcing/imerg/read_imerg.F90
@@ -24,6 +24,7 @@ subroutine read_imerg (n, kk, name_imerg, findex, order, ferror_imerg )
                          LIS_releaseUnitNumber
   use LIS_metforcingMod,only : LIS_forc
   use imerg_forcingMod, only : imerg_struc
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS:   
@@ -70,7 +71,7 @@ subroutine read_imerg (n, kk, name_imerg, findex, order, ferror_imerg )
   real :: realprecip(xd,yd)
   real :: testout(xd,yd)
   real, allocatable :: precip_regrid(:,:)                      ! Interpolated precip array
-  character(len=99) :: fname, zname                  ! Filename variables
+  character(len=LIS_CONST_PATH_LEN) :: fname ! Filename variables
   logical           :: file_exists
   integer           :: ftn
   integer           :: ireaderr
@@ -90,16 +91,16 @@ subroutine read_imerg (n, kk, name_imerg, findex, order, ferror_imerg )
  inquire(file=fname, EXIST=file_exists)
  if (file_exists) then
    if(LIS_masterproc) write(LIS_logunit,*) &
-        "[INFO] Reading HDF5 IMERG precipitation data from ", fname
+        "[INFO] Reading HDF5 IMERG precipitation data from ", trim(fname)
    call read_imerghdf(fname, xd, yd, realprecip, ireaderr)
    if (ireaderr .ne. 0) then
      if(LIS_masterproc) write(LIS_logunit,*) &
-        "[WARN] Error reading IMERG file ",fname
+        "[WARN] Error reading IMERG file ",trim(fname)
      ferror_imerg = 0
    endif
  else
    if(LIS_masterproc) write(LIS_logunit,*) &
-      "[WARN] Missing IMERG precipitation data:: ",fname
+      "[WARN] Missing IMERG precipitation data:: ",trim(fname)
    ferror_imerg = 0
  endif
 
@@ -143,7 +144,7 @@ subroutine read_imerghdf(filename, xsize, ysize, precipout, istatus)
   implicit none
 
 ! ARGUMENTS
-  character(len=99)    :: filename
+  character(len=*)    :: filename
   integer, intent(in)  :: xsize, ysize
 
   character(len=40) :: dsetname='/Grid/precipitationCal'

--- a/lis/metforcing/merra-land/get_merraland.F90
+++ b/lis/metforcing/merra-land/get_merraland.F90
@@ -29,6 +29,7 @@ subroutine get_merraland(n,findex)
   use LIS_timeMgrMod
   use LIS_logMod
   use LIS_metforcingMod
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   use merraland_forcingMod
 
   implicit none
@@ -166,7 +167,7 @@ subroutine get_merraland(n,findex)
   integer           :: c,r
   integer           :: order
   integer           :: ferror
-  character*100     :: slvname, flxname, radname, mldname, lndname
+  character(len=LIS_CONST_PATH_LEN) :: slvname, flxname, radname, mldname, lndname
   integer           :: yr1, mo1, da1, hr1, mn1, ss1, doy1
   integer           :: yr2, mo2, da2, hr2, mn2, ss2, doy2
   real*8            :: time1, time2, timenow

--- a/lis/metforcing/merra-land/merraland_forcingMod.F90
+++ b/lis/metforcing/merra-land/merraland_forcingMod.F90
@@ -58,6 +58,8 @@ module merraland_forcingMod
 !  \end{description}
 !
 ! !USES:
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
 
   PRIVATE
@@ -75,7 +77,7 @@ module merraland_forcingMod
   type, public ::  merraland_type_dec
      real    :: ts
      integer :: ncold, nrold
-     character*40 :: merralanddir   !MERRA-Land Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: merralanddir   !MERRA-Land Forcing Directory
      real*8  :: merralandtime1,merralandtime2
 
      integer :: mi

--- a/lis/metforcing/merra-land/readcrd_merraland.F90
+++ b/lis/metforcing/merra-land/readcrd_merraland.F90
@@ -52,7 +52,7 @@ subroutine readcrd_merraland()
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*) 'Using MERRA-Land forcing'
      write(LIS_logunit,*) 'MERRA-Land forcing directory: ',&
-          merraland_struc(n)%MERRALANDDIR
+          trim(merraland_struc(n)%MERRALANDDIR)
 
      merraland_struc(n)%ncold = 540
      merraland_struc(n)%nrold = 361

--- a/lis/metforcing/merra2/get_merra2.F90
+++ b/lis/metforcing/merra2/get_merra2.F90
@@ -25,6 +25,7 @@ subroutine get_merra2(n, findex)
   use LIS_logMod
   use LIS_metforcingMod
   use merra2_forcingMod
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 
@@ -162,7 +163,7 @@ subroutine get_merra2(n, findex)
 !EOP
   integer           :: order
   integer           :: ferror
-  character*100     :: slvname, flxname, lfoname, radname
+  character(len=LIS_CONST_PATH_LEN) :: slvname, flxname, lfoname, radname
   integer           :: c, r,kk
   integer           :: yr1, mo1, da1, hr1, mn1, ss1, doy1
   integer           :: yr2, mo2, da2, hr2, mn2, ss2, doy2

--- a/lis/metforcing/merra2/merra2_forcingMod.F90
+++ b/lis/metforcing/merra2/merra2_forcingMod.F90
@@ -58,6 +58,7 @@ module merra2_forcingMod
 !  \end{description}
 !
 ! !USES:
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
 
   PRIVATE
@@ -75,7 +76,7 @@ module merra2_forcingMod
   type, public ::  merra2_type_dec
      real         :: ts
      integer      :: ncold, nrold
-     character*40 :: merra2dir   !MERRA2 Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: merra2dir   !MERRA2 Forcing Directory
      real*8       :: merra2time1,merra2time2
      logical      :: reset_flag
 
@@ -113,7 +114,7 @@ module merra2_forcingMod
      integer                 :: usepcpsampling
      integer                 :: pcpscal_cmo
      integer                 :: use2mwind
-     character*100           :: scaleffile
+     character(len=LIS_CONST_PATH_LEN) :: scaleffile
      integer                 :: nbins
      real, allocatable       :: refxrange(:,:,:,:)
      real, allocatable       :: refcdf(:,:,:,:)

--- a/lis/metforcing/merra2/readcrd_merra2.F90
+++ b/lis/metforcing/merra2/readcrd_merra2.F90
@@ -120,7 +120,7 @@ subroutine readcrd_merra2()
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*) '[INFO] Using MERRA2 forcing'
      write(LIS_logunit,*) '[INFO] MERRA2 forcing directory: ',&
-          merra2_struc(n)%merra2DIR
+          trim(merra2_struc(n)%merra2DIR)
 
      merra2_struc(n)%merra2time1 = 3000.0
      merra2_struc(n)%merra2time2 = 0.0

--- a/lis/metforcing/mrms/get_mrms_grib.F90
+++ b/lis/metforcing/mrms/get_mrms_grib.F90
@@ -26,7 +26,7 @@ subroutine get_mrms_grib(n, findex)
   use LIS_logMod, only      : LIS_logunit
   use LIS_timeMgrMod, only  : LIS_tick, LIS_get_nstep
   use mrms_grib_forcingMod, only : mrms_grib_struc
-
+  use LIS_constantsMod,     only : LIS_CONST_PATH_LEN
   implicit none
 ! !ARGUMENTS: 
 
@@ -73,7 +73,7 @@ subroutine get_mrms_grib(n, findex)
   integer :: order
 
   real*8  :: lis_time, mrms_grib_file_time ! Current LIS Time and end boundary time for MRMS file
-  character(150) :: file_name               ! Filename variables for precip data sources
+  character(len=LIS_CONST_PATH_LEN) :: file_name               ! Filename variables for precip data sources
 
   integer :: doy1, yr1, mo1, da1, hr1, mn1, ss1
   integer :: doy2, yr2, mo2, da2, hr2, mn2, ss2

--- a/lis/metforcing/mrms/mrms_grib_forcingMod.F90
+++ b/lis/metforcing/mrms/mrms_grib_forcingMod.F90
@@ -58,6 +58,8 @@ module mrms_grib_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
 
   PRIVATE
@@ -77,11 +79,11 @@ module mrms_grib_forcingMod
      real               :: ts
      integer            :: ncol                 ! Number of cols
      integer            :: nrow                 ! Number of rows
-     character*80       :: mrms_grib_dir        ! MRMS Directory
+     character(len=LIS_CONST_PATH_LEN) :: mrms_grib_dir ! MRMS Directory
      real*8             :: mrms_grib_time       ! Nearest hourly instance of incoming file
      integer            :: mrms_mask_opt        ! Flag for whether or not to use mask 1=Yes
      real*8             :: mrms_mask_thresh     ! Threshold for masking MRMS data
-     character*150      :: mrms_mask_dir        ! Directory of MRMS masks
+     character(len=LIS_CONST_PATH_LEN) :: mrms_mask_dir        ! Directory of MRMS masks
      integer            :: mi                   ! Number of points in the input grid
 
 ! == Arrays for Bilinear Interpolation option (=1)

--- a/lis/metforcing/mrms/mrms_gribfile.F90
+++ b/lis/metforcing/mrms/mrms_gribfile.F90
@@ -49,8 +49,7 @@ subroutine mrms_gribfile( name, mrms_grib_dir, yr, mo, da, hr)
 ! !ARGUMENTS: 
   integer :: yr, mo, da, hr
 
-  character(150) :: name
-  character(40) :: mrms_grib_dir
+  character(len=*) :: name, mrms_grib_dir
   character(4) :: cyear
   character(2) :: cmon, cday, chour
 

--- a/lis/metforcing/mrms/read_mrms_grib.F90
+++ b/lis/metforcing/mrms/read_mrms_grib.F90
@@ -29,6 +29,7 @@ subroutine read_mrms_grib( n, fname, findex, order, yr, mo, da, ferror_mrms_grib
   use LIS_logMod,         only : LIS_logunit, LIS_verify
   use LIS_metforcingMod,  only : LIS_forc
   use mrms_grib_forcingMod,    only : mrms_grib_struc
+  use LIS_constantsMod,        only : LIS_CONST_PATH_LEN
 
 #if (defined USE_GRIBAPI)
   use grib_api
@@ -37,8 +38,8 @@ subroutine read_mrms_grib( n, fname, findex, order, yr, mo, da, ferror_mrms_grib
   implicit none
 ! !ARGUMENTS:
   integer, intent(in) :: n
-  character(len=120)   :: fname
-  character(len=200)  :: maskname          
+  character(len=*)   :: fname
+  character(len=LIS_CONST_PATH_LEN)  :: maskname          
   integer, intent(in) :: findex
   integer, intent(in) :: order
   integer             :: ferror_mrms_grib

--- a/lis/metforcing/mrms/readcrd_mrms_grib.F90
+++ b/lis/metforcing/mrms/readcrd_mrms_grib.F90
@@ -47,7 +47,7 @@ subroutine readcrd_mrms_grib()
     call ESMF_ConfigGetAttribute(LIS_config, mrms_grib_struc(n)%mrms_grib_dir,rc=rc)
 
     write(LIS_logunit,*) 'Using MRMS forcing'
-    write(LIS_logunit,*) 'MRMS forcing directory: ', mrms_grib_struc(n)%MRMS_GRIB_DIR
+    write(LIS_logunit,*) 'MRMS forcing directory: ', trim(mrms_grib_struc(n)%MRMS_GRIB_DIR)
 
     !- Setting observed precip times to zero to ensure data is read in
     !   at first time step

--- a/lis/metforcing/nam242/create_nam242f9_filename.F90
+++ b/lis/metforcing/nam242/create_nam242f9_filename.F90
@@ -60,8 +60,10 @@ subroutine create_nam242f9_filename(option, name00, name03, &
   integer :: uyr0, umo0, uda0, uhr0, umn0, uss0
   integer :: remainder
   character(len=2) :: initcode0, initcode1, fcstcode0, fcstcode1, fcstcode2
-  character*1 :: fbase(80), fdir(13), ftime(10), fsubs(26)
-  character(LEN=100) :: temp1,temp2
+  character(len=8)  :: fdir
+  character(len=26) :: fsubs
+  character(len=5), parameter  :: fsubs_prefix = 'fh.00'
+  character(len=19), parameter :: fsubs_suffix = '_tl.press_gr.awp242'
   real*8      :: time1,dumbtime
   integer     :: doy1,doy
   real        :: gmt1,gmt
@@ -179,46 +181,20 @@ subroutine create_nam242f9_filename(option, name00, name03, &
   fcstcode1 = '09'
    
   !name 00
-  write(UNIT=temp1, fmt='(a40)') namdir  
-  read(UNIT=temp1, fmt='(80a1)') (fbase(i), i=1,80)
 
-  write(UNIT=temp1, fmt='(a1, i4, i2, i2, a1, a2, a1)') '/', uyr0, umo0, uda0, '/', initcode1, '/'
-  read(UNIT=temp1, fmt='(13a1)') fdir
-  do i = 1, 13
-     if ( fdir(i) == ' ' ) fdir(i) = '0'
-  end do
+  write(UNIT=fdir, fmt='(i4, i2.2, i2.2)') uyr0, umo0, uda0
 
-  write(UNIT=temp1, fmt='(a5, a2, a19)') 'fh.00', fcstcode1, '_tl.press_gr.awp242'
-  read (UNIT=temp1, fmt='(80a1)') (fsubs(i), i=1,26)
+  write(UNIT=fsubs, fmt='(a5, a2, a19)') fsubs_prefix, fcstcode1, fsubs_suffix
 
-  c = 0
-  do i = 1, 80
-     if ( (fbase(i) == ' ') .and. (c == 0) ) c = i-1
-  end do
-
-  write(UNIT=temp1, fmt='(80a1)') (fbase(i), i=1,c), (fdir(i), i=1,13), (fsubs(i), i=1,26)
-  read(UNIT=temp1, fmt='(a80)') name00
+  name00 = trim(namdir) // '/' // fdir // '/' // initcode1 // '/' // fsubs
 
   !namef03
-  write(UNIT=temp2, fmt='(a40)') namdir  
-  read(UNIT=temp2, fmt='(80a1)') (fbase(i), i=1,80)
 
-  write(UNIT=temp2, fmt='(a1, i4, i2, i2, a1, a2, a1)') '/', uyr0, umo0, uda0, '/', initcode1, '/'
-  read(UNIT=temp2, fmt='(13a1)') fdir
-  do i = 1, 13
-     if ( fdir(i) == ' ' ) fdir(i) = '0'
-  end do
+  write(UNIT=fdir, fmt='(i4, i2.2, i2.2)') uyr0, umo0, uda0
 
-  write(UNIT=temp2, fmt='(a5, a2, a19)') 'fh.00', fcstcode1, '_tl.press_gr.awp242'
-  read (UNIT=temp2, fmt='(80a1)') (fsubs(i), i=1,26)
+  write(UNIT=fsubs, fmt='(a5, a2, a19)') fsubs_prefix, fcstcode1, fsubs_suffix
 
-  c = 0
-  do i = 1, 80
-     if ( (fbase(i) == ' ') .and. (c == 0) ) c = i-1
-  end do
-
-  write(UNIT=temp2, fmt='(80a1)') (fbase(i), i=1,c), (fdir(i), i=1,13), (fsubs(i), i=1,26)
-  read(UNIT=temp2, fmt='(a80)') name03
+  name03 = trim(namdir) // '/' // fdir // '/' // initcode1 // '/' // fsubs
 
   return
 

--- a/lis/metforcing/nam242/create_nam242filename.F90
+++ b/lis/metforcing/nam242/create_nam242filename.F90
@@ -64,8 +64,10 @@ subroutine create_nam242filename(option, name00, name03, name06, &
   integer :: uyr0, umo0, uda0, uhr0, umn0, uss0
   integer :: remainder
   character(len=2) :: initcode0, initcode1, fcstcode0, fcstcode1, fcstcode2
-  character*1 :: fbase(80), fdir(13), ftime(10), fsubs(26)
-  character(LEN=100) :: temp1,temp2
+  character(len=8) :: fdir
+  character(len=26) :: fsubs
+  character(len=5),  parameter :: fsubs_prefix = 'fh.00'
+  character(len=19), parameter :: fsubs_suffix = '_tl.press_gr.awp242'
   real*8      :: time1,dumbtime
   integer     :: doy1,doy
   real        :: gmt1,gmt
@@ -224,67 +226,28 @@ subroutine create_nam242filename(option, name00, name03, name06, &
   fcstcode2 = '06'
   
   !name00
-  write(UNIT=temp1, fmt='(a40)') namdir  
-  read(UNIT=temp1, fmt='(80a1)') (fbase(i), i=1,80)
 
-  write(UNIT=temp1, fmt='(a1, i4, i2, i2, a1, a2, a1)') '/', uyr, umo, uda, '/', initcode0, '/'
-  read(UNIT=temp1, fmt='(13a1)') fdir
-  do i = 1, 13
-     if ( fdir(i) == ' ' ) fdir(i) = '0'
-  end do
+  write(UNIT=fdir, fmt='(i4, i2.2, i2.2)') uyr, umo, uda
 
-  write(UNIT=temp1, fmt='(a5, a2, a19)') 'fh.00', fcstcode0, '_tl.press_gr.awp242'
-  read (UNIT=temp1, fmt='(80a1)') (fsubs(i), i=1,26)
+  write(UNIT=fsubs, fmt='(a5, a2, a19)') fsubs_prefix, fcstcode0, fsubs_suffix
 
-  c = 0
-  do i = 1, 80
-     if ( (fbase(i) == ' ') .and. (c == 0) ) c = i-1
-  end do
-
-  write(UNIT=temp1, fmt='(80a1)') (fbase(i), i=1,c), (fdir(i), i=1,13), (fsubs(i), i=1,26)
-  read(UNIT=temp1, fmt='(a80)') name00
+  name00 = trim(namdir) // '/' // fdir // '/' // initcode0 // '/' // fsubs
 
   !name03
-  write(UNIT=temp1, fmt='(a40)') namdir  
-  read(UNIT=temp1, fmt='(80a1)') (fbase(i), i=1,80)
 
-  write(UNIT=temp1, fmt='(a1, i4, i2, i2, a1, a2, a1)') '/', uyr0, umo0, uda0, '/', initcode1, '/'
-  read(UNIT=temp1, fmt='(13a1)') fdir
-  do i = 1, 13
-     if ( fdir(i) == ' ' ) fdir(i) = '0'
-  end do
+  write(UNIT=fdir, fmt='(i4, i2.2, i2.2)') uyr0, umo0, uda0
 
-  write(UNIT=temp1, fmt='(a5, a2, a19)') 'fh.00', fcstcode1, '_tl.press_gr.awp242'
-  read (UNIT=temp1, fmt='(80a1)') (fsubs(i), i=1,26)
+  write(UNIT=fsubs, fmt='(a5, a2, a19)') fsubs_prefix, fcstcode1, fsubs_suffix
 
-  c = 0
-  do i = 1, 80
-     if ( (fbase(i) == ' ') .and. (c == 0) ) c = i-1
-  end do
-
-  write(UNIT=temp1, fmt='(80a1)') (fbase(i), i=1,c), (fdir(i), i=1,13), (fsubs(i), i=1,26)
-  read(UNIT=temp1, fmt='(a80)') name03
+  name03 = trim(namdir) // '/' // fdir // '/' // initcode1 // '/' // fsubs
 
   !name06
-  write(UNIT=temp2, fmt='(a40)') namdir  
-  read(UNIT=temp2, fmt='(80a1)') (fbase(i), i=1,80)
 
-  write(UNIT=temp2, fmt='(a1, i4, i2, i2, a1, a2, a1)') '/', uyr0, umo0, uda0, '/', initcode1, '/'
-  read(UNIT=temp2, fmt='(13a1)') fdir
-  do i = 1, 13
-     if ( fdir(i) == ' ' ) fdir(i) = '0'
-  end do
+  write(UNIT=fdir, fmt='(i4, i2.2, i2.2)') uyr0, umo0, uda0
 
-  write(UNIT=temp2, fmt='(a5, a2, a19)') 'fh.00', fcstcode2, '_tl.press_gr.awp242'
-  read (UNIT=temp2, fmt='(80a1)') (fsubs(i), i=1,26)
+  write(UNIT=fsubs, fmt='(a5, a2, a19)') fsubs_prefix, fcstcode2, fsubs_suffix
 
-  c = 0
-  do i = 1, 80
-     if ( (fbase(i) == ' ') .and. (c == 0) ) c = i-1
-  end do
-
-  write(UNIT=temp2, fmt='(80a1)') (fbase(i), i=1,c), (fdir(i), i=1,13), (fsubs(i), i=1,26)
-  read(UNIT=temp2, fmt='(a80)') name06
+  name06 = trim(namdir) // '/' // fdir // '/' // initcode1 // '/' // fsubs
 
   return
 

--- a/lis/metforcing/nam242/get_nam242.F90
+++ b/lis/metforcing/nam242/get_nam242.F90
@@ -23,6 +23,7 @@ subroutine get_nam242(n, findex)
   use LIS_coreMod,       only : LIS_rc
   use LIS_timeMgrMod,    only : LIS_tick, LIS_get_nstep
   use LIS_logMod,        only : LIS_logunit, LIS_endrun
+  use LIS_constantsMod,  only : LIS_CONST_PATH_LEN
   use nam242_forcingMod, only : nam242_struc
 
   implicit none
@@ -81,7 +82,7 @@ subroutine get_nam242(n, findex)
   real*8  :: timenow, time1, time2
   real*8  :: dumbtime1, dumbtime2
   real    :: gmt1, gmt2
-  character(len=80) :: name00, name03, name06
+  character(len=LIS_CONST_PATH_LEN) :: name00, name03, name06
   logical :: file_exists, file_exists1, file_exists2
   integer :: option
   real :: gridDesci(50)
@@ -174,8 +175,8 @@ subroutine get_nam242(n, findex)
         try = try+1
         call create_nam242filename( order, name00, name03, name06, F06flag, &
              nam242_struc(n)%namdir, yr1, mo1, da1, hr1 )
-        write(LIS_logunit,*) 'Reading NAM file1 (I) ',name00
-        write(LIS_logunit,*) 'Reading NAM file1 (A) ',name03
+        write(LIS_logunit,*) 'Reading NAM file1 (I) ',trim(name00)
+        write(LIS_logunit,*) 'Reading NAM file1 (A) ',trim(name03)
         inquire(file=name00,exist=file_exists1) 
         inquire(file=name03,exist=file_exists2)
 !-----------------------------------------------------------------
@@ -194,7 +195,7 @@ subroutine get_nam242(n, findex)
         endif
            
         if(F06flag) then 
-           write(LIS_logunit,*) 'Reading NAM file1 (A)',name06
+           write(LIS_logunit,*) 'Reading NAM file1 (A)',trim(name06)
         endif
 
         if(status.eq.0) then
@@ -245,8 +246,8 @@ subroutine get_nam242(n, findex)
         try = try+1
         call create_nam242filename( order, name00, name03,name06, &
              F06flag, nam242_struc(n)%namdir, yr1, mo1, da1, hr1 )
-        write(LIS_logunit,*) 'First Reading NAM file2 (I) ',name00
-        write(LIS_logunit,*) 'First Reading NAM file2 (A) ',name03
+        write(LIS_logunit,*) 'First Reading NAM file2 (I) ',trim(name00)
+        write(LIS_logunit,*) 'First Reading NAM file2 (A) ',trim(name03)
 
         inquire(file=name00,exist=file_exists1) 
         inquire(file=name03,exist=file_exists2)
@@ -257,15 +258,15 @@ subroutine get_nam242(n, findex)
            inquire(file=name03,exist=file_exists2)
            if(file_exists1.and.file_exists2) then 
               status = 0 
-              write(LIS_logunit,*) 'F9 Reading NAM file2 (I) ',name00
-              write(LIS_logunit,*) 'F9 Reading NAM file2 (A) ',name03
+              write(LIS_logunit,*) 'F9 Reading NAM file2 (I) ',trim(name00)
+              write(LIS_logunit,*) 'F9 Reading NAM file2 (A) ',trim(name03)
            else
               status = 1
            endif
         endif
 
         if(F06flag) then 
-           write(LIS_logunit,*) 'Reading NAM file2 (A)',name06
+           write(LIS_logunit,*) 'Reading NAM file2 (A)',trim(name06)
         endif
         call read_nam242(n, findex, order, name00, name03, name06, &
                          F06flag, ferror, try)

--- a/lis/metforcing/nam242/nam242_forcingMod.F90
+++ b/lis/metforcing/nam242/nam242_forcingMod.F90
@@ -62,6 +62,7 @@ module nam242_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
   
   PRIVATE
@@ -79,8 +80,8 @@ module nam242_forcingMod
   type, public        :: nam242_type_dec
      integer          :: ncold, nrold
      integer          :: nmif
-     character*100    :: namdir   !NAM Forcing Directory
-     character*100    :: elevfile
+     character(len=LIS_CONST_PATH_LEN) :: namdir   !NAM Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: elevfile
      real             :: ts
      real*8           :: namtime1,namtime2
      integer          :: findtime1,findtime2

--- a/lis/metforcing/nam242/read_nam242.F90
+++ b/lis/metforcing/nam242/read_nam242.F90
@@ -25,6 +25,7 @@ subroutine read_nam242(n, findex, order, name00, name03, name06, &
   use LIS_metforcingMod,  only : LIS_forc
   use LIS_logMod,         only : LIS_logunit, LIS_endrun, LIS_verify
   use nam242_forcingMod,  only : nam242_struc
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
 
 #if (defined USE_GRIBAPI)
   use grib_api
@@ -78,7 +79,7 @@ subroutine read_nam242(n, findex, order, name00, name03, name06, &
 !EOP
 !==== Local Variables=======================
   
-  character(len=100) :: fname
+  character(len=LIS_CONST_PATH_LEN) :: fname
   integer :: lenfname
   integer :: lennamfname
   character(len=2) :: initcode

--- a/lis/metforcing/nam242/readcrd_nam242.F90
+++ b/lis/metforcing/nam242/readcrd_nam242.F90
@@ -41,7 +41,7 @@ subroutine readcrd_nam242()
 
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*) 'Using NAM242 forcing'
-     write(LIS_logunit,*) 'NAM242 forcing directory :',nam242_struc(n)%NAMDIR
+     write(LIS_logunit,*) 'NAM242 forcing directory :',trim(nam242_struc(n)%NAMDIR)
      nam242_struc(n)%namtime1  = 3000.0
      nam242_struc(n)%namtime2  = 0.0
   enddo

--- a/lis/metforcing/narr/get_narr.F90
+++ b/lis/metforcing/narr/get_narr.F90
@@ -23,6 +23,7 @@ subroutine get_narr(n, findex)
   use LIS_timeMgrMod,     only : LIS_get_nstep, LIS_tick
   use LIS_logMod,         only : LIS_logunit
   use narr_forcingMod,  only : narr_struc
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -40,7 +41,7 @@ subroutine get_narr(n, findex)
   real                :: gmt1, gmt2,ts1,ts2
   integer             :: order
   integer             :: nstep
-  character*100       :: narrfile
+  character(len=LIS_CONST_PATH_LEN) :: narrfile
 
   narr_struc(n)%findtime1 = 0 
   narr_struc(n)%findtime2 = 0 

--- a/lis/metforcing/narr/narr_forcingMod.F90
+++ b/lis/metforcing/narr/narr_forcingMod.F90
@@ -14,6 +14,7 @@ module narr_forcingMod
 ! !DESCRIPTION: 
 !  
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
   
   PRIVATE
@@ -32,7 +33,7 @@ module narr_forcingMod
      
      real             :: ts
      real*8           :: narrtime1,narrtime2
-     character*100    :: narrdir
+     character(len=LIS_CONST_PATH_LEN)    :: narrdir
      integer          :: nc,nr
      integer          :: nlevels
 

--- a/lis/metforcing/narr/readcrd_narr.F90
+++ b/lis/metforcing/narr/readcrd_narr.F90
@@ -66,7 +66,7 @@ subroutine readcrd_narr()
 
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*) 'Using NARR forcing'
-     write(LIS_logunit,*) 'NARR forcing directory :',narr_struc(n)%NARRDIR
+     write(LIS_logunit,*) 'NARR forcing directory :',trim(narr_struc(n)%NARRDIR)
      narr_struc(n)%NARRTIME1  = 3000.0
      narr_struc(n)%NARRTIME2  = 0.0
   enddo

--- a/lis/metforcing/nldas1/get_nldas1.F90
+++ b/lis/metforcing/nldas1/get_nldas1.F90
@@ -25,6 +25,7 @@ subroutine get_nldas1(n,findex)
   use LIS_coreMod,        only : LIS_rc, LIS_domain
   use LIS_timeMgrMod,     only : LIS_tick
   use LIS_logMod,         only : LIS_logunit, LIS_endrun
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
   use nldas1_forcingMod,  only : nldas1_struc
 
   implicit none
@@ -64,7 +65,7 @@ subroutine get_nldas1(n,findex)
   real*8  :: dtime1, dtime2
   integer :: yr1,mo1,da1,hr1,mn1,ss1,doy1
   integer :: yr2,mo2,da2,hr2,mn2,ss2,doy2
-  character*80 :: name
+  character(len=LIS_CONST_PATH_LEN) :: name
   real :: gmt1,gmt2,ts1,ts2
   integer:: movetime     ! 1=move time 2 data into time 1  
 

--- a/lis/metforcing/nldas1/nldas1_forcingMod.F90
+++ b/lis/metforcing/nldas1/nldas1_forcingMod.F90
@@ -85,6 +85,7 @@ module nldas1_forcingMod
 !                            Changed flag from "1"/"2" to "NCEP"/"GES-DISC".
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
 
   PRIVATE
@@ -103,9 +104,9 @@ module nldas1_forcingMod
      real         :: ts
      integer      :: ncold, nrold    ! AWIPS 212 dimensions
      character*50 :: nldas1_filesrc
-     character*80 :: nldas1dir       ! NLDAS-1 Forcing Directory
-     character*80 :: ediff_file      ! Original Elevdiff File
-     character*80 :: elevfile
+     character(len=LIS_CONST_PATH_LEN) :: nldas1dir       ! NLDAS-1 Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: ediff_file      ! Original Elevdiff File
+     character(len=LIS_CONST_PATH_LEN) :: elevfile
      character*40 :: prec_field,swdn_field
      real*8       :: nldas1time1,nldas1time2
 

--- a/lis/metforcing/nldas1/read_nldas1.F90
+++ b/lis/metforcing/nldas1/read_nldas1.F90
@@ -59,7 +59,7 @@ subroutine read_nldas1(n, findex, order, name, ferror)
   integer, intent(in)      :: n
   integer, intent(in)      :: findex
   integer, intent(in)      :: order
-  character*80, intent(in) :: name
+  character(len=*), intent(in) :: name
   integer, intent(out)     :: ferror
 !
 ! !DESCRIPTION:

--- a/lis/metforcing/nldas1/readcrd_nldas1.F90
+++ b/lis/metforcing/nldas1/readcrd_nldas1.F90
@@ -155,7 +155,7 @@ subroutine readcrd_nldas1()
   write(unit=LIS_logunit,fmt=*)'Using NLDAS-1 forcing'
 
   do n=1,LIS_rc%nnest
-     write(unit=LIS_logunit,fmt=*) 'NLDAS-1 forcing directory :',nldas1_struc(n)%nldas1dir
+     write(unit=LIS_logunit,fmt=*) 'NLDAS-1 forcing directory :',trim(nldas1_struc(n)%nldas1dir)
 
      nldas1_struc(n)%nldas1time1 = 3000.0
      nldas1_struc(n)%nldas1time2 = 0.0

--- a/lis/metforcing/nldas2/get_gesdisc_filenames.F90
+++ b/lis/metforcing/nldas2/get_gesdisc_filenames.F90
@@ -33,8 +33,8 @@
    integer                    :: n
    integer                    :: kk
    integer                    :: findex
-   character*100, intent(out) :: filename
-   character*40, intent(in)   :: nldas2dir
+   character(len=*), intent(out) :: filename
+   character(len=*), intent(in)  :: nldas2dir
    integer, intent(in)        :: yr,mo,da,doy,hr
 !
 ! !DESCRIPTION:
@@ -148,8 +148,8 @@
    integer                    :: n
    integer                    :: kk
    integer                    :: findex
-   character*100, intent(out) :: filename
-   character*40, intent(in)   :: nldas2dir
+   character(len=*), intent(out) :: filename
+   character(len=*), intent(in)   :: nldas2dir
    integer, intent(in)        :: yr,mo,da,doy,hr
 !
 ! !DESCRIPTION:

--- a/lis/metforcing/nldas2/get_ncep_filenames.F90
+++ b/lis/metforcing/nldas2/get_ncep_filenames.F90
@@ -32,8 +32,8 @@
    integer, intent(in)        :: n 
    integer, intent(in)        :: kk
    integer, intent(in)        :: findex
-   character*100, intent(out) :: filename
-   character*40, intent(in)   :: nldas2dir
+   character(len=*), intent(out) :: filename
+   character(len=*), intent(in)   :: nldas2dir
    integer, intent(in)        :: yr,mo,da,hr
 
 ! !DESCRIPTION:
@@ -58,68 +58,34 @@
 !
 !EOP
 
-   integer                  :: i, c
-   character*1              :: fbase(40),fsubs(17)
-   character*1              :: ftime(10),fdir(15)
-   character*100            :: temp
+   character(len=13) :: fdir
+   character(len=17), parameter :: fsubs = '.nldasforce-a.grb'
+   character(len=10) :: ftime
 
    !=== end variable definition =============================================
 
    !=== put together filename
 
-  if(LIS_rc%forecastMode.eq.0) then !hindcast run
+   if(LIS_rc%forecastMode.eq.0) then !hindcast run
 
-     write(UNIT=temp,fmt='(a1,i4,a1,i4,i2,i2,a1)')'/',yr,'/',yr,mo,da,'/'
-     read(UNIT=temp,fmt='(15a1)') fdir
-     do i=1,15
-        if(fdir(i).eq.(' ')) fdir(i) = '0'
-     enddo
-     write(UNIT=temp,fmt='(i4,i2,i2,i2)') yr,mo,da,hr
-     read(UNIT=temp,fmt='(10a1)')ftime
-     do i=1,10
-        if(ftime(i).eq.(' ')) ftime(i) = '0'
-     enddo
-     write(UNIT=temp,fmt='(a17)')'.nldasforce-a.grb'
-     read(UNIT=temp,fmt='(17a1)') fsubs
-     write(UNIT=temp,fmt='(a40)') nldas2dir                       
-     read(UNIT=temp,fmt='(40a1)') fbase
-     c=0
-     do i=1,40
-        if(fbase(i).eq.(' ').and.c.eq.0)c=i-1
-     enddo
-     write(UNIT=temp,fmt='(100a1)')(fbase(i),i=1,c), (fdir(i),i=1,15), & 
-          (ftime(i),i=1,10),(fsubs(i),i=1,17 ) 
-     read(UNIT=temp,fmt='(a100)') filename
+      write(UNIT=fdir,fmt='(i4,a1,i4,i2.2,i2.2)') yr, '/', yr, mo, da
+
+      write(UNIT=ftime,fmt='(i4,i2.2,i2.2,i2.2)') yr, mo, da, hr
 
    else !forecast mode
      !sample yr, mo, da
 
-     call LIS_sample_forecastDate(n, kk, findex, yr, mo, da)
-
-     write(UNIT=temp,fmt='(a1,i4,a1,i4,i2,i2,a1)')'/',yr,'/',yr,mo,da,'/'
-     read(UNIT=temp,fmt='(15a1)') fdir
-     do i=1,15
-        if(fdir(i).eq.(' ')) fdir(i) = '0'
-     enddo
-     write(UNIT=temp,fmt='(i4,i2,i2,i2)') yr,mo,da,hr
-     read(UNIT=temp,fmt='(10a1)')ftime
-     do i=1,10
-        if(ftime(i).eq.(' ')) ftime(i) = '0'
-     enddo
-     write(UNIT=temp,fmt='(a17)')'.nldasforce-a.grb'
-     read(UNIT=temp,fmt='(17a1)') fsubs
-     write(UNIT=temp,fmt='(a40)') nldas2dir
-     read(UNIT=temp,fmt='(40a1)') fbase
-     c=0
-     do i=1,40
-        if(fbase(i).eq.(' ').and.c.eq.0)c=i-1
-     enddo
-     write(UNIT=temp,fmt='(100a1)')(fbase(i),i=1,c), (fdir(i),i=1,15), &
-          (ftime(i),i=1,10),(fsubs(i),i=1,17 )
-     read(UNIT=temp,fmt='(a100)') filename
-
-  endif
- end subroutine ncep_nldas2filea
+      call LIS_sample_forecastDate(n, kk, findex, yr, mo, da)
+      
+      write(UNIT=fdir,fmt='(i4,a1,i4,i2.2,i2.2)') yr, '/', yr, mo, da
+      
+      write(UNIT=ftime,fmt='(i4,i2.2,i2.2,i2.2)') yr, mo, da, hr
+      
+   endif
+   
+   filename = trim(nldas2dir) // '/' // fdir // '/' // ftime // fsubs
+  
+end subroutine ncep_nldas2filea
 
 
 !BOP
@@ -147,8 +113,8 @@
    integer, intent(in)        :: n
    integer, intent(in)        :: kk
    integer, intent(in)        :: findex
-   character*100, intent(out) :: filename
-   character*40, intent(in)   :: nldas2dir
+   character(len=*), intent(out) :: filename
+   character(len=*), intent(in)   :: nldas2dir
    integer, intent(in)        :: yr,mo,da,hr
 !
 ! !DESCRIPTION:
@@ -173,67 +139,32 @@
 !
 !EOP
 
-   integer                  :: i, c
-   character*1              :: fbase(40),fsubs(17)
-   character*1              :: ftime(10),fdir(15)
-   character*100            :: temp
+   character(len=13) :: fdir
+   character(len=17), parameter :: fsubs = '.nldasforce-b.grb'
+   character(len=10) :: ftime
 
    !=== end variable definition =============================================
 
    !=== put together filename
 
-  if(LIS_rc%forecastMode.eq.0) then !hindcast run
+   if(LIS_rc%forecastMode.eq.0) then !hindcast run
 
-     write(UNIT=temp,fmt='(a1,i4,a1,i4,i2,i2,a1)')'/',yr,'/',yr,mo,da,'/'
-     read(UNIT=temp,fmt='(15a1)') fdir
-     do i=1,15
-        if(fdir(i).eq.(' ')) fdir(i) = '0'
-     enddo
-     write(UNIT=temp,fmt='(i4,i2,i2,i2)') yr,mo,da,hr
-     read(UNIT=temp,fmt='(10a1)')ftime
-     do i=1,10
-        if(ftime(i).eq.(' ')) ftime(i) = '0'
-     enddo
-     write(UNIT=temp,fmt='(a17)')'.nldasforce-b.grb'
-     read(UNIT=temp,fmt='(17a1)') fsubs
-     write(UNIT=temp,fmt='(a40)') nldas2dir                       
-     read(UNIT=temp,fmt='(40a1)') fbase
-     c=0
-     do i=1,40
-        if(fbase(i).eq.(' ').and.c.eq.0)c=i-1
-     enddo
-     write(UNIT=temp,fmt='(100a1)')(fbase(i),i=1,c), (fdir(i),i=1,15), & 
-          (ftime(i),i=1,10),(fsubs(i),i=1,17 ) 
-     read(UNIT=temp,fmt='(a100)') filename
-
+      write(UNIT=fdir,fmt='(i4,a1,i4,i2.2,i2.2)') yr, '/', yr, mo, da
+      
+      write(UNIT=ftime,fmt='(i4,i2.2,i2.2,i2.2)') yr, mo, da, hr
+      
    else !forecast mode
      !sample yr, mo, da
 
-     call LIS_sample_forecastDate(n, kk, findex, yr, mo, da)
+      call LIS_sample_forecastDate(n, kk, findex, yr, mo, da)
 
-    write(UNIT=temp,fmt='(a1,i4,a1,i4,i2,i2,a1)')'/',yr,'/',yr,mo,da,'/'
-     read(UNIT=temp,fmt='(15a1)') fdir
-     do i=1,15
-        if(fdir(i).eq.(' ')) fdir(i) = '0'
-     enddo
-     write(UNIT=temp,fmt='(i4,i2,i2,i2)') yr,mo,da,hr
-     read(UNIT=temp,fmt='(10a1)')ftime
-     do i=1,10
-        if(ftime(i).eq.(' ')) ftime(i) = '0'
-     enddo
-     write(UNIT=temp,fmt='(a17)')'.nldasforce-b.grb'
-     read(UNIT=temp,fmt='(17a1)') fsubs
-     write(UNIT=temp,fmt='(a40)') nldas2dir
-     read(UNIT=temp,fmt='(40a1)') fbase
-     c=0
-     do i=1,40
-        if(fbase(i).eq.(' ').and.c.eq.0)c=i-1
-     enddo
-     write(UNIT=temp,fmt='(100a1)')(fbase(i),i=1,c), (fdir(i),i=1,15), &
-          (ftime(i),i=1,10),(fsubs(i),i=1,17 )
-     read(UNIT=temp,fmt='(a100)') filename
+      write(UNIT=fdir,fmt='(i4,a1,i4,i2.2,i2.2)') yr, '/', yr, mo, da
+     
+      write(UNIT=ftime,fmt='(i4,i2.2,i2.2,i2.2)') yr, mo, da, hr
 
-  endif
+   endif
 
- end subroutine ncep_nldas2fileb
+   filename = trim(nldas2dir) // '/' // fdir // '/' // ftime // fsubs
+   
+end subroutine ncep_nldas2fileb
 

--- a/lis/metforcing/nldas2/get_nldas2.F90
+++ b/lis/metforcing/nldas2/get_nldas2.F90
@@ -26,6 +26,7 @@ subroutine get_nldas2(n,findex)
   use LIS_metforcingMod,  only : LIS_forc
   use LIS_logMod,         only : LIS_logunit, LIS_endrun
   use nldas2_forcingMod,  only : nldas2_struc
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -73,7 +74,7 @@ subroutine get_nldas2(n,findex)
   real*8  :: dtime1, dtime2
   integer :: yr1,mo1,da1,hr1,mn1,ss1,doy1
   integer :: yr2,mo2,da2,hr2,mn2,ss2,doy2
-  character*100 :: name_a,name_b
+  character(len=LIS_CONST_PATH_LEN) :: name_a,name_b
   real    :: gmt1,gmt2,ts1,ts2
   integer :: movetime     ! 1=move time 2 data into time 1  
   integer :: kk           ! Forecast member index

--- a/lis/metforcing/nldas2/nldas2_forcingMod.F90
+++ b/lis/metforcing/nldas2/nldas2_forcingMod.F90
@@ -68,6 +68,7 @@ module nldas2_forcingMod
 ! 14 Mar 2014: David Mocko: Added CAPE and PET forcing from NLDAS-2
 ! 
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
 
   PRIVATE
@@ -86,7 +87,7 @@ module nldas2_forcingMod
      real          :: ts
      integer       :: ncold, nrold   ! AWIPS 212 dimensions
      character*50  :: nldas2_filesrc
-     character*80  :: nldas2dir      ! NLDAS-2 Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: nldas2dir ! NLDAS-2 Forcing Directory
      real*8        :: nldas2time1,nldas2time2
      integer       :: model_level_data 
      integer       :: model_level_press 

--- a/lis/metforcing/nldas2/read_nldas2a.F90
+++ b/lis/metforcing/nldas2/read_nldas2a.F90
@@ -59,7 +59,7 @@ subroutine read_nldas2a(n, kk, findex, order, month, name,ferror)
   integer, intent(in)       :: findex  ! Forcing index
   integer, intent(in)       :: order
   integer, intent(out)      :: month
-  character*100, intent(in) :: name
+  character(len=*), intent(in) :: name
   integer, intent(out)      :: ferror
 !
 ! !DESCRIPTION:

--- a/lis/metforcing/nldas2/read_nldas2b.F90
+++ b/lis/metforcing/nldas2/read_nldas2b.F90
@@ -58,7 +58,7 @@ subroutine read_nldas2b(n, kk, findex, order, name,ferror)
   integer, intent(in)       :: kk      ! Forecast member index
   integer, intent(in)       :: findex  ! Forcing index
   integer, intent(in)       :: order
-  character*100, intent(in) :: name
+  character(len=*), intent(in) :: name
   integer, intent(out)      :: ferror
 !
 ! !DESCRIPTION:

--- a/lis/metforcing/nldas2/readcrd_nldas2.F90
+++ b/lis/metforcing/nldas2/readcrd_nldas2.F90
@@ -93,7 +93,7 @@ subroutine readcrd_nldas2()
   write(unit=LIS_logunit,fmt=*)'[INFO] Using NLDAS-2 forcing'
 
   do n=1,LIS_rc%nnest
-     write(unit=LIS_logunit,fmt=*) '[INFO] NLDAS-2 forcing directory : ',nldas2_struc(n)%nldas2dir
+     write(unit=LIS_logunit,fmt=*) '[INFO] NLDAS-2 forcing directory : ',trim(nldas2_struc(n)%nldas2dir)
 
      nldas2_struc(n)%ncold = 464
      nldas2_struc(n)%nrold = 224

--- a/lis/metforcing/pet_usgs/get_petusgs.F90
+++ b/lis/metforcing/pet_usgs/get_petusgs.F90
@@ -27,6 +27,7 @@ subroutine get_petusgs(n, findex)
   use LIS_timeMgrMod, only : LIS_tick, LIS_get_nstep
   use LIS_logMod,     only : LIS_logunit
   use petusgs_forcingMod, only : petusgs_struc
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
 
   implicit none
 ! !ARGUMENTS: 
@@ -67,7 +68,7 @@ subroutine get_petusgs(n, findex)
   real    :: gmt1, gmt2
   integer :: kk                          ! Forecast index
 
-  character(99) :: filename              ! Filename variables for PET data sources
+  character(len=LIS_CONST_PATH_LEN) :: filename              ! Filename variables for PET data sources
 
 !=== End Variable Definition =======================
 

--- a/lis/metforcing/pet_usgs/petusgs_forcingMod.F90
+++ b/lis/metforcing/pet_usgs/petusgs_forcingMod.F90
@@ -50,6 +50,7 @@ module petusgs_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
   PRIVATE
 !-----------------------------------------------------------------------------
@@ -65,7 +66,7 @@ module petusgs_forcingMod
 
   type, public :: petusgs_type_dec
 
-     character*100     :: petdir      ! USGS PET Forcing Directory
+     character(len=LIS_CONST_PATH_LEN) :: petdir    ! USGS PET Forcing Directory
      character*20      :: pettype     ! USGS PET File type (climatology|current)
      real*8            :: pettime
      real*8            :: griduptime1

--- a/lis/metforcing/pet_usgs/read_petusgs.F90
+++ b/lis/metforcing/pet_usgs/read_petusgs.F90
@@ -35,7 +35,7 @@ subroutine read_petusgs (n, kk, findex, pet_filename, ferror_petusgs )
   integer, intent(in) :: n 
   integer, intent(in) :: kk
   integer, intent(in) :: findex
-  character(99), intent(in) :: pet_filename  
+  character(len=*), intent(in) :: pet_filename  
   integer,intent(out) :: ferror_petusgs
 !
 ! !DESCRIPTION:
@@ -182,10 +182,10 @@ subroutine read_petusgs (n, kk, findex, pet_filename, ferror_petusgs )
          enddo
       enddo
     
-      write(LIS_logunit,*) "Obtained USGS PET data:: ", pet_filename
+      write(LIS_logunit,*) "Obtained USGS PET data:: ", trim(pet_filename)
 
    elseif( ferror_petusgs == 0 ) then
-      write(LIS_logunit,*) "Missing USGS PET data ", pet_filename
+      write(LIS_logunit,*) "Missing USGS PET data ", trim(pet_filename)
 
    endif
 

--- a/lis/metforcing/pet_usgs/readpetusgscrd.F90
+++ b/lis/metforcing/pet_usgs/readpetusgscrd.F90
@@ -59,7 +59,7 @@ subroutine readpetusgscrd()
   do n=1, LIS_rc%nnest
      
     write(LIS_logunit,*) "Using USGS PET forcing"
-    write(LIS_logunit,*) "USGS PET forcing directory :: ",petusgs_struc(n)%petdir
+    write(LIS_logunit,*) "USGS PET forcing directory :: ",trim(petusgs_struc(n)%petdir)
     write(LIS_logunit,*) "USGS PET forcing file type :: ",petusgs_struc(n)%pettype
     write(LIS_logunit,*) " "
 

--- a/lis/metforcing/pptEnsFcst/get_pptEnsFcst.F90
+++ b/lis/metforcing/pptEnsFcst/get_pptEnsFcst.F90
@@ -24,6 +24,7 @@ subroutine get_pptEnsFcst(n, findex)
   use LIS_logMod,       only : LIS_logunit, LIS_verify, LIS_endrun
   use LIS_timeMgrMod,   only : LIS_tick, LIS_get_nstep
   use LIS_metforcingMod,only : LIS_forc
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   use pptEnsFcst_forcingMod,  only : pptensfcst_struc
   use pptEnsFcst_VariablesMod
 
@@ -58,7 +59,7 @@ subroutine get_pptEnsFcst(n, findex)
   integer        :: c, r, f, m
   integer        :: metforc_hrts
   integer        :: metforc_mnts
-  character(140) :: fullfilename
+  character(len=LIS_CONST_PATH_LEN) :: fullfilename
   logical        :: file_exists
 
 ! Date/time parameters for file get/read:

--- a/lis/metforcing/pptEnsFcst/get_pptEnsFcst_filename.F90
+++ b/lis/metforcing/pptEnsFcst/get_pptEnsFcst_filename.F90
@@ -29,8 +29,8 @@
    integer,       intent(in)  :: fcstmo          ! Forecast month - Need to convert to "3-letter month"
    integer,       intent(in)  :: ensnum          ! Forecast ensemble number
    integer,       intent(in)  :: yr, mo          ! Lead-time year, month
-   character*100, intent(in)  :: directory       ! Dataset Directory
-   character*140, intent(out) :: filename        
+   character(len=*), intent(in)  :: directory    ! Dataset Directory
+   character(len=*), intent(out) :: filename
 !
 ! !DESCRIPTION:
 !   This subroutine puts together ensemble forecast 

--- a/lis/metforcing/pptEnsFcst/pptEnsFcst_VariablesMod.F90
+++ b/lis/metforcing/pptEnsFcst/pptEnsFcst_VariablesMod.F90
@@ -312,7 +312,7 @@ contains
 !
 ! !ARGUMENTS: 
    integer, intent(in) :: findex          ! Forcing index
-   character(140), intent(in) :: filename ! Forcing filename path
+   character(len=*), intent(in) :: filename ! Forcing filename path
    integer, intent(in) :: inc, inr        ! Input forcing cols, rows
 !   integer, intent(in) :: start_inc, start_inr  ! Initial col / row points of subsetted domain 
    integer, intent(in) :: tindex          ! Index of daily time pt

--- a/lis/metforcing/pptEnsFcst/pptEnsFcst_forcingMod.F90
+++ b/lis/metforcing/pptEnsFcst/pptEnsFcst_forcingMod.F90
@@ -22,6 +22,8 @@
 module pptEnsFcst_forcingMod
 !
 ! !USES:
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
 #endif
@@ -50,7 +52,7 @@ module pptEnsFcst_forcingMod
      real*8         :: findtime1, metforc_time1   ! File 1 flag and time (LIS)
      real*8         :: findtime2, metforc_time2   ! File 2 flag and time (LIS)
 
-     character(120) :: directory        ! Directory path of where files reside
+     character(len=LIS_CONST_PATH_LEN) :: directory ! Directory path of where files reside
      character(50)  :: proj_name        ! Projection name
      integer        :: proj_index       ! Projection type index
  
@@ -98,7 +100,7 @@ contains
   integer  :: varid
   real     :: gridDesci(50)
   logical  :: file_exists
-  character(140) :: fullfilename
+  character(LIS_CONST_PATH_LEN) :: fullfilename
 
   integer  :: da, hr, mn, ss
   character*50 :: timeInc

--- a/lis/metforcing/princeton/princeton_forcingMod.F90
+++ b/lis/metforcing/princeton/princeton_forcingMod.F90
@@ -59,6 +59,7 @@ module princeton_forcingMod
 !  modeling, J. Climate, 19 (13), 3088-3111 \newline
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
   
   PRIVATE
@@ -77,7 +78,7 @@ module princeton_forcingMod
   type, public :: princeton_type_dec
      real                   :: ts
      integer                :: ncold, nrold   
-     character*100          :: princetondir
+     character(len=LIS_CONST_PATH_LEN) :: princetondir
      character*100          :: elevfile
      character*100          :: version
      integer                :: mi

--- a/lis/metforcing/princeton/read_princeton.F90
+++ b/lis/metforcing/princeton/read_princeton.F90
@@ -32,6 +32,7 @@ subroutine read_princeton( order, n, findex, yr, mon, da, hr, ferror )
   use LIS_metforcingMod,    only : LIS_forc
   use LIS_timeMgrMod,       only : LIS_tick
   use LIS_logMod,           only : LIS_logunit, LIS_endrun
+  use LIS_constantsMod,     only : LIS_CONST_PATH_LEN
   use princeton_forcingMod, only : princeton_struc
   use LIS_forecastMod
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
@@ -118,7 +119,7 @@ subroutine read_princeton( order, n, findex, yr, mon, da, hr, ferror )
   integer, dimension(N_PF), parameter :: fnum = (/ &
        31, 33, 34, 35, 36, 37, 38 /) 
 
-  character*100 :: infile
+  character(len=LIS_CONST_PATH_LEN) :: infile
 
 ! netcdf variables
   integer :: ncid, varid, status

--- a/lis/metforcing/princeton/readcrd_princeton.F90
+++ b/lis/metforcing/princeton/readcrd_princeton.F90
@@ -65,7 +65,7 @@ subroutine readcrd_princeton()
   enddo
 
   do n=1,LIS_rc%nnest
-     write(LIS_logunit,*)'[INFO] PRINCETON forcing directory :',princeton_struc(n)%princetonDIR
+     write(LIS_logunit,*)'[INFO] PRINCETON forcing directory :',trim(princeton_struc(n)%princetonDIR)
      write(LIS_logunit,*)'[INFO] PRINCETON forcing version   :',princeton_struc(n)%version
      princeton_struc(n)%princetontime1 = 3000.0
      princeton_struc(n)%princetontime2 = 0.0

--- a/lis/metforcing/rdhm356/rdhm356_file_name.F90
+++ b/lis/metforcing/rdhm356/rdhm356_file_name.F90
@@ -42,8 +42,7 @@ subroutine rdhm356_temper_file( name, rdhm356_temper_dir, yr, mo, da, hr)
 ! !ARGUMENTS: 
   integer :: yr, mo, da, hr
 
-  character(len=*) :: name
-  character(40) :: rdhm356_temper_dir
+  character(len=*) :: name, rdhm356_temper_dir
   character(4) :: cyear
   character(2) :: cmon, cday, chour
 
@@ -95,8 +94,7 @@ subroutine rdhm356_precip_file( name, rdhm356_precip_dir, yr, mo, da, hr)
 ! !ARGUMENTS: 
   integer :: yr, mo, da, hr
 
-  character(len=*) :: name
-  character(40) :: rdhm356_precip_dir
+  character(len=*) :: name, rdhm356_precip_dir
   character(4) :: cyear
   character(2) :: cmon, cday, chour
 

--- a/lis/metforcing/rdhm356/rdhm356_forcingMod.F90
+++ b/lis/metforcing/rdhm356/rdhm356_forcingMod.F90
@@ -52,6 +52,8 @@ module rdhm356_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
   
   PRIVATE
@@ -71,7 +73,7 @@ module rdhm356_forcingMod
      real               :: ts
      integer            :: ncol                 ! Number of cols
      integer            :: nrow                 ! Number of rows
-     character*40       :: rdhm356dir           ! dmip II Directory
+     character(len=LIS_CONST_PATH_LEN) :: rdhm356dir ! dmip II Directory
      real*8             :: scale 
      real*8             :: rdhm356time1         ! Time of first incoming file
      real*8             :: rdhm356time2         ! Time of second incoming file

--- a/lis/metforcing/rdhm356/rdhm356_get_forcing.F90
+++ b/lis/metforcing/rdhm356/rdhm356_get_forcing.F90
@@ -23,6 +23,7 @@ subroutine get_rdhm356(n,findex)
   use LIS_coreMod, only : LIS_rc
   use LIS_timeMgrMod, only : LIS_tick, LIS_get_nstep
   use LIS_logMod, only : LIS_logunit
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   use rdhm356_forcingMod, only : rdhm356_struc_precip, &
                                  rdhm356_struc_temper
 
@@ -70,7 +71,7 @@ subroutine get_rdhm356(n,findex)
 
     real*8  :: timenow, timenowback, rdhm356_file_time1, rdhm356_file_time2      ! Current LIS Time end boundary time and file1 file2 times for dmipII file
     real*8 :: rdhm356_file_time3
-    character(128) :: file_name               ! Filename variables for precip data sources
+    character(len=LIS_CONST_PATH_LEN) :: file_name               ! Filename variables for precip data sources
     integer :: order
 
     integer :: doy1, yr1, mo1, da1, hr1, mn1, ss1

--- a/lis/metforcing/rdhm356/rdhm356_readcrd.F90
+++ b/lis/metforcing/rdhm356/rdhm356_readcrd.F90
@@ -57,7 +57,7 @@ subroutine readcrd_rdhm356()
        call ESMF_ConfigGetAttribute(LIS_config, &
                                     rdhm356_struc_precip(n)%rdhm356dir,rc=rc)
        write(LIS_logunit,*) 'RDHM precipitation forcing directory :', &
-                             rdhm356_struc_precip(n)%rdhm356dir
+                             trim(rdhm356_struc_precip(n)%rdhm356dir)
 
     !- Setting observed precip times to zero to ensure data is read in
     !   at first time step
@@ -70,7 +70,7 @@ subroutine readcrd_rdhm356()
        call ESMF_ConfigGetAttribute(LIS_config, &
                                     rdhm356_struc_temper(n)%rdhm356dir,rc=rc)
        write(LIS_logunit,*) 'RDHM temperature forcing directory :', &
-                            rdhm356_struc_temper(n)%rdhm356dir
+                            trim(rdhm356_struc_temper(n)%rdhm356dir)
 
     !- Setting observed precip times to zero to ensure data is read in
     !   at first time step

--- a/lis/metforcing/rhoneAGG/get_rhoneAGG.F90
+++ b/lis/metforcing/rhoneAGG/get_rhoneAGG.F90
@@ -21,6 +21,7 @@ subroutine get_rhoneAGG(n,findex)
   use LIS_coreMod,        only : LIS_rc
   use LIS_timeMgrMod,     only : LIS_get_nstep, LIS_tick
   use LIS_logMod,         only : LIS_logunit, LIS_endrun
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
   use rhoneAGG_forcingMod,   only : rhoneAGG_struc
 
   implicit none
@@ -62,7 +63,7 @@ subroutine get_rhoneAGG(n,findex)
   integer :: yr2,mo2,da2,hr2,mn2,ss2,doy2
   real*8 :: time1,time2,dumbtime1,dumbtime2
   real*8 :: timenow
-  character*80 :: name
+  character(len=LIS_CONST_PATH_LEN) :: name
   real :: gmt1,gmt2,ts1,ts2
   integer :: movetime       ! 1=move time 2 data into time 1
   integer :: nforce         ! RHONEAGG forcing file time, # forcing variables
@@ -215,16 +216,15 @@ subroutine rhoneAGGfile(name,rhoneAGGdir,yr,mo,da,hr,ncold)
   implicit none
       
 ! !INPUT PARAMETERS:
-  character*40, intent(in) :: rhoneAGGdir
+  character(len=*), intent(in) :: rhoneAGGdir
   integer, intent(in)      :: yr,mo,da,hr,ncold
 ! !OUTPUT PARAMETERS:
-  character*80, intent(out) :: name
+  character(len=*), intent(out) :: name
 !EOP
   integer uyr,umo,uda,uhr,i,c,ii,jj
   character(len=2) :: initcode
-  character*1 fbase(80),fsubs(80)
-  character*1 ftime(10),fdir(8)
-  character(LEN=100) :: temp
+  character(len=6)  :: fdir, fsubs
+  character(len=10) :: ftime
   
   ii = ncold
   jj = 6
@@ -260,42 +260,12 @@ subroutine rhoneAGGfile(name,rhoneAGGdir,yr,mo,da,hr,ncold)
      initcode = '21'
   endif
 
-  write(UNIT=temp,FMT='(A40)') rhoneAGGdir
-  read(UNIT=temp,FMT='(80A1)') (fbase(i),i=1,80)
+  write(UNIT=fdir,FMT='(i4,i2.2)') uyr, umo
 
-  write(UNIT=temp,FMT='(a1,i4,i2,a1)') '/',uyr,umo,'/'
-  read(UNIT=temp,FMT='(8A1)') fdir
-  do i=1,8
-     if (fdir(i).eq.(' ')) fdir(i)='0'
-  enddo
+  write(UNIT=ftime,FMT='(i4,i2.2,i2.2,a2)') uyr, umo, uda, initcode
+
+  name = trim(rhoneAGGdir) // '/' // fdir // '/' // ftime // fsubs
   
-  write(UNIT=temp,FMT='(i4,i2,i2,a2)') uyr,umo,uda,initcode
-  read(UNIT=temp,FMT='(10A1)') ftime
-  do i=1,10
-     if (ftime(i).eq.(' ')) ftime(i)='0'
-  enddo
-  
-  if (ncold.eq.360) then
-     write(UNIT=temp,FMT='(A6)') '.RHONE'
-     read(UNIT=temp,FMT='(80A1)') (fsubs(i),i=1,6)
-  else
-     write(UNIT=temp,FMT='(A6)') '.RHONE'
-     read(UNIT=temp,FMT='(80A1)') (fsubs(i),i=1,6)
-  endif
-  c=0
-  do i=1,80
-     if ((fbase(i).eq.(' ')).and.(c.eq.0)) c=i-1
-  enddo
-  
-  if (ncold.eq.360) then
-     write(UNIT=temp,FMT='(80a1)')(fbase(i),i=1,c),(fdir(i),i=1,8),&
-          (ftime(i),i=1,10),(fsubs(i),i=1,6)
-  else
-     write(UNIT=temp,FMT='(80a1)')(fbase(i),i=1,c),(fdir(i),i=1,8),&
-          (ftime(i),i=1,10),(fsubs(i),i=1,6)
-  endif
-  
-  read(UNIT=temp,FMT='(a80)') name
   return
 end subroutine rhoneAGGfile
 

--- a/lis/metforcing/rhoneAGG/read_rhoneAGG.F90
+++ b/lis/metforcing/rhoneAGG/read_rhoneAGG.F90
@@ -50,7 +50,7 @@ subroutine readrhoneAGG(n, order,findex, name,tscount,ferror)
   implicit none
   integer,      intent(in) :: n
   integer,      intent(in) :: findex
-  character*80, intent(in) :: name
+  character(len=*), intent(in) :: name
   integer, intent(in)      :: order, tscount
   integer, intent(out)     :: ferror
   integer :: mo

--- a/lis/metforcing/rhoneAGG/readcrd_rhoneAGG.F90
+++ b/lis/metforcing/rhoneAGG/readcrd_rhoneAGG.F90
@@ -48,7 +48,7 @@ subroutine readcrd_rhoneAGG()
    
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*)'Using Rhone AGG forcing'
-     write(LIS_logunit,*)'Rhone AGG forcing directory: ',rhoneAGG_struc(n)%RHONEAGGDIR
+     write(LIS_logunit,*)'Rhone AGG forcing directory: ',trim(rhoneAGG_struc(n)%RHONEAGGDIR)
      rhoneAGG_struc(n)%nmif = 9
      rhoneAGG_struc(n)%rhoneAGGtime1 = 3000.0
      rhoneAGG_struc(n)%rhoneAGGtime2 = 0.0

--- a/lis/metforcing/rhoneAGG/rhoneAGG_forcingMod.F90
+++ b/lis/metforcing/rhoneAGG/rhoneAGG_forcingMod.F90
@@ -17,6 +17,8 @@
 !EOP
 module rhoneAGG_forcingMod
 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
 
   PRIVATE
@@ -33,7 +35,7 @@ module rhoneAGG_forcingMod
 
   type, public :: rhoneAGG_type_struc
      real           :: ts
-     character*50   :: rhoneAGGdir
+     character(len=LIS_CONST_PATH_LEN) :: rhoneAGGdir
      integer        :: mi
      integer        :: ncold
      integer        :: nrold

--- a/lis/metforcing/scan/read_scan.F90
+++ b/lis/metforcing/scan/read_scan.F90
@@ -22,6 +22,7 @@ subroutine read_scan(n,ftn,findex,order)
   use LIS_logMod, only         : LIS_logunit
   use LIS_metforcingMod,  only : LIS_forc
   use LIS_coreMod, only        : LIS_rc,LIS_domain
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
   use scan_forcingMod,    only : scan_struc
 
   implicit none
@@ -62,7 +63,7 @@ subroutine read_scan(n,ftn,findex,order)
   real :: pcp(scan_struc(n)%nstns),tmppcp,dum
   real :: varfield(LIS_rc%lnc(n)*LIS_rc%lnr(n))
   real :: varfield1(LIS_rc%lnc(n),LIS_rc%lnr(n))
-  character*80 :: scan_filename
+  character(len=LIS_CONST_PATH_LEN) :: scan_filename
   character(len=500) :: line
   integer :: yr,num,hr,mon,day,mint,sec
   logical :: file_exists

--- a/lis/metforcing/scan/scan_forcingMod.F90
+++ b/lis/metforcing/scan/scan_forcingMod.F90
@@ -25,6 +25,7 @@ module scan_forcingMod
 ! !REVISION HISTORY: 
 ! 13Apr2007: Bailing Li:  Initial Specification
 ! 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
   PRIVATE
 !-----------------------------------------------------------------------------
@@ -40,7 +41,7 @@ module scan_forcingMod
 
   type, public ::  scan_type_dec
      real          :: ts
-     character*40  :: scandir 
+     character(len=LIS_CONST_PATH_LEN) :: scandir 
      character*40  :: metadata 
      real          :: undef
      real*8        :: starttime,scantime1,scantime2

--- a/lis/metforcing/snotel/read_snotel.F90
+++ b/lis/metforcing/snotel/read_snotel.F90
@@ -22,6 +22,7 @@ subroutine read_snotel(n,ftn,findex,order)
   use LIS_logMod, only         : LIS_logunit, LIS_endrun
   use LIS_coreMod, only        : LIS_rc,LIS_domain
   use LIS_metforcingMod, only : LIS_forc
+  use LIS_constantsMod,  only : LIS_CONST_PATH_LEN
   use snotel_forcingMod,    only : snotel_struc
   use map_utils,    only : latlon_to_ij
 
@@ -64,7 +65,7 @@ subroutine read_snotel(n,ftn,findex,order)
 !  real :: varfield(npts)
   real :: varfield1(LIS_rc%lnc(n),LIS_rc%lnr(n))
   integer :: npcp(LIS_rc%lnc(n),LIS_rc%lnr(n))
-  character*80 :: snotel_filename
+  character(len=LIS_CONST_PATH_LEN) :: snotel_filename
   character(len=500) :: line
   integer :: yr,num,dum,hr,mo,da,mint,sec
   logical :: file_exists, readflag

--- a/lis/metforcing/snotel/snotel_forcingMod.F90
+++ b/lis/metforcing/snotel/snotel_forcingMod.F90
@@ -25,6 +25,7 @@ module snotel_forcingMod
 ! !REVISION HISTORY: 
 ! 08Jun2010: Yuqiong Liu:  Initial Specification
 ! 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
   PRIVATE
 !-----------------------------------------------------------------------------
@@ -40,7 +41,7 @@ module snotel_forcingMod
 
   type, public ::  snotel_type_dec
      real           :: ts
-     character*100  :: snoteldir 
+     character(len=LIS_CONST_PATH_LEN) :: snoteldir 
      character*100  :: metadata 
      character*100  :: coorddata 
      real          :: undef

--- a/lis/metforcing/stg2/get_stg2.F90
+++ b/lis/metforcing/stg2/get_stg2.F90
@@ -22,6 +22,7 @@ subroutine get_stg2(n, findex)
   use LIS_coreMod, only : LIS_rc, LIS_domain
   use LIS_timeMgrMod, only : LIS_tick, LIS_get_nstep
   use LIS_logMod, only : LIS_logunit, LIS_endrun
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   use stg2_forcingMod, only : stg2_struc
 
   implicit none
@@ -69,7 +70,7 @@ subroutine get_stg2(n, findex)
 !    integer :: endtime_stg2         ! 1=get a new file 
     real*8  :: stg2_file_time1      ! Current LIS Time and end boundary time for STAGEII file
     real*8  :: stg2_file_time2      ! Current LIS Time and end boundary time for STAGEII file
-    character(80) :: file_name      ! Filename variables for precip data sources
+    character(len=LIS_CONST_PATH_LEN) :: file_name ! Filename variables for precip data sources
 
     integer :: doy1, yr1, mo1, da1, hr1, mn1, ss1
     integer :: doy2, yr2, mo2, da2, hr2, mn2, ss2
@@ -160,7 +161,7 @@ subroutine get_stg2(n, findex)
       if ( LIS_rc%time > stg2_struc(n)%stg2time ) then
      ! Determine and return filename of STAGE II file 
        call stg2file( file_name, stg2_struc(n)%stg2dir, yr2, mo2, da2, hr2 )
-       write(LIS_logunit,*) 'Getting new STAGE2 precip data:: ', file_name
+       write(LIS_logunit,*) 'Getting new STAGE2 precip data:: ', trim(file_name)
      ! Open, read, and reinterpolate STAGE II field to LIS-defined grid
        call read_stg2 ( n, file_name, findex, order, ferror_stg2 )
      ! Assign latest STAGE II file time to stored STAGE II time variable
@@ -172,7 +173,7 @@ subroutine get_stg2(n, findex)
      
      ! Determine and return filename of STAGE II file 
        call stg2file( file_name, stg2_struc(n)%stg2dir, yr1, mo1, da1, hr1 )
-       write(LIS_logunit,*) 'Getting new STAGE2 precip data:: ', file_name
+       write(LIS_logunit,*) 'Getting new STAGE2 precip data:: ', trim(file_name)
      ! Open, read, and reinterpolate STAGE II field to LIS-defined grid
        call read_stg2 ( n, file_name, findex, order, ferror_stg2 )
      ! Assign latest STAGE II file time to stored STAGE II time variable

--- a/lis/metforcing/stg2/read_stg2.F90
+++ b/lis/metforcing/stg2/read_stg2.F90
@@ -32,7 +32,7 @@ subroutine read_stg2( n, fname, findex, order, ferror_stg2 )
   implicit none
 ! !ARGUMENTS:
   integer, intent(in) :: n
-  character(len=80)   :: fname          
+  character(len=*)   :: fname          
   integer, intent(in) :: findex
   integer, intent(in) :: order
   integer             :: ferror_stg2

--- a/lis/metforcing/stg2/readcrd_stg2.F90
+++ b/lis/metforcing/stg2/readcrd_stg2.F90
@@ -43,7 +43,7 @@ subroutine readcrd_stg2()
        call ESMF_ConfigGetAttribute(LIS_config, stg2_struc(n)%stg2dir,rc=rc)
 
        write(LIS_logunit,*) 'Using STAGEII forcing'
-       write(LIS_logunit,*) 'STAGEII forcing directory :', stg2_struc(n)%STG2DIR
+       write(LIS_logunit,*) 'STAGEII forcing directory :', trim(stg2_struc(n)%STG2DIR)
 
     !- Setting observed precip times to zero to ensure data is read in
     !   at first time step

--- a/lis/metforcing/stg2/stg2_forcingMod.F90
+++ b/lis/metforcing/stg2/stg2_forcingMod.F90
@@ -52,6 +52,8 @@ module stg2_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
   PRIVATE
 !-----------------------------------------------------------------------------
@@ -70,7 +72,7 @@ module stg2_forcingMod
      real               :: ts
      integer            :: ncol                 ! Number of cols
      integer            :: nrow                 ! Number of rows
-     character*40       :: stg2dir              ! STAGE II Directory
+     character(len=LIS_CONST_PATH_LEN) :: stg2dir ! STAGE II Directory
      real*8             :: stg2time             ! Nearest hourly instance of incoming file
      real*8             :: griduptime1          ! Designated time of STAGEII grid change
      logical            :: gridchange1          ! Flag for when grid change occurs

--- a/lis/metforcing/stg2/stg2file.F90
+++ b/lis/metforcing/stg2/stg2file.F90
@@ -42,8 +42,7 @@ subroutine stg2file( name, stg2dir, yr, mo, da, hr)
 ! !ARGUMENTS: 
   integer :: yr, mo, da, hr
 
-  character(80) :: name
-  character(40) :: stg2dir
+  character(len=*) :: name, stg2dir
   character(4) :: cyear
   character(2) :: cmon, cday, chour
 

--- a/lis/metforcing/stg4/get_stg4.F90
+++ b/lis/metforcing/stg4/get_stg4.F90
@@ -22,6 +22,7 @@ subroutine get_stg4(n, findex)
   use LIS_coreMod, only     : LIS_rc, LIS_domain
   use LIS_timeMgrMod, only  : LIS_tick, LIS_get_nstep
   use LIS_logMod,      only : LIS_logunit, LIS_endrun
+  use LIS_constantsMod,only : LIS_CONST_PATH_LEN
   use stg4_forcingMod, only : stg4_struc
 
   implicit none
@@ -71,7 +72,7 @@ subroutine get_stg4(n, findex)
 
     real*8  :: stg4_file_time1       ! End boundary time for STAGEIV file
     real*8  :: stg4_file_time2       ! End boundary time for STAGEIV file
-    character(80) :: file_name       ! Filename variables for precip data sources
+    character(len=LIS_CONST_PATH_LEN) :: file_name       ! Filename variables for precip data sources
 
     integer :: doy1, yr1, mo1, da1, hr1, mn1, ss1
     integer :: doy2, yr2, mo2, da2, hr2, mn2, ss2
@@ -158,7 +159,7 @@ subroutine get_stg4(n, findex)
 
       ! Determine and return filename of STAGE IV file 
         call stg4file( file_name, stg4_struc(n)%stg4dir, yr2, mo2, da2, hr2 )
-        write(LIS_logunit,*) 'Getting new STAGE4 precip data:: ', file_name
+        write(LIS_logunit,*) 'Getting new STAGE4 precip data:: ', trim(file_name)
       ! Open, read, and reinterpolate STAGE IV field to LIS-defined grid
         call read_stg4 ( n, file_name, findex, order, ferror_stg4 )
       ! Assign latest STAGE IV file time to stored STAGE IV time variable
@@ -170,7 +171,7 @@ subroutine get_stg4(n, findex)
 
      ! Determine and return filename of STAGE IV file 
        call stg4file( file_name, stg4_struc(n)%stg4dir, yr1, mo1, da1, hr1 )
-       write(LIS_logunit,*) 'Getting new STAGE4 precip data:: ', file_name
+       write(LIS_logunit,*) 'Getting new STAGE4 precip data:: ', trim(file_name)
      ! Open, read, and reinterpolate STAGE IV field to LIS-defined grid
        call read_stg4 ( n, file_name, findex, order, ferror_stg4 )
      ! Assign latest STAGE IV file time to stored STAGE IV time variable

--- a/lis/metforcing/stg4/read_stg4.F90
+++ b/lis/metforcing/stg4/read_stg4.F90
@@ -33,7 +33,7 @@ subroutine read_stg4( n, fname,findex,order, ferror_stg4 )
   implicit none
 ! !ARGUMENTS:
   integer, intent(in) :: n
-  character(len=80)   :: fname          
+  character(len=*)    :: fname          
   integer, intent(in) :: findex
   integer, intent(in) :: order
   integer             :: ferror_stg4

--- a/lis/metforcing/stg4/readcrd_stg4.F90
+++ b/lis/metforcing/stg4/readcrd_stg4.F90
@@ -43,7 +43,7 @@ subroutine readcrd_stg4()
        call ESMF_ConfigGetAttribute(LIS_config, stg4_struc(n)%stg4dir,rc=rc)
 
        write(LIS_logunit,*) 'Using STAGEIV forcing'
-       write(LIS_logunit,*) 'STAGEIV forcing directory :', stg4_struc(n)%STG4DIR
+       write(LIS_logunit,*) 'STAGEIV forcing directory :', trim(stg4_struc(n)%STG4DIR)
 
     !- Setting observed precip times to zero to ensure data is read in
     !   at first time step

--- a/lis/metforcing/stg4/stg4_forcingMod.F90
+++ b/lis/metforcing/stg4/stg4_forcingMod.F90
@@ -52,6 +52,8 @@ module stg4_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
 
   PRIVATE
@@ -71,7 +73,7 @@ module stg4_forcingMod
      real               :: ts
      integer            :: ncol                 ! Number of cols
      integer            :: nrow                 ! Number of rows
-     character*40       :: stg4dir              ! STAGE IV Directory
+     character(len=LIS_CONST_PATH_LEN) :: stg4dir ! STAGE IV Directory
      real*8             :: stg4time             ! Nearest hourly instance of incoming file
      real*8             :: griduptime1          ! Designated time of STAGEIV grid change
      logical            :: gridchange1          ! Flag for when grid change occurs

--- a/lis/metforcing/stg4/stg4file.F90
+++ b/lis/metforcing/stg4/stg4file.F90
@@ -42,8 +42,7 @@ subroutine stg4file( name, stg4dir, yr, mo, da, hr)
 ! !ARGUMENTS: 
   integer :: yr, mo, da, hr
 
-  character(80) :: name
-  character(40) :: stg4dir
+  character(len=*) :: name, stg4dir
   character(4) :: cyear
   character(2) :: cmon, cday, chour
 

--- a/lis/metforcing/vicforcing.4.1.2/getvicforcing.F90
+++ b/lis/metforcing/vicforcing.4.1.2/getvicforcing.F90
@@ -16,6 +16,7 @@
 subroutine getvicforcing(n, findex)
 ! !USES:
   use LIS_coreMod,        only : LIS_rc
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN 
   use vic_forcingMod,     only : vicforcing_struc
 
   implicit none
@@ -43,7 +44,7 @@ subroutine getvicforcing(n, findex)
 
    integer :: yr1, mo1, da1, hr1
    integer :: ferror
-   character(len=140) :: fname
+   character(len=LIS_CONST_PATH_LEN) :: fname
 
 
    yr1 = LIS_rc%yr
@@ -67,8 +68,8 @@ subroutine get_vicforcing_filename(filename, dir, year, month, day, hour)
 ! !USES:
   implicit none
 ! !ARGUMENTS: 
-   character(len=140), intent(out) :: filename
-   character(len=100), intent(in) :: dir
+   character(len=*), intent(out) :: filename
+   character(len=*), intent(in) :: dir
    integer, intent(in) :: year
    integer, intent(in) :: month
    integer, intent(in) :: day

--- a/lis/metforcing/vicforcing.4.1.2/getvicforcing.F90.tinterp
+++ b/lis/metforcing/vicforcing.4.1.2/getvicforcing.F90.tinterp
@@ -19,6 +19,7 @@ subroutine getvicforcing(n, findex, suppdata1, suppdata2)
   use LIS_coreMod,        only : LIS_rc, LIS_domain
   use LIS_baseforcingMod, only : LIS_forc, LIS_FORC_State
   use LIS_timeMgrMod,     only : LIS_tick
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
   use vic_forcingMod,     only : vicforcing_struc
 
   implicit none
@@ -53,7 +54,7 @@ subroutine getvicforcing(n, findex, suppdata1, suppdata2)
    real*8  :: time1, time2, timenow
    integer :: fstep
    integer :: ferror
-   character(len=140) :: fname
+   character(len=LIS_CONST_PATH_LEN) :: fname
 
    LIS_rc%findtime1(n) = 0
    LIS_rc%findtime2(n) = 0
@@ -144,8 +145,8 @@ subroutine get_vicforcing_filename(filename, dir, year, month, day, hour)
 ! !USES:
   implicit none
 ! !ARGUMENTS: 
-   character(len=140), intent(out) :: filename
-   character(len=100), intent(in) :: dir
+   character(len=*), intent(out) :: filename
+   character(len=*), intent(in) :: dir
    integer, intent(in) :: year
    integer, intent(in) :: month
    integer, intent(in) :: day

--- a/lis/metforcing/vicforcing.4.1.2/readviccrd.F90
+++ b/lis/metforcing/vicforcing.4.1.2/readviccrd.F90
@@ -87,7 +87,7 @@ subroutine readviccrd()
 
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*) 'Using VIC formatted forcing'
-     write(LIS_logunit,*) 'VIC forcing directory :',vicforcing_struc(n)%vicdir
+     write(LIS_logunit,*) 'VIC forcing directory :',trim(vicforcing_struc(n)%vicdir)
   enddo
 
 end subroutine readviccrd

--- a/lis/metforcing/vicforcing.4.1.2/vic412_read_gridded_forcing_data.F90
+++ b/lis/metforcing/vicforcing.4.1.2/vic412_read_gridded_forcing_data.F90
@@ -28,7 +28,7 @@ subroutine vic412_read_gridded_forcing_data(n, findex, filename, ferror)
 
    integer, intent(in)            :: n
    integer, intent(in)            :: findex
-   character(len=140), intent(in) :: filename
+   character(len=*), intent(in) :: filename
    integer, intent(out)           :: ferror
 
 ! !DESCRIPTION: 

--- a/lis/metforcing/vicforcing.4.1.2/vic_forcingMod.F90
+++ b/lis/metforcing/vicforcing.4.1.2/vic_forcingMod.F90
@@ -54,6 +54,7 @@ module vic_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
   implicit none
 
   PRIVATE
@@ -69,7 +70,7 @@ module vic_forcingMod
 !EOP
 
   type, public :: vicforcing_type_dec
-     character*100 :: vicdir
+     character(len=LIS_CONST_PATH_LEN) :: vicdir
      integer       :: forcingInterval
      integer       :: NC
      integer       :: NR

--- a/lis/metforcing/vicforcing/getvicforcing.F90
+++ b/lis/metforcing/vicforcing/getvicforcing.F90
@@ -16,6 +16,7 @@
 subroutine getvicforcing(n, findex)
 ! !USES:
   use LIS_coreMod,        only : LIS_rc
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
   use vic_forcingMod,     only : vicforcing_struc
 
   implicit none
@@ -43,7 +44,7 @@ subroutine getvicforcing(n, findex)
 
    integer :: yr1, mo1, da1, hr1
    integer :: ferror
-   character(len=140) :: fname
+   character(len=LIS_CONST_PATH_LEN) :: fname
 
 
    yr1 = LIS_rc%yr
@@ -67,8 +68,8 @@ subroutine get_vicforcing_filename(filename, dir, year, month, day, hour)
 ! !USES:
   implicit none
 ! !ARGUMENTS: 
-   character(len=140), intent(out) :: filename
-   character(len=100), intent(in) :: dir
+   character(len=*), intent(out) :: filename
+   character(len=*), intent(in) :: dir
    integer, intent(in) :: year
    integer, intent(in) :: month
    integer, intent(in) :: day

--- a/lis/metforcing/vicforcing/getvicforcing.F90.tinterp
+++ b/lis/metforcing/vicforcing/getvicforcing.F90.tinterp
@@ -19,6 +19,7 @@ subroutine getvicforcing(n, findex, suppdata1, suppdata2)
   use LIS_coreMod,        only : LIS_rc, LIS_domain
   use LIS_baseforcingMod, only : LIS_forc, LIS_FORC_State
   use LIS_timeMgrMod,     only : LIS_tick
+  use LIS_constantsMod,   only : LIS_CONST_PATH_LEN
   use vic_forcingMod,     only : vicforcing_struc
 
   implicit none
@@ -53,7 +54,7 @@ subroutine getvicforcing(n, findex, suppdata1, suppdata2)
    real*8  :: time1, time2, timenow
    integer :: fstep
    integer :: ferror
-   character(len=140) :: fname
+   character(len=LIS_CONST_PATH_LEN) :: fname
 
    LIS_rc%findtime1(n) = 0
    LIS_rc%findtime2(n) = 0
@@ -144,8 +145,8 @@ subroutine get_vicforcing_filename(filename, dir, year, month, day, hour)
 ! !USES:
   implicit none
 ! !ARGUMENTS: 
-   character(len=140), intent(out) :: filename
-   character(len=100), intent(in) :: dir
+   character(len=*), intent(out) :: filename
+   character(len=*), intent(in) :: dir
    integer, intent(in) :: year
    integer, intent(in) :: month
    integer, intent(in) :: day

--- a/lis/metforcing/vicforcing/readviccrd.F90
+++ b/lis/metforcing/vicforcing/readviccrd.F90
@@ -87,7 +87,7 @@ subroutine readviccrd()
 
   do n=1,LIS_rc%nnest
      write(LIS_logunit,*) 'Using VIC formatted forcing'
-     write(LIS_logunit,*) 'VIC forcing directory :',vicforcing_struc(n)%vicdir
+     write(LIS_logunit,*) 'VIC forcing directory :',trim(vicforcing_struc(n)%vicdir)
   enddo
 
 end subroutine readviccrd

--- a/lis/metforcing/vicforcing/vic411_read_gridded_forcing_data.F90
+++ b/lis/metforcing/vicforcing/vic411_read_gridded_forcing_data.F90
@@ -28,7 +28,7 @@ subroutine vic411_read_gridded_forcing_data(n, findex, filename, ferror)
 
    integer, intent(in)            :: n
    integer, intent(in)            :: findex
-   character(len=140), intent(in) :: filename
+   character(len=*), intent(in) :: filename
    integer, intent(out)           :: ferror
 
 ! !DESCRIPTION: 

--- a/lis/metforcing/vicforcing/vic_forcingMod.F90
+++ b/lis/metforcing/vicforcing/vic_forcingMod.F90
@@ -54,6 +54,8 @@ module vic_forcingMod
 !  \end{description}
 !
 ! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
   implicit none
 
   PRIVATE
@@ -69,7 +71,7 @@ module vic_forcingMod
 !EOP
 
   type, public :: vicforcing_type_dec
-     character*100 :: vicdir
+     character(len=LIS_CONST_PATH_LEN) :: vicdir
      integer       :: forcingInterval
      integer       :: NC
      integer       :: NR


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Expands path length in LIS metforcing readers by defining a global constant (`LIS_CONST_PATH_LEN`) in `lis/core/LIS_constantsMod.F90` and using that to define string lengths for directory and filename variables. Hardcoded path-lengths elsewhere in readers are changed to assumed length where possible.

Most changes are trivial, but in some readers I refactored code constructing filepaths to remove hardcoded Fortran format edit descriptors where possible (see `lis/metforcing/3B42V7/get_TRMM3B42V7.F90` for an example). To ensure these updates didn't break the filename construction, I wrote a simple Fortran program for each routine to compare the outputs of the old routines against the output of the updated routines.

Resolves #533 

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->
Tested with the internal regression test suite.

### Next Steps
Propagate this fix to paths elsewhere in LIS and duplicate in LDT and LVT to address #371.

