### PR TITLE
Update revision history for the Users' Guides for the LISF Public 7.3.2 release

### DIFF
--- a/docs/LDT_users_guide/LDT_usersguide.adoc
+++ b/docs/LDT_users_guide/LDT_usersguide.adoc
@@ -1,6 +1,6 @@
 = Land Data Toolkit (LDT): LDT {lisfrevision} Users' Guide
-:revnumber: 1.13
-:revdate: 31 Mar 2021
+:revnumber: 1.16
+:revdate: 06 Dec 2021
 :doctype: book
 :sectnums:
 :toc:

--- a/docs/LDT_users_guide/revision_table.adoc
+++ b/docs/LDT_users_guide/revision_table.adoc
@@ -2,6 +2,7 @@
 |====
 | Revision | Summary of Changes             | Date
 
+| 1.16     | LISF Public 7.3.2 release      | Dec 06, 2021
 | 1.13     | LISF Public 7.3.1 release      | Mar 31, 2021
 | 1.10     | LISF Public 7.3.0 release      | Dec 21, 2020
 | 1.9      | LDT 557WW 7.3.0 release        | Aug 24, 2020

--- a/docs/LIS_users_guide/LIS_usersguide.adoc
+++ b/docs/LIS_users_guide/LIS_usersguide.adoc
@@ -1,6 +1,6 @@
 = Land Information System (LIS): LIS {lisfrevision} Users' Guide
-:revnumber: 1.16
-:revdate: 31 Mar 2021
+:revnumber: 1.18
+:revdate: 06 Dec 2021
 :doctype: book
 :sectnums:
 :toc:

--- a/docs/LIS_users_guide/revision_table.adoc
+++ b/docs/LIS_users_guide/revision_table.adoc
@@ -2,6 +2,7 @@
 |====
 |Revision | Summary of Changes                         | Date
 
+|1.18     | LISF Public 7.3.2 release                  | Dec 06, 2021
 |1.16     | LISF Public 7.3.1 release                  | Mar 31, 2021
 |1.13     | LISF Public 7.3.0 release                  | Dec 21, 2020
 |1.12     | LIS 557WW 7.3.0 release                    | Aug 24, 2020

--- a/docs/LVT_users_guide/LVT_usersguide.adoc
+++ b/docs/LVT_users_guide/LVT_usersguide.adoc
@@ -1,6 +1,6 @@
 = Land surface Verification Toolkit (LVT): LVT {lisfrevision} Users' Guide
-:revnumber: 1.8
-:revdate: 31 Mar 2021
+:revnumber: 1.9
+:revdate: 06 Dec 2021
 :doctype: book
 :sectnums:
 :toc:

--- a/docs/LVT_users_guide/revision_table.adoc
+++ b/docs/LVT_users_guide/revision_table.adoc
@@ -2,6 +2,7 @@
 |===
 | Revision | Summary of Changes              | Date
 
+| 1.9      | LISF Public 7.3.2 release       | Dec 06, 2021
 | 1.8      | LISF Public 7.3.1 release       | Mar 31, 2021
 | 1.6      | LISF Public 7.3.0 release       | Dec 21, 2020
 | 1.5      | LVT 557WW 7.3.0 release         | Aug 24, 2020

--- a/lvt/configs/lvt.config.adoc
+++ b/lvt/configs/lvt.config.adoc
@@ -1084,9 +1084,9 @@ AGRMET data area of data:             GLOBAL
 
 `ALEXI data directory:` specifies the location of the ALEXI ET data.
 
-`ALEXI data domain extent:` specifies the domain extent of the ALEXI data. Acceptable values are `"CONUS"` and `"GLOBAL"`.
+`ALEXI data domain extent:` specifies the domain extent of the ALEXI data. Acceptable values are "`CONUS`" and "`GLOBAL`".
 
-`ALEXI data resolution (in km):` specifies the resolution of the ALEXI ET data in km. Acceptable values are 4 or 10 (for `"CONUS"`) or 5 (for `"GLOBAL"`).
+`ALEXI data resolution (in km):` specifies the resolution of the ALEXI ET data in km. Acceptable values are 4 or 10 (for "`CONUS`") or 5 (for "`GLOBAL`").
 
 .Example _lvt.config_ entry
 ....


### PR DESCRIPTION
### Description

Update revision history for the Users' Guides for the upcoming LISF Public 7.3.2 release.

Note that some of the revision numbers jumped because of updates to the documentation in the support/lisf-557ww-7.4 branch.  I will make sure that everything merges correctly into master.
