### PR TITLE
Deallocate Noah-MP-4.0.1 variables in coldstart for multiple nests

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_coldstart.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_coldstart.F90
@@ -453,6 +453,11 @@ subroutine NoahMP401_coldstart(mtype)
 
         endif       ! coldstart
 
+        deallocate(zsnso)
+        deallocate(tsnow)
+        deallocate(snice)
+        deallocate(snliq)
+        deallocate(zsoil)
         deallocate(tsnoxy)
         deallocate(zsnsoxy)
         deallocate(snicexy)


### PR DESCRIPTION
This bug fix deallocates variables within the NoahMP401_coldstart
routine, to prevent a LIS crash when running with multiple nests.

Re-doing this PR due to (my) accidental deletion of this branch.
Everything was restored, except for this commit.

Resolves: #954
