### PR TITLE
Fix/retune bratseth

### DIFF
--- a/lis/compile
+++ b/lis/compile
@@ -116,7 +116,7 @@ fi
 # Compile standalone Fortran utilities for tuning Air Force Bratseth scheme.
 if [ "$compile_autotune" = "YES" ]; then
     echo "Compiling Air Force Bratseth tuning utilities"
-    if cd utils/afwa/retune_bratseth/src
+    if cd utils/usaf/retune_bratseth/src # EMK Fix path
     then
         echo ""
         make -f Makefile

--- a/lis/utils/usaf/retune_bratseth/cfgs/autotune.cfg
+++ b/lis/utils/usaf/retune_bratseth/cfgs/autotune.cfg
@@ -3,14 +3,14 @@
 #
 
 [Input]
-workdir: /discover/nobackup/emkemp/AFWA/autoretune/work
+workdir: /discover/nobackup/projects/lis_aist17/emkemp/AFWA/lis74_bratseth_retuning_for_ops/2021
 
-scriptdir: /discover/nobackup/emkemp/AFWA/autoretune/LISF/lis/utils/usaf/retune_bratseth/scripts
+scriptdir: /discover/nobackup/projects/lis_aist17/emkemp/AFWA/lis74_bratseth_retuning_for_ops/build/LISF/lis/utils/usaf/retune_bratseth/scripts
 
-cfgdir: /discover/nobackup/emkemp/AFWA/autoretune/LISF/lis/utils/usaf/retune_bratseth/cfgs
+cfgdir: /discover/nobackup/projects/lis_aist17/emkemp/AFWA/lis74_bratseth_retuning_for_ops/build/LISF/lis/utils/usaf/retune_bratseth/cfgs
 
-bindir: /discover/nobackup/emkemp/AFWA/autoretune/LISF/lis/utils/usaf/retune_bratseth/src
+bindir: /discover/nobackup/projects/lis_aist17/emkemp/AFWA/lis74_bratseth_retuning_for_ops/build/LISF/lis/utils/usaf/retune_bratseth/src
 
-lis_cfg_template: /discover/nobackup/emkemp/AFWA/autoretune/LISF/lis/configs/557WW-7.3-FOC/lis.config.global.jules50.ops
+lis_cfg_template: /discover/nobackup/projects/lis_aist17/emkemp/AFWA/lis74_bratseth_retuning_for_ops/build/LISF/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noah39.ops
 
-varlist: rh2m,spd10m,t2m,gage,cmorph,geoprecip,imerg,ssmi
+varlist: rh2m,spd10m,t2m,gage,imerg

--- a/lis/utils/usaf/retune_bratseth/cfgs/blacklist_spd10m.cfg
+++ b/lis/utils/usaf/retune_bratseth/cfgs/blacklist_spd10m.cfg
@@ -5,7 +5,7 @@
 [Input]
 network_thresh: 1
 count_thresh: 28
-omb_thresh: 3
+omb_thresh: 1.5
 
 data_directory: spd10m_OBA
 data_frequency: 01

--- a/lis/utils/usaf/retune_bratseth/cfgs/blacklist_spd10m.cfg
+++ b/lis/utils/usaf/retune_bratseth/cfgs/blacklist_spd10m.cfg
@@ -5,7 +5,7 @@
 [Input]
 network_thresh: 1
 count_thresh: 28
-omb_thresh: 1.5
+omb_thresh: 1.
 
 data_directory: spd10m_OBA
 data_frequency: 01

--- a/lis/utils/usaf/retune_bratseth/cfgs/blacklist_t2m.cfg
+++ b/lis/utils/usaf/retune_bratseth/cfgs/blacklist_t2m.cfg
@@ -5,7 +5,7 @@
 [Input]
 network_thresh: 1
 count_thresh: 28
-omb_thresh: 5
+omb_thresh: 2.5
 
 data_directory: t2m_OBA
 data_frequency: 01

--- a/lis/utils/usaf/retune_bratseth/cfgs/blacklist_t2m.cfg
+++ b/lis/utils/usaf/retune_bratseth/cfgs/blacklist_t2m.cfg
@@ -5,7 +5,7 @@
 [Input]
 network_thresh: 1
 count_thresh: 28
-omb_thresh: 2.5
+omb_thresh: 2.
 
 data_directory: t2m_OBA
 data_frequency: 01

--- a/lis/utils/usaf/retune_bratseth/scripts/autotune.py
+++ b/lis/utils/usaf/retune_bratseth/scripts/autotune.py
@@ -8,6 +8,7 @@ OBA (Observation, Background, Analaysis) files.
 REVISION HISTORY:
 03 Nov 2020:  Eric Kemp.  Initial specification.
 16 Dec 2020:  Eric Kemp.  Now calls create_blacklist via function call.
+13 Dec 2021:  Eric Kemp.  Added checks for missing satellite data.
 """
 
 import configparser
@@ -272,49 +273,57 @@ class AutomateTuning:
             line += " %s\n" %(self.sigma2o["gage"])
             lines.append(line)
 
-        if self.Lo["geoprecip"] > 0:
-            line = \
-        "AGRMET GALWEM Precip GEOPRECIP observation error scale length (m):"
-            line += " %s\n" %(self.Lo["geoprecip"])
-            lines.append(line)
+        if "geoprecip" in self.Lo:
+            if self.Lo["geoprecip"] > 0:
+                line = \
+                    "AGRMET GALWEM Precip GEOPRECIP observation error scale length (m):"
+                line += " %s\n" %(self.Lo["geoprecip"])
+                lines.append(line)
 
-        if self.sigma2o["geoprecip"] > 0:
-            line = "AGRMET GALWEM Precip GEOPRECIP observation error variance:"
-            line += " %s\n" %(self.sigma2o["geoprecip"])
-            lines.append(line)
+        if "geoprecip" in self.sigma2o:
+            if self.sigma2o["geoprecip"] > 0:
+                line = "AGRMET GALWEM Precip GEOPRECIP observation error variance:"
+                line += " %s\n" %(self.sigma2o["geoprecip"])
+                lines.append(line)
 
-        if self.Lo["ssmi"] > 0:
-            line = \
-                "AGRMET GALWEM Precip SSMI observation error scale length (m):"
-            line += " %s\n" %(self.Lo["ssmi"])
-            lines.append(line)
+        if "ssmi" in self.Lo:
+            if self.Lo["ssmi"] > 0:
+                line = \
+                    "AGRMET GALWEM Precip SSMI observation error scale length (m):"
+                line += " %s\n" %(self.Lo["ssmi"])
+                lines.append(line)
 
-        if self.sigma2o["ssmi"] > 0:
-            line = "AGRMET GALWEM Precip SSMI observation error variance:"
-            line += " %s\n" %(self.sigma2o["ssmi"])
-            lines.append(line)
+        if "ssmi" in self.sigma2o:
+            if self.sigma2o["ssmi"] > 0:
+                line = "AGRMET GALWEM Precip SSMI observation error variance:"
+                line += " %s\n" %(self.sigma2o["ssmi"])
+                lines.append(line)
 
-        if self.Lo["cmorph"] > 0:
-            line = \
-            "AGRMET GALWEM Precip CMORPH observation error scale length (m):"
-            line += " %s\n" %(self.Lo["cmorph"])
-            lines.append(line)
+        if "cmorph" in self.Lo:
+            if self.Lo["cmorph"] > 0:
+                line = \
+                    "AGRMET GALWEM Precip CMORPH observation error scale length (m):"
+                line += " %s\n" %(self.Lo["cmorph"])
+                lines.append(line)
 
-        if self.sigma2o["cmorph"] > 0:
-            line = "AGRMET GALWEM Precip CMORPH observation error variance:"
-            line += " %s\n" %(self.sigma2o["cmorph"])
-            lines.append(line)
+        if "cmorph" in self.sigma2o:
+            if self.sigma2o["cmorph"] > 0:
+                line = "AGRMET GALWEM Precip CMORPH observation error variance:"
+                line += " %s\n" %(self.sigma2o["cmorph"])
+                lines.append(line)
 
-        if self.Lo["imerg"] > 0:
-            line = \
-                "AGRMET GALWEM Precip IMERG observation error scale length (m)"
-            line += " %s\n" %(self.Lo["imerg"])
-            lines.append(line)
+        if "imerg" in self.Lo:
+            if self.Lo["imerg"] > 0:
+                line = \
+                    "AGRMET GALWEM Precip IMERG observation error scale length (m)"
+                line += " %s\n" %(self.Lo["imerg"])
+                lines.append(line)
 
-        if self.sigma2o["imerg"] > 0:
-            line = "AGRMET GALWEM Precip IMERG observation error variance:"
-            line += " %s\n" %(self.sigma2o["imerg"])
-            lines.append(line)
+        if "imerg" in self.sigma2o:
+            if self.sigma2o["imerg"] > 0:
+                line = "AGRMET GALWEM Precip IMERG observation error variance:"
+                line += " %s\n" %(self.sigma2o["imerg"])
+                lines.append(line)
 
         if self.Lb["t2m"] > 0:
             line = "AGRMET GALWEM T2M background error scale length (m):"

--- a/lis/utils/usaf/retune_bratseth/scripts/fit_semivariogram.py
+++ b/lis/utils/usaf/retune_bratseth/scripts/fit_semivariogram.py
@@ -10,6 +10,7 @@ REVISION HISTORY:
 26 Oct 2020: Eric Kemp. Initial Specification.
 03 Nov 2020: Eric Kemp. Removed plotting.  Fitted parameters are now saved
                to file.
+13 Dec 2021: Eric Kemp. Changed first guess for covariance settings.
 """
 
 # Standard library
@@ -56,8 +57,8 @@ distvector, variovector, samplesize = \
 
 # Fit function
 # Comparing gages to background field.  Three parameters must be fit.
-sigma2_gage_guess = np.amin(variovector)
-sigma2_back_guess = np.amax(variovector) - sigma2_gage_guess
+sigma2_gage_guess = (np.amin(variovector) + np.amax(variovector)) / 2.
+sigma2_back_guess = sigma2_gage_guess
 L_back_guess = distvector[2]
 fit_func = semivar.fit_func_dict[function_type]
 sigma2_gage_min = 0.1*sigma2_gage_guess

--- a/lis/utils/usaf/retune_bratseth/scripts/run_autotune_discover.sh
+++ b/lis/utils/usaf/retune_bratseth/scripts/run_autotune_discover.sh
@@ -24,6 +24,8 @@
 #
 # REVISION HISTORY:
 # 17 Dec 2020:  Eric Kemp.  Initial specification.
+# 13 Dec 2021:  Eric Kemp.  Updated module, and removed obsolete satellite
+#   data feeds.
 #
 #------------------------------------------------------------------------------
 
@@ -39,16 +41,16 @@ fi
 module purge
 unset LD_LIBRARY_PATH
 module use --append /home/emkemp/privatemodules
-module load lisf_7_intel_19_1_3_304_traceback-work-around
+module load lisf_7_intel_2021.4.0_s2s
 
 # Define the variables to be processed
 NWPVARS=(gage rh2m spd10m t2m)
-SATVARS=(cmorph geoprecip imerg ssmi)
+SATVARS=(imerg)
 
 # Paths on local system
-SCRIPTDIR=/discover/nobackup/emkemp/AFWA/autoretune/LISF/lis/utils/usaf/retune_bratseth/scripts
-CFGDIR=/discover/nobackup/emkemp/AFWA/autoretune/LISF/lis/utils/usaf/retune_bratseth/cfgs
-BINDIR=/discover/nobackup/emkemp/AFWA/autoretune/LISF/lis/utils/usaf/retune_bratseth/src
+SCRIPTDIR=/discover/nobackup/projects/lis_aist17/emkemp/AFWA/lis74_bratseth_retuning_for_ops/build/LISF/lis/utils/usaf/retune_bratseth/scripts
+CFGDIR=/discover/nobackup/projects/lis_aist17/emkemp/AFWA/lis74_bratseth_retuning_for_ops/build/LISF/lis/utils/usaf/retune_bratseth/cfgs
+BINDIR=/discover/nobackup/projects/lis_aist17/emkemp/AFWA/lis74_bratseth_retuning_for_ops/build/LISF/lis/utils/usaf/retune_bratseth/src
 
 # Get the command line arguments to specify the training period.
 if [ -z "$1" ] ; then


### PR DESCRIPTION

### Description

Bug fixes for LIS 7.4 Air Force branch, involving Bratseth error covariance retuning software.

* Changed lis/compile script to update path to Fortran code, so retuning executables are actually compiled.
* Updated batch script for running on Discover (new environment module)
* Updates to disable GEOPRECIP, SSMI, and CMORPH processing
* Logic change to first guess settings to prevent Scipy from issuing a fatal error for wind speed best-fit (not sure if this is due to Scipy version change on Discover)
* Tightened the screening for 10-m wind speed and 2-meter temperature to reduce scatter in recent 28-day empirical semivariograms (created for 29 Nov through 5 Dec).



