### PR TITLE
Trim filenames when writing to log in a few metforcing readers

### DIFF
--- a/lis/metforcing/HiMAT_GMU/read_HiMATGMU.F90
+++ b/lis/metforcing/HiMAT_GMU/read_HiMATGMU.F90
@@ -85,7 +85,7 @@ subroutine read_HiMATGMU( n, fname,findex,order, ferror_HiMATGMU )
 !-- Check initially if file exists:
   inquire (file=fname, exist=file_exists ) ! Check if file exists
   if (.not. file_exists)  then 
-     write(LIS_logunit,*)"** Missing HiMAT GMU precipitation file: ", fname
+     write(LIS_logunit,*)"** Missing HiMAT GMU precipitation file: ", trim(fname)
      ferror_HiMATGMU = 1
      return
   endif

--- a/lis/metforcing/cmorph/read_cmorph.F90
+++ b/lis/metforcing/cmorph/read_cmorph.F90
@@ -125,7 +125,7 @@ subroutine read_cmorph (n, kk, name_cmorph, findex, order, ferror_cmorph, iflg )
        read (ftn,rec=iflg) precip, timestamp, staid
        call LIS_releaseUnitNumber(ftn)
      else ! either file does not exist 
-       if(LIS_masterproc) write(LIS_logunit,*) "[WARN] Missing CMORPH precipitation data ",fname
+       if(LIS_masterproc) write(LIS_logunit,*) "[WARN] Missing CMORPH precipitation data ",trim(fname)
        ferror_cmorph = 0
      endif
    endif ! J.Case added  for .gz support (2/10/2015)

--- a/lis/metforcing/gefs/get_gefs.F90
+++ b/lis/metforcing/gefs/get_gefs.F90
@@ -428,7 +428,7 @@ subroutine get_gefs(n,findex)
                  gefs_struc(n)%fcst_hour,m)
          endif
          
-         write(LIS_logunit,*)'[INFO] getting file2.. ',filename
+         write(LIS_logunit,*)'[INFO] getting file2.. ',trim(filename)
          order = 2
          call read_gefs_operational(n,m,findex,order,filename,ferror)
 

--- a/lis/metforcing/mrms/read_mrms_grib.F90
+++ b/lis/metforcing/mrms/read_mrms_grib.F90
@@ -99,7 +99,7 @@ subroutine read_mrms_grib( n, fname, findex, order, yr, mo, da, ferror_mrms_grib
 !-- Check initially if file exists:
   inquire (file=fname, exist=file_exists ) ! Check if file exists
   if (.not. file_exists)  then 
-     if (LIS_masterproc) write(LIS_logunit,*) "** Missing MRMS precipitation file: ", fname
+     if (LIS_masterproc) write(LIS_logunit,*) "** Missing MRMS precipitation file: ", trim(fname)
      ferror_mrms_grib = 1
      return
   endif
@@ -137,7 +137,7 @@ subroutine read_mrms_grib( n, fname, findex, order, yr, mo, da, ferror_mrms_grib
     if ( mo >= 10) write ( cmon, '(i2)' ) mo
 
     maskname = trim(mrms_grib_struc(n)%mrms_mask_dir)//'AvgRQI_'//cmon//'_conus_sm.grib2'
-    write(LIS_logunit,*) 'Using mask ',maskname
+    write(LIS_logunit,*) 'Using mask ',trim(maskname)
     !write(LIS_logunit,*) 'With cutoff theshold ',maskthresh
 
     call grib_open_file(ftn2,trim(maskname),'r',iret)

--- a/lis/metforcing/scan/read_scan.F90
+++ b/lis/metforcing/scan/read_scan.F90
@@ -75,7 +75,7 @@ subroutine read_scan(n,ftn,findex,order)
      write(scan_filename,'(i4,a,i4,i2.2,a)')scan_struc(n)%stnid(i),'_',&
           LIS_rc%yr,LIS_rc%mo,'.txt'
      scan_filename = trim(scan_struc(n)%scandir)//'/'//trim(scan_filename)
-     write(LIS_logunit,*) 'Reading SCAN file ',scan_filename
+     write(LIS_logunit,*) 'Reading SCAN file ',trim(scan_filename)
      inquire(file=scan_filename,exist=file_exists)
      if(file_exists) then 
         open(ftn,file=scan_filename,form='formatted',status='old')

--- a/lis/metforcing/snotel/read_snotel.F90
+++ b/lis/metforcing/snotel/read_snotel.F90
@@ -89,7 +89,7 @@ subroutine read_snotel(n,ftn,findex,order)
 
      inquire(file=snotel_filename,exist=file_exists)
      if(file_exists) then 
-        write(LIS_logunit,*) 'Reading SNOTEL file ',snotel_filename
+        write(LIS_logunit,*) 'Reading SNOTEL file ',trim(snotel_filename)
         open(ftn,file=snotel_filename,form='formatted',status='old')
         read(ftn,*) ! skip the header line
 

--- a/lis/metforcing/stg2/read_stg2.F90
+++ b/lis/metforcing/stg2/read_stg2.F90
@@ -85,7 +85,7 @@ subroutine read_stg2( n, fname, findex, order, ferror_stg2 )
 !-- Check initially if file exists:
   inquire (file=fname, exist=file_exists ) ! Check if file exists
   if (.not. file_exists)  then 
-     write(LIS_logunit,*)"** Missing STAGE IV precipitation file: ", fname
+     write(LIS_logunit,*)"** Missing STAGE IV precipitation file: ", trim(fname)
      ferror_stg2 = 1
      return
   endif

--- a/lis/metforcing/stg4/read_stg4.F90
+++ b/lis/metforcing/stg4/read_stg4.F90
@@ -87,7 +87,7 @@ subroutine read_stg4( n, fname,findex,order, ferror_stg4 )
 !-- Check initially if file exists:
   inquire (file=fname, exist=file_exists ) ! Check if file exists
   if (.not. file_exists)  then 
-     write(LIS_logunit,*)"** Missing STAGE IV precipitation file: ", fname
+     write(LIS_logunit,*)"** Missing STAGE IV precipitation file: ", trim(fname)
      ferror_stg4 = 1
      return
   endif


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

In #944, I expanded the filename character limit in the metforcing readers to 500 char. This change resulted in large amounts of trailing whitespace when filenames were written to the log so I added `trim` statements when the filenames are logged. I just noticed that I missed a couple logging messages so I've fixed them here.

The changes from #944 aren't in the support branch yet, so I'm pushing this "fix" to master. 

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->


