### PR TITLE
Add workaround for Cray compilers

### DIFF
--- a/lis/make/Makefile
+++ b/lis/make/Makefile
@@ -155,6 +155,11 @@ version.F90:
 	@echo "Building version file $@"
 	sh build_version.sh
 
+ifeq ($(LIS_ARCH),cray_cray)
+model_interface_mod.o: model_interface_mod.F90
+	$(FC) $(FFLAGS) -O0 $(HEADER_DIRS) $<
+endif
+
 .PHONY: help
 help:
 	@echo ""


### PR DESCRIPTION
### Description

The Cray compilers have an issue compiling
jules.5.0/src/io/model_interface/model_interface_mod.F90
when using either the -O2 or -O1 optimization flags.  Force this file
to compile with -O0.