### PR TITLE
Inherit max path length from ESMF

### DIFF
--- a/lis/core/LIS_constantsMod.F90
+++ b/lis/core/LIS_constantsMod.F90
@@ -21,11 +21,12 @@ module LIS_constantsMod
 !
 !EOP
 !BOC
+   use ESMF, only : ESMF_MAXPATHLEN
    public
 !----------------------------------------------------------------------------
 ! software constants
 !----------------------------------------------------------------------------
-   integer,parameter :: LIS_CONST_PATH_LEN  = 500    ! max path length (in char)
+   integer,parameter :: LIS_CONST_PATH_LEN  = ESMF_MAXPATHLEN ! max path length (in char)
 
 !----------------------------------------------------------------------------
 ! physical constants (all data public)


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Replaces the arbitrary 500 char max path length added in #944 with ESMF's built-in `ESMF_MAXPATHLEN` which holds the value of 1024.

An alternative approach would involve abandoning `LIS_CONST_PATH_LEN` altogether and replacing it with `ESMF_MAXPATHLEN`.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->

Tested with the MERRA-2 testcase from our internal suite by modifying the `MERRA2 forcing directory` entry to artificially create a long path, for example:
`MERRA2 forcing directory: ././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././././input/METFORCING/MERRA2`
