### PR TITLE
Add kluge for compiling soil_htc_jls_mod.F90 on Cray systems

### DIFF
--- a/lis/make/Makefile
+++ b/lis/make/Makefile
@@ -158,6 +158,8 @@ version.F90:
 ifeq ($(LIS_ARCH),cray_cray)
 model_interface_mod.o: model_interface_mod.F90
 	$(FC) $(FFLAGS) -O0 $(HEADER_DIRS) $<
+soil_htc_jls_mod.o: soil_htc_jls_mod.F90
+	$(FC) $(FFLAGS) -O0 $(HEADER_DIRS) $<
 endif
 
 .PHONY: help


### PR DESCRIPTION
### Description

Compiling surfacemodels/land/jules.5.0/src/science/soil/soil_htc_jls_mod.F90 on a Cray system with Cray Fortran version 13.0.0 raised this error:

```
ftn-7991 crayftn: INTERNAL SOIL_HTC, File = ../surfacemodels/land/jules.5.0/src/science/soil/soil_htc_jls_mod.F90, Line = 650
  INTERNAL COMPILER ERROR:  "local_ud_remap: required match not found" (pdgcs/v_cycles.c, line 2785, version 8988d3ca66b7108628fec6cc8ace3a51d9046db6)
```

I resolved this internal compiler error by forcing this file to compile
with "-O0" optimization.