### PR TITLE
Adds the GDDP metforcing reader and makes changes to core routines related to multiprocessor mode

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -348,6 +348,7 @@ endif::devonly[]
 |"`ERA5`"                      | ERA5 reanalysis meteorology
 |"`AWRAL processed forcing`"   | AWRA-L processed forcing
 |"`PLUMBER2`"                  | PLUMBER2 forcing
+|"`GDDP`"                      | NEX GDDP forcing
 |====
 
 .Example _lis.config_ entry
@@ -6365,6 +6366,25 @@ AWRAL domain y-dimension size:         681
 PLUMBER2 forcing file: ./input/PLUMBER2/AU-Cow_2010-2015_OzFlux_Met.nc          
 PLUMBER2 Station ID: AU-Cow                                                      
 PLUMBER2 Time Delta: 1800  
+....
+
+[[sssec_gddpforcing,GDDP]]
+==== GDDP
+
+`GDDP forcing file:` specifies the location of the GDDP metforcing data.
+
+`GDDP forcing scenario:` specifies the GDDP forcing scenario. Currently only `historical` is supported.
+
+`GDDP reference daily climatology directory:` specifies the location of the GDDP reference daily climatology data.
+
+`GDDP reference hourly climatology directory:` specifies the location of the GDDP reference hourly climatology data.
+
+.Example _lis.config_ entry
+....
+GDDP forcing directory:                      ./input/MET_FORCING/NEX-GDDP-CMIP6/
+GDDP forcing scenario:                       historical
+GDDP reference daily climatology directory:  ./input/MET_FORCING/M2CLIMO/DAILY/
+GDDP reference hourly climatology directory: ./input/MET_FORCING/M2CLIMO/HOURLY/
 ....
 
 [[ssec_lsm,Land surface models]]

--- a/lis/core/LIS_LMLCMod.F90
+++ b/lis/core/LIS_LMLCMod.F90
@@ -285,12 +285,13 @@ subroutine read_landcover(n)
      allocate(LIS_LMLC(n)%landcover(LIS_rc%lnc(n),LIS_rc%lnr(n), &
           LIS_rc%nsurfacetypes))
 
-     allocate(lc(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nsurfacetypes))
-
      ios = nf90_inq_varid(nid,'LANDCOVER',lcid)
      call LIS_verify(ios,'LANDCOVER field not found in the LIS param file')
 
-     ios = nf90_get_var(nid,lcid,lc)
+     ios = nf90_get_var(nid,lcid,LIS_LMLC(n)%landcover,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1),1/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),LIS_rc%nsurfacetypes/))
      call LIS_verify(ios,'Error in nf90_get_var in read_landcover')
 
      ios = nf90_get_att(nid, NF90_GLOBAL, 'BARESOILCLASS', LIS_rc%bareclass)
@@ -331,13 +332,6 @@ subroutine read_landcover(n)
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in read_landcover')
 
-     LIS_LMLC(n)%landcover(:,:,:) = lc(&
-          LIS_ews_halo_ind(n,LIS_localPet+1):&         
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1),:)
-
-     deallocate(lc)
   else
      write(LIS_logunit,*) '[ERR] landcover map: ',LIS_rc%paramfile(n), ' does not exist'
      write(LIS_logunit,*) '[ERR] program stopping ...'
@@ -423,24 +417,20 @@ subroutine read_surfacetype(n)
 
      allocate(LIS_LMLC(n)%surfacetype(LIS_rc%lnc(n),LIS_rc%lnr(n), LIS_rc%nsurfacetypes))
 
-     allocate(lc(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nsurfacetypes))
+!     allocate(lc(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nsurfacetypes))
 
      ios = nf90_inq_varid(nid,'SURFACETYPE',lcid)
      call LIS_verify(ios,'SURFACETYPE field not found in the LIS param file')
 
-     ios = nf90_get_var(nid,lcid,lc)
+     ios = nf90_get_var(nid,lcid,LIS_LMLC(n)%surfacetype,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1),1/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),LIS_rc%nsurfacetypes/))
      call LIS_verify(ios,'Error in nf90_get_var in read_surfacetype')
 
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in read_surfacetype')
 
-     LIS_LMLC(n)%surfacetype(:,:,:) = lc(&
-          LIS_ews_halo_ind(n,LIS_localPet+1):&         
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1),:)
-     
-     deallocate(lc)
   else
      write(LIS_logunit,*) '[ERR] surfacetype map: ',LIS_rc%paramfile(n), ' does not exist'
      write(LIS_logunit,*) '[ERR] program stopping ...'

--- a/lis/core/LIS_albedoMod.F90
+++ b/lis/core/LIS_albedoMod.F90
@@ -280,7 +280,6 @@ contains
   integer :: ios1
   integer :: ios,nid,mxsnalid,ncId, nrId
   integer :: nc,nr,t
-  real    :: mxsnal(LIS_rc%gnc(n),LIS_rc%gnr(n))
   real    :: tmpalb(LIS_rc%lnc(n), LIS_rc%lnr(n))
   logical :: file_exists
 
@@ -310,17 +309,15 @@ contains
      ios = nf90_inq_varid(nid,'MXSNALBEDO',mxsnalid)
      call LIS_verify(ios,'MXSNALBEDO field not found in the LIS param file')
 
-     ios = nf90_get_var(nid,mxsnalid,mxsnal)
+     ios = nf90_get_var(nid,mxsnalid,tmpalb,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/))
      call LIS_verify(ios,'Error in nf90_get_var in read_mxsnalb')
 
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in read_mxsnalb')
 
-     tmpalb(:,:) = &
-          mxsnal(LIS_ews_halo_ind(n,LIS_localPet+1):&
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1))
   else
      write(LIS_logunit,*) '[INFO] max snow albedo map: ', &
           LIS_rc%paramfile(n), ' does not exist'
@@ -735,24 +732,18 @@ contains
        call LIS_verify(ios,&
             'Error in nf90_inquire_dimension in read_albedoclimo')
 
-       allocate(albedo(LIS_rc%gnc(n),LIS_rc%gnr(n),months))
-
        ios = nf90_inq_varid(nid,'ALBEDO',albedoid)
        call LIS_verify(ios,'ALBEDO field not found in the LIS param file')
 
-       ios = nf90_get_var(nid,albedoid,albedo)
+       ios = nf90_get_var(nid,albedoid,array,&
+            start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+            LIS_nss_halo_ind(n,LIS_localPet+1),q/),&
+            count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),1/))
        call LIS_verify(ios,'Error in nf90_get_var in read_albedoclimo')
 
        ios = nf90_close(nid)
        call LIS_verify(ios,'Error in nf90_close in read_albedoclimo')
 
-       array(:,:) = &
-            albedo(LIS_ews_halo_ind(n,LIS_localPet+1):&
-            LIS_ewe_halo_ind(n,LIS_localPet+1), &
-            LIS_nss_halo_ind(n,LIS_localPet+1): &
-            LIS_nse_halo_ind(n,LIS_localPet+1),q)
-
-       deallocate(albedo)
     else
        write(LIS_logunit,*) '[ERR] albedo map: ',LIS_rc%paramfile(n), &
             ' does not exist'

--- a/lis/core/LIS_fileIOMod.F90
+++ b/lis/core/LIS_fileIOMod.F90
@@ -3177,7 +3177,6 @@ subroutine LIS_create_gain_filename(n, fname, mname)
   integer :: ios1
   integer :: ios,nid,paramid,ncId, nrId
   integer :: nc,nr,c,r
-  real    :: param(LIS_rc%gnc(n),LIS_rc%gnr(n))
   logical :: file_exists
 
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
@@ -3203,17 +3202,14 @@ subroutine LIS_create_gain_filename(n, fname, mname)
      ios = nf90_inq_varid(nid,trim(pname),paramid)
      call LIS_verify(ios,trim(pname)//' field not found in the LIS param file')
 
-     ios = nf90_get_var(nid,paramid,param)
+     ios = nf90_get_var(nid,paramid,array,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/))            
      call LIS_verify(ios,'Error in nf90_get_var in readparam_real_2d')
      
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in readparam_real_2d')
-
-     array(:,:) = &
-          param(LIS_ews_halo_ind(n,LIS_localPet+1):&         
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1))
 
   else
      write(LIS_logunit,*) '[ERR] '//trim(pname)//' map: ',&
@@ -3270,7 +3266,6 @@ end subroutine readparam_real_2d
   integer :: ios1
   integer :: ios,nid,paramid,ncId, nrId
   integer :: nc,nr,c,r
-  real    :: param(LIS_rc%gnc(n),LIS_rc%gnr(n))
   logical :: file_exists
 
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
@@ -3297,17 +3292,15 @@ end subroutine readparam_real_2d
      if(ios.ne.0) then 
         rc = 1
      else
-        ios = nf90_get_var(nid,paramid,param)
+        ios = nf90_get_var(nid,paramid,array,&
+             start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+             LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+             count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/))
         call LIS_verify(ios,'Error in nf90_get_var in readparam_real_2d')
         
         ios = nf90_close(nid)
         call LIS_verify(ios,'Error in nf90_close in readparam_real_2d')
         
-        array(:,:) = &
-             param(LIS_ews_halo_ind(n,LIS_localPet+1):&         
-             LIS_ewe_halo_ind(n,LIS_localPet+1), &
-             LIS_nss_halo_ind(n,LIS_localPet+1): &
-             LIS_nse_halo_ind(n,LIS_localPet+1))
         rc = 0 
      endif
   else
@@ -3569,17 +3562,20 @@ end subroutine readgparam_real_2d_rc
      ios = nf90_inq_varid(nid,trim(pname),paramid)
      call LIS_verify(ios,trim(pname)//' field not found in the LIS param file')
 
-     ios = nf90_get_var(nid,paramid,param)
+     ios = nf90_get_var(nid,paramid,array,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/))          
      call LIS_verify(ios,'Error in nf90_get_var in readparam_int_2d')
      
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in readparam_int_2d')
 
-     array(:,:) = &
-          nint(param(LIS_ews_halo_ind(n,LIS_localPet+1):&         
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1)))
+!     array(:,:) = &
+!          nint(param(LIS_ews_halo_ind(n,LIS_localPet+1):&         
+!          LIS_ewe_halo_ind(n,LIS_localPet+1), &
+!          LIS_nss_halo_ind(n,LIS_localPet+1): &
+!          LIS_nse_halo_ind(n,LIS_localPet+1)))
 
   else
      write(LIS_logunit,*) '[ERR] '//trim(pname)//' map: ',&

--- a/lis/core/LIS_soilsMod.F90
+++ b/lis/core/LIS_soilsMod.F90
@@ -405,22 +405,17 @@ subroutine read_porosity(n)
      ios = nf90_inq_varid(nid,'POROSITY',porosityid)
      call LIS_verify(ios,'POROSITY field not found in the LIS param file')
 
-     allocate(porosity(LIS_rc%gnc(n),LIS_rc%gnr(n),3))
      allocate(LIS_soils(n)%porosity(LIS_rc%lnc(n),LIS_rc%lnr(n),3))
 
-     ios = nf90_get_var(nid,porosityid,porosity)
+     ios = nf90_get_var(nid,porosityid,LIS_soils(n)%porosity,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1),1/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),3/))
      call LIS_verify(ios,'Error in nf90_get_var in read_porosity')
      
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in read_porosity')
 
-     LIS_soils(n)%porosity(:,:,:) = &
-          porosity(LIS_ews_halo_ind(n,LIS_localPet+1):&         
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1),:)
-     
-     deallocate(porosity)
   else
      write(LIS_logunit,*) '[ERR] porosity map: ',LIS_rc%paramfile(n), ' does not exist'
      write(LIS_logunit,*) '[ERR] program stopping ...'
@@ -506,24 +501,18 @@ subroutine read_soiltexture(n)
      allocate(LIS_soils(n)%texture(LIS_rc%lnc(n),LIS_rc%lnr(n), &
           LIS_rc%nsoiltypes))
 
-     allocate(txt(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nsoiltypes))
-
      ios = nf90_inq_varid(nid,'TEXTURE',txtid)
      call LIS_verify(ios,'TEXTURE field not found in the LIS param file')
 
-     ios = nf90_get_var(nid,txtid,txt)
+     ios = nf90_get_var(nid,txtid,LIS_soils(n)%texture, &
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1),1/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),LIS_rc%nsoiltypes/))
      call LIS_verify(ios,'Error in nf90_get_var in read_soiltexture')
 
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in read_soiltexture')
 
-     LIS_soils(n)%texture(:,:,:) = txt(&
-          LIS_ews_halo_ind(n,LIS_localPet+1):&         
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1),:)
-
-     deallocate(txt)
   else
      write(LIS_logunit,*) '[ERR] soiltexture map: ',LIS_rc%paramfile(n), &
           ' does not exist'
@@ -616,38 +605,23 @@ subroutine read_soilfraction(n)
      allocate(LIS_soils(n)%clay(LIS_rc%lnc(n),LIS_rc%lnr(n), &
           LIS_rc%nsoilfbands))
 
-     allocate(sand(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nsoilfbands))
-     allocate(clay(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nsoilfbands))
-
      ios = nf90_inq_varid(nid,'SAND',sandid)
      call LIS_verify(ios,'SAND field not found in the LIS param file')
 
-     ios = nf90_get_var(nid,sandid,sand)
+     ios = nf90_get_var(nid,sandid,LIS_soils(n)%sand,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1),1/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),LIS_rc%nsoilfbands/))
      call LIS_verify(ios,'Error in nf90_get_var in read_soilfraction')
-
-     LIS_soils(n)%sand(:,:,:) = sand(&
-          LIS_ews_halo_ind(n,LIS_localPet+1):&         
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1),:)
-
-     deallocate(sand)
 
      ios = nf90_inq_varid(nid,'CLAY',clayid)
      call LIS_verify(ios,'CLAY field not found in the LIS param file')
 
-     ios = nf90_get_var(nid,clayid,clay)
+     ios = nf90_get_var(nid,clayid,LIS_soils(n)%clay,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1),1/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),LIS_rc%nsoilfbands/))
      call LIS_verify(ios,'Error in nf90_get_var in read_soilfraction')
-
-     LIS_soils(n)%clay(:,:,:) = clay(&
-          LIS_ews_halo_ind(n,LIS_localPet+1):&         
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1),:)
-
-     deallocate(clay)
-
-     allocate(soilfgrd(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nsoilfbands))
 
      allocate(LIS_soils(n)%soilffgrd(LIS_rc%lnc(n),LIS_rc%lnr(n),&
           LIS_rc%nsoilfbands))
@@ -655,16 +629,11 @@ subroutine read_soilfraction(n)
      ios = nf90_inq_varid(nid,'SOILSFGRD',soilfgrdid)
      call LIS_verify(ios,'SOILSFGRD field not found in the LIS param file')
 
-     ios = nf90_get_var(nid,soilfgrdid,soilfgrd)
+     ios = nf90_get_var(nid,soilfgrdid,LIS_soils(n)%soilffgrd,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1),1/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),LIS_rc%nsoilfbands/))
      call LIS_verify(ios,'Error in nf90_get_var in read_soilfraction')
-
-     LIS_soils(n)%soilffgrd(:,:,:) = soilfgrd(&
-          LIS_ews_halo_ind(n,LIS_localPet+1):&         
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1),:)
-     
-     deallocate(soilfgrd)
 
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in read_soilfraction')

--- a/lis/core/LIS_topoMod.F90
+++ b/lis/core/LIS_topoMod.F90
@@ -240,38 +240,27 @@ contains
        allocate(LIS_topo(n)%elevfgrd(LIS_rc%lnc(n),LIS_rc%lnr(n), &
             LIS_rc%nelevbands))
        
-       allocate(elev(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nelevbands))
-       
        ios = nf90_inq_varid(nid,'ELEVATION',elevid)
        call LIS_verify(ios,'ELEVATION field not found in the LIS param file')
        
-       ios = nf90_get_var(nid,elevid,elev)
+       ios = nf90_get_var(nid,elevid,LIS_topo(n)%elevation,&
+            start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+            LIS_nss_halo_ind(n,LIS_localPet+1),1/),&
+            count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),LIS_rc%nelevbands/))
        call LIS_verify(ios,'Error in nf90_get_var in read_elevation')
        
-       LIS_topo(n)%elevation(:,:,:) = elev(&
-            LIS_ews_halo_ind(n,LIS_localPet+1):&         
-            LIS_ewe_halo_ind(n,LIS_localPet+1), &
-            LIS_nss_halo_ind(n,LIS_localPet+1): &
-            LIS_nse_halo_ind(n,LIS_localPet+1),:)
-       deallocate(elev)
-
-       allocate(elevfgrd(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nelevbands))
-
        ios = nf90_inq_varid(nid,'ELEVFGRD',elevfgrdid)
        call LIS_verify(ios,'ELEVFGRD field not found in the LIS param file')
        
-       ios = nf90_get_var(nid,elevfgrdid,elevfgrd)
+       ios = nf90_get_var(nid,elevfgrdid,LIS_topo(n)%elevfgrd,&
+            start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+            LIS_nss_halo_ind(n,LIS_localPet+1),1/),&
+            count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),LIS_rc%nelevbands/))
        call LIS_verify(ios,'Error in nf90_get_var in read_elevation')
        
        ios = nf90_close(nid)
        call LIS_verify(ios,'Error in nf90_close in read_elevation')
        
-       LIS_topo(n)%elevfgrd(:,:,:) = elevfgrd(&
-            LIS_ews_halo_ind(n,LIS_localPet+1):&         
-            LIS_ewe_halo_ind(n,LIS_localPet+1), &
-            LIS_nss_halo_ind(n,LIS_localPet+1): &
-            LIS_nse_halo_ind(n,LIS_localPet+1),:)
-       deallocate(elevfgrd)
     else
        write(LIS_logunit,*) '[ERR] elevation map: ',LIS_rc%paramfile(n), &
             ' does not exist'
@@ -365,39 +354,27 @@ contains
        allocate(LIS_topo(n)%slopefgrd(LIS_rc%lnc(n),LIS_rc%lnr(n), &
             LIS_rc%nslopebands))
        
-       allocate(slope(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nslopebands))
-       
        ios = nf90_inq_varid(nid,'SLOPE',slopeid)
        call LIS_verify(ios,'SLOPE field not found in the LIS param file')
        
-       ios = nf90_get_var(nid,slopeid,slope)
+       ios = nf90_get_var(nid,slopeid,LIS_topo(n)%slope,&
+            start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+            LIS_nss_halo_ind(n,LIS_localPet+1),1/),&
+            count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),LIS_rc%nslopebands/))
        call LIS_verify(ios,'Error in nf90_get_var in read_slope')
       
-       LIS_topo(n)%slope(:,:,:) = slope(&
-            LIS_ews_halo_ind(n,LIS_localPet+1):&         
-            LIS_ewe_halo_ind(n,LIS_localPet+1), &
-            LIS_nss_halo_ind(n,LIS_localPet+1): &
-            LIS_nse_halo_ind(n,LIS_localPet+1),:)
-       deallocate(slope)
-
-       allocate(slopefgrd(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nslopebands))
-
        ios = nf90_inq_varid(nid,'SLOPEFGRD',slopefgrdid)
        call LIS_verify(ios,'SLOPEFGRD field not found in the LIS param file')
        
-       ios = nf90_get_var(nid,slopefgrdid,slopefgrd)
+       ios = nf90_get_var(nid,slopefgrdid,LIS_topo(n)%slopefgrd,&
+            start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+            LIS_nss_halo_ind(n,LIS_localPet+1),1/),&
+            count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),LIS_rc%nslopebands/))
        call LIS_verify(ios,'Error in nf90_get_var in read_slope')
        
        ios = nf90_close(nid)
        call LIS_verify(ios,'Error in nf90_close in read_slope')
        
-       LIS_topo(n)%slopefgrd(:,:,:) = slopefgrd(&
-            LIS_ews_halo_ind(n,LIS_localPet+1):&         
-            LIS_ewe_halo_ind(n,LIS_localPet+1), &
-            LIS_nss_halo_ind(n,LIS_localPet+1): &
-            LIS_nse_halo_ind(n,LIS_localPet+1),:)
-       deallocate(slopefgrd)
-
     else
        write(LIS_logunit,*) '[ERR] slope map: ',LIS_rc%paramfile(n), &
             ' does not exist'
@@ -492,40 +469,27 @@ contains
        allocate(LIS_topo(n)%aspectfgrd(LIS_rc%lnc(n),LIS_rc%lnr(n), &
             LIS_rc%naspectbands))
 
-       allocate(aspect(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%naspectbands))
-              
        ios = nf90_inq_varid(nid,'ASPECT',aspectid)
        call LIS_verify(ios,'ASPECT field not found in the LIS param file')
        
-       ios = nf90_get_var(nid,aspectid,aspect)
+       ios = nf90_get_var(nid,aspectid,LIS_topo(n)%aspect,&
+            start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+            LIS_nss_halo_ind(n,LIS_localPet+1),1/),&
+            count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),LIS_rc%naspectbands/))
        call LIS_verify(ios,'Error in nf90_get_var in read_aspect')
        
-       LIS_topo(n)%aspect(:,:,:) = aspect(&
-            LIS_ews_halo_ind(n,LIS_localPet+1):&         
-            LIS_ewe_halo_ind(n,LIS_localPet+1), &
-            LIS_nss_halo_ind(n,LIS_localPet+1): &
-            LIS_nse_halo_ind(n,LIS_localPet+1),:)
-       deallocate(aspect)
-       
-       allocate(aspectfgrd(LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%naspectbands))
-
        ios = nf90_inq_varid(nid,'ASPECTFGRD',aspectfgrdid)
        call LIS_verify(ios,'ASPECTFGRD field not found in the LIS param file')
        
-       ios = nf90_get_var(nid,aspectfgrdid,aspectfgrd)
+       ios = nf90_get_var(nid,aspectfgrdid,LIS_topo(n)%aspectfgrd,&
+            start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+            LIS_nss_halo_ind(n,LIS_localPet+1),1/),&
+            count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),LIS_rc%naspectbands/))
        call LIS_verify(ios,'Error in nf90_get_var in read_aspect')
        
        ios = nf90_close(nid)
        call LIS_verify(ios,'Error in nf90_close in read_aspect')
        
-       LIS_topo(n)%aspectfgrd(:,:,:) = aspectfgrd(&
-            LIS_ews_halo_ind(n,LIS_localPet+1):&         
-            LIS_ewe_halo_ind(n,LIS_localPet+1), &
-            LIS_nss_halo_ind(n,LIS_localPet+1): &
-            LIS_nse_halo_ind(n,LIS_localPet+1),:)
-       deallocate(aspectfgrd)
-
-
     else
        write(LIS_logunit,*) '[ERR] aspect map: ',LIS_rc%paramfile(n), &
             ' does not exist'

--- a/lis/core/LIS_vegDataMod.F90
+++ b/lis/core/LIS_vegDataMod.F90
@@ -647,24 +647,17 @@ contains
        call LIS_verify(ios, &
             'Error in nf90_inquire_dimension in read_gfracclimo')
 
-       allocate(gfrac(LIS_rc%gnc(n),LIS_rc%gnr(n),months))
-
        ios = nf90_inq_varid(nid,'GREENNESS',gfracid)
        call LIS_verify(ios,'GREENNESS field not found in the LIS param file')
 
-       ios = nf90_get_var(nid,gfracid,gfrac)
+       ios = nf90_get_var(nid,gfracid,localgfrac,&
+             start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+             LIS_nss_halo_ind(n,LIS_localPet+1),mo/),&
+             count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),1/))
        call LIS_verify(ios,'Error in nf90_get_var in read_gfracclimo')
 
        ios = nf90_close(nid)
        call LIS_verify(ios,'Error in nf90_close in read_gfracclimo')
-
-       localgfrac(:,:) = &
-            gfrac(LIS_ews_halo_ind(n,LIS_localPet+1):&
-            LIS_ewe_halo_ind(n,LIS_localPet+1), &
-            LIS_nss_halo_ind(n,LIS_localPet+1): &
-            LIS_nse_halo_ind(n,LIS_localPet+1),mo)
-
-       deallocate(gfrac)
 
        do t=1,LIS_rc%ntiles(n)
           array(t) = localgfrac(LIS_domain(n)%tile(t)%col,&
@@ -710,7 +703,6 @@ contains
   integer :: ios1
   integer :: ios,nid,shdminid,ncId, nrId
   integer :: nc,nr,c,r
-  real    :: shdmin(LIS_rc%gnc(n),LIS_rc%gnr(n))
   logical :: file_exists
 
   TRACE_ENTER("green_readmin")
@@ -740,17 +732,14 @@ contains
      ios = nf90_inq_varid(nid,'SHDMIN',shdminid)
      call LIS_verify(ios,'SHDMIN field not found in the LIS param file')
 
-     ios = nf90_get_var(nid,shdminid,shdmin)
+     ios = nf90_get_var(nid,shdminid,array,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/))
      call LIS_verify(ios,'Error in nf90_get_var in LIS_read_shdmin')
 
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in LIS_read_shdmin')
-
-     array(:,:) = &
-          shdmin(LIS_ews_halo_ind(n,LIS_localPet+1):&
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1))
 
   else
      write(LIS_logunit,*) '[ERR] SHDMIN map: ',&
@@ -795,7 +784,6 @@ contains
   integer :: ios1
   integer :: ios,nid,shdmaxid,ncId, nrId
   integer :: nc,nr,c,r
-  real    :: shdmax(LIS_rc%gnc(n),LIS_rc%gnr(n))
   logical :: file_exists
 
   TRACE_ENTER("green_readmax")
@@ -825,17 +813,14 @@ contains
      ios = nf90_inq_varid(nid,'SHDMAX',shdmaxid)
      call LIS_verify(ios,'SHDMAX field not found in the LIS param file')
 
-     ios = nf90_get_var(nid,shdmaxid,shdmax)
+     ios = nf90_get_var(nid,shdmaxid,array,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/))
      call LIS_verify(ios,'Error in nf90_get_var in LIS_read_shdmax')
 
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in LIS_read_shdmax')
-
-     array(:,:) = &
-          shdmax(LIS_ews_halo_ind(n,LIS_localPet+1):&
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1))
 
   else
      write(LIS_logunit,*) '[ERR] SHDMAX map: ',&
@@ -880,7 +865,6 @@ contains
   integer :: ios1
   integer :: ios,nid,laiminid,ncId, nrId
   integer :: nc,nr,c,r
-  real    :: laimin(LIS_rc%gnc(n),LIS_rc%gnr(n))
   logical :: file_exists
 
   TRACE_ENTER("lai_readmin")
@@ -910,17 +894,14 @@ contains
      ios = nf90_inq_varid(nid,'LAIMIN',laiminid)
      call LIS_verify(ios,'LAIMIN field not found in the LIS param file')
 
-     ios = nf90_get_var(nid,laiminid,laimin)
+     ios = nf90_get_var(nid,laiminid,array,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/))
      call LIS_verify(ios,'Error in nf90_get_var in LIS_read_laimin')
 
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in LIS_read_laimin')
-
-     array(:,:) = &
-          laimin(LIS_ews_halo_ind(n,LIS_localPet+1):&
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1))
 
   else
      write(LIS_logunit,*) '[ERR] LAIMIN map: ',&
@@ -965,7 +946,6 @@ contains
   integer :: ios1
   integer :: ios,nid,laimaxid,ncId, nrId
   integer :: nc,nr,c,r
-  real    :: laimax(LIS_rc%gnc(n),LIS_rc%gnr(n))
   logical :: file_exists
 
   TRACE_ENTER("lai_readmax")
@@ -995,17 +975,14 @@ contains
      ios = nf90_inq_varid(nid,'LAIMAX',laimaxid)
      call LIS_verify(ios,'LAIMAX field not found in the LIS param file')
 
-     ios = nf90_get_var(nid,laimaxid,laimax)
+     ios = nf90_get_var(nid,laimaxid,array,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/))          
      call LIS_verify(ios,'Error in nf90_get_var in LIS_read_laimax')
 
      ios = nf90_close(nid)
      call LIS_verify(ios,'Error in nf90_close in LIS_read_laimax')
-
-     array(:,:) = &
-          laimax(LIS_ews_halo_ind(n,LIS_localPet+1):&
-          LIS_ewe_halo_ind(n,LIS_localPet+1), &
-          LIS_nss_halo_ind(n,LIS_localPet+1): &
-          LIS_nse_halo_ind(n,LIS_localPet+1))
 
   else
      write(LIS_logunit,*) '[ERR] LAIMAX map: ',&
@@ -1479,24 +1456,17 @@ contains
        call LIS_verify(ios, &
             'Error in nf90_inquire_dimension in read_roughnessclimo')
 
-       allocate(roughness(LIS_rc%gnc(n),LIS_rc%gnr(n),months))
-
        ios = nf90_inq_varid(nid,'ROUGHNESS',roughnessid)
        call LIS_verify(ios,'ROUGHNESS field not found in the LIS param file')
 
-       ios = nf90_get_var(nid,roughnessid,roughness)
+       ios = nf90_get_var(nid,roughnessid,localroughness,&
+            start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+            LIS_nss_halo_ind(n,LIS_localPet+1),mo/),&
+            count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),1/))
        call LIS_verify(ios,'Error in nf90_get_var in read_roughnessclimo')
 
        ios = nf90_close(nid)
        call LIS_verify(ios,'Error in nf90_close in read_roughnessclimo')
-
-       localroughness(:,:) = &
-            roughness(LIS_ews_halo_ind(n,LIS_localPet+1):&
-            LIS_ewe_halo_ind(n,LIS_localPet+1), &
-            LIS_nss_halo_ind(n,LIS_localPet+1): &
-            LIS_nse_halo_ind(n,LIS_localPet+1),mo)
-
-       deallocate(roughness)
 
        do t=1,LIS_rc%ntiles(n)
           array(t) = localroughness(LIS_domain(n)%tile(t)%col,&
@@ -2759,24 +2729,17 @@ contains
        ios = nf90_inquire_dimension(nid,mId, len=months)
        call LIS_verify(ios,'Error in nf90_inquire_dimension in read_laiclimo')
 
-       allocate(lai(LIS_rc%gnc(n),LIS_rc%gnr(n),months))
-
        ios = nf90_inq_varid(nid,'LAI',laiid)
        call LIS_verify(ios,'LAI field not found in the LIS param file')
 
-       ios = nf90_get_var(nid,laiid,lai)
+       ios = nf90_get_var(nid,laiid,locallai,&
+            start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+            LIS_nss_halo_ind(n,LIS_localPet+1),mo/),&
+            count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),1/))
        call LIS_verify(ios,'Error in nf90_get_var in read_laiclimo')
 
        ios = nf90_close(nid)
        call LIS_verify(ios,'Error in nf90_close in read_laiclimo')
-
-       locallai(:,:) = &
-            lai(LIS_ews_halo_ind(n,LIS_localPet+1):&
-            LIS_ewe_halo_ind(n,LIS_localPet+1), &
-            LIS_nss_halo_ind(n,LIS_localPet+1): &
-            LIS_nse_halo_ind(n,LIS_localPet+1),mo)
-
-       deallocate(lai)
 
        do t=1,LIS_rc%ntiles(n)
           array(t) = locallai(LIS_domain(n)%tile(t)%col,&
@@ -2865,24 +2828,17 @@ contains
        ios = nf90_inquire_dimension(nid,mId, len=months)
        call LIS_verify(ios,'Error in nf90_inquire_dimension in read_saiclimo')
 
-       allocate(sai(LIS_rc%gnc(n),LIS_rc%gnr(n),months))
-
        ios = nf90_inq_varid(nid,'SAI',saiid)
        call LIS_verify(ios,'SAI field not found in the LIS param file')
 
-       ios = nf90_get_var(nid,saiid,sai)
+       ios = nf90_get_var(nid,saiid,localsai,&
+            start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+            LIS_nss_halo_ind(n,LIS_localPet+1),mo/),&
+            count=(/LIS_rc%lnc(n),LIS_rc%lnr(n),1/))
        call LIS_verify(ios,'Error in nf90_get_var in read_saiclimo')
 
        ios = nf90_close(nid)
        call LIS_verify(ios,'Error in nf90_close in read_saiclimo')
-
-       localsai(:,:) = &
-            sai(LIS_ews_halo_ind(n,LIS_localPet+1):&
-            LIS_ewe_halo_ind(n,LIS_localPet+1), &
-            LIS_nss_halo_ind(n,LIS_localPet+1): &
-            LIS_nse_halo_ind(n,LIS_localPet+1),mo)
-
-       deallocate(sai)
 
        do t=1,LIS_rc%ntiles(n)
           array(t) = localsai(LIS_domain(n)%tile(t)%col,&

--- a/lis/make/default.cfg
+++ b/lis/make/default.cfg
@@ -458,6 +458,11 @@ enabled: True
 macro: MF_MRMS
 path: metforcing/mrms
 
+[GDDP]
+enabled: True
+macro: MF_GDDP
+path: metforcing/gddp
+
 #}}}
 
 #

--- a/lis/metforcing/gddp/finalize_gddp.F90
+++ b/lis/metforcing/gddp/finalize_gddp.F90
@@ -1,0 +1,30 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !MODULE: finalize_gddp
+! \label{finalize_gddp}
+!
+! !REVISION HISTORY: 
+! 25Oct2005; Sujay Kumar, Initial Code
+! 
+! !INTERFACE:
+subroutine finalize_gddp
+! !USES:
+  use gddp_forcingMod, only : gddp_struc
+!
+! !DESCRIPTION:
+!  Routine to cleanup allocated structures for GDDP forcing. 
+!
+!EOP  
+  implicit none
+  
+  deallocate(gddp_struc)
+
+end subroutine finalize_gddp

--- a/lis/metforcing/gddp/gddp_forcingMod.F90
+++ b/lis/metforcing/gddp/gddp_forcingMod.F90
@@ -73,7 +73,8 @@ module gddp_forcingMod
      
      integer                :: findtime1, findtime2
      real, allocatable      :: metdata1(:,:,:) 
-     real, allocatable      :: metdata2(:,:,:) 
+     real, allocatable      :: metdata2(:,:,:)
+     real, allocatable      :: metdata(:,:,:) 
 
      integer                :: nmodels   
 
@@ -156,10 +157,14 @@ contains
        allocate(gddp_struc(n)%metdata2(gddp_struc(n)%nmodels,&
             LIS_rc%met_nf(findex),&
             LIS_rc%ngrid(n)))
+       allocate(gddp_struc(n)%metdata(gddp_struc(n)%nmodels,&
+            LIS_rc%met_nf(findex),&
+            LIS_rc%ngrid(n)))
 
        gddp_struc(n)%metdata1 = 0
        gddp_struc(n)%metdata2 = 0
-
+       gddp_struc(n)%metdata = 0
+       
        gddp_struc(n)%day_check1 = -1
        gddp_struc(n)%day_check2 = -1
        

--- a/lis/metforcing/gddp/gddp_forcingMod.F90
+++ b/lis/metforcing/gddp/gddp_forcingMod.F90
@@ -1,0 +1,248 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+module gddp_forcingMod
+!BOP
+! !MODULE: gddp_forcingMod
+!
+! !DESCRIPTION: 
+!  This module contains variables and data structures that are used
+!  for the implementation of the forcing data from the NASA Earth
+!  Exchange Global Daily Downscaled Projections (NEX-GDDP)  
+!
+!  https://www.nasa.gov/nex/gddp
+!  https://www.nccs.nasa.gov/services/data-collections/land-based-products/nex-gddp-cmip6
+!
+! ! !REVISION HISTORY:
+!
+! 03 Feb 2022; Sujay Kumar; Initial Specification
+
+! !USES: 
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+  implicit none
+  
+  PRIVATE
+!-----------------------------------------------------------------------------
+! !PUBLIC MEMBER FUNCTIONS:
+!-----------------------------------------------------------------------------
+  public :: init_GDDP      !defines the native resolution of 
+                                  !the input data
+!-----------------------------------------------------------------------------
+! !PUBLIC TYPES:
+!-----------------------------------------------------------------------------
+  public :: gddp_struc
+!EOP
+
+  type, public ::  gddp_type_dec
+     real     :: ts
+     integer  :: nc, nr, vector_len   
+     real*8   :: gddptime1,gddptime2
+     character(len=LIS_CONST_PATH_LEN) :: odir
+     character(len=LIS_CONST_PATH_LEN) :: scenario
+
+     character(len=LIS_CONST_PATH_LEN) :: ref_dclimodir
+     character(len=LIS_CONST_PATH_LEN) :: ref_hclimodir
+
+     integer, allocatable   :: gindex(:,:)
+
+     integer :: mi
+     integer                :: day_check1
+     integer                :: day_check2
+     
+     integer, allocatable   :: n111(:)
+     integer, allocatable   :: n121(:)
+     integer, allocatable   :: n211(:)
+     integer, allocatable   :: n221(:)
+     real, allocatable      :: w111(:),w121(:)
+     real, allocatable      :: w211(:),w221(:)
+     
+     integer, allocatable   :: n112(:,:)
+     integer, allocatable   :: n122(:,:)
+     integer, allocatable   :: n212(:,:)
+     integer, allocatable   :: n222(:,:)
+     real, allocatable      ::  w112(:,:),w122(:,:)
+     real, allocatable      ::  w212(:,:),w222(:,:)
+
+     integer, allocatable   :: n113(:)
+     
+     integer                :: findtime1, findtime2
+     real, allocatable      :: metdata1(:,:,:) 
+     real, allocatable      :: metdata2(:,:,:) 
+
+     integer                :: nmodels   
+
+     real, allocatable      :: tair_climo(:,:)
+     real, allocatable      :: qair_climo(:,:)
+     real, allocatable      :: swdown_climo(:,:)
+     real, allocatable      :: lwdown_climo(:,:)
+     real, allocatable      :: wind_climo(:,:)
+     real, allocatable      :: psurf_climo(:,:)
+     real, allocatable      :: prcp_climo(:,:)
+  
+
+  end type gddp_type_dec
+  
+  type(gddp_type_dec), allocatable :: gddp_struc(:)
+!EOP
+contains
+  
+!BOP
+!
+! !ROUTINE: init_GDDP
+! \label{init_GDDP}
+! 
+! !REVISION HISTORY: 
+! 11Dec2003: Sujay Kumar; Initial Specification
+! 
+! !INTERFACE:
+  subroutine init_GDDP(findex)
+! !USES: 
+    use LIS_coreMod,    only : LIS_rc, LIS_domain
+    use LIS_timeMgrMod, only : LIS_update_timestep
+    use LIS_logMod,     only : LIS_logunit, LIS_endrun
+
+    implicit none
+! !USES: 
+    integer, intent(in)  :: findex
+! 
+! !DESCRIPTION: 
+!  Defines the native resolution of the input forcing for GDDP
+!  data. The grid description arrays are based on the decoding
+!  schemes used by NCEP and followed in the LIS interpolation
+!  schemes (see Section~\ref{interp}).
+!
+!EOP
+
+
+    integer :: n 
+    real  :: gridDesci(LIS_rc%nnest, 50)
+
+    ! Forecast mode -- NOT Available at this time for this forcing reader:
+    if( LIS_rc%forecastMode.eq.1 ) then
+       write(LIS_logunit,*) '[ERR] Currently the GDDP forcing reader'
+       write(LIS_logunit,*) '[ERR]  is not set up to run in forecast mode.'
+       write(LIS_logunit,*) '[ERR]  May be added in future releases.'
+       write(LIS_logunit,*) '[ERR]  LIS forecast run-time ending.'
+       call LIS_endrun()
+    endif
+    
+    allocate(gddp_struc(LIS_rc%nnest))
+    call readcrd_gddp()
+
+    do n=1, LIS_rc%nnest
+       gddp_struc(n)%nmodels = 25
+       gddp_struc(n)%ts = 3600
+       call LIS_update_timestep(LIS_rc, n, gddp_struc(n)%ts)
+    enddo
+
+    gridDesci = 0 
+
+    LIS_rc%met_nf(findex) = 7
+
+    gddp_struc(:)%nc = 1440
+    gddp_struc(:)%nr = 600
+
+    do n=1,LIS_rc%nnest
+
+       allocate(gddp_struc(n)%metdata1(gddp_struc(n)%nmodels,&
+            LIS_rc%met_nf(findex),&
+            LIS_rc%ngrid(n)))
+       allocate(gddp_struc(n)%metdata2(gddp_struc(n)%nmodels,&
+            LIS_rc%met_nf(findex),&
+            LIS_rc%ngrid(n)))
+
+       gddp_struc(n)%metdata1 = 0
+       gddp_struc(n)%metdata2 = 0
+
+       gddp_struc(n)%day_check1 = -1
+       gddp_struc(n)%day_check2 = -1
+       
+       gridDesci(n,1) = 0
+       gridDesci(n,2) = gddp_struc(n)%nc
+       gridDesci(n,3) = gddp_struc(n)%nr
+       gridDesci(n,4) = -59.875
+       gridDesci(n,5) = -179.875
+       gridDesci(n,7) = 89.875
+       gridDesci(n,8) = 179.875
+       gridDesci(n,6) = 128
+       gridDesci(n,9) = 0.25
+       gridDesci(n,10) = 0.25
+       gridDesci(n,20) = 0.0
+       gddp_struc(n)%mi = gddp_struc(n)%nc*gddp_struc(n)%nr
+       gddp_struc(n)%gddptime1 = 3000.0
+       gddp_struc(n)%gddptime2 = 0.0
+
+!Setting up weights for Interpolation
+       if(trim(LIS_rc%met_interp(findex)).eq."bilinear") then 
+
+          allocate(gddp_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+          call bilinear_interp_input(n,gridDesci(n,:),&
+               gddp_struc(n)%n111,gddp_struc(n)%n121,&
+               gddp_struc(n)%n211,gddp_struc(n)%n221,&
+               gddp_struc(n)%w111,gddp_struc(n)%w121,&
+               gddp_struc(n)%w211,gddp_struc(n)%w221)
+
+       elseif(trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then 
+
+          allocate(gddp_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(gddp_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+          call bilinear_interp_input(n,gridDesci(n,:),&
+               gddp_struc(n)%n111,gddp_struc(n)%n121,&
+               gddp_struc(n)%n211,gddp_struc(n)%n221,&
+               gddp_struc(n)%w111,gddp_struc(n)%w121,&
+               gddp_struc(n)%w211,gddp_struc(n)%w221)
+
+          allocate(gddp_struc(n)%n112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(gddp_struc(n)%n122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(gddp_struc(n)%n212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(gddp_struc(n)%n222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(gddp_struc(n)%w112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(gddp_struc(n)%w122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(gddp_struc(n)%w212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(gddp_struc(n)%w222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+
+          call conserv_interp_input(n,gridDesci(n,:),&
+               gddp_struc(n)%n112,gddp_struc(n)%n122,&
+               gddp_struc(n)%n212,gddp_struc(n)%n222,&
+               gddp_struc(n)%w112,gddp_struc(n)%w122,&
+               gddp_struc(n)%w212,gddp_struc(n)%w222)
+       elseif(trim(LIS_rc%met_interp(findex)).eq."neighbor") then 
+
+          allocate(gddp_struc(n)%n113(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+          call neighbor_interp_input(n,gridDesci(n,:),&
+               gddp_struc(n)%n113)
+       endif
+       allocate(gddp_struc(n)%tair_climo(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+       allocate(gddp_struc(n)%qair_climo(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+       allocate(gddp_struc(n)%swdown_climo(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+       allocate(gddp_struc(n)%lwdown_climo(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+       allocate(gddp_struc(n)%wind_climo(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+       allocate(gddp_struc(n)%psurf_climo(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+       allocate(gddp_struc(n)%prcp_climo(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+       
+    enddo
+    
+  end subroutine init_GDDP
+end module gddp_forcingMod

--- a/lis/metforcing/gddp/get_gddp.F90
+++ b/lis/metforcing/gddp/get_gddp.F90
@@ -1,0 +1,525 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
+!BOP
+!
+! !ROUTINE: get_gddp
+! \label{get_gddp}
+!  
+! !REVISION HISTORY:
+!
+! 03 Feb 2022; Sujay Kumar; Initial Specification
+!
+! !INTERFACE:
+subroutine get_gddp(n, findex)
+! !USES:
+  use LIS_coreMod
+  use LIS_metforcingMod
+  use LIS_timeMgrMod
+  use LIS_logMod
+  use LIS_constantsMod
+  use gddp_forcingMod
+
+  implicit none
+! !ARGUMENTS: 
+  integer, intent(in) :: n 
+  integer, intent(in) :: findex
+!  
+! !DESCRIPTION:
+!  Opens, reads, and interpolates the daily GDDP forcing. 
+!.
+!  The arguments are: 
+!  \begin{description}
+!  \item[n]
+!    index of the nest
+!  \end{description}
+!
+!  The routines invoked are: 
+!  \begin{description}
+!  \item[LIS\_tick](\ref{LIS_tick}) \newline
+!    determines the GDDP data times
+!  \item[read\_gddp](\ref{read_gddp}) \newline
+!      Interpolates GDDP data to LIS grid
+!  \end{description}
+  !EOP
+  
+  integer, parameter :: ndays = 10  ! # days to look back for forcing data
+  integer            :: c,f,order,ferror,try
+  integer            :: yr1,mo1,da1,hr1,mn1,ss1,doy1
+  integer            :: yr2,mo2,da2,hr2,mn2,ss2,doy2
+  integer            :: ryr1,rmo1,rda1,rhr1,rmn1,rss1,rdoy1
+  integer            :: ryr2,rmo2,rda2,rhr2,rmn2,rss2,rdoy2
+  real*8             :: time1,time2,rtime1,rtime2
+  real*8             :: dtime1, dtime2
+  real*8             :: timenow
+  real               :: gmt1,gmt2,rgmt1,rgmt2,ts1,ts2,ts3,rts
+
+  character(len=LIS_CONST_PATH_LEN) :: names(gddp_struc(n)%nmodels,7)
+  character(len=LIS_CONST_PATH_LEN) :: ref_dailyclimofile
+  character(len=LIS_CONST_PATH_LEN) :: ref_hourlyclimofile(7)
+    
+  integer :: movetime      ! 1=move time 2 data into time 1
+  integer :: nforce     ! GDDP forcing file time, # forcing variables
+  integer :: nstep
+
+  nstep = LIS_get_nstep(LIS_rc,n)
+!-------------------------------------------------------------------
+! Determine the correct number of forcing variables
+!-------------------------------------------------------------------
+  nforce = LIS_rc%met_nf(findex)
+  gddp_struc(n)%findtime1=0
+  gddp_struc(n)%findtime2=0
+  LIS_rc%shortflag = 2
+  LIS_rc%longflag=2             !Time averaged LW 
+  movetime=0
+!-------------------------------------------------------------------
+! Determine Required GDDP Data Times 
+! (The previous hour & the future hour)
+!-------------------------------------------------------------------
+  yr1=LIS_rc%yr    !Time now
+  mo1=LIS_rc%mo
+  da1=LIS_rc%da
+  hr1=LIS_rc%hr
+  mn1=LIS_rc%mn
+  ss1=0
+  ts1=0        
+  
+  call LIS_tick(timenow,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+
+  if(mod(nint(LIS_rc%ts),3600).eq.0) then
+
+     ryr1=LIS_rc%yr
+     rmo1=LIS_rc%mo
+     rda1=LIS_rc%da
+     rhr1=0 
+     rmn1=0
+     rss1=0
+     rts=-24*60*60
+     call LIS_tick(rtime1,rdoy1,rgmt1,ryr1,rmo1,rda1,rhr1,rmn1,rss1,rts)
+
+     ryr2=LIS_rc%yr
+     rmo2=LIS_rc%mo
+     rda2=LIS_rc%da
+     rhr2=0 
+     rmn2=0
+     rss2=0     
+     rts=0
+     call LIS_tick(rtime2,rdoy2,rgmt2,ryr2,rmo2,rda2,rhr2,rmn2,rss2,rts)
+     
+     if(timenow.ge.gddp_struc(n)%gddptime2) then
+        yr1=LIS_rc%yr
+        mo1=LIS_rc%mo
+        da1=LIS_rc%da
+        hr1=LIS_rc%hr
+        mn1=0
+        ss1=0
+        ts1=-60*60
+        call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+
+        yr2=LIS_rc%yr    !next hour
+        mo2=LIS_rc%mo
+        da2=LIS_rc%da
+        hr2=LIS_rc%hr
+        mn2=0
+        ss2=0
+        ts2=0
+        call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+        movetime = 1
+        gddp_struc(n)%findtime2 = 1
+     endif
+  else
+
+     if(timenow.ge.gddp_struc(n)%gddptime2) then
+        yr1 = LIS_rc%yr
+        mo1=LIS_rc%mo
+        da1=LIS_rc%da
+        hr1=LIS_rc%hr
+        mn1=0
+        ss1=0
+        ts1=0
+        call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+
+        yr2=LIS_rc%yr    !next hour
+        mo2=LIS_rc%mo
+        da2=LIS_rc%da
+        hr2=LIS_rc%hr
+        mn2=0
+        ss2=0
+        ts2=60*60
+        call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+
+        movetime = 1
+        gddp_struc(n)%findtime2 = 1
+     endif
+  endif
+  
+ if(LIS_rc%tscount(n).eq.1 .or.LIS_rc%rstflag(n).eq.1  ) then   
+     gddp_struc(n)%findtime1=1
+     gddp_struc(n)%findtime2=1
+     movetime=0
+     LIS_rc%rstflag(n) = 0
+  endif
+
+  if(movetime.eq.1) then
+     gddp_struc(n)%gddptime1=gddp_struc(n)%gddptime2
+     do f=1,LIS_rc%met_nf(findex)
+        do c=1,LIS_rc%ngrid(n)
+           gddp_struc(n)%metdata1(:,f,c)=gddp_struc(n)%metdata2(:,f,c)
+        enddo
+     enddo
+  endif    !end of movetime=1
+
+  if(gddp_struc(n)%findtime1.eq.1) then
+
+     ferror=0
+     try=0
+     ts1=-60*60*24
+     do
+        if ( ferror /= 0 ) exit
+        try=try+1
+        
+        call create_gddpfilenames(n,       &
+             gddp_struc(n)%odir,           &
+             gddp_struc(n)%ref_dclimodir,  &
+             gddp_struc(n)%ref_hclimodir,  &
+             names,                        &
+             ref_dailyclimofile,           &
+             ref_hourlyclimofile,          & 
+             ryr1,rmo1,rda1,hr1)
+        
+        order = 1
+        call read_gddp(n,findex,order,ryr1,rdoy1, &
+             names,                         &
+             ref_dailyclimofile,            &
+             ref_hourlyclimofile,           &
+             ferror)
+
+        if(ferror.ge.1) gddp_struc(n)%gddptime1=time1
+        call LIS_tick(dtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+        if(try.gt.11)then
+           write(LIS_logunit,*)'[ERR] GDDP data gap exceeds 10 days on file 1'
+           write(LIS_logunit,*)'[ERR] Program stopping...'
+           call LIS_endrun()
+        endif
+     enddo
+!=== end of data search
+  endif   !end of LIS_rc%findtime=1  
+
+
+  if(gddp_struc(n)%findtime2.eq.1) then
+     ferror=0
+     try=0
+     ts2=-60*60*24
+     do
+        if ( ferror /= 0 ) exit
+        try=try+1
+        
+        call create_gddpfilenames(n,       &
+             gddp_struc(n)%odir,           &
+             gddp_struc(n)%ref_dclimodir,  &
+             gddp_struc(n)%ref_hclimodir,  &
+             names,                        &
+             ref_dailyclimofile,           &
+             ref_hourlyclimofile,          & 
+             yr2,mo2,da2,hr2)
+       
+        order = 2
+        call read_gddp(n,findex,order,yr2,rdoy2,&
+             names,                         &
+             ref_dailyclimofile,            &
+             ref_hourlyclimofile,           &
+             ferror)
+        
+        if(ferror.ge.1) then
+           gddp_struc(n)%gddptime2=time2
+        endif
+        call LIS_tick(dtime2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+        if(try.gt.11)then
+           write(LIS_logunit,*)'[ERR] GDDP data gap exceeds 10 days on file 2'
+           write(LIS_logunit,*)'[ERR] Program stopping...'
+           call LIS_endrun()
+        endif
+     enddo
+     !=== end of data search
+  endif   ! end of findtime2=1
+  
+end subroutine get_gddp
+
+!BOP
+!
+! !ROUTINE: create_gddpfilename
+! \label{create_gddpfilename}
+!  
+!
+! !INTERFACE:
+subroutine create_gddpfilenames(n,&
+     gddpdir,                &
+     refdclimodir,           &
+     refhclimodir,           & 
+     fnames,                 &
+     ref_dailyclimofile,     &
+     ref_hourlyclimofile,    & 
+     yr, mo, da, hr)
+! !USES:
+  use gddp_forcingMod,    only : gddp_struc
+  use LIS_constantsMod
+!
+! !DESCRIPTION:
+! This routine creates the filenames for the GDDP data. 25 ensemble members
+! are employed in the current setup
+!
+!EOP
+  implicit none
+
+! !ARGUMENTS:
+  integer                         :: n
+
+  character(len=*), intent(out)   :: fnames(gddp_struc(n)%nmodels,7)
+  character(len=*), intent(in)    :: gddpdir
+  character(len=*), intent(in)    :: refdclimodir
+  character(len=*), intent(in)    :: refhclimodir
+  character(len=*)                :: ref_dailyclimofile
+  character(len=*)                :: ref_hourlyclimofile(7)
+  integer, intent(in)             :: yr,mo,da,hr
+
+  integer                         :: doy
+  integer                         :: t,k
+  
+  character*4                     :: fyr
+  character*2                     :: fmo
+  character*2                     :: fda
+  character*2                     :: fhr
+  character*3                     :: fdoy
+
+  character(len=LIS_CONST_PATH_LEN) :: gddpdir2
+  character(len=LIS_CONST_PATH_LEN) :: dname(gddp_struc(n)%nmodels)
+  character(len=LIS_CONST_PATH_LEN) :: mname(gddp_struc(n)%nmodels)
+  character(len=LIS_CONST_PATH_LEN) :: extn1(gddp_struc(n)%nmodels)
+  character(len=LIS_CONST_PATH_LEN) :: extn2(gddp_struc(n)%nmodels)
+
+  
+  dname(1) = 'ACCESS-CM2'
+  dname(2) = 'ACCESS-ESM1-5'
+  dname(3) = 'CESM2'
+  dname(4) = 'CESM2-WACCM'
+  dname(5) = 'CMCC-CM2-SR5'
+  dname(6) = 'CMCC-ESM2'
+  dname(7) = 'CNRM-CM6-1'
+  dname(8) = 'CNRM-ESM2-1'
+  dname(9) = 'EC-Earth3'
+  dname(10) = 'FGOALS-g3'
+  dname(11) = 'GFDL-CM4'
+  dname(12) = 'GFDL-CM4_gr2'
+  dname(13) = 'GFDL-ESM4'
+  dname(14) = 'GISS-E2-1-G'
+  dname(15) = 'IITM-ESM'
+  dname(16) = 'INM-CM4-8'
+  dname(17) = 'INM-CM5-0'
+  dname(18) = 'KACE-1-0-G'
+  dname(19) = 'MIROC-ES2L'
+  dname(20) = 'MPI-ESM1-2-HR'
+  dname(21) = 'MPI-ESM1-2-LR'
+  dname(22) = 'MRI-ESM2-0'
+  dname(23) = 'NorESM2-LM'
+  dname(24) = 'NorESM2-MM'
+  dname(25) = 'TaiESM1'
+
+  mname = dname
+  mname(12) = 'GFDL-CM4'
+ 
+  extn2(1) =  'gn'
+  extn2(2) =  'gn'
+  extn2(3) =  'gn'
+  extn2(4) =  'gn'
+  extn2(5) =  'gn'
+  extn2(6) =  'gn'
+  extn2(7) =  'gr'
+  extn2(8) =  'gr'
+  extn2(9) =  'gr'
+  extn2(10) = 'gn'
+  extn2(11) = 'gr1'
+  extn2(12) = 'gr2'
+  extn2(13) = 'gr1'
+  extn2(14) = 'gn'
+  extn2(15) = 'gn'
+  extn2(16) = 'gr1'
+  extn2(17) = 'gr1'
+  extn2(18) = 'gr'
+  extn2(19) = 'gn'
+  extn2(20) = 'gn'
+  extn2(21) = 'gn'
+  extn2(22) = 'gn'
+  extn2(23) = 'gn'
+  extn2(24) = 'gn'
+  extn2(25) = 'gn'
+
+  extn1(1) = 'r1i1p1f1'
+  extn1(2) = 'r1i1p1f1'
+  extn1(3) = 'r4i1p1f1'
+  extn1(4) = 'r3i1p1f1'
+  extn1(5) = 'r1i1p1f1'
+  extn1(6) = 'r1i1p1f1'
+  extn1(7) = 'r1i1p1f2'
+  extn1(8) = 'r1i1p1f2'
+  extn1(9) = 'r1i1p1f1'
+  extn1(10) = 'r3i1p1f1'
+  extn1(11) = 'r1i1p1f1'
+  extn1(12) = 'r1i1p1f1'
+  extn1(13) = 'r1i1p1f1'  
+  extn1(14) = 'r1i1p1f2'
+  extn1(15) = 'r1i1p1f1'
+  extn1(16) = 'r1i1p1f1'
+  extn1(17) = 'r1i1p1f1'
+  extn1(18) = 'r1i1p1f1'
+  extn1(19) = 'r1i1p1f2'
+  extn1(20) = 'r1i1p1f1'  
+  extn1(21) = 'r1i1p1f1'
+  extn1(22) = 'r1i1p1f1'
+  extn1(23) = 'r1i1p1f1'
+  extn1(24) = 'r1i1p1f1'
+  extn1(25) = 'r1i1p1f1'
+
+
+  write(unit=fyr, fmt='(i4.4)') yr
+  write(unit=fmo, fmt='(i2.2)') mo
+  write(unit=fda, fmt='(i2.2)') da
+  !because the files use a 1 to 24 convention
+  write(unit=fhr, fmt='(i2.2)') hr+1
+
+  !
+  ! compute DOY consistent with the climatology calculation where
+  ! the number of days in a year are from 1 to 366.
+  !
+
+  call compute_doy(yr,mo,da,doy)
+  write(unit=fdoy, fmt='(i3.3)') doy
+
+
+  ref_dailyclimofile =trim(refdclimodir)//&
+       '/MERRA2_DAILY_CLIMO'//trim(fdoy)//'.nc' 
+
+  ref_hourlyclimofile(1) = trim(refhclimodir)//&
+       '/TAIR/'//'MERRA2_HOURLY_CLIMO_TAIR_'//trim(fdoy)//&
+       '_'//trim(fhr)//'.nc'
+  ref_hourlyclimofile(2) = trim(refhclimodir)//&
+       '/QAIR/'//'MERRA2_HOURLY_CLIMO_QAIR_'//trim(fdoy)//&
+       '_'//trim(fhr)//'.nc'
+  ref_hourlyclimofile(3) = trim(refhclimodir)//&
+       '/SWDOWN/'//'MERRA2_HOURLY_CLIMO_SWDOWN_'//trim(fdoy)//&
+       '_'//trim(fhr)//'.nc'
+  ref_hourlyclimofile(4) = trim(refhclimodir)//&
+       '/LWDOWN/'//'MERRA2_HOURLY_CLIMO_LWDOWN_'//trim(fdoy)//&
+       '_'//trim(fhr)//'.nc'
+  ref_hourlyclimofile(5) = trim(refhclimodir)//&
+       '/WIND/'//'MERRA2_HOURLY_CLIMO_WIND_'//trim(fdoy)//&
+       '_'//trim(fhr)//'.nc'
+  ref_hourlyclimofile(6) = trim(refhclimodir)//&
+       '/PSURF/'//'MERRA2_HOURLY_CLIMO_PSURF_'//trim(fdoy)//&
+       '_'//trim(fhr)//'.nc'
+  ref_hourlyclimofile(7) = trim(refhclimodir)//&
+       '/PRCP/'//'MERRA2_HOURLY_CLIMO_PRCP_'//trim(fdoy)//&
+       '_'//trim(fhr)//'.nc' 
+  
+  do t=1,gddp_struc(n)%nmodels
+     
+     gddpdir2 = trim(gddpdir)//'/'//trim(dname(t))//'/'//&
+          trim(gddp_struc(n)%scenario)//'/'//&
+          trim(extn1(t))//'/'
+     
+     do k=1,7        
+        fnames(t,1) = trim(gddpdir2)//'/tas/tas_day_'//trim(mname(t))//&
+             '_'//trim(gddp_struc(n)%scenario)//'_'//&
+             trim(extn1(t))//'_'//trim(extn2(t))//'_'//&
+             trim(fyr)//'.nc'
+        fnames(t,2) = trim(gddpdir2)//'/huss/huss_day_'//trim(mname(t))//&
+             '_'//trim(gddp_struc(n)%scenario)//'_'//&
+             trim(extn1(t))//'_'//trim(extn2(t))//'_'//&
+             trim(fyr)//'.nc'
+        fnames(t,3) = trim(gddpdir2)//'/rsds/rsds_day_'//trim(mname(t))//&
+             '_'//trim(gddp_struc(n)%scenario)//'_'//&
+             trim(extn1(t))//'_'//trim(extn2(t))//'_'//&
+             trim(fyr)//'.nc'
+        fnames(t,4) = trim(gddpdir2)//'/rlds/rlds_day_'//trim(mname(t))//&
+             '_'//trim(gddp_struc(n)%scenario)//'_'//&
+             trim(extn1(t))//'_'//trim(extn2(t))//'_'//&
+             trim(fyr)//'.nc'
+        fnames(t,5) = trim(gddpdir2)//'/sfcWind/sfcWind_day_'//trim(mname(t))//&
+             '_'//trim(gddp_struc(n)%scenario)//'_'//&
+             trim(extn1(t))//'_'//trim(extn2(t))//'_'//&
+          trim(fyr)//'.nc'
+        fnames(t,6) = trim(gddpdir2)//'/pr/pr_day_'//trim(mname(t))//&
+             '_'//trim(gddp_struc(n)%scenario)//'_'//&
+             trim(extn1(t))//'_'//trim(extn2(t))//'_'//&
+             trim(fyr)//'.nc'
+        fnames(t,7) = trim(gddpdir2)//'/hurs/hurs_day_'//trim(mname(t))//&
+             '_'//trim(gddp_struc(n)%scenario)//'_'//&
+             trim(extn1(t))//'_'//trim(extn2(t))//'_'//&
+             trim(fyr)//'.nc'
+
+     enddo
+  enddo
+  
+end subroutine create_gddpfilenames
+
+subroutine compute_doy(yr,mo,da,doy)
+
+  implicit none
+! !ARGUMENTS:
+  integer :: yr,mo,da,doy
+
+! !DESCRIPTION:
+!
+!  determines the time, time in GMT, and the day of the year
+!  based on the value of year, month, day of month, hour of
+!  the day, minute and second. This method is the inverse of
+!  time2date
+!
+!  The arguments are:
+!  \begin{description}
+!  \item[yr]
+!    year
+!  \item[mo]
+!   month
+!  \item[da]
+!   day of the month
+!  \item[hr]
+!   hour of day
+!  \item[mn]
+!   minute
+!  \item[ss]
+!   second
+!  \item[time]
+!   lvt time
+!  \item[gmt]
+!   time in GMT
+!  \item[doy]
+!   day of the year
+!  \end{description}
+!EOP
+  integer :: yrdays,days(13),k
+  data days /31,28,31,30,31,30,31,31,30,31,30,31,30/
+
+  if((mod(yr,4).eq.0.and.mod(yr,100).ne.0) &     !correct for leap year
+       .or.(mod(yr,400).eq.0))then             !correct for y2k
+     yrdays=366
+     days(2) = 29
+  else
+     yrdays=365
+     days(2) = 29
+  endif
+  yrdays = 366
+
+  doy=0
+  do k=1,(mo-1)
+     doy=doy+days(k)
+  enddo
+  doy=doy+da
+  
+end subroutine compute_doy

--- a/lis/metforcing/gddp/read_gddp.F90
+++ b/lis/metforcing/gddp/read_gddp.F90
@@ -1,0 +1,920 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
+!BOP
+! !ROUTINE: read_gddp
+!  \label{read_gddp}
+!
+! !REVISION HISTORY:
+!  03 Feb 2022: Sujay Kumar, Initial specification
+! 
+! !INTERFACE:
+
+subroutine read_gddp(n, findex, order, year, doy, &
+     names,ref_dailyclimofile, &
+     ref_hourlyclimofile, ferror)
+  
+! !USES:
+  use LIS_coreMod
+  use LIS_logMod
+  use LIS_metforcingMod
+  use gddp_forcingMod
+  
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+  use netcdf
+#endif
+
+  implicit none
+! !ARGUMENTS: 
+  integer, intent(in)          :: n
+  integer, intent(in)          :: findex  ! Forcing index
+  integer, intent(in)          :: order
+  integer, intent(in)          :: year 
+  integer, intent(in)          :: doy
+  character(len=*), intent(in) :: names(gddp_struc(n)%nmodels,7)
+  character(len=*), intent(in) :: ref_dailyclimofile
+  character(len=*), intent(in) :: ref_hourlyclimofile(7)
+  integer, intent(out)         :: ferror
+!
+! !DESCRIPTION:
+!  For the given time, reads parameters from
+!  GDDP data, transforms into LIS forcing 
+!  parameters and interpolates to the LIS domain.
+!
+!  A (MERRA2-based) climatology temporal disaggregation of the daily
+!  data to hourly is performed.
+!  The code expects the availability of the climatology of the reference
+!  data generated at hourly and daily timescales.
+!
+!    The temporal disaggreation is performed as:
+!
+!      GDDP_new = GDDP_orig * REF_H/REF_D
+!
+!   where GDDP_new is the temporally disaggreated data
+!         GDDP_orig is the original GDDP data
+!         REF_H is the hourly climatology data
+!         REF_D is the daily climatology data
+!  
+!EOP
+
+  integer                   :: iv, ftn
+  integer                   :: ngddp
+  integer                   :: k,t,m,c,r,iret,rc
+  integer                   :: var_index
+  real                      :: missingValue 
+  integer                   :: nvars
+  integer                   :: tasid,hussid,rsdsid,rldsid
+  integer                   :: sfcWindid,prid,hursid,psid
+  integer                   :: tdimId, tdims
+  integer                   :: igrib
+  logical                   :: pcp_flag, var_found
+  logical                   :: var_status(11)
+  logical                   :: file_exists
+  logical*1, allocatable    :: lb(:)
+  real, allocatable         :: f(:)
+  logical                   :: found
+  integer                   :: inpnc,inpnr,rad
+  integer                   :: c1,c2,r1,r2,i,j
+  integer                   :: doy_upd
+  real                      :: tas_c, es, e
+  logical                   :: read_flag
+  logical                   :: leap_year
+  real                      :: tas_inp(gddp_struc(n)%nc,gddp_struc(n)%nr)
+  real                      :: huss_inp(gddp_struc(n)%nc,gddp_struc(n)%nr)
+  real                      :: hurs_inp(gddp_struc(n)%nc,gddp_struc(n)%nr)
+  real                      :: rsds_inp(gddp_struc(n)%nc,gddp_struc(n)%nr)
+  real                      :: rlds_inp(gddp_struc(n)%nc,gddp_struc(n)%nr)
+  real                      :: sfcWind_inp(gddp_struc(n)%nc,gddp_struc(n)%nr)
+  real                      :: pr_inp(gddp_struc(n)%nc,gddp_struc(n)%nr)
+  real                      :: psurf_inp(gddp_struc(n)%nc,gddp_struc(n)%nr)
+
+  real                      :: tair_climo1(LIS_rc%lnc(n),LIS_rc%lnr(n))
+  real                      :: qair_climo1(LIS_rc%lnc(n),LIS_rc%lnr(n))
+  real                      :: swdown_climo1(LIS_rc%lnc(n),LIS_rc%lnr(n))
+  real                      :: lwdown_climo1(LIS_rc%lnc(n),LIS_rc%lnr(n))
+  real                      :: wind_climo1(LIS_rc%lnc(n),LIS_rc%lnr(n))
+  real                      :: psurf_climo1(LIS_rc%lnc(n),LIS_rc%lnr(n))
+  real                      :: prcp_climo1(LIS_rc%lnc(n),LIS_rc%lnr(n))
+  
+  real                      :: varfield(LIS_rc%lnc(n),LIS_rc%lnr(n))
+
+  ferror = 1
+  iv = 0
+
+  inpnc = gddp_struc(n)%nc
+  inpnr = gddp_struc(n)%nr
+  
+  ngddp = (gddp_struc(n)%nc*gddp_struc(n)%nr)
+  
+!  allocate(gddp_forcing(gddp_struc(n)%nc*gddp_struc(n)%nr,11))
+
+  if((mod(year,4) .eq. 0 .and. mod(year, 100).ne.0) &!leap year
+         .or.(mod(year,400) .eq.0)) then 
+     leap_year = .true. 
+  else 
+     leap_year = .false. 
+  endif
+  
+  varfield = 0 
+  ferror = 1
+  var_status = .false.
+
+  read_flag = .false. 
+  if(order.eq.1) then
+     if(gddp_struc(n)%day_check1.ne.doy) then 
+        read_flag = .true.
+        gddp_struc(n)%day_check1 = doy
+     endif
+  else
+     if(gddp_struc(n)%day_check2.ne.doy) then 
+        read_flag = .true.
+        gddp_struc(n)%day_check2 = doy
+     endif
+  endif
+
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)  
+
+  inquire (file=ref_hourlyclimofile(1), exist=file_exists)
+
+  if (file_exists) then
+
+     call LIS_verify(nf90_open(path=ref_hourlyclimofile(1),&
+          mode=nf90_nowrite,ncid=ftn),&
+          'Error in opening file '//trim(ref_hourlyclimofile(1)))
+     call LIS_verify(nf90_inq_varid(ftn,'TAIR',tasid),&
+          'Error in nf90_inq_varid: TAIR')
+     call LIS_verify(nf90_get_var(ftn,tasid,tair_climo1,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&
+          'Error in nf90_get_var:TAIR')
+     call LIS_verify(nf90_close(ftn))
+
+     call LIS_verify(nf90_open(path=ref_hourlyclimofile(2),&
+          mode=nf90_nowrite,ncid=ftn),&
+          'Error in opening file '//trim(ref_hourlyclimofile(2)))     
+     call LIS_verify(nf90_inq_varid(ftn,'QAIR',hussid),&
+          'Error in nf90_inq_varid: QAIR')
+     call LIS_verify(nf90_get_var(ftn,hussid,qair_climo1,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&
+          'Error in nf90_get_var:QAIR')
+     call LIS_verify(nf90_close(ftn))
+
+     call LIS_verify(nf90_open(path=ref_hourlyclimofile(3),&
+          mode=nf90_nowrite,ncid=ftn),&
+          'Error in opening file '//trim(ref_hourlyclimofile(3)))
+     call LIS_verify(nf90_inq_varid(ftn,'SWDOWN',rsdsid),&
+          'Error in nf90_inq_varid: SWDOWN')
+     call LIS_verify(nf90_get_var(ftn,rsdsid,swdown_climo1,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&
+          'Error in nf90_get_var:SWDOWN')
+     call LIS_verify(nf90_close(ftn))
+
+     call LIS_verify(nf90_open(path=ref_hourlyclimofile(4),&
+          mode=nf90_nowrite,ncid=ftn),&
+          'Error in opening file '//trim(ref_hourlyclimofile(4)))
+     call LIS_verify(nf90_inq_varid(ftn,'LWDOWN',rldsid),&
+          'Error in nf90_inq_varid: LWDOWN')
+     call LIS_verify(nf90_get_var(ftn,rldsid,lwdown_climo1,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&          
+          'Error in nf90_get_var:LWDOWN')
+     call LIS_verify(nf90_close(ftn))
+
+     call LIS_verify(nf90_open(path=ref_hourlyclimofile(5),&
+          mode=nf90_nowrite,ncid=ftn),&
+          'Error in opening file '//trim(ref_hourlyclimofile(5)))     
+     call LIS_verify(nf90_inq_varid(ftn,'WIND',sfcwindid),&
+          'Error in nf90_inq_varid: WIND')
+     call LIS_verify(nf90_get_var(ftn,sfcwindid,wind_climo1,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&
+          'Error in nf90_get_var:WIND')
+     call LIS_verify(nf90_close(ftn))
+
+     call LIS_verify(nf90_open(path=ref_hourlyclimofile(6),&
+          mode=nf90_nowrite,ncid=ftn),&
+          'Error in opening file '//trim(ref_hourlyclimofile(6)))     
+     call LIS_verify(nf90_inq_varid(ftn,'PSURF',psid),&
+          'Error in nf90_inq_varid: PSURF')
+     call LIS_verify(nf90_get_var(ftn,psid,psurf_climo1,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&          
+          'Error in nf90_get_var:PSURF')
+     call LIS_verify(nf90_close(ftn))
+
+     call LIS_verify(nf90_open(path=ref_hourlyclimofile(7),&
+          mode=nf90_nowrite,ncid=ftn),&
+          'Error in opening file '//trim(ref_hourlyclimofile(7)))          
+     call LIS_verify(nf90_inq_varid(ftn,'PRCP',prid),&
+          'Error in nf90_inq_varid: PRCP')
+     call LIS_verify(nf90_get_var(ftn,prid,prcp_climo1,&
+          start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+          LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+          count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&
+          'Error in nf90_get_var:PRCP')     
+     call LIS_verify(nf90_close(ftn))
+     
+     
+  else
+     write(LIS_logunit,*) '[ERR] climatology file '//trim(ref_hourlyclimofile(1))
+     write(LIS_logunit,*) '[ERR] does not exist '
+     call LIS_endrun()
+  endif
+
+  if(read_flag) then 
+     inquire (file=ref_dailyclimofile, exist=file_exists)
+     if (file_exists) then
+        
+        call LIS_verify(nf90_open(path=ref_dailyclimofile,mode=nf90_nowrite,ncid=ftn),&
+             'Error in opening file '//trim(ref_dailyclimofile))
+        call LIS_verify(nf90_inq_varid(ftn,'TAIR',tasid),&
+             'Error in nf90_inq_varid: TAIR')
+        call LIS_verify(nf90_get_var(ftn,tasid,gddp_struc(n)%tair_climo,&
+             start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+             LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+             count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&
+             'Error in nf90_get_var:TAIR')
+        
+        call LIS_verify(nf90_inq_varid(ftn,'QAIR',hussid),&
+             'Error in nf90_inq_varid: QAIR')
+        call LIS_verify(nf90_get_var(ftn,hussid,gddp_struc(n)%qair_climo,&
+             start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+             LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+             count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&
+             'Error in nf90_get_var:QAIR')
+        
+        call LIS_verify(nf90_inq_varid(ftn,'SWDOWN',rsdsid),&
+             'Error in nf90_inq_varid: SWDOWN')
+        call LIS_verify(nf90_get_var(ftn,rsdsid,gddp_struc(n)%swdown_climo,&
+             start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+             LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+             count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&
+             'Error in nf90_get_var:SWDOWN')
+        
+        call LIS_verify(nf90_inq_varid(ftn,'LWDOWN',rldsid),&
+             'Error in nf90_inq_varid: LWDOWN')
+        call LIS_verify(nf90_get_var(ftn,rldsid,gddp_struc(n)%lwdown_climo,&
+             start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+             LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+             count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&          
+             'Error in nf90_get_var:LWDOWN')
+        
+        call LIS_verify(nf90_inq_varid(ftn,'WIND',sfcwindid),&
+             'Error in nf90_inq_varid: WIND')
+        call LIS_verify(nf90_get_var(ftn,sfcwindid,gddp_struc(n)%wind_climo,&
+             start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+             LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+             count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&
+             'Error in nf90_get_var:WIND')
+        
+        call LIS_verify(nf90_inq_varid(ftn,'PSURF',psid),&
+             'Error in nf90_inq_varid: PSURF')
+        call LIS_verify(nf90_get_var(ftn,psid,gddp_struc(n)%psurf_climo,&
+             start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+             LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+             count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&          
+             'Error in nf90_get_var:PSURF')
+        
+        call LIS_verify(nf90_inq_varid(ftn,'PRCP',prid),&
+             'Error in nf90_inq_varid: PRCP')
+        call LIS_verify(nf90_get_var(ftn,prid,gddp_struc(n)%prcp_climo,&
+             start=(/LIS_ews_halo_ind(n,LIS_localPet+1),&
+             LIS_nss_halo_ind(n,LIS_localPet+1)/),&
+             count=(/LIS_rc%lnc(n),LIS_rc%lnr(n)/)),&
+             'Error in nf90_get_var:PRCP')
+        
+        call LIS_verify(nf90_close(ftn))
+        
+        
+     else
+        write(LIS_logunit,*) '[ERR] climatology file '//trim(ref_dailyclimofile)
+        write(LIS_logunit,*) '[ERR] does not exist '
+        call LIS_endrun()
+     endif
+     
+     do m=1,gddp_struc(n)%nmodels
+        inquire (file=names(m,1), exist=file_exists)
+        if (file_exists) then
+           write(LIS_logunit,*)'[INFO] reading.. ',trim(names(m,1))
+           call LIS_verify(nf90_open(path=names(m,1),mode=nf90_nowrite,ncid=ftn),&
+                'Error in opening file '//trim(names(m,1)))
+           call LIS_verify(nf90_inq_dimid(ftn,'time',tdimID),&
+                'Error in opening nf90_inq_dimid')
+           call LIS_verify(nf90_inquire_dimension(ftn,tdimId,len=tdims),&
+                'Error in nf90_inquire_dimension')
+           
+           call LIS_verify(nf90_inq_varid(ftn,'tas',tasid),&
+                'Error in nf90_inq_varid: tas')
+           doy_upd = doy
+           if(leap_year.and.tdims.ne.366.and.tdims.eq.365) then
+              if(doy.gt.60) then !feb 29th onwards
+                 doy_upd = doy-1   
+              endif
+           endif
+           if(tdims.eq.360) then
+              if(leap_year) then !distribute 6 days
+                 if(doy.ge.366) then
+                    doy_upd = doy-6
+                 elseif(doy.ge.305) then
+                    doy_upd = doy-5
+                 elseif(doy.ge.244) then
+                    doy_upd = doy-4
+                 elseif(doy.ge.183) then
+                    doy_upd = doy-3
+                 elseif(doy.ge.122) then
+                    doy_upd = doy-2
+                 elseif(doy.ge.61) then
+                    doy_upd = doy-1
+                 endif
+              else !distribute 5 days
+                 if(doy.ge.365) then
+                    doy_upd = doy-5
+                 elseif(doy.ge.292) then
+                    doy_upd = doy-4
+                 elseif(doy.ge.219) then
+                    doy_upd = doy-3
+                 elseif(doy.ge.146) then
+                    doy_upd = doy-2
+                 elseif(doy.ge.73) then
+                    doy_upd = doy-1
+                 endif                 
+                 
+              endif
+           elseif(tdims.eq.364) then
+              if(leap_year) then !distribute 2 days
+                 if(doy.ge.366) then
+                    doy_upd = doy-2
+                 elseif(doy.ge.183) then
+                    doy_upd = doy-1
+                 endif
+              else !distribute 1 days
+                 if(doy.ge.365) then
+                    doy_upd = doy-1
+                 endif                                  
+              endif              
+           endif
+           
+           call LIS_verify(nf90_get_var(ftn,tasid,tas_inp,&
+                start=(/1,1,doy_upd/),count=(/inpnc,inpnr,1/)),&
+                'Error in nf90_get_var:tas')
+           call LIS_verify(nf90_close(ftn))
+           
+           
+           call LIS_verify(nf90_open(path=names(m,2),mode=nf90_nowrite,ncid=ftn),&
+                'Error in opening file '//trim(names(m,2)))
+           call LIS_verify(nf90_inq_varid(ftn,'huss',hussid),&
+                'Error in nf90_inq_varid: huss')
+           call LIS_verify(nf90_get_var(ftn,hussid,huss_inp,&
+                start=(/1,1,doy_upd/),count=(/inpnc,inpnr,1/)),&
+                'Error in nf90_get_var:huss')
+           call LIS_verify(nf90_close(ftn))
+           
+           call LIS_verify(nf90_open(path=names(m,3),mode=nf90_nowrite,ncid=ftn),&
+                'Error in opening file '//trim(names(m,3)))
+           call LIS_verify(nf90_inq_varid(ftn,'rsds',rsdsid),&
+                'Error in nf90_inq_varid: rsds')
+           call LIS_verify(nf90_get_var(ftn,rsdsid,rsds_inp,&
+                start=(/1,1,doy_upd/),count=(/inpnc,inpnr,1/)),&
+                'Error in nf90_get_var:rsds')
+           call LIS_verify(nf90_close(ftn))
+           
+           
+           call LIS_verify(nf90_open(path=names(m,4),mode=nf90_nowrite,ncid=ftn),&
+                'Error in opening file '//trim(names(m,4)))
+           call LIS_verify(nf90_inq_varid(ftn,'rlds',rldsid),&
+                'Error in nf90_inq_varid: rlds')
+           call LIS_verify(nf90_get_var(ftn,rldsid,rlds_inp,&
+                start=(/1,1,doy_upd/),count=(/inpnc,inpnr,1/)),&
+                'Error in nf90_get_var:rlds')
+           call LIS_verify(nf90_close(ftn))
+           
+           
+           call LIS_verify(nf90_open(path=names(m,5),mode=nf90_nowrite,ncid=ftn),&
+                'Error in opening file '//trim(names(m,5)))
+           call LIS_verify(nf90_inq_varid(ftn,'sfcWind',sfcWindid),&
+                'Error in nf90_inq_varid: sfcWind')
+           call LIS_verify(nf90_get_var(ftn,sfcWindid,sfcWind_inp,&
+                start=(/1,1,doy_upd/),count=(/inpnc,inpnr,1/)),&
+                'Error in nf90_get_var:sfcWind')
+           call LIS_verify(nf90_close(ftn))
+           
+           
+           call LIS_verify(nf90_open(path=names(m,6),mode=nf90_nowrite,ncid=ftn),&
+                'Error in opening file '//trim(names(m,6)))
+           call LIS_verify(nf90_inq_varid(ftn,'pr',prid),&
+                'Error in nf90_inq_varid: pr')
+           call LIS_verify(nf90_get_var(ftn,prid,pr_inp,&
+                start=(/1,1,doy_upd/),count=(/inpnc,inpnr,1/)),&
+                'Error in nf90_get_var:pr')             
+           call LIS_verify(nf90_close(ftn))
+           
+           call LIS_verify(nf90_open(path=names(m,7),mode=nf90_nowrite,ncid=ftn),&
+                'Error in opening file '//trim(names(m,7)))
+           call LIS_verify(nf90_inq_varid(ftn,'hurs',hursid),&
+                'Error in nf90_inq_varid: hurs')
+           call LIS_verify(nf90_get_var(ftn,hursid,hurs_inp,&
+                start=(/1,1,doy_upd/),count=(/inpnc,inpnr,1/)),&
+                'Error in nf90_get_var:hurs')             
+           call LIS_verify(nf90_close(ftn))
+           
+           do r=1,inpnr
+              do c=1,inpnc
+                 if(huss_inp(c,r).le.0) then
+                    rad = 1
+                    found = .false.
+                    do while(.not.found)
+                       c1 = max(1,c-rad)
+                       c2 = min(inpnc,c+rad)
+                       r1 = max(1,r-rad)
+                       r2 = min(inpnr,r+rad)
+                       
+                       do j=r1,r2
+                          do i=c1,c2
+                             if(huss_inp(i,j).ne.0) then
+                                huss_inp(c,r) = huss_inp(i,j)
+                                found = .true.
+                                exit
+                             endif
+                          enddo
+                          if(found) exit
+                       enddo
+                       if(.not.found) rad = rad+1
+                    enddo
+                 elseif(huss_inp(c,r).lt.0) then
+                    write(LIS_logunit,*)'[ERR] negative huss ',huss_inp(c,r)
+                    write(LIS_logunit,*)'[ERR] Program stopping...'
+                    call LIS_endrun()
+                 endif
+              enddo
+           enddo
+           
+           do r=1,inpnr
+              do c=1,inpnc
+                 if(tas_inp(c,r).ne.1e+20) then
+                    tas_c = tas_inp(c,r)-273.15
+                    !August-Roche-Magnus formula
+                    es = 6.112*exp((17.67*tas_c)/(tas_c+243.04))
+                    e = hurs_inp(c,r)*es/100.0
+                    psurf_inp(c,r) = 100*(0.622+0.378*huss_inp(c,r))*e/&
+                         (huss_inp(c,r)) !in Pascals                       
+                 else
+                    psurf_inp(c,r) = 1e+20
+                 endif
+              enddo
+           enddo
+
+           do r=1,inpnr
+              do c=1,inpnc
+                 if(psurf_inp(c,r).le.60000) then !approaching infeasible range
+                    rad = 1
+                    found = .false.
+                    do while(.not.found)
+                       c1 = max(1,c-rad)
+                       c2 = min(inpnc,c+rad)
+                       r1 = max(1,r-rad)
+                       r2 = min(inpnr,r+rad)
+                       
+                       do j=r1,r2
+                          do i=c1,c2
+                             if(psurf_inp(i,j).gt.60000.and.&
+                                  psurf_inp(i,j).ne.1e+20) then
+                                psurf_inp(c,r) = psurf_inp(i,j)
+                                tas_inp(c,r) = tas_inp(i,j)
+                                huss_inp(c,r) = huss_inp(i,j)
+                                hurs_inp(c,r) = hurs_inp(i,j)
+                                found = .true.
+                                exit
+                             endif
+                          enddo
+                          if(found) exit
+                       enddo
+                       if(.not.found) rad = rad+1
+                    enddo
+                 endif
+              enddo
+           enddo           
+        
+           allocate(lb(gddp_struc(n)%nc*gddp_struc(n)%nr))
+           
+           !tair
+           pcp_flag = .false.
+           
+           call interp_gddp(n, 1,findex,  pcp_flag, inpnc,inpnr,&
+                tas_inp, & 
+                lb, LIS_rc%gridDesc(n,:), &
+                LIS_rc%lnc(n),LIS_rc%lnr(n),varfield )
+           
+           do r=1,LIS_rc%lnr(n)
+              do c=1,LIS_rc%lnc(n)
+                 if(LIS_domain(n)%gindex(c,r).ne.-1) then 
+                    if(order.eq.1) then 
+                       gddp_struc(n)%metdata1(m,1,&
+                            LIS_domain(n)%gindex(c,r)) &
+                            = varfield(c,r)*tair_climo1(c,r)/&
+                            gddp_struc(n)%tair_climo(c,r)
+                    elseif(order.eq.2) then 
+                       gddp_struc(n)%metdata2(m,1,&
+                            LIS_domain(n)%gindex(c,r))&
+                            = varfield(c,r)*tair_climo1(c,r)/&
+                            gddp_struc(n)%tair_climo(c,r)
+                    endif
+                 endif
+              end do
+           enddo
+           
+           !qair        
+           pcp_flag = .false. 
+           call interp_gddp(n, 2, findex,  pcp_flag, inpnc,inpnr,&
+                huss_inp, & 
+                lb, LIS_rc%gridDesc(n,:), &
+                LIS_rc%lnc(n),LIS_rc%lnr(n),varfield )
+           
+           do r=1,LIS_rc%lnr(n)
+              do c=1,LIS_rc%lnc(n)
+                 if(LIS_domain(n)%gindex(c,r).ne.-1) then 
+                    if(order.eq.1) then 
+                       gddp_struc(n)%metdata1(m,2,&
+                            LIS_domain(n)%gindex(c,r)) &
+                            = varfield(c,r)*qair_climo1(c,r)/&
+                            gddp_struc(n)%qair_climo(c,r)
+                    elseif(order.eq.2) then 
+                       gddp_struc(n)%metdata2(m,2,&
+                            LIS_domain(n)%gindex(c,r))&
+                            = varfield(c,r)*qair_climo1(c,r)/&
+                            gddp_struc(n)%qair_climo(c,r)
+                    endif
+                 endif
+              end do
+           enddo
+           
+           !swdown        
+           pcp_flag = .false. 
+           call interp_gddp(n, 3, findex,  pcp_flag, inpnc,inpnr,&
+                rsds_inp, & 
+                lb, LIS_rc%gridDesc(n,:), &
+                LIS_rc%lnc(n),LIS_rc%lnr(n),varfield )
+           
+           do r=1,LIS_rc%lnr(n)
+              do c=1,LIS_rc%lnc(n)
+                 if(LIS_domain(n)%gindex(c,r).ne.-1) then
+                    if(varfield(c,r).lt.0) varfield(c,r) = 0.0
+                    if(order.eq.1) then
+                       if(gddp_struc(n)%swdown_climo(c,r).ne.0) then 
+                          gddp_struc(n)%metdata1(m,3,&
+                               LIS_domain(n)%gindex(c,r)) &
+                               = varfield(c,r)*swdown_climo1(c,r)/&
+                               gddp_struc(n)%swdown_climo(c,r)
+                       else
+                          gddp_struc(n)%metdata1(m,3,&
+                               LIS_domain(n)%gindex(c,r)) &
+                               = varfield(c,r)
+                       endif
+                       
+                    elseif(order.eq.2) then
+                       if(gddp_struc(n)%swdown_climo(c,r).ne.0) then 
+                          gddp_struc(n)%metdata2(m,3,&
+                               LIS_domain(n)%gindex(c,r))&
+                               = varfield(c,r)*swdown_climo1(c,r)/&
+                               gddp_struc(n)%swdown_climo(c,r)
+                       else
+                          gddp_struc(n)%metdata2(m,3,&
+                               LIS_domain(n)%gindex(c,r))&
+                               = varfield(c,r)
+                       endif
+                    endif
+                 endif
+              end do
+           enddo
+           !lwdown        
+           pcp_flag = .false. 
+           call interp_gddp(n, 4, findex,  pcp_flag, inpnc,inpnr,&
+                rlds_inp, & 
+                lb, LIS_rc%gridDesc(n,:), &
+                LIS_rc%lnc(n),LIS_rc%lnr(n),varfield )
+           
+           do r=1,LIS_rc%lnr(n)
+              do c=1,LIS_rc%lnc(n)
+                 if(LIS_domain(n)%gindex(c,r).ne.-1) then 
+                    if(order.eq.1) then 
+                       gddp_struc(n)%metdata1(m,4,&
+                            LIS_domain(n)%gindex(c,r)) &
+                            = varfield(c,r)*lwdown_climo1(c,r)/&
+                            gddp_struc(n)%lwdown_climo(c,r)
+                    elseif(order.eq.2) then 
+                       gddp_struc(n)%metdata2(m,4,&
+                            LIS_domain(n)%gindex(c,r))&
+                            = varfield(c,r)*lwdown_climo1(c,r)/&
+                            gddp_struc(n)%lwdown_climo(c,r)
+                    endif
+                 endif
+              end do
+           enddo
+           !wind
+           pcp_flag = .false. 
+           call interp_gddp(n, 5, findex,  pcp_flag, inpnc,inpnr,&
+                sfcwind_inp, & 
+                lb, LIS_rc%gridDesc(n,:), &
+                LIS_rc%lnc(n),LIS_rc%lnr(n),varfield )
+           
+           do r=1,LIS_rc%lnr(n)
+              do c=1,LIS_rc%lnc(n)
+                 if(LIS_domain(n)%gindex(c,r).ne.-1) then 
+                    if(order.eq.1) then 
+                       gddp_struc(n)%metdata1(m,5,&
+                            LIS_domain(n)%gindex(c,r)) &
+                            = varfield(c,r)*wind_climo1(c,r)/&
+                            gddp_struc(n)%wind_climo(c,r)
+                    elseif(order.eq.2) then 
+                       gddp_struc(n)%metdata2(m,5,&
+                            LIS_domain(n)%gindex(c,r))&
+                            = varfield(c,r)*wind_climo1(c,r)/&
+                            gddp_struc(n)%wind_climo(c,r)
+                    endif
+                 endif
+              end do
+           enddo
+           !psurf        
+           pcp_flag = .false. 
+           call interp_gddp(n, 6, findex,  pcp_flag, inpnc,inpnr,&
+                psurf_inp, & 
+                lb, LIS_rc%gridDesc(n,:), &
+                LIS_rc%lnc(n),LIS_rc%lnr(n),varfield )
+           
+           do r=1,LIS_rc%lnr(n)
+              do c=1,LIS_rc%lnc(n)
+                 if(LIS_domain(n)%gindex(c,r).ne.-1) then 
+                    if(order.eq.1) then 
+                       gddp_struc(n)%metdata1(m,6,&
+                            LIS_domain(n)%gindex(c,r)) &
+                            = varfield(c,r)*psurf_climo1(c,r)/&
+                            gddp_struc(n)%psurf_climo(c,r)
+                    elseif(order.eq.2) then 
+                       gddp_struc(n)%metdata2(m,6,&
+                            LIS_domain(n)%gindex(c,r))&
+                            = varfield(c,r)*psurf_climo1(c,r)/&
+                            gddp_struc(n)%psurf_climo(c,r)
+                    endif
+                 endif
+              end do
+           enddo
+           !precip        
+           pcp_flag = .false. 
+           call interp_gddp(n, 7, findex,  pcp_flag, inpnc,inpnr,&
+                pr_inp, & 
+                lb, LIS_rc%gridDesc(n,:), &
+                LIS_rc%lnc(n),LIS_rc%lnr(n),varfield )
+           
+           do r=1,LIS_rc%lnr(n)
+              do c=1,LIS_rc%lnc(n)
+                 if(LIS_domain(n)%gindex(c,r).ne.-1) then 
+                    if(order.eq.1) then 
+                       gddp_struc(n)%metdata1(m,7,&
+                            LIS_domain(n)%gindex(c,r)) &
+                            = varfield(c,r)*prcp_climo1(c,r)/&
+                            gddp_struc(n)%prcp_climo(c,r)
+                    elseif(order.eq.2) then 
+                       gddp_struc(n)%metdata2(m,7,&
+                            LIS_domain(n)%gindex(c,r))&
+                            = varfield(c,r)*prcp_climo1(c,r)/&
+                            gddp_struc(n)%prcp_climo(c,r)
+                    endif
+                 endif
+              end do
+           enddo
+           
+           deallocate(lb)
+        else
+           write(LIS_logunit,*) &
+                '[ERR] Could not find file: ',trim(names(m,1))
+           ferror = 0
+           call LIS_endrun()
+                      
+        end if
+     enddo
+  endif
+#endif
+
+end subroutine read_gddp
+
+
+
+
+!BOP
+! !ROUTINE: interp_gddp
+! \label{interp_gddp}
+!
+! !INTERFACE:
+subroutine interp_gddp(n,vid, findex, pcp_flag, &
+     input_nc, input_nr,input_data,input_bitmap,&
+     lis_gds,nc,nr, &
+     output_2d)
+! !USES:
+  use LIS_coreMod
+  use LIS_spatialDownscalingMod
+  use LIS_logMod
+  use gddp_forcingMod, only :gddp_struc
+ 
+  implicit none
+
+! !ARGUMENTS:   
+  integer, intent(in)   :: n 
+  integer, intent(in)   :: vid
+  integer, intent(in)   :: findex
+  logical, intent(in)   :: pcp_flag
+  integer, intent(in)   :: input_nc
+  integer, intent(in)   :: input_nr
+  real                  :: input_data(input_nc,input_nr)
+  logical*1             :: input_bitmap(input_nc*input_nr)
+  real, intent(in)      :: lis_gds(50)
+  integer, intent(in)   :: nc
+  integer, intent(in)   :: nr
+  real, intent(inout)   :: output_2d(nc,nr)
+!
+! !DESCRIPTION:
+!   This subroutine interpolates a given GDDP field 
+!   to the LIS grid. 
+!  The arguments are: 
+!  \begin{description}
+! \item[n]
+!  index of the nest
+! \item[kpds]
+!  grib decoding array
+! \item[input\_size]
+!  number of elements in the input grid
+! \item[f]
+!  input data array to be interpolated
+! \item[input\_bitmap]
+!  input bitmap
+! \item[lis\_gds]
+!  array description of the LIS grid
+! \item[nc]
+!  number of columns (in the east-west dimension) in the LIS grid
+! \item[nr]
+!  number of rows (in the north-south dimension) in the LIS grid
+! \item[output\_2d]
+!  output interpolated field
+!  \end{description} 
+! 
+!
+!  The routines invoked are: 
+!  \begin{description}
+!  \item[bilinear\_interp](\ref{bilinear_interp}) \newline
+!    spatially interpolate the forcing data using bilinear interpolation
+!  \item[conserv\_interp](\ref{conserv_interp}) \newline
+!    spatially interpolate the forcing data using conservative interpolation
+!  \item[neighbor\_interp](\ref{neighbor_interp}) \newline
+!    spatially interpolate the forcing data using nearest neighbor interpolation
+! \end{description}
+!EOP
+  integer   :: iret
+  integer   :: maxrad = 25
+  integer   :: c,r,mo
+  integer   :: rad, c1,r1,c2,r2
+  logical   :: found
+  integer   :: i,j
+  real      :: input_data_1d(input_nc*input_nr)
+  real      :: output_data(nc*nr)
+  logical*1 :: output_bitmap(nc*nr)
+
+!=== End variable declarations
+
+  mo = nc*nr
+  input_bitmap = .false.
+  output_2d = LIS_rc%udef
+  
+  do r=1,input_nr
+     do c=1,input_nc/2
+        if(input_data(c,r).eq.1e+20) input_data(c,r) = LIS_rc%udef
+        c1 = c+input_nc/2
+        input_data_1d(c1+(r-1)*input_nc) = input_data(c,r)
+        if(input_data(c,r).ne.LIS_rc%udef) then
+           input_bitmap(c1+(r-1)*input_nc) = .true.
+        endif
+     enddo
+  enddo
+
+  do r=1,input_nr
+     do c=input_nc/2,input_nc
+        if(input_data(c,r).eq.1e+20) input_data(c,r) = LIS_rc%udef
+        c1 = c-input_nc/2+1
+        input_data_1d(c1+(r-1)*input_nc) = input_data(c,r)
+        if(input_data(c,r).ne.LIS_rc%udef) then
+           input_bitmap(c1+(r-1)*input_nc) = .true.
+        endif
+     enddo
+  enddo
+  
+!-----------------------------------------------------------------------
+! Initialize output bitmap. 
+!-----------------------------------------------------------------------
+  output_bitmap = .true.
+
+!-----------------------------------------------------------------------  
+! Interpolate to LIS grid
+!-----------------------------------------------------------------------
+  select case( LIS_rc%met_interp(findex) )
+
+    case( "bilinear" )
+     call bilinear_interp(lis_gds,input_bitmap,input_data_1d,&
+          output_bitmap,&
+          output_data,gddp_struc(n)%mi,mo,&
+          LIS_domain(n)%lat, LIS_domain(n)%lon,&
+          gddp_struc(n)%w111, gddp_struc(n)%w121,&
+          gddp_struc(n)%w211,gddp_struc(n)%w221,&
+          gddp_struc(n)%n111,gddp_struc(n)%n121,&
+          gddp_struc(n)%n211,gddp_struc(n)%n221,LIS_rc%udef,iret)
+
+    case( "budget-bilinear" )
+     if (pcp_flag) then     
+        call conserv_interp(lis_gds,input_bitmap,input_data_1d,&
+             output_bitmap,&
+             output_data,gddp_struc(n)%mi,mo,& 
+             LIS_domain(n)%lat, LIS_domain(n)%lon,&
+             gddp_struc(n)%w112,gddp_struc(n)%w122,&
+             gddp_struc(n)%w212,gddp_struc(n)%w222,&
+             gddp_struc(n)%n112,gddp_struc(n)%n122,&
+             gddp_struc(n)%n212,gddp_struc(n)%n222,LIS_rc%udef,iret)
+     else 
+        call bilinear_interp(lis_gds,input_bitmap,input_data_1d,&
+             output_bitmap,&
+             output_data,gddp_struc(n)%mi,mo,&
+             LIS_domain(n)%lat, LIS_domain(n)%lon,&
+             gddp_struc(n)%w111,gddp_struc(n)%w121,&
+             gddp_struc(n)%w211,gddp_struc(n)%w221,&
+             gddp_struc(n)%n111,gddp_struc(n)%n121,&
+             gddp_struc(n)%n211,gddp_struc(n)%n221,LIS_rc%udef,iret)
+     endif
+     
+  case( "neighbor" )
+     call neighbor_interp(lis_gds,input_bitmap,input_data_1d,&
+          output_bitmap,&
+          output_data,gddp_struc(n)%mi,mo,&
+          LIS_domain(n)%lat, LIS_domain(n)%lon,&
+          gddp_struc(n)%n113,LIS_rc%udef,iret)
+
+  end select
+
+!-----------------------------------------------------------------------    
+! convert the interpolated data to 2d. 
+!-----------------------------------------------------------------------    
+
+  do j = 1, nr
+     do i = 1, nc
+        output_2d(i,j) = output_data(i+(j-1)*nc)
+     enddo
+  enddo
+
+  do r=1,nr
+     do c=1,nc
+        found = .true. 
+        if(LIS_domain(n)%gindex(c,r).ne.-1.and.output_2d(c,r).eq.-9999.0) then
+           rad = 1
+           found = .false.
+
+           do while(.not.found)
+              c1 = max(1,c-rad)
+              c2 = min(nc,c+rad)
+              r1 = max(1,r-rad)
+              r2 = min(nr,r+rad)
+              
+              do j=r1,r2
+                 do i=c1,c2
+                    if(output_2d(i,j).ne.-9999.0) then
+                       output_2d(c,r) = output_2d(i,j)
+                       found = .true.
+                       
+                       exit
+                    endif
+                 enddo
+                 if(found) exit
+              enddo
+              if(.not.found) rad = rad +1
+              if(rad.gt.maxrad) exit
+           enddo
+           
+        endif
+        if(.not.found) then
+           write(LIS_logunit,*)'[ERR] unable to fill', LIS_localPet, vid,  c,r,output_2d(c,r),found
+           write(LIS_logunit,*)'[ERR] Program stopping...'
+           call LIS_endrun()
+        endif
+     enddo
+  enddo
+  
+   
+end subroutine interp_gddp

--- a/lis/metforcing/gddp/readcrd_gddp.F90
+++ b/lis/metforcing/gddp/readcrd_gddp.F90
@@ -1,0 +1,70 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+!
+! !ROUTINE: readcrd_gddp
+! \label{readcrd_gddp}
+!
+! !REVISION HISTORY:
+! 03 Feb 2022; Sujay Kumar, Initial Code
+!
+! !INTERFACE:    
+subroutine readcrd_gddp()
+! !USES:
+  use LIS_logMod
+  use LIS_coreMod
+  use gddp_forcingMod
+  use ESMF
+!
+! !DESCRIPTION:
+!
+!  This routine reads the options specific to GDDP forcing from 
+!  the LIS configuration file. 
+!  
+!EOP
+
+  implicit none
+  integer :: n, rc
+
+  call ESMF_ConfigFindLabel(LIS_config,"GDDP forcing directory:",rc=rc)
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,gddp_struc(n)%odir,rc=rc)
+     call LIS_verify(rc,"GDDP forcing directory: is not defined")
+  enddo
+
+    call ESMF_ConfigFindLabel(LIS_config,"GDDP forcing scenario:",rc=rc)
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,gddp_struc(n)%scenario,rc=rc)
+     call LIS_verify(rc,"GDDP forcing scenario: is not defined")
+     if (trim(gddp_struc(n)%scenario).ne."historical") then
+        write(LIS_logunit,*) "[ERR] This GDDP forcing scenario is not supported: ",&
+                            trim(gddp_struc(n)%scenario)
+        write(LIS_logunit,*) "[ERR] ... Please select: 'historical'"
+        write(LIS_logunit,*) "[ERR] Program stopping ..."
+        call LIS_endrun()
+     endif
+  enddo
+  
+  call ESMF_ConfigFindLabel(LIS_config,"GDDP reference daily climatology directory:",rc=rc)
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,gddp_struc(n)%ref_dclimodir,rc=rc)
+     call LIS_verify(rc,"GDDP reference daily climatology directory: is not defined")
+  enddo
+
+  call ESMF_ConfigFindLabel(LIS_config,"GDDP reference hourly climatology directory:",rc=rc)
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,gddp_struc(n)%ref_hclimodir,rc=rc)
+     call LIS_verify(rc,"GDDP reference hourly climatology directory: is not defined")
+  enddo
+
+  
+  write(LIS_logunit,*)'[INFO] Using GDDP forcing'
+
+end subroutine readcrd_gddp

--- a/lis/metforcing/gddp/reset_gddp.F90
+++ b/lis/metforcing/gddp/reset_gddp.F90
@@ -1,0 +1,38 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
+!BOP
+! !MODULE: reset_gddp
+!  \label{reset_gddp}
+!
+! !REVISION HISTORY: 
+! 03 Feb 2022; Sujay Kumar, Initial Code
+! 
+! !INTERFACE:
+subroutine reset_gddp()
+! !USES:
+  use LIS_coreMod,       only : LIS_rc
+  use gddp_forcingMod, only : gddp_struc
+!
+! !DESCRIPTION:
+!  Routine to reset GDDP forcing related memory allocations.   
+! 
+!EOP
+  implicit none
+  
+  integer   :: n
+  integer   :: findex
+
+  do n=1,LIS_rc%nnest
+     gddp_struc(n)%gddptime1 = 3000.0
+     gddp_struc(n)%gddptime2 = 0.0
+  enddo
+
+end subroutine reset_gddp

--- a/lis/metforcing/gddp/timeinterp_gddp.F90
+++ b/lis/metforcing/gddp/timeinterp_gddp.F90
@@ -199,6 +199,8 @@ subroutine timeinterp_gddp(n,findex)
      do m=1,mfactor
         t = m + (k-1)*mfactor
         index1 = LIS_domain(n)%tile(t)%index
+
+
         zdoy=LIS_rc%doy
         
            ! compute and apply zenith angle weights
@@ -220,17 +222,8 @@ subroutine timeinterp_gddp(n,findex)
                    gddp_struc(n)%metdata2(m,3,index1)*swt2
            endif
         endif
-
-        if (swd(t).gt.LIS_CONST_SOLAR) then
-           write(unit=LIS_logunit,fmt=*)'[WARN] sw radiation too high!!'
-           write(unit=LIS_logunit,fmt=*)'[WARN] it is', LIS_localPet, t, swd(t)
-           write(unit=LIS_logunit,fmt=*)'[WARN] data1=',gddp_struc(n)%metdata1(m,3,index1)
-           write(unit=LIS_logunit,fmt=*)'[WARN] data2=',gddp_struc(n)%metdata2(m,3,index1)
-           write(unit=LIS_logunit,fmt=*)'[WARN] wts=',wt1,wt2
-           write(unit=LIS_logunit,fmt=*)'[WARN] zw1=',zw1,'zw2=',zw2
-           write(unit=LIS_logunit,fmt=*)'[WARN] swt1=',swt1,'swt2=',swt2
-           !call LIS_endrun()
-        elseif(swd(t).lt.0.0) then
+        
+        if(swd(t).lt.0.0) then
            write(unit=LIS_logunit,fmt=*)'[ERR] sw radiation is unphysical'
            write(unit=LIS_logunit,fmt=*)'[ERR] it is', LIS_localPet, t, swd(t)
            write(unit=LIS_logunit,fmt=*)'[ERR] data1=',gddp_struc(n)%metdata1(m,3,index1)
@@ -350,7 +343,6 @@ subroutine timeinterp_gddp(n,findex)
         
      enddo
   enddo
-
   
 end subroutine timeinterp_gddp
  

--- a/lis/metforcing/gddp/timeinterp_gddp.F90
+++ b/lis/metforcing/gddp/timeinterp_gddp.F90
@@ -1,0 +1,356 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
+!BOP
+! !ROUTINE: timeinterp_gddp
+! \label{timeinterp_gddp}
+!
+! !REVISION HISTORY:
+!
+! 03 Feb 2022: Sujay Kumar, Initial specification
+!
+! !INTERFACE:
+subroutine timeinterp_gddp(n,findex)
+! !USES:
+  use ESMF
+  use LIS_coreMod
+  use LIS_constantsMod
+  use LIS_metforcingMod
+  use LIS_FORC_AttributesMod
+  use LIS_timeMgrMod
+  use LIS_logMod
+  use gddp_forcingMod
+  use LIS_forecastMod
+ 
+  implicit none
+! !ARGUMENTS: 
+  integer, intent(in) :: n
+  integer, intent(in) :: findex
+!
+! !DESCRIPTION:
+!  Temporally interpolates the forcing data to the current model 
+!  timestep. Downward shortwave radiation is interpolated using a
+!  zenith-angled based approach. Precipitation and longwave radiation
+!  are not temporally interpolated, and the previous 3 hourly value
+!  is used. All other variables are linearly interpolated between 
+!  the 3 hourly blocks. 
+! 
+!  The routines invoked are: 
+!  \begin{description}
+!   \item[LIS\_time2date](\ref{LIS_time2date}) \newline
+!    converts the time to a date format
+!   \item[LIS\_tick](\ref{LIS_tick}) \newline
+!    advances or retracts time by the specified amount
+!   \item[zterp](\ref{zterp}) \newline
+!    zenith-angle based interpolation
+!  \end{description}
+!EOP
+  integer :: zdoy
+  real    :: zw1, zw2
+  real    :: czm, cze, czb
+  real    :: wt1, wt2,swt1,swt2
+  real    :: gmt1, gmt2, tempbts
+  integer :: t,index1
+  integer :: bdoy,byr,bmo,bda,bhr,bmn
+  real*8  :: btime,newtime1,newtime2
+  real    :: tempgmt1,tempgmt2
+  integer :: tempbdoy,tempbyr,tempbmo,tempbda,tempbhr,tempbmn
+  integer :: tempbss
+  integer            :: status
+  type(ESMF_Field)   :: tmpField,q2Field,uField,vField,swdField,lwdField
+  type(ESMF_Field)   :: psurfField,pcpField,cpcpField,fhgtField,acondField
+  type(ESMF_Field)   :: PETField,CAPEField
+  real,pointer       :: tmp(:),q2(:),uwind(:),vwind(:)
+  real,pointer       :: swd(:),lwd(:),psurf(:),pcp(:),cpcp(:)
+  real,pointer       :: fheight(:),acond(:),pet(:),cape(:)
+  logical            :: forcing_z, forcing_ch, forcing_pet, forcing_cape
+  integer            :: mfactor, m, k, kk
+! ________________________________________
+
+  btime=gddp_struc(n)%gddptime1
+  call LIS_time2date(btime,bdoy,gmt1,byr,bmo,bda,bhr,bmn)
+  
+  tempbdoy=bdoy
+  tempgmt1=gmt1
+  tempbyr=byr
+  tempbmo=bmo
+  tempbda=bda
+  tempbhr=bhr
+  if (tempbhr.eq.24) tempbhr=0
+  tempbmn=bmn
+  tempbss=0
+  tempbts=0
+  call LIS_tick(newtime1,tempbdoy,tempgmt1,& 
+       tempbyr,tempbmo,tempbda,tempbhr,tempbmn, & 
+       tempbss,tempbts)
+  
+  btime=gddp_struc(n)%gddptime2
+  call LIS_time2date(btime,bdoy,gmt2,byr,bmo,bda,bhr,bmn)
+  tempbdoy=bdoy
+  tempgmt2=gmt2
+  tempbyr=byr
+  tempbmo=bmo
+  tempbda=bda
+  tempbhr=bhr
+  if (tempbhr.eq.24) tempbhr=0
+  tempbmn=bmn
+  tempbss=0
+  tempbts=0
+  call LIS_tick(newtime2,tempbdoy,tempgmt2,&
+       tempbyr,tempbmo,tempbda,tempbhr,tempbmn,&
+       tempbss,tempbts)
+  
+!=== Interpolate Data in time      
+  wt1=(gddp_struc(n)%gddptime2-LIS_rc%time)/ & 
+       (gddp_struc(n)%gddptime2-gddp_struc(n)%gddptime1)
+
+
+  wt2=1.0-wt1
+  swt1=(newtime2-LIS_rc%time)/(newtime2-newtime1)
+  swt2=1.0-swt1
+
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Tair%varname(1),tmpField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable Tair in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Qair%varname(1),q2Field,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable Qair in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_SWdown%varname(1),swdField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable SWdown in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_LWdown%varname(1),lwdField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable LWdown in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Wind_E%varname(1),uField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable Wind_E in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Wind_N%varname(1),vField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable Wind_N in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Psurf%varname(1),psurfField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable Psurf in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Rainf%varname(1),pcpField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable Rainf in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_CRainf%varname(1),cpcpField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable CRainf in the forcing variables list')
+
+  if(LIS_FORC_Forc_Hgt%selectOpt.eq.1) then 
+     call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Forc_Hgt%varname(1),&
+          fhgtField, rc=status)
+     call LIS_verify(status, 'Error: Enable Forc_Hgt in the forcing variables list')
+     forcing_z = .true.
+  else
+     forcing_z = .false.
+  endif
+
+  if(LIS_FORC_Ch%selectOpt.eq.1) then 
+     call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Ch%varname(1),acondField,&
+          rc=status)
+     call LIS_verify(status, 'Error: Enable Ch in the forcing variables list')
+     forcing_ch = .true.
+  else
+     forcing_ch = .false.
+  endif
+
+  if(LIS_FORC_PET%selectOpt.eq.1) then 
+     call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_PET%varname(1),PETField,&
+          rc=status)
+     call LIS_verify(status, 'Error: Enable PET in the forcing variables list')
+     forcing_pet = .true.
+  else
+     forcing_pet = .false.
+  endif
+
+  if(LIS_FORC_CAPE%selectOpt.eq.1) then 
+     call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_CAPE%varname(1),CAPEField,&
+          rc=status)
+     call LIS_verify(status, 'Error: Enable CAPE in the forcing variables list')
+     forcing_cape = .true.
+  else
+     forcing_cape = .false.
+  endif
+
+  call ESMF_FieldGet(swdField,localDE=0,farrayPtr=swd,rc=status)
+  call LIS_verify(status)
+
+! Loop over number of forcing ensembles:
+  mfactor = LIS_rc%nensem(n)
+
+  do k=1,LIS_rc%ntiles(n)/mfactor
+     do m=1,mfactor
+        t = m + (k-1)*mfactor
+        index1 = LIS_domain(n)%tile(t)%index
+        zdoy=LIS_rc%doy
+        
+           ! compute and apply zenith angle weights
+        call zterp(1,LIS_domain(n)%grid(index1)%lat,&
+             LIS_domain(n)%grid(index1)%lon,&
+             gmt1,gmt2,LIS_rc%gmt,zdoy,zw1,zw2,czb,cze,czm,LIS_rc)
+        
+        if(gddp_struc(n)%metdata1(m,3,index1).ne.LIS_rc%udef.and.&
+             gddp_struc(n)%metdata2(m,3,index1).ne.LIS_rc%udef) then 
+           swd(t) = gddp_struc(n)%metdata1(m,3,index1)*zw1+&
+                gddp_struc(n)%metdata2(m,3,index1)*zw2
+          ! In cases of small cos(zenith) angles, use linear weighting
+          !  to avoid overly large weights
+
+           if((swd(t).gt.gddp_struc(n)%metdata1(m,3,index1).and. & 
+                swd(t).gt.gddp_struc(n)%metdata2(m,3,index1)).and. & 
+                (czb.lt.0.1.or.cze.lt.0.1))then
+              swd(t) = gddp_struc(n)%metdata1(m,3,index1)*swt1+ & 
+                   gddp_struc(n)%metdata2(m,3,index1)*swt2
+           endif
+        endif
+
+        if (swd(t).gt.LIS_CONST_SOLAR) then
+           write(unit=LIS_logunit,fmt=*)'[WARN] sw radiation too high!!'
+           write(unit=LIS_logunit,fmt=*)'[WARN] it is', LIS_localPet, t, swd(t)
+           write(unit=LIS_logunit,fmt=*)'[WARN] data1=',gddp_struc(n)%metdata1(m,3,index1)
+           write(unit=LIS_logunit,fmt=*)'[WARN] data2=',gddp_struc(n)%metdata2(m,3,index1)
+           write(unit=LIS_logunit,fmt=*)'[WARN] wts=',wt1,wt2
+           write(unit=LIS_logunit,fmt=*)'[WARN] zw1=',zw1,'zw2=',zw2
+           write(unit=LIS_logunit,fmt=*)'[WARN] swt1=',swt1,'swt2=',swt2
+           !call LIS_endrun()
+        elseif(swd(t).lt.0.0) then
+           write(unit=LIS_logunit,fmt=*)'[ERR] sw radiation is unphysical'
+           write(unit=LIS_logunit,fmt=*)'[ERR] it is', LIS_localPet, t, swd(t)
+           write(unit=LIS_logunit,fmt=*)'[ERR] data1=',gddp_struc(n)%metdata1(m,3,index1)
+           write(unit=LIS_logunit,fmt=*)'[ERR] data2=',gddp_struc(n)%metdata2(m,3,index1)
+           write(unit=LIS_logunit,fmt=*)'[ERR] wts=',wt1,wt2
+           call LIS_endrun()
+
+        endif
+     enddo  ! End for SWdown
+  enddo
+  
+  ! do block precipitation interpolation
+  call ESMF_FieldGet(pcpField,localDE=0,farrayPtr=pcp,rc=status)
+  call LIS_verify(status)
+
+  do k=1,LIS_rc%ntiles(n)/mfactor
+     do m=1,mfactor
+        t = m + (k-1)*mfactor
+        index1 = LIS_domain(n)%tile(t)%index
+        if(gddp_struc(n)%metdata2(m,7,index1).ne.LIS_rc%udef) then 
+           pcp(t)=gddp_struc(n)%metdata2(m,7,index1)
+           if(pcp(t).lt.0) then
+              pcp(t) = 0.0
+           endif
+        endif
+     enddo
+  enddo
+
+  !linearly interpolate everything else
+
+  call ESMF_FieldGet(tmpField,localDE=0,farrayPtr=tmp,rc=status)
+  call LIS_verify(status)
+  
+  do k=1,LIS_rc%ntiles(n)/mfactor
+     do m=1,mfactor
+        t = m + (k-1)*mfactor
+        index1 = LIS_domain(n)%tile(t)%index
+        if((gddp_struc(n)%metdata1(m,1,index1).ne.LIS_rc%udef).and.&
+             (gddp_struc(n)%metdata2(m,1,index1).ne.LIS_rc%udef)) then 
+           tmp(t) = gddp_struc(n)%metdata1(m,1,index1)*wt1+ & 
+                gddp_struc(n)%metdata2(m,1,index1)*wt2
+        endif
+     enddo
+  enddo
+  
+  call ESMF_FieldGet(q2Field,localDE=0,farrayPtr=q2,rc=status)
+  call LIS_verify(status)
+
+  do k=1,LIS_rc%ntiles(n)/mfactor
+     do m=1,mfactor
+        t = m + (k-1)*mfactor
+        index1 = LIS_domain(n)%tile(t)%index
+        if((gddp_struc(n)%metdata1(m,2,index1).ne.LIS_rc%udef).and.&
+             (gddp_struc(n)%metdata2(m,2,index1).ne.LIS_rc%udef)) then 
+           q2(t) =gddp_struc(n)%metdata1(m,2,index1)*wt1+ & 
+                gddp_struc(n)%metdata2(m,2,index1)*wt2
+        endif
+     enddo
+  enddo
+
+  call ESMF_FieldGet(lwdField,localDE=0,farrayPtr=lwd,rc=status)
+  call LIS_verify(status)
+
+  do k=1,LIS_rc%ntiles(n)/mfactor
+     do m=1,mfactor
+        t = m + (k-1)*mfactor
+        index1 = LIS_domain(n)%tile(t)%index
+        if((gddp_struc(n)%metdata1(m,4,index1).ne.LIS_rc%udef).and.&
+             (gddp_struc(n)%metdata2(m,4,index1).ne.LIS_rc%udef)) then 
+           lwd(t) =gddp_struc(n)%metdata1(m,4,index1)*wt1+ & 
+                gddp_struc(n)%metdata2(m,4,index1)*wt2
+        endif
+     enddo
+  enddo
+
+  call ESMF_FieldGet(uField,localDE=0,farrayPtr=uwind,rc=status)
+  call LIS_verify(status)
+
+  do k=1,LIS_rc%ntiles(n)/mfactor
+     do m=1,mfactor
+        t = m + (k-1)*mfactor
+        index1 = LIS_domain(n)%tile(t)%index
+
+        if((gddp_struc(n)%metdata1(m,5,index1).ne.LIS_rc%udef).and.&
+             (gddp_struc(n)%metdata2(m,5,index1).ne.LIS_rc%udef)) then 
+           uwind(t) = gddp_struc(n)%metdata1(m,5,index1)*wt1+ & 
+                gddp_struc(n)%metdata2(m,5,index1)*wt2
+        endif
+     enddo
+  enddo
+  
+  call ESMF_FieldGet(vField,localDE=0,farrayPtr=vwind,rc=status)
+  call LIS_verify(status)
+
+  do k=1,LIS_rc%ntiles(n)/mfactor
+     do m=1,mfactor
+        t = m + (k-1)*mfactor
+        index1 = LIS_domain(n)%tile(t)%index
+        
+        vwind(t) = 0.0           
+
+     enddo
+  enddo
+  call ESMF_FieldGet(psurfField,localDE=0,farrayPtr=psurf,rc=status)
+  call LIS_verify(status)
+
+  do k=1,LIS_rc%ntiles(n)/mfactor
+     do m=1,mfactor
+        t = m + (k-1)*mfactor
+        index1 = LIS_domain(n)%tile(t)%index
+        
+        if((gddp_struc(n)%metdata1(m,6,index1).ne.LIS_rc%udef).and.&
+             (gddp_struc(n)%metdata2(m,6,index1).ne.LIS_rc%udef)) then 
+           psurf(t) =gddp_struc(n)%metdata1(m,6,index1)*wt1+ & 
+                gddp_struc(n)%metdata2(m,6,index1)*wt2
+        endif
+        
+     enddo
+  enddo
+
+  
+end subroutine timeinterp_gddp
+ 

--- a/lis/plugins/LIS_metforcing_pluginMod.F90
+++ b/lis/plugins/LIS_metforcing_pluginMod.F90
@@ -292,6 +292,10 @@ subroutine LIS_metforcing_plugin
    use mrms_grib_forcingMod
 #endif
 
+#if ( defined MF_GDDP )
+   use gddp_forcingMod
+#endif   
+
 #if ( defined MF_MET_TEMPLATE )
    external get_metForcTemplate
    external timeinterp_metForcTemplate
@@ -623,6 +627,13 @@ subroutine LIS_metforcing_plugin
    external reset_mrms_grib
 #endif
 
+#if ( defined MF_GDDP )
+   external get_gddp
+   external timeinterp_gddp
+   external finalize_gddp
+   external reset_gddp
+#endif
+   
 #if ( defined MF_MET_TEMPLATE )
 ! - Meteorological Forcing Template:
    call registerinitmetforc(trim(LIS_metForcTemplateId)//char(0), &
@@ -1118,6 +1129,14 @@ subroutine LIS_metforcing_plugin
                                   timeinterp_mrms_grib)
    call registerfinalmetforc(trim(LIS_mrmsId)//char(0),finalize_mrms_grib)
    call registerresetmetforc(trim(LIS_mrmsId)//char(0),reset_mrms_grib)
+#endif
+#if ( defined MF_GDDP)
+   call registerinitmetforc(trim(LIS_gddpId)//char(0),init_gddp)
+   call registerretrievemetforc(trim(LIS_gddpId)//char(0),get_gddp)
+   call registertimeinterpmetforc(trim(LIS_gddpId)//char(0), &
+                                  timeinterp_gddp)
+   call registerfinalmetforc(trim(LIS_gddpId)//char(0),finalize_gddp)
+   call registerresetmetforc(trim(LIS_gddpId)//char(0),reset_gddp)
 #endif
 end subroutine LIS_metforcing_plugin
 

--- a/lis/plugins/LIS_pluginIndices.F90
+++ b/lis/plugins/LIS_pluginIndices.F90
@@ -172,6 +172,7 @@ module LIS_pluginIndices
    character*50, public,  parameter :: LIS_mrmsId            = "MRMS"
    character*50, public,  parameter :: LIS_era5Id            = "ERA5"
    character*50, public,  parameter :: LIS_plumber2Id        = "PLUMBER2"
+   character*50, public,  parameter :: LIS_gddpId        = "GDDP"
 !-------------------------------------------------------------------------
 ! land surface parameters
 !-------------------------------------------------------------------------


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Original description from #990:

>Adds the support for the NEX GDDP climate data as forcing. The plugin
temporally disaggregates the daily GDDP data to subdaily resolution.
>
>The code also updates includes updates to the parameter reading routines
so that in a multiprocessor mode, each process directly reads the subsetted
data slice. The older version of the code read the global data and subsetted it.

The original PR was reverted in #999 after bugs were identified. This PR includes all of the original changes as well as fixes for the bugs.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase

I retested the updated branch by comparing against outputs generated by an executable compiled by @sujayvkumar. The outputs were identical. 

