### PR TITLE
Fix use of input LAI for Noah-MP-4.0.1 vegetation options

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -8002,18 +8002,56 @@ in the LIS implementation are indicated with [NS].  Acceptable values are:
 |====
 |Value | Note | Description
  
-| 1    |      | off (use table LAI; use FVEG = SHDFAC from input)
-| 2    |      | on  (dynamic vegetation; must use Ball-Berry canopy option)
-| 3    |      | off (use table LAI; calculate FVEG)
-| 4    |  **  | off (use table LAI; use maximum vegetation fraction)
-| 5    |  **  | on  (use maximum vegetation fraction)
-| 6    |      | on  (use FVEG = SHDFAC from input)
-| 7    |      | off (use input LAI; use FVEG = SHDFAC from input)
-| 8    |      | off (use input LAI; calculate FVEG)
-| 9    |      | off (use input LAI; use maximum vegetation fraction)
+| 1    |      | off (use table LAI/SAI; use input GVF)
+| 2    |      | on  (dynamic vegetation; GVF is a function of LAI/SAI)
+| 3    |      | off (use table LAI/SAI; GVF is a function of LAI/SAI)
+| 4    |  **  | off (use table LAI/SAI; GVF is the maximum value)
+| 5    |  **  | on  (dynamic vegetation; GVF is the maximum value)
+| 6    |      | on  (dynamic vegetation; use input GVF)
+| 7    |      | off (use input LAI/SAI; use input GVF)
+| 8    |      | off (use input LAI/SAI; GVF is a function of LAI/SAI)
+| 9    |      | off (use input LAI/SAI; GVF is the maximum value)
 |10    |  NS  | crop model on (use maximum vegetation fraction)
 |====
- 
+
+When using options 1 through 6, users should set `LAI data source:` to
+"`none`".  For options 1, 3, or 4, the LAI value will be read from the
+`Noah-MP.4.0.1 MP parameter table:` file (typically, "`MPTABLE.TBL`")
+based on the vegetation class of the tile and the current month.  For
+options 2, 5, or 6, the LAI is a prognostic variable as a function of
+the LeafMass calculated from the dynamic vegetation scheme.  When using
+options 7 through 9, users should set `LAI data source:` to "`LDT`",
+after running LDT to include an LAI dataset as one of the parameters
+in the `LIS domain and parameter data file:`.
+
+When using options 1 through 6, users should set `SAI data source:` to
+"`none`".  For options 1, 3, or 4, the SAI value will be read from the
+`Noah-MP.4.0.1 MP parameter table:` file (typically, "`MPTABLE.TBL`")
+based on the vegetation class of the tile and the current month.  For
+options 2, 5, or 6, the SAI is a prognostic variable as a function of
+the StemMass calculated from the dynamic vegetation scheme.  When using
+options 7 through 9, users can set `SAI data source:` to "`LDT`", after
+running LDT to include an SAI dataset as one of the parameters in the
+`LIS domain and parameter data file:`.  Alternatively, for these options
+(7, 8, or 9), users can choose to not use an input SAI dataset by setting
+`SAI data source:` to "`none`", in which case the SAI value will be set
+from the `Noah-MP.4.0.1 MP parameter table:` file.
+
+When using options 1, 4, 5, 6, 7, or 9, users should set `Greenness data
+source:` to "`LDT`", after running LDT to include a greenness dataset as
+one of the parameters in the `LIS domain and parameter data file:`.  The
+greenness parameter variable name can be referred to as GVF (greenness
+vegetation fraction), FVEG, or SHDFAC in the Noah-MP.4.0.1 physics code.
+When using options 1, 6, or 7, the greenness value is set to the monthly
+climatology value for each tile (unless "`CONSTANT`" was chosen when LDT
+was run for the `Greenness data source:`).  When using options 4, 5, or 9,
+the greenness value for each tile is set to the maximum value of all months
+from the monthly climatology at that tile.  When using options 2, 3, or 8,
+the greenness is a function of LAI and SAI at each tile for each timestep.
+
+Note that when using dynamic vegetation option 2, 5, or 6, the Ball-Berry
+canopy stomatal resistance option must be selected for the following config.
+
 `Noah-MP.4.0.1 canopy stomatal resistance option:` specifies the canopy
 stomatal resistance option for Noah-MP-4.0.1 LSM.  Options generally
 recommended for use by the model developers are indicated with [**].

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
@@ -511,6 +511,8 @@ subroutine NoahMP401_main(n)
 ! fill in the LAI or SAI values from MPTABLE.
                if (tmp_lai.eq.LIS_rc%udef) then
                   tmp_lai          = NOAHMP401_struc(n)%noahmp401(t)%lai
+               endif
+               if (tmp_sai.eq.LIS_rc%udef) then
                   tmp_sai          = NOAHMP401_struc(n)%noahmp401(t)%sai
                endif
             else

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
@@ -23,6 +23,7 @@
 !   05/15/19: Yeosang Yoon; code added for snow DA to work
 !   10/29/19: David Mocko; Added RELSMC to output, and an option
 !                          for different units for Qs/Qsb/Albedo
+!   03/09/22: David Mocko: Fixed "input LAI" for dynamic vegetation options 7/8/9
 !
 ! !INTERFACE:
 subroutine NoahMP401_main(n)
@@ -31,6 +32,7 @@ subroutine NoahMP401_main(n)
     use LIS_histDataMod
     use LIS_timeMgrMod, only : LIS_isAlarmRinging
     use LIS_constantsMod,  only : LIS_CONST_RHOFW   !New
+    use LIS_vegDataMod,    only : LIS_lai, LIS_sai
     use LIS_logMod, only     : LIS_logunit, LIS_endrun
     use LIS_FORC_AttributesMod
     use NoahMP401_lsmMod
@@ -43,7 +45,7 @@ subroutine NoahMP401_main(n)
     real                 :: dt
     real                 :: lat, lon
     real                 :: tempval
-    integer              :: row, col
+    integer              :: row, col, tid
     integer              :: year, month, day, hour, minute, second
     logical              :: alarmCheck
 
@@ -483,8 +485,38 @@ subroutine NoahMP401_main(n)
             tmp_wood            = NOAHMP401_struc(n)%noahmp401(t)%wood
             tmp_stblcp          = NOAHMP401_struc(n)%noahmp401(t)%stblcp
             tmp_fastcp          = NOAHMP401_struc(n)%noahmp401(t)%fastcp
-            tmp_lai             = NOAHMP401_struc(n)%noahmp401(t)%lai
-            tmp_sai             = NOAHMP401_struc(n)%noahmp401(t)%sai
+! DMM - If dynamic vegetation option DVEG = 7, 8, or 9 for "input LAI",
+! then send LAI/SAI from input to the Noah-MP-4.0.1 physics.  If any
+! tile has an undefined LAI/SAI value, instead use the value from the
+! MPTABLE file for that vegetation class and for the month.
+            if ((tmp_dveg_opt.ge.7).and.(tmp_dveg_opt.le.9)) then
+               tid = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%tile_id
+! If "LAI data source:" is set to "none" for these three Noah-MP-4.0.1
+! input LAI vegetation options, stop the run.
+               if (LIS_rc%useLAImap(n).ne."none") then
+                  tmp_lai          = LIS_lai(n)%tlai(tid)
+               else
+                  write(LIS_logunit,*)                                 &
+                       '[ERR] Attempting to use input LAI, however'
+                  write(LIS_logunit,*)                                 &
+                       '[ERR] "LAI data source:" is set to "none".'
+                  call LIS_endrun()
+               endif
+! If "SAI data source:" is set to "none" for these three Noah-MP-4.0.1
+! input LAI vegetation options, fill in the SAI values from MPTABLE.
+               if (LIS_rc%useSAImap(n).ne."none") then
+                  tmp_sai          = LIS_sai(n)%tsai(tid)
+               endif
+! If any LAI or SAI values are undefined at a tile,
+! fill in the LAI or SAI values from MPTABLE.
+               if (tmp_lai.eq.LIS_rc%udef) then
+                  tmp_lai          = NOAHMP401_struc(n)%noahmp401(t)%lai
+                  tmp_sai          = NOAHMP401_struc(n)%noahmp401(t)%sai
+               endif
+            else
+               tmp_lai          = NOAHMP401_struc(n)%noahmp401(t)%lai
+               tmp_sai          = NOAHMP401_struc(n)%noahmp401(t)%sai
+            endif
             tmp_tauss           = NOAHMP401_struc(n)%noahmp401(t)%tauss
             tmp_smoiseq(:)      = NOAHMP401_struc(n)%noahmp401(t)%smoiseq(:)
             tmp_smcwtd          = NOAHMP401_struc(n)%noahmp401(t)%smcwtd

--- a/lis/surfacemodels/land/noahmp.4.0.1/noahmp_driver_401.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/noahmp_driver_401.F90
@@ -547,11 +547,12 @@ subroutine noahmp_driver_401(n, ttile, itimestep, &
   call calc_declin_401(nowdate(1:4)//"-"//nowdate(5:6)//"-"//nowdate(7:8)//"_"//nowdate(9:10)//":"//nowdate(11:12)//":00", &
       latitude, longitude, cosz, yearlen, julian)
 
-  if ( dveg_opt == 1 ) then
-    ! with dveg_opt==1, shdfac is fed directly to fveg
+  if ((dveg_opt.eq.1).or.(dveg_opt.eq.6).or.(dveg_opt.eq.7)) then
+    ! with dveg_opt==1/6/7, shdfac is fed directly to fveg
     vegfra = month_d_401(shdfac_monthly, nowdate)
   else
-    ! with dveg_opt==2, fveg is computed from lai and sai, and shdfac is unused
+    ! with dveg_opt==2/3/8, fveg is computed from lai and sai, and shdfac is unused
+    ! with dveg_opt==4/5/9, fveg is set to the maximum shdfac, and shdfac is unused
     vegfra = -1.E36   ! To match with HRLDAS initialization
   endif
   vegmax = maxval(shdfac_monthly)


### PR DESCRIPTION
For Noah-MP-4.0.1 dynamic vegetation options 7, 8, or 9, the input
LAI was not being correctly used in the model physics.  This pull
request fixes this bug, and allows the use of input LAI or SAI in
the model physics.  The LIS Users' Guide was also updated to give
further details of the config entries that need to be provided for
all of the different options.

Options 1 to 6 for this physics option is not affected by this fix.

Resolves: #1011 