### PR TITLE
Include LIS endrun statement for missing USAF files

### DIFF
--- a/lis/metforcing/usaf/readagrmetforcinganalysis.F90
+++ b/lis/metforcing/usaf/readagrmetforcinganalysis.F90
@@ -26,7 +26,8 @@ subroutine readagrmetforcinganalysis(n,findex, order, agrfile, month)
 ! !USES:
   use LIS_coreMod, only         : LIS_rc, LIS_domain, LIS_masterproc
   use LIS_timeMgrMod,only       : LIS_get_julhr,LIS_tick,LIS_time2date
-  use LIS_logMod, only          : LIS_logunit, LIS_verify, LIS_warning
+  use LIS_logMod, only          : LIS_logunit, LIS_verify, LIS_warning,&
+                                  LIS_endrun
   use LIS_spatialDownscalingMod
   use AGRMET_forcingMod,   only : agrmet_struc
 
@@ -109,7 +110,7 @@ subroutine readagrmetforcinganalysis(n,findex, order, agrfile, month)
      call grib_open_file(ftn,trim(agrfile),'r',iret)
      if(iret.ne.0) then 
         write(LIS_logunit,*) &
-             'Could not open file: ',trim(agrfile)
+             '[WARN] Could not open file: ',trim(agrfile)
         ferror = 0
         return
      endif
@@ -125,9 +126,9 @@ subroutine readagrmetforcinganalysis(n,findex, order, agrfile, month)
         call LIS_warning(iret, 'error in grib_new_from_file in read_agrmet')
         if(iret.ne.0) then 
            write(LIS_logunit,*) &
-                'Error code: ',iret
+                '[WARN] Error code: ',iret
            write(LIS_logunit,*) &
-                'Could not retrieve entries in file: ',trim(agrfile)
+                '[WARN] Could not retrieve entries in file: ',trim(agrfile)
            ferror = 0
            deallocate(lb)
            deallocate(f)
@@ -167,9 +168,9 @@ subroutine readagrmetforcinganalysis(n,findex, order, agrfile, month)
 
         if(rc.ne.0) then 
            write(LIS_logunit,*) &
-                'Error code: ',rc
+                '[WARN] Error code: ',rc
            write(LIS_logunit,*) &
-                'Could not retrieve entries in file: ',trim(agrfile)
+                '[WARN] Could not retrieve entries in file: ',trim(agrfile)
            write(LIS_logunit,*) 'for variables ',kk
            ferror = 0
            deallocate(lb)
@@ -286,17 +287,18 @@ subroutine readagrmetforcinganalysis(n,findex, order, agrfile, month)
      do kk=1,iv_total
         if(.not.var_status(kk)) then 
            write(LIS_logunit,*) &
-                'Could not retrieve entries in file: ',trim(agrfile)
+                '[WARN] Could not retrieve entries in file: ',trim(agrfile)
            write(LIS_logunit,*) &
-                'kk,var_status = ',kk,var_status(kk)
+                '[WARN] kk,var_status = ',kk,var_status(kk)
            ferror = 0
            return
         endif
      enddo
   else
      write(LIS_logunit,*) &
-          'Could not find file: ',trim(agrfile)
+          '[ERR] Could not find file: ',trim(agrfile)
      ferror = 0
+     call LIS_endrun
   endif
 
 #endif


### PR DESCRIPTION
 The USAF/AGRMET retrospective forcing reader does
 not stop running when an input forcing file is missing.
 In that case, same forcing values could be interpolated
 farther into time or 0s could be interpolated in, when
 no values present.

 Added a LIS_endrun call to the routine along with
 when it was called with an "[ERR]" message and applied
 "[WARN]" to other warning statments when other errors
 occur during a file read. (Note: Reader continues
 with no stopping when the latter occurs).

<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Replace this text with a concise description of *what* was changed and *why*.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->


