### PR TITLE
Fix GEFS grid input

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -6055,8 +6055,15 @@ or mean sea level (msl) can be selected (which is not supported yet).
 of GEFS ensemble members being read in. Reforecast2 currently
 supports up to a 11 members.
 
-`GEFS forecast grid resolution:` specifies the grid resolution of the GEFS
-forecast data. The current resolutions supported are 0.50 and 0.25.
+`GEFS forecast grid resolution:` specifies the grid resolution in degrees
+of the GEFS forecast data. The current resolutions supported are:
+
+|====
+|GEFS forecast type | Resolutions
+
+|`Reforecast2`      | `0.25` and `1.0`
+|`Operational`      | `0.25` and `0.50`
+|====
 
 .Example _lis.config_ entry
 ....

--- a/lis/metforcing/gefs/gefs_forcingMod.F90
+++ b/lis/metforcing/gefs/gefs_forcingMod.F90
@@ -216,8 +216,8 @@ contains
               gefs_struc(n)%gridDesc(7) = -90.0   ! original GEFS
               gefs_struc(n)%gridDesc(8) = lonEnd
 !              gefs_struc(n)%gridDesc(8) = 359.00  ! original GEFS
-              gefs_struc(n)%gridDesc(9) =  1.0
-              gefs_struc(n)%gridDesc(10) = 1.0
+              gefs_struc(n)%gridDesc(9) =  gefs_struc(n)%gefs_res
+              gefs_struc(n)%gridDesc(10) = gefs_struc(n)%gefs_res
               gefs_struc(n)%gridDesc(20) = 64  ! -180 to 180?
 !              gefs_struc(n)%gridDesc(20) = 0   ! for 0 to 360?
 
@@ -271,8 +271,8 @@ contains
                 gefs_struc(n)%gridDesc(7) = -90.0   ! original GEFS
                 gefs_struc(n)%gridDesc(8) = lonEnd
 !              gefs_struc(n)%gridDesc(8) = 359.00  ! original GEFS
-                gefs_struc(n)%gridDesc(9) =  0.5
-                gefs_struc(n)%gridDesc(10) = 0.5
+                gefs_struc(n)%gridDesc(9) =  gefs_struc(n)%gefs_res
+                gefs_struc(n)%gridDesc(10) = gefs_struc(n)%gefs_res
                 gefs_struc(n)%gridDesc(20) = 64  ! -180 to 180?
 !              gefs_struc(n)%gridDesc(20) = 0   ! for 0 to 360?
 

--- a/lis/metforcing/gefs/readcrd_gefs.F90
+++ b/lis/metforcing/gefs/readcrd_gefs.F90
@@ -79,11 +79,14 @@ subroutine readcrd_gefs()
      do n=1,LIS_rc%nnest
         call ESMF_ConfigGetAttribute(LIS_config,gefs_struc(n)%gefs_res,rc=rc)
         
-        if(gefs_struc(n)%gefs_res.ne.0.50 .and. gefs_struc(n)%gefs_res.ne.0.25) then
-           write(LIS_logunit,*) '[ERR] GEFS forecast grid resolution: not equal to 0.50'
-           write(LIS_logunit,*) '[ERR] or 0.25. The GEFS reader currently only supports'
-           write(LIS_logunit,*) '[ERR] these two data resolutions.'
-           write(LIS_logunit,*) '[ERR] Please change data source and config option.'
+        if( (gefs_struc(n)%gefs_fcsttype.eq.'Reforecast2' .and. (gefs_struc(n)%gefs_res.ne.0.25 .and. gefs_struc(n)%gefs_res.ne.1.0)) &
+            .or. (gefs_struc(n)%gefs_fcsttype.eq.'Operational' .and. (gefs_struc(n)%gefs_res.ne.0.25 .and. gefs_struc(n)%gefs_res.ne.0.50))) then
+
+           write(LIS_logunit,*) '[ERR] GEFS forecast grid resolution error:'
+           write(LIS_logunit,*) '[ERR] The GEFS reader currently only supports the following:'
+           write(LIS_logunit,*) '[ERR] -- Reforecast2 mode with 1.0 degree or 0.25 degree data.'
+           write(LIS_logunit,*) '[ERR] -- Operational mode with 0.5 degree or 0.25 degree data.'
+           write(LIS_logunit,*) '[ERR] Please change GEFS mode, data source, and/or data resolution.'
            write(LIS_logunit,*) '[ERR] Stopping...'
            call LIS_endrun()
         endif

--- a/lis/metforcing/gefs/readcrd_gefs.F90
+++ b/lis/metforcing/gefs/readcrd_gefs.F90
@@ -71,9 +71,9 @@ subroutine readcrd_gefs()
   !call LIS_verify(rc, 'GEFS forecast grid resolution: not defined ')
   if(rc.ne.0) then
      write(LIS_logunit,*) '[WARN] GEFS forecast grid resolution: not defined '
-     write(LIS_logunit,*) '[WARN] GEFS forecast grid resolution set to 0.50 as default. '
+     write(LIS_logunit,*) '[WARN] GEFS forecast grid resolution set to 0.25 as default. '
      do n=1,LIS_rc%nnest
-        gefs_struc(n)%gefs_res = 0.50
+        gefs_struc(n)%gefs_res = 0.25
      enddo
   else
      do n=1,LIS_rc%nnest
@@ -119,6 +119,8 @@ subroutine readcrd_gefs()
           gefs_struc(n)%max_ens_members
      write(LIS_logunit,*) '[INFO] GEFS pressure level field:  ',&
           gefs_struc(n)%gefs_preslevel
+     write(LIS_logunit,*) '[INFO] GEFS forecast grid resolution:  ',&
+          gefs_struc(n)%gefs_res
 
      gefs_struc(n)%fcsttime1 = 3000.0
      gefs_struc(n)%fcsttime2 = 0.0

--- a/lis/testcases/metforcing/gefs/lis.config
+++ b/lis/testcases/metforcing/gefs/lis.config
@@ -158,6 +158,7 @@ GEFS forecast run mode:          forecast         # forecast | analysis
 GEFS forecast grid projection:   latlon           # latlon | gaussian
 GEFS pressure level field:       surface          # surface | msl
 GEFS forecast number of ensemble members:  11
+GEFS forecast grid resolution: 1.0
 
 
 #-----------------------LAND SURFACE MODELS--------------------------


### PR DESCRIPTION
The grid spacing variables gefs_struc(n)%gridDesc(9) and gefs_struc(n)%gridDesc(10) were not being set according to the config option. This has now been fixed for both the reforecast and operational dataset.

The old test case that was previously submitted should still work to test this commit if needed.

Resolves: #1022 
