### PR TITLE
Manually add bug fix to HYMAP2_initMod.F90

### DIFF
--- a/lis/routing/HYMAP2_router/HYMAP2_initMod.F90
+++ b/lis/routing/HYMAP2_router/HYMAP2_initMod.F90
@@ -426,7 +426,13 @@ contains
         do i=1,nz
            stonow=rivlen(iseq)*(rivwth(iseq)+wthinc*(real(i)-0.5))*(fldhgt(iseq,i)-hgtpre)
            fldstomax(iseq,i)=stopre+stonow
-           fldgrd(iseq,i)=(fldhgt(iseq,i)-hgtpre) / wthinc
+           !           fldgrd(iseq,i)=(fldhgt(iseq,i)-hgtpre) / wthinc
+           if(wthinc <=0.0) then
+!              write(LIS_logunit,*) '[WARN] set_fldg withinc= 0'
+              fldgrd(iseq,i) = 0.0
+           else
+              fldgrd(iseq,i) = (fldhgt(iseq,i)-hgtpre)/wthinc
+           endif
            stopre=fldstomax(iseq,i)
            hgtpre=fldhgt(iseq,i)
         enddo


### PR DESCRIPTION
### Description

This bug fix was lifted from commit dfe051caa274c4f7949322caea0910359e02a022.
See PR #1018.

This fixes a crash that occurs when wthinc is 0.  This is needed
for the global S2S work.

Resolves #1027