### PR TITLE
Fix the wind field when using GEFS 0.25 Reforecast

### DIFF
--- a/lis/metforcing/gefs/get_gefs.F90
+++ b/lis/metforcing/gefs/get_gefs.F90
@@ -76,7 +76,7 @@ subroutine get_gefs(n,findex)
   character(len=LIS_CONST_PATH_LEN) :: filename
 
 !  character(10), dimension(LIS_rc%met_nf(findex)), parameter :: gefs_vars = (/ &
-  character(10), dimension(8), parameter :: gefs_vars = (/ &
+  character(10), dimension(8) :: gefs_vars = (/ &
        'tmp_2m    ',    &     ! (1) Inst
        'spfh_2m   ',    &     ! (2) Inst
        'dswrf_sfc ',    &     ! (3) Ave
@@ -118,6 +118,12 @@ subroutine get_gefs(n,findex)
 
   ! Read in required GEFS files:
   if( gefs_struc(n)%gefs_fcsttype .eq. "Reforecast2" ) then
+
+    ! The 0.25deg Reforecast wind files naming convention has changed to the following:
+    if(gefs_struc(n)%gefs_res == 0.25) then
+      gefs_vars(5) = 'ugrd_hgt'
+      gefs_vars(6) = 'vgrd_hgt'
+    endif
 
     ! First timestep of run:
     if( LIS_rc%tscount(n).eq.1 .or. &
@@ -507,7 +513,7 @@ subroutine get_reforecast_filename(filename,gefsdir,gefsproj,gefsres,&
   endif
 
   if( gefsres .eq. 0.25 ) then
-    filename = trim(gefsdir)//'/'//ftime0//'/'//ftime2//&
+    filename = trim(gefsdir)//'/'//trim(ftime0)//'/'//ftime2//&
        "00/"//trim(var)//'_'//ftime2//'00_'//fens//'.grib2'
   else
     filename = trim(gefsdir)//'/'//trim(gefsproj)//'/'//trim(ftime1)//&

--- a/lis/metforcing/gefs/read_gefs_reforecast.F90
+++ b/lis/metforcing/gefs/read_gefs_reforecast.F90
@@ -84,7 +84,7 @@ subroutine read_gefs_reforecast(n, m, findex, order, filename, varname, ferror)
   real, allocatable  :: gefs_grib_data(:)              ! Read-in data
   real        :: varfield(LIS_rc%lnc(n),LIS_rc%lnr(n)) ! Interp field
   logical     :: pcp_flag                              ! Precip flag for spatial interp
-  !character*50  :: shortName                           ! variable for wind data
+  character*50  :: shortName                           ! variable for 0.25 degree wind data
 
 ! ______________________________________________________________________________
 
@@ -163,6 +163,8 @@ subroutine read_gefs_reforecast(n, m, findex, order, filename, varname, ferror)
          call LIS_verify(rc,' grib_get error: stepRange in read_gefs_reforecast')
 !         print *, 'grib records: ', i, igrib, stepRange, gefs_struc(n)%fcst_hour
 
+         call grib_get(igrib,'shortName',shortName,rc)
+         call LIS_verify(rc,'error in grib_get: shortName in read_gefs_reforecast')
          ! Check if local forecast hour exceeds max grib file forecast hour:
          if( gefs_struc(n)%fcst_hour > 192 ) then   
             write(LIS_logunit,*) &
@@ -295,7 +297,7 @@ subroutine read_gefs_reforecast(n, m, findex, order, filename, varname, ferror)
        enddo
      endif
 
-     if( trim(varname) == "ugrd_10m" ) then
+     if( trim(varname) == "ugrd_10m" .or. shortName.eq."10u") then
        do r=1,LIS_rc%lnr(n)
           do c=1,LIS_rc%lnc(n)
             if(LIS_domain(n)%gindex(c,r).ne.-1) then 
@@ -313,7 +315,7 @@ subroutine read_gefs_reforecast(n, m, findex, order, filename, varname, ferror)
        enddo
      endif
 
-     if( trim(varname) == "vgrd_10m" ) then
+     if( trim(varname) == "vgrd_10m" .or. shortName.eq."10v") then
        do r=1,LIS_rc%lnr(n)
           do c=1,LIS_rc%lnc(n)
             if(LIS_domain(n)%gindex(c,r).ne.-1) then


### PR DESCRIPTION
The GEFS reforecsast data at 0.25 degrees introduced a notation
change for the wind fields. The bug has been fixed and the GEFS
reader will now properly read in the wind fields from the reforecast2
data at 0.25 degrees and 1.0 degrees. The operational mode of the reader
is not affected by this change and works properly.

This is the final fix for all currently known bugs in the GEFS 0.25 degree reader.

Resolves: #1030 


