### PR TITLE
Fix/fault tolerance

### DIFF
--- a/lis/dataassim/obs/SMAP_NRTsm/read_SMAPNRTsm.F90
+++ b/lis/dataassim/obs/SMAP_NRTsm/read_SMAPNRTsm.F90
@@ -790,7 +790,6 @@ subroutine read_SMAPNRT_data(n, k, fname, smobs_inp, time)
   call h5close_f(status)
 
   if (trim(LIS_rc%runmode) .eq. LIS_agrmetrunID) then
-     write(LIS_logunit,*)'EMK: HERE'
      message(:) = ''
      message(1) = '[ERR] Program:  LIS'
      message(2) = '  Routine:  read_SMAPNRT_data.'

--- a/lis/dataassim/obs/SMAP_NRTsm/read_SMAPNRTsm.F90
+++ b/lis/dataassim/obs/SMAP_NRTsm/read_SMAPNRTsm.F90
@@ -8,7 +8,6 @@
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
 #include "LIS_misc.h"
-#include "LIS_plugins.h"
 
 !BOP
 ! !ROUTINE: read_NASASMAPNRTsm
@@ -502,6 +501,7 @@ subroutine read_SMAPNRT_data(n, k, fname, smobs_inp, time)
 
   use LIS_coreMod,  only : LIS_rc, LIS_domain, LIS_masterproc
   use LIS_logMod, only: LIS_logunit, LIS_alert
+  use LIS_pluginIndices, only: LIS_agrmetrunId
   use LIS_timeMgrMod
   use SMAPNRTsm_Mod, only : SMAPNRTsm_struc
 #if (defined USE_HDF5) 
@@ -570,7 +570,8 @@ subroutine read_SMAPNRT_data(n, k, fname, smobs_inp, time)
   integer                        :: status,ios
   character(len=100) :: message(20)
   integer :: alert_number
-
+  integer :: m
+  
   ! EMK 20220324 Added fault tolerance
   file_id = -1
   sm_gr_id = -1
@@ -789,16 +790,18 @@ subroutine read_SMAPNRT_data(n, k, fname, smobs_inp, time)
   if (file_id > -1) call h5fclose_f(file_id, status)
   call h5close_f(status)
 
-#ifdef MF_AGRMET
-  message(:) = ''
-  message(1) = '[ERR] Program:  LIS'
-  message(2) = '  Routine:  read_SMAPNRT_data.'
-  message(3) = '  Problem reading SMAPNRT data from ' // trim(fname)
-  alert_number = alert_number + 1
-  if(LIS_masterproc) then
-     call lis_alert('SMAPNRT              ', alert_number, message )
-  end if
-#endif
+  do m = 1, LIS_rc%nmetforc
+     if (trim(LIS_rc%metforc(m)) .eq. LIS_agrmetrunID) then
+        message(:) = ''
+        message(1) = '[ERR] Program:  LIS'
+        message(2) = '  Routine:  read_SMAPNRT_data.'
+        message(3) = '  Problem reading SMAPNRT data from ' // trim(fname)
+        alert_number = alert_number + 1
+        if(LIS_masterproc) then
+           call lis_alert('SMAPNRT              ', alert_number, message )
+        end if
+     end if
+  end do
 
 #endif
 

--- a/lis/dataassim/obs/SMAP_NRTsm/read_SMAPNRTsm.F90
+++ b/lis/dataassim/obs/SMAP_NRTsm/read_SMAPNRTsm.F90
@@ -8,6 +8,8 @@
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
 #include "LIS_misc.h"
+#include "LIS_plugins.h"
+
 !BOP
 ! !ROUTINE: read_NASASMAPNRTsm
 ! \label{read_NASASMAPNRTsm}
@@ -498,8 +500,8 @@ subroutine read_SMAPNRT_data(n, k, fname, smobs_inp, time)
 ! 
 ! !USES:   
 
-  use LIS_coreMod,  only : LIS_rc, LIS_domain
-  use LIS_logMod, only: LIS_logunit
+  use LIS_coreMod,  only : LIS_rc, LIS_domain, LIS_masterproc
+  use LIS_logMod, only: LIS_logunit, LIS_alert
   use LIS_timeMgrMod
   use SMAPNRTsm_Mod, only : SMAPNRTsm_struc
 #if (defined USE_HDF5) 
@@ -566,6 +568,8 @@ subroutine read_SMAPNRT_data(n, k, fname, smobs_inp, time)
   real                           :: smobs_ip(LIS_rc%obs_lnc(k)*LIS_rc%obs_lnr(k))
 
   integer                        :: status,ios
+  character(len=100) :: message(20)
+  integer :: alert_number
 
   ! EMK 20220324 Added fault tolerance
   file_id = -1
@@ -784,6 +788,17 @@ subroutine read_SMAPNRT_data(n, k, fname, smobs_inp, time)
   if (sm_gr_id > -1) call h5gclose_f(sm_gr_id, status)
   if (file_id > -1) call h5fclose_f(file_id, status)
   call h5close_f(status)
+
+#ifdef MF_AGRMET
+  message(:) = ''
+  message(1) = '[ERR] Program:  LIS'
+  message(2) = '  Routine:  read_SMAPNRT_data.'
+  message(3) = '  Problem reading SMAPNRT data from ' // trim(fname)
+  alert_number = alert_number + 1
+  if(LIS_masterproc) then
+     call lis_alert('SMAPNRT              ', alert_number, message )
+  end if
+#endif
 
 #endif
 

--- a/lis/dataassim/obs/SMAP_NRTsm/read_SMAPNRTsm.F90
+++ b/lis/dataassim/obs/SMAP_NRTsm/read_SMAPNRTsm.F90
@@ -568,9 +568,9 @@ subroutine read_SMAPNRT_data(n, k, fname, smobs_inp, time)
   real                           :: smobs_ip(LIS_rc%obs_lnc(k)*LIS_rc%obs_lnr(k))
 
   integer                        :: status,ios
-  character(len=100) :: message(20)
+  character(len=512) :: message(20)
   integer :: alert_number
-  integer :: m
+
   
   ! EMK 20220324 Added fault tolerance
   file_id = -1
@@ -790,18 +790,17 @@ subroutine read_SMAPNRT_data(n, k, fname, smobs_inp, time)
   if (file_id > -1) call h5fclose_f(file_id, status)
   call h5close_f(status)
 
-  do m = 1, LIS_rc%nmetforc
-     if (trim(LIS_rc%metforc(m)) .eq. LIS_agrmetrunID) then
-        message(:) = ''
-        message(1) = '[ERR] Program:  LIS'
-        message(2) = '  Routine:  read_SMAPNRT_data.'
-        message(3) = '  Problem reading SMAPNRT data from ' // trim(fname)
-        alert_number = alert_number + 1
-        if(LIS_masterproc) then
-           call lis_alert('SMAPNRT              ', alert_number, message )
-        end if
+  if (trim(LIS_rc%runmode) .eq. LIS_agrmetrunID) then
+     write(LIS_logunit,*)'EMK: HERE'
+     message(:) = ''
+     message(1) = '[ERR] Program:  LIS'
+     message(2) = '  Routine:  read_SMAPNRT_data.'
+     message(3) = '  Problem reading SMAPNRT data from ' // trim(fname)
+     alert_number = alert_number + 1
+     if(LIS_masterproc) then
+        call lis_alert('SMAPNRT              ', alert_number, message )
      end if
-  end do
+  end if
 
 #endif
 

--- a/lis/dataassim/obs/SMAP_NRTsm/read_SMAPNRTsm.F90
+++ b/lis/dataassim/obs/SMAP_NRTsm/read_SMAPNRTsm.F90
@@ -106,7 +106,6 @@ subroutine read_SMAPNRTsm(n, k, OBS_State, OBS_Pert_State)
   character(len=4) :: istring
   character(len=200) :: cmd
   integer :: rc
-
   integer, external :: create_filelist ! C function
 
   smap_filename = ""
@@ -569,7 +568,7 @@ subroutine read_SMAPNRT_data(n, k, fname, smobs_inp, time)
 
   integer                        :: status,ios
   character(len=512) :: message(20)
-  integer :: alert_number
+  integer, save :: alert_number = 0
 
   
   ! EMK 20220324 Added fault tolerance

--- a/lis/dataassim/obs/SMAP_NRTsm/read_SMAPNRTsm.F90
+++ b/lis/dataassim/obs/SMAP_NRTsm/read_SMAPNRTsm.F90
@@ -13,9 +13,11 @@
 ! \label{read_NASASMAPNRTsm}
 !
 ! !REVISION HISTORY:
-!  17 Jun 2010: Sujay Kumar; Updated for use with LPRM AMSRE Version 5. 
-!  20 Sep 2012: Sujay Kumar; Updated to the NETCDF version of the data. 
-!  1  Apr 2019: Yonghwan Kwon: Upated for reading monthy CDF for the current month
+!  17 Jun 2010: Sujay Kumar; Updated for use with LPRM AMSRE Version 5.
+!  20 Sep 2012: Sujay Kumar; Updated to the NETCDF version of the data.
+!  01 Apr 2019: Yonghwan Kwon: Upated for reading monthy CDF for the current
+!               month
+!  24 Mar 2022: Eric Kemp; Added fault tolerance for reading SMAP file.
 !
 ! !INTERFACE: 
 subroutine read_SMAPNRTsm(n, k, OBS_State, OBS_Pert_State)
@@ -497,7 +499,7 @@ subroutine read_SMAPNRT_data(n, k, fname, smobs_inp, time)
 ! !USES:   
 
   use LIS_coreMod,  only : LIS_rc, LIS_domain
-  use LIS_logMod
+  use LIS_logMod, only: LIS_logunit
   use LIS_timeMgrMod
   use SMAPNRTsm_Mod, only : SMAPNRTsm_struc
 #if (defined USE_HDF5) 
@@ -565,102 +567,187 @@ subroutine read_SMAPNRT_data(n, k, fname, smobs_inp, time)
 
   integer                        :: status,ios
 
+  ! EMK 20220324 Added fault tolerance
+  file_id = -1
+  sm_gr_id = -1
+  sm_field_id = -1
+  row_id = -1
+  col_id = -1
+  sm_qa_id = -1
+  dspace_id = -1
+
   call h5open_f(status)
-  call LIS_verify(status, 'Error opening HDF fortran interface')
-  
-  call h5fopen_f(trim(fname),H5F_ACC_RDONLY_F, file_id, status) 
-  call LIS_verify(status, 'Error opening SMAP NRT file ')
-  
-  call h5gopen_f(file_id,sm_gr_name,sm_gr_id, status)
-  call LIS_verify(status, 'Error opening SM group in SMAP NRT file')
-  
-  call h5dopen_f(sm_gr_id,sm_field_name,sm_field_id, status)
-  call LIS_verify(status, 'Error opening SM field in SMAP NRT file')
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot initialize HDF5 Fortran interface!'
+     goto 100
+  end if
 
-  call h5dopen_f(sm_gr_id,"EASE_row_index",row_id, status)
-  call LIS_verify(status, 'Error opening row index field in SMAP NRT file')
+  call h5fopen_f(trim(fname), H5F_ACC_RDONLY_F, file_id, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot open file ', trim(fname)
+     goto 100
+  end if
 
-  call h5dopen_f(sm_gr_id,"EASE_column_index",col_id, status)
-  call LIS_verify(status, 'Error opening column index field in SMAP NRT file')
+  call h5gopen_f(file_id, sm_gr_name, sm_gr_id, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot open SM group ', trim(sm_gr_name)
+     goto 100
+  end if
 
-  call h5dopen_f(sm_gr_id, sm_qa_name,sm_qa_id, status)
-  call LIS_verify(status, 'Error opening QA field in SMAP NRT file')
-  
+  call h5dopen_f(sm_gr_id, sm_field_name, sm_field_id, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot open SM field ', trim(sm_field_name)
+     goto 100
+  end if
+
+  call h5dopen_f(sm_gr_id, "EASE_row_index", row_id, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot open EASE_row_index '
+     goto 100
+  end if
+
+  call h5dopen_f(sm_gr_id, "EASE_column_index", col_id, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot open EASE_column_index '
+     goto 100
+  end if
+
+  call h5dopen_f(sm_gr_id, sm_qa_name, sm_qa_id, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot open ', trim(sm_qa_name)
+     goto 100
+  end if
+
   call h5dget_space_f(sm_field_id, dspace_id, status)
-  call LIS_verify(status, 'Error in h5dget_space_f: readSMAP NRTObs')
-  
-! Size of the arrays
-! This routine returns -1 on failure, rank on success. 
-  call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, status) 
-  if(status.eq.-1) then 
-     call LIS_verify(status, 'Error in h5sget_simple_extent_dims_f: readSMAP NRTObs')
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot copy SM field ', trim(sm_field_name)
+     goto 100
+  end if
+
+  ! Size of the arrays
+  ! This routine returns -1 on failure, rank on success.
+  call h5sget_simple_extent_dims_f(dspace_id, dims, maxdims, status)
+  if (status .eq. -1) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot get dims from ', trim(sm_field_name)
+     goto 100
   endif
-  
+
   allocate(sm_field(maxdims(1)))
   allocate(sm_qa(maxdims(1)))
   allocate(ease_row(maxdims(1)))
   allocate(ease_col(maxdims(1)))
 
-  call h5dread_f(row_id, H5T_NATIVE_INTEGER,ease_row,dims,status)
-  call LIS_verify(status, 'Error extracting row index from SMAP NRTfile')
+  call h5dread_f(row_id, H5T_NATIVE_INTEGER, ease_row, dims, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot get row index!'
+     goto 100
+  end if
 
-  call h5dread_f(col_id, H5T_NATIVE_INTEGER,ease_col,dims,status)
-  call LIS_verify(status, 'Error extracting col index from SMAP NRTfile')
-  
-  call h5dread_f(sm_field_id, H5T_NATIVE_REAL,sm_field,dims,status)
-  call LIS_verify(status, 'Error extracting SM field from SMAP NRTfile')
+  call h5dread_f(col_id, H5T_NATIVE_INTEGER, ease_col, dims, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot get column index!'
+     goto 100
+  end if
 
-  call h5dread_f(sm_qa_id, H5T_NATIVE_INTEGER,sm_qa,dims,status)
-  call LIS_verify(status, 'Error extracting SM field from SMAP NRTfile')
-  
-  call h5dclose_f(sm_qa_id,status)
-  call LIS_verify(status,'Error in H5DCLOSE call')
+  call h5dread_f(sm_field_id, H5T_NATIVE_REAL, sm_field, dims, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot extract ', trim(sm_field_name)
+     goto 100
+  end if
 
-  call h5dclose_f(row_id,status)
-  call LIS_verify(status,'Error in H5DCLOSE call')
+  call h5dread_f(sm_qa_id, H5T_NATIVE_INTEGER, sm_qa, dims, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot extract ', trim(sm_qa_name)
+     goto 100
+  end if
 
-  call h5dclose_f(col_id,status)
-  call LIS_verify(status,'Error in H5DCLOSE call')
+  call h5dclose_f(sm_qa_id, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot close ', trim(sm_qa_name)
+     goto 100
+  end if
 
-  call h5dclose_f(sm_field_id,status)
-  call LIS_verify(status,'Error in H5DCLOSE call')
-  
-  call h5gclose_f(sm_gr_id,status)
-  call LIS_verify(status,'Error in H5GCLOSE call')
-    
-  call h5fclose_f(file_id,status)
-  call LIS_verify(status,'Error in H5FCLOSE call')
-  
+  call h5dclose_f(row_id, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot close EASE_row_index'
+     goto 100
+  end if
+
+  call h5dclose_f(col_id, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot close EASE_column_index'
+     goto 100
+  end if
+
+  call h5dclose_f(sm_field_id, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot close ', trim(sm_field_name)
+     goto 100
+  end if
+
+  call h5gclose_f(sm_gr_id, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot close ', trim(sm_gr_name)
+     goto 100
+  end if
+
+  call h5fclose_f(file_id, status)
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot close ', trim(fname)
+     goto 100
+  end if
+
   call h5close_f(status)
-  call LIS_verify(status,'Error in H5CLOSE call')
+  if (status .ne. 0) then
+     write(LIS_logunit,*) &
+          '[WARN] read_SMAPNRT_data cannot close HDF5 Fortran interface'
+     goto 100
+  end if
 
   sm_data = LIS_rc%udef
-  sm_data_b = .false. 
+  sm_data_b = .false.
 
 !grid the data in EASE projection
-  do t=1,maxdims(1)
-     if(ibits(sm_qa(t),0,1).eq.0) then 
-        sm_data(ease_col(t) + (ease_row(t)-1)*SMAPNRTsm_struc(n)%nc) = sm_field(t) 
-        if(sm_field(t).ne.-9999.0) then 
-           sm_data_b(ease_col(t) + (ease_row(t)-1)*SMAPNRTsm_struc(n)%nc) = .true. 
+  do t = 1, maxdims(1)
+     if (ibits(sm_qa(t), 0, 1) .eq. 0) then
+        sm_data(ease_col(t) + (ease_row(t)-1)*SMAPNRTsm_struc(n)%nc) = &
+             sm_field(t)
+        if (sm_field(t) .ne. -9999.0) then
+           sm_data_b(ease_col(t) + (ease_row(t)-1)*SMAPNRTsm_struc(n)%nc) = &
+                .true.
         endif
      endif
   enddo
-
-!  open(100,file='smobs.bin',form='unformatted')
-!  write(100) sm_data
-!  close(100)
 
   t = 1
 
 !--------------------------------------------------------------------------
 ! Interpolate to the LIS running domain
-!-------------------------------------------------------------------------- 
-  call neighbor_interp(LIS_rc%obs_gridDesc(k,:),&
+!--------------------------------------------------------------------------
+  call neighbor_interp(LIS_rc%obs_gridDesc(k,:), &
        sm_data_b, sm_data, smobs_b_ip, smobs_ip, &
        SMAPNRTsm_struc(n)%nc*SMAPNRTsm_struc(n)%nr, &
        LIS_rc%obs_lnc(k)*LIS_rc%obs_lnr(k), &
-       SMAPNRTsm_struc(n)%rlat, SMAPNRTsm_struc(n)%rlon,&
+       SMAPNRTsm_struc(n)%rlat, SMAPNRTsm_struc(n)%rlon, &
        SMAPNRTsm_struc(n)%n11, LIS_rc%udef, ios)
 
   deallocate(sm_field)
@@ -668,18 +755,35 @@ subroutine read_SMAPNRT_data(n, k, fname, smobs_inp, time)
   deallocate(ease_row)
   deallocate(ease_col)
 
-!overwrite the input data 
-  do r=1,LIS_rc%obs_lnr(k)
-     do c=1,LIS_rc%obs_lnc(k)
-        if(smobs_ip(c+(r-1)*LIS_rc%obs_lnc(k)).ne.-9999.0) then 
+  !overwrite the input data
+  do r = 1, LIS_rc%obs_lnr(k)
+     do c = 1, LIS_rc%obs_lnc(k)
+        if (smobs_ip(c+(r-1)*LIS_rc%obs_lnc(k)) .ne. -9999.0) then
            smobs_inp(c+(r-1)*LIS_rc%obs_lnc(k)) = &
                 smobs_ip(c+(r-1)*LIS_rc%obs_lnc(k))
 
-           SMAPNRTsm_struc(n)%smtime(c,r) = & 
+           SMAPNRTsm_struc(n)%smtime(c,r) = &
                 time
         endif
      enddo
   enddo
+
+  return
+
+  ! Handle problem from HDF5 before returning.  We'll ignore the status
+  ! codes here since we want to force a full HDF5 shutdown.
+  100 continue
+  if (allocated(sm_field)) deallocate(sm_field)
+  if (allocated(sm_qa)) deallocate(sm_qa)
+  if (allocated(ease_row)) deallocate(ease_row)
+  if (allocated(ease_col)) deallocate(ease_col)
+  if (sm_qa_id > -1) call h5dclose_f(sm_qa_id, status)
+  if (col_id > -1) call h5dclose_f(col_id, status)
+  if (row_id > -1) call h5dclose_f(row_id, status)
+  if (sm_field_id > -1) call h5dclose_f(sm_field_id, status)
+  if (sm_gr_id > -1) call h5gclose_f(sm_gr_id, status)
+  if (file_id > -1) call h5fclose_f(file_id, status)
+  call h5close_f(status)
 
 #endif
 

--- a/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
+++ b/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
@@ -487,7 +487,7 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
   integer         :: updoy,yr1,mo1,da1,hr1,mn1,ss1,offset
   real            :: upgmt
   real*8          :: file_time
-
+  integer :: imsg
 
 #if(defined USE_GRIBAPI)
   ! When we are reading the 6-hourly datasets, we read the file HR+6
@@ -537,7 +537,6 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
         'as SMOPS version 3.0'
   endif
 
-
   call grib_open_file(ftn, trim(fname), 'r', iret)
   if (iret .ne. 0) then
      write(LIS_logunit,*) '[WARN] Could not open file: ', trim(fname)
@@ -545,12 +544,14 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
   endif
   call grib_multi_support_on
 
+  imsg = 0
   do
      call grib_new_from_file(ftn, igrib, iret)
 
      if ( iret == GRIB_END_OF_FILE ) then
         exit
      endif
+     imsg = imsg + 1
 
      call grib_get(igrib, 'parameterNumber', param_num, iret)
      if (iret .ne. 0) then
@@ -710,6 +711,10 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
   enddo
 
   call grib_close_file(ftn)
+
+  if (imsg .eq. 0) then
+     write(LIS_logunit,*)'[WARN] No GRIB messages found in ', trim(fname)
+  end if
 
   ! Table 3.6.1 – SMOPS soil moisture product Quality Assessment (QA) bits.
   ! (d) ASCAT Soil Moisture Product QA

--- a/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
+++ b/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
@@ -491,7 +491,7 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
   real*8          :: file_time
   integer :: imsg
   character(len=512) :: message(20)
-  integer :: alert_number
+  integer, save :: alert_number = 0
 
 #if(defined USE_GRIBAPI)
   ! When we are reading the 6-hourly datasets, we read the file HR+6

--- a/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
+++ b/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
@@ -8,7 +8,7 @@
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
 #include "LIS_misc.h"
-#include "LIS_plugins.h"
+
 !BOP
 ! !ROUTINE: read_SMOPS_ASCATsm
 ! \label{read_SMOPS_ASCATsm}
@@ -399,6 +399,7 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
 #endif
   use LIS_coreMod,  only : LIS_rc, LIS_domain, LIS_masterproc
   use LIS_logMod
+  use LIS_pluginIndices, only: LIS_agrmetrunId
   use LIS_timeMgrMod
   use SMOPS_ASCATsm_Mod, only : SMOPS_ASCATsm_struc
 
@@ -491,6 +492,7 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
   integer :: imsg
   character(len=100) :: message(20)
   integer :: alert_number
+  integer :: m
 
 #if(defined USE_GRIBAPI)
   ! When we are reading the 6-hourly datasets, we read the file HR+6
@@ -729,16 +731,20 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
      if (imsg .eq. 0) then
         write(LIS_logunit,*)'[WARN] No GRIB messages found in ', trim(fname)
      end if
-#ifdef MF_AGRMET
-     message(:) = ''
-     message(1) = '[ERR] Program:  LIS'
-     message(2) = '  Routine:  read_SMOPS_ASCATsm_data.'
-     message(3) = '  Problem reading SMOPS_ASCATsm data from ' // trim(fname)
-     alert_number = alert_number + 1
-     if(LIS_masterproc) then
-        call lis_alert('SMOPS_ASCATsm              ', alert_number, message )
-     end if
-#endif
+     do m = 1, LIS_rc%nmetforc
+        if (trim(LIS_rc%metforc(m)) .eq. LIS_agrmetrunId) then
+           message(:) = ''
+           message(1) = '[ERR] Program:  LIS'
+           message(2) = '  Routine:  read_SMOPS_ASCATsm_data.'
+           message(3) = '  Problem reading SMOPS_ASCATsm data from ' &
+                // trim(fname)
+           alert_number = alert_number + 1
+           if(LIS_masterproc) then
+              call lis_alert('SMOPS_ASCATsm              ', alert_number, &
+                   message )
+           end if
+        end if
+     end do
      return
   end if
 

--- a/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
+++ b/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
@@ -562,7 +562,6 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
         write(LIS_logunit,*) &
              '[WARN] Problem reading parameterNumber from ', trim(fname)
         call grib_release(igrib, iret)
-        call grib_close_file(ftn)
         imsg = -1
         exit
      end if
@@ -576,7 +575,6 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
         if (iret .ne. 0) then
            write(LIS_logunit,*)'[WARN] Problem reading values for ASCAT_A'
            call grib_release(igrib, iret)
-           call grib_close_file(ftn)
            imsg = -1
            exit
         end if
@@ -598,7 +596,6 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
         if (iret .ne. 0) then
            write(LIS_logunit,*)'[WARN] Problem reading QA values for ASCAT_A'
            call grib_release(igrib, iret)
-           call grib_close_file(ftn)
            imsg = -1
            exit
         end if
@@ -620,7 +617,6 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
         if (iret .ne. 0) then
            write(LIS_logunit,*)'[WARN] Problem reading hr values for ASCAT_A'
            call grib_release(igrib, iret)
-           call grib_close_file(ftn)
            imsg = -1
            exit
         end if
@@ -635,7 +631,6 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
         if (iret .ne. 0) then
            write(LIS_logunit,*)'[WARN] Problem reading mn values for ASCAT_A'
            call grib_release(igrib, iret)
-           call grib_close_file(ftn)
            imsg = -1
            exit
         end if
@@ -650,7 +645,6 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
         if (iret .ne. 0) then
            write(LIS_logunit,*)'[WARN] Problem reading values for ASCAT_B'
            call grib_release(igrib, iret)
-           call grib_close_file(ftn)
            imsg = -1
            exit
         end if
@@ -672,7 +666,6 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
         if (iret .ne. 0) then
            write(LIS_logunit,*)'[WARN] Problem reading QA values for ASCAT_B'
            call grib_release(igrib, iret)
-           call grib_close_file(ftn)
            imsg = -1
            exit
         end if
@@ -694,7 +687,6 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
         if (iret .ne. 0) then
            write(LIS_logunit,*)'[WARN] Problem reading hr values for ASCAT_B'
            call grib_release(igrib, iret)
-           call grib_close_file(ftn)
            imsg = -1
            exit
         end if
@@ -709,7 +701,6 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
         if (iret .ne. 0) then
            write(LIS_logunit,*)'[WARN] Problem reading mn values for ASCAT_B'
            call grib_release(igrib, iret)
-           call grib_close_file(ftn)
            imsg = -1
            exit
         end if
@@ -718,7 +709,6 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
      call grib_release(igrib, iret)
      if (iret .ne. 0) then
         write(LIS_logunit,*)'[WARN] Problem releasing from ', trim(fname)
-        call grib_close_file(ftn)
         imsg = -1
         exit
      end if

--- a/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
+++ b/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
@@ -490,9 +490,8 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
   real            :: upgmt
   real*8          :: file_time
   integer :: imsg
-  character(len=100) :: message(20)
+  character(len=512) :: message(20)
   integer :: alert_number
-  integer :: m
 
 #if(defined USE_GRIBAPI)
   ! When we are reading the 6-hourly datasets, we read the file HR+6
@@ -731,20 +730,17 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
      if (imsg .eq. 0) then
         write(LIS_logunit,*)'[WARN] No GRIB messages found in ', trim(fname)
      end if
-     do m = 1, LIS_rc%nmetforc
-        if (trim(LIS_rc%metforc(m)) .eq. LIS_agrmetrunId) then
-           message(:) = ''
-           message(1) = '[ERR] Program:  LIS'
-           message(2) = '  Routine:  read_SMOPS_ASCATsm_data.'
-           message(3) = '  Problem reading SMOPS_ASCATsm data from ' &
-                // trim(fname)
-           alert_number = alert_number + 1
-           if(LIS_masterproc) then
-              call lis_alert('SMOPS_ASCATsm              ', alert_number, &
-                   message )
-           end if
+     if (trim(LIS_rc%runmode) .eq. LIS_agrmetrunId) then
+        message(:) = ''
+        message(1) = '[ERR] Program:  LIS'
+        message(2) = '  Routine:  read_SMOPS_ASCATsm_data.'
+        message(3) = '  Problem reading SMOPS_ASCATsm data from '// trim(fname)
+        alert_number = alert_number + 1
+        if(LIS_masterproc) then
+           call lis_alert('SMOPS_ASCATsm              ', alert_number, &
+                message )
         end if
-     end do
+     end if
      return
   end if
 

--- a/lvt/utils/usaf/templates/submit_lvt_discover_3hr_noah.py
+++ b/lvt/utils/usaf/templates/submit_lvt_discover_3hr_noah.py
@@ -57,7 +57,8 @@ fi
 
 module purge
 module use --append ~/privatemodules
-module load lisf_7_intel_19_1_3_304
+#module load lisf_7_intel_19_1_3_304
+module load lisf_7_intel_2021.4.0_s2s
 
 if [ ! -e ./LVT ] ; then
    echo "ERROR, LVT does not exist!" && exit 1


### PR DESCRIPTION


### Description

Revised SMAPNRT and SMOPS_ASCATsm readers to add fault tolerance (gracefully returning from readers and continuing running LIS, instead of calling LIS_endrun) in the event a problem occurs in opening or reading a file. This change was requested by 557 WW. 

In addition, if LIS is run in "AGRMET Ops" mode, alert.SMAPNRT.### or alert.SMOPS_ASCATsm.### files are written to indicate which observation file could not be read correctly. This is useful for notifying 557 WW Operations that a data feed problem is occurring.

Finally, the Discover environment module for a LVT postprocessing script was updated to allow use in testing.

NOTE: This branch reproduced results created from the latest support/lisf-557ww-7.4 code (after postprocessing from LVT), when SMAPNRT and SMOPS-ASCATsm data are used. However, the postprocessed output from the existing USAF LIS-Noah use case is not reproduced past 3 hours. I'm assuming this is due to a separate change to the code since the use case was created.
