### PR TITLE
Customize "optimization level 2" flags for cray_cray architecture

### DIFF
--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -264,8 +264,14 @@ elsif($opt_lev == 1) {
    $sys_c_opt = "";
 }
 elsif($opt_lev == 2) {
-   $sys_opt = "-O2";
-   $sys_c_opt = "";
+   if($sys_arch eq "cray_cray") {
+      $sys_opt = "-O2 -h ipa2,scalar0,vector0 ";
+      $sys_c_opt = "";
+   }
+   else {
+      $sys_opt = "-O2 ";
+      $sys_c_opt = "";
+   }
 }
 elsif($opt_lev == 3) {
    $sys_opt = "-O3";


### PR DESCRIPTION
### Description

Customize "optimization level 2" flags for cray_cray architecture.

This resolves an issue in which LIS crashes calling ESMF.
