### PR TITLE
Fix support URL in bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 <!-- Looking for LISF support? -->
-<!-- Visit https://modelingguru.nasa.gov/community/atmospheric/lis -->
+<!-- Visit https://github.com/NASA-LIS/LISF/discussions -->
 
 ### Bug Description
 


### PR DESCRIPTION
Updates the support URL in GitHub issue template for bugs from ModelingGuru to GitHub Discussions page.
