### PR TITLE
Write soil layer global attributes to quilted NetCDF file in LVT "LIS postprocessing" mode

### DIFF
--- a/lvt/configs/lvt.config.adoc
+++ b/lvt/configs/lvt.config.adoc
@@ -2632,3 +2632,23 @@ Number of fields in the LIS output: 11
 ....
 Number of vertical levels in the LIS output: 4
 ....
+
+`LIS output number of soil moisture layers:` specifies the number of soil moisture layers used in the LIS output. This is optional and defaults to 0.
+
+`LIS output soil moisture layer thickness:` specifies the number of soil moisture layers used in the LIS output. These values will be written to the NetCDF as global attributes and should match those used in the LIS configuration file to define the LSM soil moisture layer thicknesses. If the number of soil moisture layers is omitted or set to 0, this entry is not read and soil moisture layer thicknesses are not written to the NetCDF global attributes.
+
+.Example _lvt.config_ entry
+....
+LIS output number of soil moisture layers:  4
+LIS output soil moisture layer thickness: 0.1 0.3 0.6 1.0
+....
+
+`LIS output number of soil temperature layers:` specifies the thicknesses of soil moisture layers in the LIS output. This is optional and defaults to 0.
+
+`LIS output soil temperature layer thickness:` specifies the thicknesses of soil temperature layers in the LIS output. These values will be written to the NetCDF as global attributes and should match those used in the LIS configuration file to define the LSM soil temperature layer thicknesses. If the number of soil temperature layers is omitted or set to 0, this entry is not read and soil temperature layer thicknesses are not written to the NetCDF global attributes.
+
+.Example _lvt.config_ entry
+....
+LIS output number of soil temperature layers:  4
+LIS output soil temperature layer thickness:  0.1 0.3 0.6 1.0
+....

--- a/lvt/core/LVT_LISpostMod.F90
+++ b/lvt/core/LVT_LISpostMod.F90
@@ -62,6 +62,8 @@ module LVT_LISpostMod
      integer   :: npes
      integer   :: nfields
      integer   :: nlevels
+     integer   :: nsoilmoistlayers, nsoiltemplayers
+     real, pointer :: soilmoistlyrthk(:), soiltemplyrthk(:)
   end type lispost_type_dec
   
   type(lispost_type_dec) :: LVT_LISpost
@@ -87,7 +89,7 @@ contains
 ! 
 !EOP
 
-    integer           :: rc
+    integer           :: i, rc
 
     call ESMF_ConfigGetAttribute(LVT_config,LVT_LISpost%npes,&
          label="Number of processors used in the LIS output generation:",rc=rc)
@@ -98,6 +100,36 @@ contains
     call ESMF_ConfigGetAttribute(LVT_config,LVT_LISpost%nlevels,&
          label="Number of vertical levels in the LIS output:",rc=rc)
     call LVT_verify(rc,'Number of vertical levels in the LIS output: option not specified in the config file')
+    call ESMF_ConfigGetAttribute(LVT_config, LVT_LISpost%nsoilmoistlayers, &
+         label="LIS output number of soil moisture layers:", default=0, rc=rc)
+    call ESMF_ConfigGetAttribute(LVT_config, LVT_LISpost%nsoiltemplayers, &
+         label="LIS output number of soil temperature layers:", default=0, rc=rc)
+    
+    if (LVT_LISpost%nsoilmoistlayers .gt. 0) then
+       allocate(LVT_LISpost%soilmoistlyrthk(LVT_LISpost%nsoilmoistlayers))
+
+       call ESMF_ConfigFindLabel(LVT_config, "LIS output soil moisture layer thickness:", rc=rc)
+       call LVT_verify(rc, 'LIS output soil moisture layer thickness: option not specified in the config file')
+
+       do i=1, LVT_LISpost%nsoilmoistlayers
+          call ESMF_ConfigGetAttribute(LVT_config,LVT_LISpost%soilmoistlyrthk(i), rc=rc)
+          call LVT_verify(rc, 'The number of soil moisture layers indicated in the  &
+               config file is greater than the number of thickness values provided')
+       enddo
+    endif
+    
+    if (LVT_LISpost%nsoiltemplayers .gt. 0) then
+       allocate(LVT_LISpost%soiltemplyrthk(LVT_LISpost%nsoiltemplayers))
+
+       call ESMF_ConfigFindLabel(LVT_config, "LIS output soil temperature layer thickness:", rc=rc)
+       call LVT_verify(rc, 'LIS output soil temperature layer thickness: option not specified in the config file')
+
+       do i=1, LVT_LISpost%nsoilmoistlayers
+          call ESMF_ConfigGetAttribute(LVT_config,LVT_LISpost%soiltemplyrthk(i), rc=rc)
+          call LVT_verify(rc, 'The number of soil temperature layers indicated in the & 
+               config file is greater than the number of thickness values provided')
+       enddo
+    endif
 
   end subroutine LVT_initialize_LISpost
 
@@ -266,12 +298,24 @@ contains
                'nf90_def_att for lat failed in LVT_LISpostMod')    
           
     ! Global attributes
-!    call LVT_verify(nf90_put_att(ftn_nc,NF90_GLOBAL,"NUM_SOIL_LAYERS", &
-!         nsoillayers),&
-!         'nf90_put_att for title failed in LVT_LISpostMod')
-!    call LVT_verify(nf90_put_att(ftn_nc,NF90_GLOBAL,"SOIL_LAYER_THICKNESSES", &
-!         lyrthk),&
-!         'nf90_put_att for title failed in LVT_LISpostMod')
+          if (LVT_LISpost%nsoilmoistlayers .gt. 0) then
+             call LVT_verify(nf90_put_att(ftn_nc,NF90_GLOBAL,"NUM_SOIL_MOIST_LAYERS", &
+                  LVT_LISpost%nsoilmoistlayers),&
+                  'nf90_put_att for NUM_SOIL_MOIST_LAYERS failed in LVT_LISpostMod')
+             call LVT_verify(nf90_put_att(ftn_nc,NF90_GLOBAL,"SOIL_MOIST_LAYER_THICKNESSES", &
+                  LVT_LISpost%soilmoistlyrthk),&
+                  'nf90_put_att for SOIL_MOIST_LAYER_THICKNESSES failed in LVT_LISpostMod')
+          endif
+          
+          if (LVT_LISpost%nsoiltemplayers .gt. 0) then
+             call LVT_verify(nf90_put_att(ftn_nc,NF90_GLOBAL,"NUM_SOIL_TEMP_LAYERS", &
+                  LVT_LISpost%nsoiltemplayers),&
+                  'nf90_put_att for NUM_SOIL_TEMP_LAYERS failed in LVT_LISpostMod')
+             call LVT_verify(nf90_put_att(ftn_nc,NF90_GLOBAL,"SOIL_TEMP_LAYER_THICKNESSES", &
+                  LVT_LISpost%soiltemplyrthk),&
+                  'nf90_put_att for SOIL_TEMP_LAYER_THICKNESSES failed in LVT_LISpostMod')
+          endif
+
           call LVT_verify(nf90_put_att(ftn_nc,NF90_GLOBAL,"title", &
                "LIS land surface model output"),&
                'nf90_put_att for title failed in LVT_LISpostMod')


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

The "LIS postprocessing" mode introduced to LVT in #1042 does not write `NUM_SOIL_LAYERS` or `SOIL_LAYER_THICKNESSES` global attributes to the quilted NetCDF file because they are not contained in the LIS-generated binary output files. This fix adds optional LVT configuration entries for both attributes so users can write these attributes if they wish.

The `history` attribute is still not written. I'm torn on whether to add support for that too. It does [*not* appear to be required by the CF conventions](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.9/cf-conventions.html#description-of-file-contents) and users would have to enter, and update, a properly formatted string in their config file (e.g., `"created on date: 2020-07-17T11:04:15.799"`). Seems prone to error and inaccuracy.

@sujayvkumar, let me know what you think.

Resolves #1047

### Testcase

`/discover/nobackup/projects/lis/PR_TESTCASES/1042/testing/`