### PR TITLE
Added -fp0 flag for Cray compilers, for IEEE compliance.

### DIFF
--- a/ldt/arch/Config.pl
+++ b/ldt/arch/Config.pl
@@ -175,8 +175,9 @@ elsif($opt_lev == 1) {
    $sys_c_opt = "";
 }
 elsif($opt_lev == 2) {
-   if($sys_arch eq "cray_cray") {
-      $sys_opt = "-O2 -h ipa2,scalar0,vector0 ";
+  if($sys_arch eq "cray_cray") {
+      # EMK 14 Apr 2022...For best conformity to IEEE standard, use fp0
+      $sys_opt = "-O2 -h ipa2,scalar0,vector0,fp0 ";
       $sys_c_opt = "";
    }
    else {


### PR DESCRIPTION

### Description

Added fp0 to optimization flag list for Cray compiler for LDT.

This flag appears to yield the closest conformance to the IEEE floating point standard for the Cray compiler, and helps
improve agreement in USAFSI analyses produced on HPC11 versus analyses produced on Discover with the -fp-model consistent flag for the Intel compiler.

Similar changes may be needed for LIS and LVT, but have not been tested yet.  Adding -fp-model consistent for Intel compilers is also deferred at least until @jvgeiger returns from leave.

