### PR TITLE
Fix: enable LDT to compile without HDF5

### DIFF
--- a/ldt/USAFSI/USAFSI_amsr2Mod.F90
+++ b/ldt/USAFSI/USAFSI_amsr2Mod.F90
@@ -238,6 +238,7 @@ contains
                                                   tb23h_raw(:,:), tb23v_raw(:,:), &
                                                   tb37h_raw(:,:), tb37v_raw(:,:), &
                                                   tb89h_raw(:,:), tb89v_raw(:,:)
+#if (defined USE_HDF5)
       integer(hsize_t), dimension(2)           :: dims_lat, maxdims_lat
       integer(hsize_t), dimension(2)           :: dims_lon, maxdims_lon
       integer(hsize_t), dimension(3)           :: dims_tb, maxdims_tb
@@ -627,7 +628,7 @@ contains
 
       call h5close_f(status)
       call LDT_verify(status,'Error in H5CLOSE call') 
-
+#endif
    end subroutine read_amsr2_attributes
 
 

--- a/ldt/USAFSI/USAFSI_xcalgmiMod.F90
+++ b/ldt/USAFSI/USAFSI_xcalgmiMod.F90
@@ -233,7 +233,7 @@ contains
                                                   tb89v(:)
       integer,      allocatable, intent(inout) :: qcflag_1d(:)
       real,         allocatable                :: tb_field(:,:,:)
-
+#if (defined USE_HDF5)
       integer(hsize_t), dimension(2)           :: dims_lat, maxdims_lat
       integer(hsize_t), dimension(2)           :: dims_lon, maxdims_lon
       integer(hsize_t), dimension(3)           :: dims_tb, maxdims_tb
@@ -504,7 +504,7 @@ contains
 
       call h5close_f(status)
       call LDT_verify(status,'Error in H5CLOSE call') 
-
+#endif
    end subroutine read_xcalgmi_attributes
 
 


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Adds checks for HDF5 usage to allow LDT to compile without HDF5.

Resolves #1057

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
Configure LDT with HDF5 disabled and then compile.