### PR TITLE
Correct LSM_finalize routines

### DIFF
--- a/lis/surfacemodels/land/awral.6.0.0/AWRAL600_finalize.F90
+++ b/lis/surfacemodels/land/awral.6.0.0/AWRAL600_finalize.F90
@@ -20,7 +20,7 @@
 !   12/18/18: Wendy Sharples, Shugong Wang; initial implementation for AWRAL600 with LIS-7
 !
 ! !INTERFACE:
-subroutine AWRAL600_finalize(n)
+subroutine AWRAL600_finalize()
 ! !USES:
     use LIS_coreMod, only : LIS_rc
     use AWRAL600_lsmMod

--- a/lis/surfacemodels/land/noahmp.3.6/NoahMP36_finalize.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/NoahMP36_finalize.F90
@@ -20,7 +20,7 @@
 !   9/4/14: Shugong Wang; initial implementation for NoahMP36 with LIS-7
 !
 ! !INTERFACE:
-subroutine NoahMP36_finalize(n)
+subroutine NoahMP36_finalize()
 ! !USES:
     use LIS_coreMod, only : LIS_rc
     use NoahMP36_lsmMod

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_finalize.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_finalize.F90
@@ -21,7 +21,7 @@
 !   10/25/18: Shugong Wang, Zhuo Wang; initial implementation for NoahMP401 with LIS-7
 !
 ! !INTERFACE:
-subroutine NoahMP401_finalize(n)
+subroutine NoahMP401_finalize()
 ! !USES:
     use LIS_coreMod, only : LIS_rc
     use NoahMP401_lsmMod

--- a/lis/surfacemodels/land/rdhm.3.5.6/RDHM356_finalize.F90
+++ b/lis/surfacemodels/land/rdhm.3.5.6/RDHM356_finalize.F90
@@ -20,7 +20,7 @@
 !   11/5/13: Shugong Wang; initial implementation for RDHM356 with LIS-7
 !
 ! !INTERFACE:
-subroutine RDHM356_finalize(n)
+subroutine RDHM356_finalize()
 ! !USES:
     use LIS_coreMod, only : LIS_rc
     use RDHM356_lsmMod

--- a/lis/surfacemodels/land/ruc.3.7/RUC37_finalize.F90
+++ b/lis/surfacemodels/land/ruc.3.7/RUC37_finalize.F90
@@ -20,7 +20,7 @@
 !   1/15/15: Shugong Wang; initial implementation for RUC37 with LIS-7
 !
 ! !INTERFACE:
-subroutine RUC37_finalize(n)
+subroutine RUC37_finalize()
 ! !USES:
     use LIS_coreMod, only : LIS_rc
     use RUC37_lsmMod


### PR DESCRIPTION
### Description

Remove argument "n" from definition of LSM_finalize routines.

The LSM_finalize routines do not take arguments.  Also "n" clashes with
a local variable used to loop over LIS_rc%nnest.



