### PR TITLE
Updated MPI decompositions to 576 by 1.

### DIFF
--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.jules50.ops
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.jules50.ops
@@ -64,8 +64,8 @@ Minimum cutoff percentage (aspect bands):         0.05
 
 #Processor layout
 #Should match the total number of processors used
-Number of processors along x:          24
-Number of processors along y:          24
+Number of processors along x:         576
+Number of processors along y:           1
 Halo size along x:                      0
 Halo size along y:                      0
 

--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.jules50.ops.galwem10
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.jules50.ops.galwem10
@@ -64,8 +64,8 @@ Minimum cutoff percentage (aspect bands):         0.05
 
 #Processor layout
 #Should match the total number of processors used
-Number of processors along x:          24
-Number of processors along y:          24
+Number of processors along x:         576
+Number of processors along y:           1
 Halo size along x:                      0
 Halo size along y:                      0
 

--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noah39.ops
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noah39.ops
@@ -64,8 +64,8 @@ Minimum cutoff percentage (aspect bands):         0.05
 
 #Processor layout
 #Should match the total number of processors used
-Number of processors along x:          24
-Number of processors along y:          24
+Number of processors along x:         576
+Number of processors along y:           1
 Halo size along x:                      0
 Halo size along y:                      0
 

--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noah39.ops.galwem10
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noah39.ops.galwem10
@@ -64,8 +64,8 @@ Minimum cutoff percentage (aspect bands):         0.05
 
 #Processor layout
 #Should match the total number of processors used
-Number of processors along x:          24
-Number of processors along y:          24
+Number of processors along x:         576
+Number of processors along y:           1
 Halo size along x:                      0
 Halo size along y:                      0
 

--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noahmp401.ops
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noahmp401.ops
@@ -64,8 +64,8 @@ Minimum cutoff percentage (aspect bands):         0.05
 
 #Processor layout
 #Should match the total number of processors used
-Number of processors along x:          24
-Number of processors along y:          24
+Number of processors along x:         576
+Number of processors along y:           1
 Halo size along x:                      0
 Halo size along y:                      0
 

--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noahmp401.ops.galwem10
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noahmp401.ops.galwem10
@@ -64,8 +64,8 @@ Minimum cutoff percentage (aspect bands):         0.05
 
 #Processor layout
 #Should match the total number of processors used
-Number of processors along x:          24
-Number of processors along y:          24
+Number of processors along x:         576
+Number of processors along y:           1
 Halo size along x:                      0
 Halo size along y:                      0
 


### PR DESCRIPTION
Updated MPI decompositions for FOC reference lis.config files for Air Force.

This is based on timing tests with LIS-Noah on HPC11.


