### PR TITLE
Add LVT Seasonal average for 3-month calendar/WY

### DIFF
--- a/lvt/configs/lvt.config.adoc
+++ b/lvt/configs/lvt.config.adoc
@@ -697,12 +697,13 @@ Stratification attributes file:         ./strat_attribs.txt
 
 [cols="<,<",]
 |===
-| Value     | Description
+| Value        | Description
 
-| monthly   | monthly seasonal cycles (default)
-| 3 monthly | 3-monthly seasonal cycles (DJF,MAM,JJA,SON)
-| 6 monthly | 6-monthly seasonal cycles
-| yearly    | yearly seasonal cycles
+| monthly      | monthly seasonal cycles (default)
+| 3 monthly    | 3-monthly seasonal cycles (DJF,MAM,JJA,SON)
+| 3 monthly WY | 3-monthly seasonal cycles based on water/calendar year (JFM,MAJ,JAS,OND)
+| 6 monthly    | 6-monthly seasonal cycles
+| yearly       | yearly seasonal cycles
 |===
 
 .Example _lvt.config_ entry

--- a/lvt/core/LVT_coreMod.F90
+++ b/lvt/core/LVT_coreMod.F90
@@ -503,7 +503,7 @@ contains
                    LVT_rc%monthCount = 0 
                 endif
              endif
-          elseif(mod(LVT_rc%tavgInterval,7776000).eq.0)then !3 monthly 
+          elseif(mod(LVT_rc%tavgInterval,7776000).eq.0)then !3 monthly
              if(LVT_rc%mo.ne.LVT_rc%prev_mo_tavg) then 
                 LVT_rc%prev_mo_tavg = LVT_rc%mo
                 LVT_rc%monthCount = LVT_rc%monthCount + 1

--- a/lvt/core/LVT_getSeasonalCycleIndex.F90
+++ b/lvt/core/LVT_getSeasonalCycleIndex.F90
@@ -88,6 +88,35 @@ subroutine LVT_getSeasonalCycleTimeIndex(interval,tind)
         endif
 
      endif
-
+  elseif(interval.eq.21) then
+     if(LVT_rc%statswriteint.eq.2592000) then
+        if(LVT_rc%mo.eq.2.or.LVT_rc%mo.eq.3.or.LVT_rc%mo.eq.4) then
+           !JFM
+           tind = 1
+        elseif(LVT_rc%mo.eq.5.or.LVT_rc%mo.eq.6.or.LVT_rc%mo.eq.7) then
+           !AMJ
+           tind = 2
+        elseif(LVT_rc%mo.eq.8.or.LVT_rc%mo.eq.9.or.LVT_rc%mo.eq.10) then
+           !JAS
+           tind = 3
+        elseif(LVT_rc%mo.eq.11.or.LVT_rc%mo.eq.12.or.LVT_rc%mo.eq.1) then
+           !OND
+           tind = 4
+        endif
+     elseif(LVT_rc%statswriteint.lt.2592000) then
+        if(LVT_rc%mo.eq.1.or.LVT_rc%mo.eq.2.or.LVT_rc%mo.eq.3) then
+           !JFM
+           tind = 1
+        elseif(LVT_rc%mo.eq.4.or.LVT_rc%mo.eq.5.or.LVT_rc%mo.eq.6) then
+           !AMJ
+           tind = 2
+        elseif(LVT_rc%mo.eq.7.or.LVT_rc%mo.eq.8.or.LVT_rc%mo.eq.9) then
+           !JAS
+           tind = 3
+        elseif(LVT_rc%mo.eq.10.or.LVT_rc%mo.eq.11.or.LVT_rc%mo.eq.12) then
+           !OND
+           tind = 4
+        endif
+     endif
   endif
 end subroutine LVT_getSeasonalCycleTimeIndex

--- a/lvt/core/LVT_readConfig.F90
+++ b/lvt/core/LVT_readConfig.F90
@@ -502,9 +502,11 @@ subroutine LVT_readConfig(configfile)
         LVT_rc%scInterval = 6
      elseif(scInterval.eq."yearly") then 
         LVT_rc%scInterval = 12
+     elseif(scInterval.eq."3 monthly WY") then
+        LVT_rc%scInterval = 21 !scInterval is 2 with a variation of the 3 monthly
      else
         write(LVT_logunit,*) '[ERR] Seasonal cycle interval type must be -- '
-        write(LVT_logunit,*) '[ERR] monthly, 3 monthly, 6 monthly or yearly'
+        write(LVT_logunit,*) '[ERR] monthly, 3 monthly, 3 monthly WY, 6 monthly or yearly'
         call LVT_endrun()
      endif
      

--- a/lvt/core/LVT_statsMod.F90
+++ b/lvt/core/LVT_statsMod.F90
@@ -216,6 +216,13 @@ contains
        LVT_rc%scname(2) = 'MAM'
        LVT_rc%scname(3) = 'JJA'
        LVT_rc%scname(4) = 'SON'      
+    elseif(LVT_rc%scInterval.eq.21) then
+       LVT_rc%nasc = 4 ! =12/3
+       allocate(LVT_rc%scname(LVT_rc%nasc))
+       LVT_rc%scname(1) = 'JFM'
+       LVT_rc%scname(2) = 'AMJ'
+       LVT_rc%scname(3) = 'JAS'
+       LVT_rc%scname(4) = 'OND'
     elseif(LVT_rc%scInterval.eq.6) then 
        LVT_rc%nasc = 2 ! =12/6
        allocate(LVT_rc%scname(LVT_rc%nasc))


### PR DESCRIPTION
This commit will add an option to LVT to allow the user to do a 3-month seasonal average via calendar/water year monthly triplets (JFM, AMJ, JAS, OND). The master config file now reflects the added option of '3 monthly WY' as a valid option in the LVT config file.

Resolves issue #1085.
