### PR TITLE
Fix/lvt74 usafsipost endrun

### DIFF
--- a/lvt/runmodes/USAFSIpost/LVT_run_USAFSIpost.F90
+++ b/lvt/runmodes/USAFSIpost/LVT_run_USAFSIpost.F90
@@ -43,5 +43,5 @@ subroutine LVT_run_USAFSIpost()
 
    ! Clean up
    call USAFSIpost%delete()
-   call LVT_endrun()
+
 end subroutine LVT_run_USAFSIpost

--- a/lvt/runmodes/USAFSIpost/LVT_run_USAFSIpost.F90
+++ b/lvt/runmodes/USAFSIpost/LVT_run_USAFSIpost.F90
@@ -44,4 +44,6 @@ subroutine LVT_run_USAFSIpost()
    ! Clean up
    call USAFSIpost%delete()
 
+   write(LVT_logunit,*)'[INFO] LVT successfully ended!'
+   
 end subroutine LVT_run_USAFSIpost

--- a/lvt/runmodes/USAFSIpost/LVT_run_USAFSIpost.F90
+++ b/lvt/runmodes/USAFSIpost/LVT_run_USAFSIpost.F90
@@ -45,5 +45,5 @@ subroutine LVT_run_USAFSIpost()
    call USAFSIpost%delete()
 
    write(LVT_logunit,*)'[INFO] LVT successfully ended!'
-   
+
 end subroutine LVT_run_USAFSIpost


### PR DESCRIPTION

### Description

Removed call to LVT_endrun() at end of USAFSIpost runmode, to remove false-alarm error message in lvtlog file.
This was requested by the USAF TADS contractor.


