### PR TITLE
Extended dimID array for restarts to 11.

### DIFF
--- a/lis/core/LIS_historyMod.F90
+++ b/lis/core/LIS_historyMod.F90
@@ -3650,7 +3650,7 @@ contains
     integer,   intent(in)     :: m
     integer,   intent(in)     :: ftn
     character(len=*), intent(in) :: model_name
-    integer                   :: dimID(10)
+    integer                   :: dimID(11)
     integer,    optional      :: dim1
     integer,    optional      :: dim2
     integer,    optional      :: dim3
@@ -3755,7 +3755,7 @@ contains
           endif
           if(present(dim10)) then
              call LIS_verify(nf90_def_dim(ftn,"dim10",&
-                  dim10,dimID(10)),&
+                  dim10,dimID(11)),&
                   'nf90_def_dim failed for dim10 in LIS_writeGlobalHeader_restart')
           endif
           call LIS_verify(nf90_put_att(ftn,NF90_GLOBAL,"missing_value", &
@@ -3900,7 +3900,7 @@ contains
 ! !ARGUMENTS:     
     integer                    :: ftn
     integer                    :: n
-    integer                    :: dimID(10)
+    integer                    :: dimID(11)
     integer                    :: vid
     character(len=*)           :: standard_name
     character(len=*)           :: long_name
@@ -3972,6 +3972,8 @@ contains
           dimID_t(2) = dimID(9)
        elseif(var_flag_tmp.eq."dim9") then 
           dimID_t(2) = dimID(10)
+       elseif(var_flag_tmp.eq."dim10") then 
+          dimID_t(2) = dimID(11)
        elseif(var_flag_tmp.eq."tbot_lagday") then 
           call LIS_verify(nf90_inq_dimid(ftn, "tbot_lagday", dimID_t(2)),&
                'nf90_inq_dimid for tbot_lagday failed '//&

--- a/lis/core/LIS_tbotAdjustMod.F90
+++ b/lis/core/LIS_tbotAdjustMod.F90
@@ -311,7 +311,7 @@ contains
 ! !ARGUMENTS:
       integer,intent(in)          :: n
       integer,intent(in)          :: ftn
-      integer,intent(in)          :: dimID(10)
+      integer,intent(in)          :: dimID(11)
       character(len=*),intent(in) :: wformat
 ! !DESCRIPTION:
 !

--- a/lis/surfacemodels/glacier/noahmp.3.9.1.1/noahmpglacier3911_writerst.F90
+++ b/lis/surfacemodels/glacier/noahmp.3.9.1.1/noahmpglacier3911_writerst.F90
@@ -199,7 +199,7 @@ subroutine noahmpglacier3911_dump_restart(n, ftn, wformat)
                
     integer :: l, t 
     real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%glacier_index))
-    integer :: dimID(10)
+    integer :: dimID(11)
     integer :: albold_ID
     integer :: sneqvo_ID
     integer :: sstc_ID

--- a/lis/surfacemodels/lake/FLake.1.0/FLake1_writerst.F90
+++ b/lis/surfacemodels/lake/FLake.1.0/FLake1_writerst.F90
@@ -182,7 +182,7 @@ subroutine FLake1_dump_restart(n, ftn, wformat)
   
   integer :: l, t 
   real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lake_index))
-  integer :: dimID(10)
+  integer :: dimID(11)
   integer :: T_snow_ID
   integer :: T_ice_ID
   integer :: T_mnw_ID

--- a/lis/surfacemodels/land/awral.6.0.0/AWRAL600_writerst.F90
+++ b/lis/surfacemodels/land/awral.6.0.0/AWRAL600_writerst.F90
@@ -169,7 +169,7 @@ subroutine AWRAL600_dump_restart(n, ftn, wformat)
                
     integer :: l, t 
     real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index))
-    integer :: dimID(10) ! veg classes hardcoded to 10 I guess copied from everyone else
+    integer :: dimID(11)
     integer :: sr_ID
     integer :: sg_ID
     integer :: s0_ID

--- a/lis/surfacemodels/land/cable/cable_writerst.F90
+++ b/lis/surfacemodels/land/cable/cable_writerst.F90
@@ -186,7 +186,7 @@ subroutine cable_dump_restart(n,ftn,wformat)
 !  \end{description}
 !EOP
   integer :: l,t
-  integer :: dimID(10)
+  integer :: dimID(11)
   integer :: canstoId,rtsoilId, ssdnnId, snowdId,osnowdId
   integer :: snageId,isflagId, wbtotId,wbiceId,tggsnId
   integer :: ssdnId, smassId,albsoilsnId,wgId,tggId

--- a/lis/surfacemodels/land/clsm.f2.5/clsmf25_writerst.F90
+++ b/lis/surfacemodels/land/clsm.f2.5/clsmf25_writerst.F90
@@ -161,7 +161,7 @@ subroutine clsmf25_dump_restart(n, ftn, wformat)
 !EOP
    integer :: t,l
    real, allocatable :: temp(:)
-   integer :: dimID(10)
+   integer :: dimID(11)
    integer :: tc1Id, tc2Id, tc4Id, qa1Id, qa2Id, qa4Id
    integer :: capacId, ghtId, wesnId, htsnId, sndzId
    integer :: catdefId, rzexcId, srfexcId

--- a/lis/surfacemodels/land/hyssib/hyssib_writerst.F90
+++ b/lis/surfacemodels/land/hyssib/hyssib_writerst.F90
@@ -175,7 +175,7 @@ subroutine hyssib_dump_restart(n, ftn,wformat)
 !
 !EOP
   integer :: l
-  integer :: dimID(10)
+  integer :: dimID(11)
   integer :: tcId, tgId, tsnId, tdId, wwwId, capacId, snowId, sgfgId, sdensId
 
   call LIS_writeGlobalHeader_restart(ftn,n,LIS_rc%lsm_index,&

--- a/lis/surfacemodels/land/jules.5.0/jules50_writerst.F90
+++ b/lis/surfacemodels/land/jules.5.0/jules50_writerst.F90
@@ -203,7 +203,7 @@ subroutine jules50_dump_restart(n, ftn, wformat)
                
     integer :: l, t 
     real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index))
-    integer :: dimID(10)
+    integer :: dimID(11)
     integer :: tsoil_deep_ID
     integer :: wood_prod_fast_ID
     integer :: wood_prod_med_ID

--- a/lis/surfacemodels/land/jules.5.1/jules51_writerst.F90
+++ b/lis/surfacemodels/land/jules.5.1/jules51_writerst.F90
@@ -203,7 +203,7 @@ subroutine jules51_dump_restart(n, ftn, wformat)
                
     integer :: l, t 
     real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index))
-    integer :: dimID(10)
+    integer :: dimID(11)
     integer :: tsoil_deep_ID
     integer :: wood_prod_fast_ID
     integer :: wood_prod_med_ID

--- a/lis/surfacemodels/land/jules.5.2/jules52_writerst.F90
+++ b/lis/surfacemodels/land/jules.5.2/jules52_writerst.F90
@@ -202,7 +202,7 @@ subroutine jules52_dump_restart(n, ftn, wformat)
                
     integer :: l, t 
     real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index))
-    integer :: dimID(10)
+    integer :: dimID(11)
     integer :: tsoil_deep_ID
     integer :: wood_prod_fast_ID
     integer :: wood_prod_med_ID

--- a/lis/surfacemodels/land/jules.5.3/jules53_writerst.F90
+++ b/lis/surfacemodels/land/jules.5.3/jules53_writerst.F90
@@ -203,7 +203,7 @@ subroutine jules53_dump_restart(n, ftn, wformat)
                
     integer :: l, t 
     real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index))
-    integer :: dimID(10)
+    integer :: dimID(11)
     integer :: tsoil_deep_ID
     integer :: wood_prod_fast_ID
     integer :: wood_prod_med_ID

--- a/lis/surfacemodels/land/jules.5.4/jules54_writerst.F90
+++ b/lis/surfacemodels/land/jules.5.4/jules54_writerst.F90
@@ -203,7 +203,7 @@ subroutine jules54_dump_restart(n, ftn, wformat)
                
     integer :: l, t 
     real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index))
-    integer :: dimID(10)
+    integer :: dimID(11)
     integer :: tsoil_deep_ID
     integer :: wood_prod_fast_ID
     integer :: wood_prod_med_ID

--- a/lis/surfacemodels/land/jules.5.x/jules5x_writerst.F90
+++ b/lis/surfacemodels/land/jules.5.x/jules5x_writerst.F90
@@ -204,7 +204,7 @@ subroutine jules5x_dump_restart(n, ftn, wformat)
                
     integer :: l, t 
     real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index))
-    integer :: dimID(10)
+    integer :: dimID(11)
     integer :: tsoil_deep_ID
     integer :: wood_prod_fast_ID
     integer :: wood_prod_med_ID

--- a/lis/surfacemodels/land/mosaic/mos_writerst.F90
+++ b/lis/surfacemodels/land/mosaic/mos_writerst.F90
@@ -169,7 +169,7 @@ subroutine mos_dump_restart(ftn,n,wformat)
 !EOP
   integer             :: l,t
   integer             :: ctId, qaId, icsId, snowId,SoTId,SoWETid
-  integer             :: dimID(10)
+  integer             :: dimID(11)
   real, allocatable   :: tmptilen(:)
 
   allocate(tmptilen(LIS_rc%npatch(n,LIS_rc%lsm_index)))

--- a/lis/surfacemodels/land/noah.2.7.1/noah271_writerst.F90
+++ b/lis/surfacemodels/land/noah.2.7.1/noah271_writerst.F90
@@ -174,7 +174,7 @@ subroutine noah271_dump_restart(n, ftn, wformat)
 !
 !EOP
    integer :: l,t
-   integer :: dimID(10)
+   integer :: dimID(11)
    integer :: t1Id, cmcid, snowhid, sneqvid, smcid, sh2oId, stcId
    integer :: cmId, chId
    real, allocatable :: tmptilen(:)

--- a/lis/surfacemodels/land/noah.3.2/noah32_writerst.F90
+++ b/lis/surfacemodels/land/noah.3.2/noah32_writerst.F90
@@ -183,7 +183,7 @@ subroutine noah32_dump_restart(n, ftn, wformat)
 !
 !EOP
    integer :: l,t
-   integer :: dimID(10)
+   integer :: dimID(11)
    integer :: t1Id, cmcid, snowhid, sneqvid, smcid, sh2oId, stcId
    integer :: cmId, chId,snotime1Id,emissId,z0Id,albId,q1Id
    real, allocatable :: tmptilen(:)

--- a/lis/surfacemodels/land/noah.3.3/noah33_writerst.F90
+++ b/lis/surfacemodels/land/noah.3.3/noah33_writerst.F90
@@ -185,7 +185,7 @@ subroutine noah33_dump_restart(n, ftn, wformat)
 !
 !EOP
    integer :: l,t
-   integer :: dimID(10)
+   integer :: dimID(11)
    integer :: t1Id, cmcid, snowhid, sneqvid, smcid, sh2oId, stcId
    integer :: cmId, chId,snotime1Id,emissId,z0Id,albId,q1Id
    real, allocatable :: tmptilen(:)

--- a/lis/surfacemodels/land/noah.3.6/noah36_writerst.F90
+++ b/lis/surfacemodels/land/noah.3.6/noah36_writerst.F90
@@ -186,7 +186,7 @@ subroutine noah36_dump_restart(n, ftn, wformat)
 !
 !EOP
    integer :: l,t
-   integer :: dimID(10)
+   integer :: dimID(11)
    integer :: t1Id, cmcid, snowhid, sneqvid, smcid, sh2oId, stcId
    integer :: cmId, chId,snotime1Id,emissId,z0Id,albId,q1Id
    real, allocatable :: tmptilen(:)

--- a/lis/surfacemodels/land/noah.3.9/noah39_writerst.F90
+++ b/lis/surfacemodels/land/noah.3.9/noah39_writerst.F90
@@ -186,7 +186,7 @@ subroutine noah39_dump_restart(n, ftn, wformat)
 !
 !EOP
    integer :: l,t
-   integer :: dimID(10)
+   integer :: dimID(11)
    integer :: t1Id, cmcid, snowhid, sneqvid, smcid, sh2oId, stcId
    integer :: cmId, chId,snotime1Id,emissId,z0Id,albId,q1Id
    integer :: xsda_qfx_Id 

--- a/lis/surfacemodels/land/noahmp.3.6/NoahMP36_writerst.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/NoahMP36_writerst.F90
@@ -200,7 +200,7 @@ subroutine NoahMP36_dump_restart(n, ftn, wformat)
                
     integer :: l, t 
     real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index))
-    integer :: dimID(10)
+    integer :: dimID(11)
     integer :: albold_ID
     integer :: sneqvo_ID
     integer :: sstc_ID

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
@@ -216,7 +216,7 @@ subroutine NoahMP401_dump_restart(n, ftn, wformat)
                
     integer :: l, t 
     real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index))
-    integer :: dimID(10)
+    integer :: dimID(11)
     integer :: sfcrunoff_ID
     integer :: udrrunoff_ID
     integer :: smc_ID

--- a/lis/surfacemodels/land/rdhm.3.5.6/RDHM356_writerst.F90
+++ b/lis/surfacemodels/land/rdhm.3.5.6/RDHM356_writerst.F90
@@ -198,7 +198,7 @@ subroutine RDHM356_dump_restart(n, ftn, wformat)
                
     integer :: l, t 
     real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index))
-    integer :: dimID(10)
+    integer :: dimID(11)
     integer :: UZTWC_ID
     integer :: UZFWC_ID
     integer :: LZTWC_ID

--- a/lis/surfacemodels/land/ruc.3.7/RUC37_writerst.F90
+++ b/lis/surfacemodels/land/ruc.3.7/RUC37_writerst.F90
@@ -185,7 +185,7 @@ subroutine RUC37_dump_restart(n, ftn, wformat)
                
     integer :: l, t 
     real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index))
-    integer :: dimID(10)
+    integer :: dimID(11)
     integer :: emiss_ID
     integer :: ch_ID
     integer :: cm_ID

--- a/lis/surfacemodels/land/vic.4.1.2.l/vic412_writerst.F90
+++ b/lis/surfacemodels/land/vic.4.1.2.l/vic412_writerst.F90
@@ -62,7 +62,7 @@ subroutine vic412_writerst(n)
    integer, allocatable, dimension(:) :: vegclasses! added by Shugong Wang to support MPI-safe tile ID, 05/07/2012
    integer       :: t, chunk_size
    real, allocatable :: state_chunk(:) ! chunk of state variable 
-   integer       :: state_chunk_ID, dimID(10) 
+   integer       :: state_chunk_ID, dimID(11) 
    integer       :: ftn, l
    real, allocatable :: tmptilen(:)
    character*3   :: fnest 


### PR DESCRIPTION
This is required to support JULES restarts.  This bug was originally detected
in 2019 but was tabled w/o a patch as it did not appear to affect LIS-JULES
runs with the Intel compiler.  It has now been found to cause crashes with
the Cray compiler, hence the patch.


