### PR TITLE
Changed templates and 24-hr "make" Python scripts to end at 12Z.

### DIFF
--- a/lvt/utils/usaf/templates/lvt.config.template
+++ b/lvt/utils/usaf/templates/lvt.config.template
@@ -23,7 +23,7 @@ Starting second: 00
 Ending year: 2007
 Ending month: 11
 Ending day: 04
-Ending hour: 03
+Ending hour: 12
 Ending minute: 00
 Ending second: 00
 LVT clock timestep: "3hr"

--- a/lvt/utils/usaf/templates/lvt.config.template.jules50
+++ b/lvt/utils/usaf/templates/lvt.config.template.jules50
@@ -23,7 +23,7 @@ Starting second: 00
 Ending year: 2007
 Ending month: 11
 Ending day: 04
-Ending hour: 03
+Ending hour: 12
 Ending minute: 00
 Ending second: 00
 LVT clock timestep: "3hr"

--- a/lvt/utils/usaf/templates/lvt.config.template.noah39
+++ b/lvt/utils/usaf/templates/lvt.config.template.noah39
@@ -23,7 +23,7 @@ Starting second: 00
 Ending year: 2007
 Ending month: 11
 Ending day: 04
-Ending hour: 03
+Ending hour: 12
 Ending minute: 00
 Ending second: 00
 LVT clock timestep: "3hr"

--- a/lvt/utils/usaf/templates/lvt.config.template.noahmp401
+++ b/lvt/utils/usaf/templates/lvt.config.template.noahmp401
@@ -23,7 +23,7 @@ Starting second: 00
 Ending year: 2007
 Ending month: 11
 Ending day: 04
-Ending hour: 03
+Ending hour: 12
 Ending minute: 00
 Ending second: 00
 LVT clock timestep: "3hr"

--- a/lvt/utils/usaf/templates/make_lvt_config_24hr_jules.py
+++ b/lvt/utils/usaf/templates/make_lvt_config_24hr_jules.py
@@ -16,8 +16,8 @@ import sys
 
 template = "template/lvt.config.template.jules50"
 
-startdt = datetime.datetime(2007, 12, 1, 0)
-enddt = datetime.datetime(2007, 12, 2, 0)
+startdt = datetime.datetime(2007, 12, 1, 12)
+enddt = datetime.datetime(2007, 12, 2, 12)
 
 output = "netcdf"
 #output = "grib2"

--- a/lvt/utils/usaf/templates/make_lvt_config_24hr_noah.py
+++ b/lvt/utils/usaf/templates/make_lvt_config_24hr_noah.py
@@ -16,8 +16,8 @@ import sys
 
 template = "template/lvt.config.template.noah39"
 
-startdt = datetime.datetime(2007, 12, 1, 0)
-enddt = datetime.datetime(2007, 12, 2, 0)
+startdt = datetime.datetime(2007, 12, 1, 12)
+enddt = datetime.datetime(2007, 12, 2, 12)
 
 output = "netcdf"
 #output = "grib2"

--- a/lvt/utils/usaf/templates/make_lvt_config_24hr_noahmp.py
+++ b/lvt/utils/usaf/templates/make_lvt_config_24hr_noahmp.py
@@ -16,8 +16,8 @@ import sys
 
 template = "template/lvt.config.template.noahmp401"
 
-startdt = datetime.datetime(2007, 12, 1, 0)
-enddt = datetime.datetime(2007, 12, 2, 0)
+startdt = datetime.datetime(2007, 12, 1, 12)
+enddt = datetime.datetime(2007, 12, 2, 12)
 
 output = "netcdf"
 #output = "grib2"


### PR DESCRIPTION

### Description

Modified lvt.config templates and Python "make" scripts for 24hr products to ensure 24-hr products are generated at 12Z, not 00Z.


