### PR TITLE
Add total runoff output field in NoahMP401

### DIFF
--- a/lis/configs/MODEL_OUTPUT_LIST.TBL.adoc
+++ b/lis/configs/MODEL_OUTPUT_LIST.TBL.adoc
@@ -144,7 +144,7 @@ Evap:         1  kg/m2s  UP   1 0 0 1  57 10000   # Total evapotranspiration (kg
 Qs:           1  kg/m2s  OUT  1 0 0 1 235 10000   # Surface runoff (kg/m2s)
 Qrec:         0  kg/m2s  IN   1 0 0 1 163 10000   # Recharge (kg/m2s)
 Qsb:          1  kg/m2s  OUT  1 0 0 1 234 10000   # Subsurface runoff (kg/m2s)
-Qtot:         1  kg/m2s  OUT  1 0 0 1 235 10000   # Total runoff (kg/m2s)
+Qtot:         1  kg/m2s  OUT  1 0 0 1 235 10000   # Total runoff or discharge to stream (kg/m2s)
 Qsm:          0  kg/m2s  S2L  1 0 0 1  99 10000   # Snowmelt (kg/m2s)
 Qfz:          0  kg/m2s  L2S  1 0 0 1 130 10000   # Refreezing of water in the snowpack (kg/m2s)
 Qst:          0  kg/m2s  -    1 0 0 1 131 10000   # Snow throughfall (kg/m2s)

--- a/lis/configs/MODEL_OUTPUT_LIST.TBL.adoc
+++ b/lis/configs/MODEL_OUTPUT_LIST.TBL.adoc
@@ -144,6 +144,7 @@ Evap:         1  kg/m2s  UP   1 0 0 1  57 10000   # Total evapotranspiration (kg
 Qs:           1  kg/m2s  OUT  1 0 0 1 235 10000   # Surface runoff (kg/m2s)
 Qrec:         0  kg/m2s  IN   1 0 0 1 163 10000   # Recharge (kg/m2s)
 Qsb:          1  kg/m2s  OUT  1 0 0 1 234 10000   # Subsurface runoff (kg/m2s)
+Qtot:         1  kg/m2s  OUT  1 0 0 1 235 10000   # Total runoff (kg/m2s)
 Qsm:          0  kg/m2s  S2L  1 0 0 1  99 10000   # Snowmelt (kg/m2s)
 Qfz:          0  kg/m2s  L2S  1 0 0 1 130 10000   # Refreezing of water in the snowpack (kg/m2s)
 Qst:          0  kg/m2s  -    1 0 0 1 131 10000   # Snow throughfall (kg/m2s)
@@ -402,7 +403,7 @@ Irrigated water: 0  kg/m2s   -   0 0 0 1 256 10  # Irrigated water amount
 #AWRAL600 output
 e0:           1  mm      -    0 0 0 1 0 1 # potential evaporation
 etot:         1  mm      -    0 0 0 1 0 1 # actual evapotranspiration
-qtot:         1  mm      -    0 0 0 1 0 1 # total discharge to stream
+Qtot:         1  mm      -    0 0 0 1 0 1 # total discharge to stream
 sr:           1  mm      -    0 0 0 1 0 1 # volume of water in the surface water store
 sg:           1  mm      -    0 0 0 1 0 1 # groundwater storage in the unconfined aquifer
 dd:           1  mm      -    0 0 0 1 0 1 # vertical drainage from the bottom of the deep soil layer

--- a/lis/core/LIS_histDataMod.F90
+++ b/lis/core/LIS_histDataMod.F90
@@ -5530,9 +5530,9 @@ contains
             model_patch=.true.)
     endif
    
-    call ESMF_ConfigFindLabel(modelSpecConfig,"qtot:",rc=rc)
+    call ESMF_ConfigFindLabel(modelSpecConfig,"Qtot:",rc=rc)
     call get_moc_attributes(modelSpecConfig, LIS_histData(n)%head_lsm_list, &
-         "qtot",&
+         "Qtot",&
          "total_discharge_to_stream",&
          "total discharge to stream",rc)
     if ( rc == 1 ) then

--- a/lis/core/LIS_histDataMod.F90
+++ b/lis/core/LIS_histDataMod.F90
@@ -5538,7 +5538,8 @@ contains
     if ( rc == 1 ) then
        call register_dataEntry(LIS_MOC_LSM_COUNT,LIS_MOC_QTOT, &
             LIS_histData(n)%head_lsm_list,&
-            n,1,ntiles,(/"mm"/),1,("-"),2,1,1,&
+            n,3,ntiles,(/"mm    ","kg/m2s","kg/m2 "/),&
+            3,(/"-  ","IN ","OUT"/),2,1,1,&
             model_patch=.true.)
     endif
 

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
@@ -1142,6 +1142,15 @@ subroutine NoahMP401_main(n)
             call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_QSB, value = NOAHMP401_struc(n)%noahmp401(t)%runsb*dt, &
                                               vlevel=1, unit="kg m-2", direction="OUT", surface_type = LIS_rc%lsm_index)
 
+            ! Combined output variable:  qtot (unit=mm | mm/s). *** total runoff
+            call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_QTOT, &
+                             value = NOAHMP401_struc(n)%noahmp401(t)%runsf + NOAHMP401_struc(n)%noahmp401(t)%runsb, &
+                             vlevel=1, unit="kg m-2 s-1", direction="OUT", surface_type = LIS_rc%lsm_index)
+
+            call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_QTOT, &
+                             value = NOAHMP401_struc(n)%noahmp401(t)%runsf*dt + NOAHMP401_struc(n)%noahmp401(t)%runsb*dt, &
+                             vlevel=1, unit="kg m-2", direction="OUT", surface_type = LIS_rc%lsm_index)
+
             ![ 55] output variable: ecan (unit=mm/s ). ***  evaporation of intercepted water
             call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_ECANOP, value = NOAHMP401_struc(n)%noahmp401(t)%ecan, &
                                               vlevel=1, unit="kg m-2 s-1", direction="UP", surface_type = LIS_rc%lsm_index)

--- a/lis/testcases/surfacemodels/land/awral.6.0.0/AWRAL600_OUTPUT_LIST.TBL
+++ b/lis/testcases/surfacemodels/land/awral.6.0.0/AWRAL600_OUTPUT_LIST.TBL
@@ -123,7 +123,7 @@ Streamflow:   0  m3/s    -    1 0 0 1 333 1       # Streamflow
 #AWRAL600
 e0:           1  mm      -    0 0 0 1 0 1 # potential evaporation
 etot:         1  mm      -    0 0 0 1 0 1 # actual evapotranspiration
-qtot:         1  mm      -    0 0 0 1 0 1 # total discharge to stream
+Qtot:         1  mm      -    0 0 0 1 0 1 # total discharge to stream
 sr:           1  mm      -    0 0 0 1 0 1 # volume of water in the surface water store
 sg:           1  mm      -    0 0 0 1 0 1 # groundwater storage in the unconfined aquifer
 dd:           1  mm      -    0 0 0 1 0 1 # vertical drainage from the bottom of the deep soil layer


### PR DESCRIPTION
 Added new total runoff option into NoahMP401 LSM in LIS, which
  combines surface and baseflow runoff fluxes.
 Expand this output option to include different units and
  user options.

 Add to your model output table as:

qtot: 1 mm - 0 0 0 1 0 1 # total discharge to stream

This addresses GitHub issue #1092 . 

<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Replace this text with a concise description of *what* was changed and *why*.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->


