### PR TITLE
Silence err message when output dir already exists

### DIFF
--- a/lis/core/LIS_create_subdirs.c
+++ b/lis/core/LIS_create_subdirs.c
@@ -144,19 +144,24 @@ int FTN(lis_create_subdirs) (int  *length,
 
                 /* Handle error */
                 if (mkdir_rc == -1) {
-                    /* Attempt to report error message */
-                    error_string = NULL;
-                    error_string = malloc((length_copy+1+21)*sizeof(char));
-                    if (error_string != NULL) {
-                        sprintf(error_string,
+                    /* EEXIST is returned via errno if the directory
+                    * already exists. This isn't an error because
+                    * we are attempting to create the directory.*/
+                    if (errno != EEXIST) {
+                        /* Attempt to report error message */
+                        error_string = NULL;
+                        error_string = malloc((length_copy+1+21)*sizeof(char));
+                        if (error_string != NULL) {
+                            sprintf(error_string,
                                 "ERROR calling mkdir %s",work);
-                        perror(error_string);
-                        free(error_string);
-                        error_string = NULL;			    
+                            perror(error_string);
+                            free(error_string);
+                            error_string = NULL;			    
+                        }
+                        error = 1;
                     }
-                    error = 1;
-                }
-            }            
+                }            
+            }
         }
 
         /* Restore subdirectory token if necessary */


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

After #1042, an error message may be printed if a LIS process attempts to create an output directory that was already created by another process. This fix silences that error message by checking that `errno != EEXIST` after calling `mkdir` (suggested by @emkemp).

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->

Reproducible with any LSM testcase run on multiple processes.

