### PR TITLE
Fixed typo in output lis.config from autotuning software

### DIFF
--- a/lis/utils/usaf/retune_bratseth/scripts/autotune.py
+++ b/lis/utils/usaf/retune_bratseth/scripts/autotune.py
@@ -315,7 +315,7 @@ class AutomateTuning:
         if "imerg" in self.Lo:
             if self.Lo["imerg"] > 0:
                 line = \
-                    "AGRMET GALWEM Precip IMERG observation error scale length (m)"
+                    "AGRMET GALWEM Precip IMERG observation error scale length (m):"
                 line += " %s\n" %(self.Lo["imerg"])
                 lines.append(line)
 


### PR DESCRIPTION


### Description

Fixed bug in autotuning script for writing out updated lis.config entry for Bratseth scheme.  A ":" was missing, which will prevent LIS from reading that line, and subsequently abort.


