### PR TITLE
Fix compiling Bratseth retuning code using Cray compilers

### DIFF
--- a/lis/utils/usaf/retune_bratseth/src/Makefile
+++ b/lis/utils/usaf/retune_bratseth/src/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Fortran utilities
 #
-# To use, first run lvt/configure script to generate configure.lis in lis/make.
+# To use, first run lis/configure script to generate configure.lis in lis/make.
 #
 # Eric Kemp, SSAI and NASA/GSFC, 26 Oct 2020
 #------------------------------------------------------------------------------

--- a/lis/utils/usaf/retune_bratseth/src/procOBA_NWP.F90
+++ b/lis/utils/usaf/retune_bratseth/src/procOBA_NWP.F90
@@ -697,7 +697,6 @@ contains
         use_blacklist, nstns, blacklist_stns)
 
       ! Imports
-      use esmf
       use mpi
       use USAF_ReportsMod, only: Reports, newReports, getNobs, getReport, &
            destroyReports, appendToReports, bcast_reports

--- a/lis/utils/usaf/retune_bratseth/src/procOBA_NWP.F90
+++ b/lis/utils/usaf/retune_bratseth/src/procOBA_NWP.F90
@@ -697,7 +697,6 @@ contains
         use_blacklist, nstns, blacklist_stns)
 
       ! Imports
-      use mpi
       use USAF_ReportsMod, only: Reports, newReports, getNobs, getReport, &
            destroyReports, appendToReports, bcast_reports
       use USAF_StationsMod, only: great_circle_distance

--- a/lis/utils/usaf/retune_bratseth/src/procOBA_Sat.F90
+++ b/lis/utils/usaf/retune_bratseth/src/procOBA_Sat.F90
@@ -867,7 +867,6 @@ contains
         use_blacklist, nstns, blacklist_stns)
 
       ! Imports
-      use mpi
       use USAF_GridHashMod, only: GridHash, newGridHash, destroyGridHash, &
            insertIntoGridHash, getObindexVectorFromGridHash, &
            createIJForGridHash

--- a/lis/utils/usaf/retune_bratseth/src/procOBA_Sat.F90
+++ b/lis/utils/usaf/retune_bratseth/src/procOBA_Sat.F90
@@ -867,7 +867,6 @@ contains
         use_blacklist, nstns, blacklist_stns)
 
       ! Imports
-      use esmf
       use mpi
       use USAF_GridHashMod, only: GridHash, newGridHash, destroyGridHash, &
            insertIntoGridHash, getObindexVectorFromGridHash, &


### PR DESCRIPTION
### Description

This removes multiple uses of ESMF within two program files.  The multiple uses of the ESMF module led to a compiler error with the Cray compilers. 