### PR TITLE
Fix/new bratseth tunings

### DIFF
--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.jules50.ops
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.jules50.ops
@@ -249,7 +249,7 @@ AGRMET IMERG Probability Liquid Precip Threshold: 100
 # Bratseth runtime settings
 AGRMET maximum precip obs:                 2000000         # Max observations to store in memory
 AGRMET minimum wind speed:                 0.25            # Sanity minimum value for winds
-AGRMET output OBA data:                    0               # 0 = do not output diagnostic data from Bratseth
+AGRMET output OBA data:                    1               # 1= output diagnostic data from Bratseth
 AGRMET skip backQC:                        0               # 0 = do not skip backQC check in Bratseth
 AGRMET skip superstatQC:                   0               # 0 = do not skip superstatQC check in Bratseth
 AGRMET 3hr maximum precip ceiling:         200.0

--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.jules50.ops
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.jules50.ops
@@ -254,31 +254,30 @@ AGRMET skip backQC:                        0               # 0 = do not skip bac
 AGRMET skip superstatQC:                   0               # 0 = do not skip superstatQC check in Bratseth
 AGRMET 3hr maximum precip ceiling:         200.0
 
-# EMK...New recommended settings based on sample NWP and observations
-# for 2 Feb - 7 Mar 2020 and no Box-Cox transformation.
-
-# Bratseth error covariance settings for GALWEM-17km background field.
+# EMK...New recommended settings for GALWEM-17 km based on 28 days of
+# observation and background comparisons ending 00Z 23 May 2022.
 # Replace with commented entries below when GALWEM switches to 10-km.
-AGRMET GALWEM Precip background error scale length (m):            102000.
-AGRMET GALWEM Precip background error variance:                         0.83
-AGRMET GALWEM Precip Gauge observation error variance:                  0.86
+AGRMET GALWEM Precip background error scale length (m): 74753.54866737088
+AGRMET GALWEM Precip background error variance: 0.14443165072415012
+AGRMET GALWEM Precip Gauge observation error variance: 0.19098082428226776
+AGRMET GALWEM Precip IMERG observation error scale length (m): 94469.023085624
+AGRMET GALWEM Precip IMERG observation error variance: 0.26354998284736975
+AGRMET GALWEM T2M background error scale length (m): 96761.82529455773
+AGRMET GALWEM T2M background error variance: 0.42402717590178063
+AGRMET GALWEM T2M station observation error variance: 1.2655757019800733
+AGRMET GALWEM RH2M background error scale length (m): 34127.84847117105
+AGRMET GALWEM RH2M background error variance: 12.636473357129143
+AGRMET GALWEM RH2M station observation error variance: 41.81798264332559
+AGRMET GALWEM SPD10M background error scale length (m): 55063.07623954051
+AGRMET GALWEM SPD10M background error variance: 0.23406032434793003
+AGRMET GALWEM SPD10M station observation error variance: 1.1451826020714888
+# Older satellite estimates, not for use with LISF 7.4
 AGRMET GALWEM Precip GEOPRECIP observation error scale length (m): 132000.
 AGRMET GALWEM Precip GEOPRECIP observation error variance:              1.24
 AGRMET GALWEM Precip SSMI observation error scale length (m):      133000.
 AGRMET GALWEM Precip SSMI observation error variance:                   2.58
 AGRMET GALWEM Precip CMORPH observation error scale length (m):     89000.
 AGRMET GALWEM Precip CMORPH observation error variance:                 1.15
-AGRMET GALWEM Precip IMERG observation error scale length (m):     101000.
-AGRMET GALWEM Precip IMERG observation error variance:                  1.93
-AGRMET GALWEM T2M background error scale length (m):               110000.
-AGRMET GALWEM T2M background error variance:                            1.48
-AGRMET GALWEM T2M station observation error variance:                   2.30
-AGRMET GALWEM RH2M background error scale length (m):              119000.
-AGRMET GALWEM RH2M background error variance:                          30.7
-AGRMET GALWEM RH2M station observation error variance:                 65.8
-AGRMET GALWEM SPD10M background error scale length (m):             53000.
-AGRMET GALWEM SPD10M background error variance:                         0.62
-AGRMET GALWEM SPD10M station observation error variance:                2.37
 
 # Bratseth error covariance settings for GALWEM-10km background field.
 # AGRMET GALWEM Precip background error scale length (m):            110000.

--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.jules50.ops.galwem10
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.jules50.ops.galwem10
@@ -249,7 +249,7 @@ AGRMET IMERG Probability Liquid Precip Threshold: 100
 # Bratseth runtime settings
 AGRMET maximum precip obs:                 2000000         # Max observations to store in memory
 AGRMET minimum wind speed:                 0.25            # Sanity minimum value for winds
-AGRMET output OBA data:                    0               # 0 = do not output diagnostic data from Bratseth
+AGRMET output OBA data:                    1               # 1 = output diagnostic data from Bratseth
 AGRMET skip backQC:                        0               # 0 = do not skip backQC check in Bratseth
 AGRMET skip superstatQC:                   0               # 0 = do not skip superstatQC check in Bratseth
 AGRMET 3hr maximum precip ceiling:         200.0

--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noah39.ops
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noah39.ops
@@ -254,31 +254,30 @@ AGRMET skip backQC:                        0               # 0 = do not skip bac
 AGRMET skip superstatQC:                   0               # 0 = do not skip superstatQC check in Bratseth
 AGRMET 3hr maximum precip ceiling:         200.0
 
-# EMK...New recommended settings based on sample NWP and observations
-# for 2 Feb - 7 Mar 2020 and no Box-Cox transformation.
-
-# Bratseth error covariance settings for GALWEM-17km background field.
+# EMK...New recommended settings for GALWEM-17 km based on 28 days of
+# observation and background comparisons ending 00Z 23 May 2022.
 # Replace with commented entries below when GALWEM switches to 10-km.
-AGRMET GALWEM Precip background error scale length (m):            102000.
-AGRMET GALWEM Precip background error variance:                         0.83
-AGRMET GALWEM Precip Gauge observation error variance:                  0.86
+AGRMET GALWEM Precip background error scale length (m): 74753.54866737088
+AGRMET GALWEM Precip background error variance: 0.14443165072415012
+AGRMET GALWEM Precip Gauge observation error variance: 0.19098082428226776
+AGRMET GALWEM Precip IMERG observation error scale length (m): 94363.0036932168
+AGRMET GALWEM Precip IMERG observation error variance: 0.2669320692915471
+AGRMET GALWEM T2M background error scale length (m): 96761.82529455773
+AGRMET GALWEM T2M background error variance: 0.42402717590178063
+AGRMET GALWEM T2M station observation error variance: 1.2655757019800733
+AGRMET GALWEM RH2M background error scale length (m): 34127.84847117105
+AGRMET GALWEM RH2M background error variance: 12.636473357129143
+AGRMET GALWEM RH2M station observation error variance: 41.81798264332559
+AGRMET GALWEM SPD10M background error scale length (m): 55063.07623954051
+AGRMET GALWEM SPD10M background error variance: 0.23406032434793003
+AGRMET GALWEM SPD10M station observation error variance: 1.1451826020714888
+# Older satellite estimates, not for use with LISF 7.4
 AGRMET GALWEM Precip GEOPRECIP observation error scale length (m): 132000.
 AGRMET GALWEM Precip GEOPRECIP observation error variance:              1.24
 AGRMET GALWEM Precip SSMI observation error scale length (m):      133000.
 AGRMET GALWEM Precip SSMI observation error variance:                   2.58
 AGRMET GALWEM Precip CMORPH observation error scale length (m):     89000.
 AGRMET GALWEM Precip CMORPH observation error variance:                 1.15
-AGRMET GALWEM Precip IMERG observation error scale length (m):     101000.
-AGRMET GALWEM Precip IMERG observation error variance:                  1.93
-AGRMET GALWEM T2M background error scale length (m):               110000.
-AGRMET GALWEM T2M background error variance:                            1.48
-AGRMET GALWEM T2M station observation error variance:                   2.30
-AGRMET GALWEM RH2M background error scale length (m):              119000.
-AGRMET GALWEM RH2M background error variance:                          30.7
-AGRMET GALWEM RH2M station observation error variance:                 65.8
-AGRMET GALWEM SPD10M background error scale length (m):             53000.
-AGRMET GALWEM SPD10M background error variance:                         0.62
-AGRMET GALWEM SPD10M station observation error variance:                2.37
 
 # Bratseth error covariance settings for GALWEM-10km background field.
 # AGRMET GALWEM Precip background error scale length (m):            110000.

--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noah39.ops
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noah39.ops
@@ -249,7 +249,7 @@ AGRMET IMERG Probability Liquid Precip Threshold: 100
 # Bratseth runtime settings
 AGRMET maximum precip obs:                 2000000         # Max observations to store in memory
 AGRMET minimum wind speed:                 0.25            # Sanity minimum value for winds
-AGRMET output OBA data:                    0               # 0 = do not output diagnostic data from Bratseth
+AGRMET output OBA data:                    1               # 1 = output diagnostic data from Bratseth
 AGRMET skip backQC:                        0               # 0 = do not skip backQC check in Bratseth
 AGRMET skip superstatQC:                   0               # 0 = do not skip superstatQC check in Bratseth
 AGRMET 3hr maximum precip ceiling:         200.0

--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noah39.ops.galwem10
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noah39.ops.galwem10
@@ -249,7 +249,7 @@ AGRMET IMERG Probability Liquid Precip Threshold: 100
 # Bratseth runtime settings
 AGRMET maximum precip obs:                 2000000         # Max observations to store in memory
 AGRMET minimum wind speed:                 0.25            # Sanity minimum value for winds
-AGRMET output OBA data:                    0               # 0 = do not output diagnostic data from Bratseth
+AGRMET output OBA data:                    1               # 1 = output diagnostic data from Bratseth
 AGRMET skip backQC:                        0               # 0 = do not skip backQC check in Bratseth
 AGRMET skip superstatQC:                   0               # 0 = do not skip superstatQC check in Bratseth
 AGRMET 3hr maximum precip ceiling:         200.0

--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noahmp401.ops
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noahmp401.ops
@@ -254,31 +254,30 @@ AGRMET skip backQC:                        0               # 0 = do not skip bac
 AGRMET skip superstatQC:                   0               # 0 = do not skip superstatQC check in Bratseth
 AGRMET 3hr maximum precip ceiling:         200.0
 
-# EMK...New recommended settings based on sample NWP and observations
-# for 2 Feb - 7 Mar 2020 and no Box-Cox transformation.
-
-# Bratseth error covariance settings for GALWEM-17km background field.
+# EMK...New recommended settings for GALWEM-17 km based on 28 days of
+# observation and background comparisons ending 00Z 23 May 2022.
 # Replace with commented entries below when GALWEM switches to 10-km.
-AGRMET GALWEM Precip background error scale length (m):            102000.
-AGRMET GALWEM Precip background error variance:                         0.83
-AGRMET GALWEM Precip Gauge observation error variance:                  0.86
+AGRMET GALWEM Precip background error scale length (m): 74753.54866737088
+AGRMET GALWEM Precip background error variance: 0.14443165072415012
+AGRMET GALWEM Precip Gauge observation error variance: 0.19098082428226776
+AGRMET GALWEM Precip IMERG observation error scale length (m): 94462.38998508919
+AGRMET GALWEM Precip IMERG observation error variance: 0.26496359208559706
+AGRMET GALWEM T2M background error scale length (m): 96761.82529455773
+AGRMET GALWEM T2M background error variance: 0.42402717590178063
+AGRMET GALWEM T2M station observation error variance: 1.2655757019800733
+AGRMET GALWEM RH2M background error scale length (m): 34127.84847117105
+AGRMET GALWEM RH2M background error variance: 12.636473357129143
+AGRMET GALWEM RH2M station observation error variance: 41.81798264332559
+AGRMET GALWEM SPD10M background error scale length (m): 55063.07623954051
+AGRMET GALWEM SPD10M background error variance: 0.23406032434793003
+AGRMET GALWEM SPD10M station observation error variance: 1.1451826020714888
+# Older satellite estimates, not for use with LISF 7.4
 AGRMET GALWEM Precip GEOPRECIP observation error scale length (m): 132000.
 AGRMET GALWEM Precip GEOPRECIP observation error variance:              1.24
 AGRMET GALWEM Precip SSMI observation error scale length (m):      133000.
 AGRMET GALWEM Precip SSMI observation error variance:                   2.58
 AGRMET GALWEM Precip CMORPH observation error scale length (m):     89000.
 AGRMET GALWEM Precip CMORPH observation error variance:                 1.15
-AGRMET GALWEM Precip IMERG observation error scale length (m):     101000.
-AGRMET GALWEM Precip IMERG observation error variance:                  1.93
-AGRMET GALWEM T2M background error scale length (m):               110000.
-AGRMET GALWEM T2M background error variance:                            1.48
-AGRMET GALWEM T2M station observation error variance:                   2.30
-AGRMET GALWEM RH2M background error scale length (m):              119000.
-AGRMET GALWEM RH2M background error variance:                          30.7
-AGRMET GALWEM RH2M station observation error variance:                 65.8
-AGRMET GALWEM SPD10M background error scale length (m):             53000.
-AGRMET GALWEM SPD10M background error variance:                         0.62
-AGRMET GALWEM SPD10M station observation error variance:                2.37
 
 # Bratseth error covariance settings for GALWEM-10km background field.
 # AGRMET GALWEM Precip background error scale length (m):            110000.

--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noahmp401.ops
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noahmp401.ops
@@ -249,7 +249,7 @@ AGRMET IMERG Probability Liquid Precip Threshold: 100
 # Bratseth runtime settings
 AGRMET maximum precip obs:                 2000000         # Max observations to store in memory
 AGRMET minimum wind speed:                 0.25            # Sanity minimum value for winds
-AGRMET output OBA data:                    0               # 0 = do not output diagnostic data from Bratseth
+AGRMET output OBA data:                    1               # 1 = output diagnostic data from Bratseth
 AGRMET skip backQC:                        0               # 0 = do not skip backQC check in Bratseth
 AGRMET skip superstatQC:                   0               # 0 = do not skip superstatQC check in Bratseth
 AGRMET 3hr maximum precip ceiling:         200.0

--- a/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noahmp401.ops.galwem10
+++ b/lis/configs/557WW-7.4-FOC/NRT_GLOBAL/lis.config.global.noahmp401.ops.galwem10
@@ -249,7 +249,7 @@ AGRMET IMERG Probability Liquid Precip Threshold: 100
 # Bratseth runtime settings
 AGRMET maximum precip obs:                 2000000         # Max observations to store in memory
 AGRMET minimum wind speed:                 0.25            # Sanity minimum value for winds
-AGRMET output OBA data:                    0               # 0 = do not output diagnostic data from Bratseth
+AGRMET output OBA data:                    1               # 1 = output diagnostic data from Bratseth
 AGRMET skip backQC:                        0               # 0 = do not skip backQC check in Bratseth
 AGRMET skip superstatQC:                   0               # 0 = do not skip superstatQC check in Bratseth
 AGRMET 3hr maximum precip ceiling:         200.0

--- a/lis/utils/usaf/retune_bratseth/README
+++ b/lis/utils/usaf/retune_bratseth/README
@@ -1,7 +1,7 @@
 #
 # README for Air Force Bratseth scheme tuning software
 # Eric Kemp, SSAI and NASA GSFC
-# Last modified 7 Jan 2020
+# Last modified 9 Jan 2022
 #
 #------------------------------------------------------------------------------
 
@@ -18,7 +18,7 @@ LIS versions, these covariances settings were "canned" based on
 semivariographic analyses of limited time periods (usually around one month).
 However, dynamic updates to the covariances are warranted.
 
-A collection of Python 3 scripts, a Bash script, and Fortran programs have
+A collection of Python 3 scripts, two Bash scripts, and Fortran programs have
 been developed to automatically perform semivariogram analyses, generated new
 best-fit covariance parameters, and then update the relevant lis.config
 settings.  The software is included in subdirectories and are described below.
@@ -65,34 +65,39 @@ And sample contents are:
 A Bash batch script "run_autotune_discover.sh" has been developed to automate
 underlying steps in the covariance fitting.  This script was designed to run
 on the NASA Discover supercomputer using the SLURM batch queueing system.
-It is intended to serve as an example for writing similar scripts on other
+A companion batch script "run_autotune_hpc11.sh" is customized for the USAF
+HPC11 system.  These serve as examples for writing similar scripts on other
 systems, with porting changes (queuing system, queue names, local enviroment
 modules) being limited to the batch script itself.
 
 The batch script is run by:
 
-    sbatch run_autotune_discover.sh $YYYYMMDDHH $DD
+    sbatch run_autotune_discover.sh $YYYYMMDDHH $DD # Or
+    sbatch run_autotune_hpc11.sh    $YYYYMMDDHH $DD
 
 where $YYYYMMDDHH is the end date/time of the OBA training period, and
 $DD is the length (in days) of the OBA training period.
 
 The script performs several major steps:
 
-(1) Customize config files for procOBA_NWP, a Fortran program that creates
-empirical semivariograms for gauge and surface observations against NWP
-background.  This step includes construction of a station blacklist file
+(1) Customize config files for procOBA_NWP and procOBA_Sat, Fortran programs
+that create empirical semivariograms for gauge and surface observations
+against a NWP background, and semivariograms for gauges against satellite
+data.  This step includes construction of a station blacklist file
 to screen out locations with: large mean differences between observation
 and background values; small sample sizes; and multiple networks for the
 same station.  Customization also includes setting the start and end times
 of the tuning period and the frequency for reading OBA files.
 This step is performed by customize_procoba_nwp.py, and the script is run in
 parallel for precipitation, relative humidity, wind speed, and temperature.
+The customize_procoba_sat.py customizes for procOBA_Sat, and does not
+generate a blacklist.
 
 (2) In parallel, run procOBA_NWP for precipitation, relative humidity,
-wind speed, and temperature.  This Fortran program will read the customized
-config files set in (1) above, read the OBA files for the requested time
-period, and construct empirical semivariograms. The empirical semivariograms
-are output in text files.
+wind speed, and temperature; and run procOBA_Sat for IMERG precipitation.
+The Fortran programs will read the customized config files set in (1) above,
+read the OBA files for the requested time period, and construct empirical
+semivariograms. The empirical semivariograms are output in text files.
 
 (3) In parallel, run fit_semivariogram.py to calculate best-fits to the
 empirical semivarograms calculated in (2) above.  This is run for
@@ -100,37 +105,18 @@ precipitation, relative humidity, wind speed, and temperature. Best-fit
 parameters (observation error variance, background error variance, and
 background error correlation length) are output in text files.
 
-(4) Customize config files for procOBA_Sat, a Fortran program for creating
-empirical semivariograms from gauges and nearby satellite retrievals.
-Customization includes setting the start and end times of the tuning period
-and the frequency for reading OBA files.  This step is performed by
-customize_procoba_sat.py, and the script is run in parallel for IMERG,
-CMORPH, GEOPRECIP, and SSMIS data.
-
-(5) In parallel, run procOBA_Sat for IMERG, CMORPH, GEOPRECIP, and SSMIS data.
-This will read in the customized config files set in (4) above, read the
-OBA files for the requested time period, match gauges with nearest
-satellite estimates within a specified radius, and construct empirical
-semivariograms.  The empirical semivariograms are output in text files.
-
-(6) In parallel, run fit_semivariogram.py to calculate best-fits to the
-empirical semivariograms calculated in (5) above.  This is run for IMERG,
-CMORPH, GEOPRECIP, and SSMIS data.  Best-fit parameters (gage observation
-error variance, satellite observation error variance, and satellite
-observation error correlation length) are output to text files.
-
-(7) In parallel, run rescale_sat_sigma2.py to rescale the satellite error
-variances to be w/r/t NWP background. This is accomplished by multiplying
-the satellite error variance from (6) with the gage error variance from (3)
-and then dividing by the gage error variance in (6).  This is performed
-for IMERG, CMORPH, GEOPRECIP, and SSMIS data. The rescaled satellite error
+(4) Run rescale_sat_sigma2.py to rescale the satellite error variances to be
+w/r/t NWP background. This is accomplished by multiplying the gage-satellite
+error variance from (3) with the gage-NWP error variance from (3) and then
+dividing by the gage error variance from (3).  The rescaled satellite error
 variances are output to text files.
 
-(8) Reads a lis.config file, and generates a replacement with new Bratseth
+(5) Reads a lis.config file, and generates a replacement with new Bratseth
 error covariance settings. This is performed by customize_lis_config.py.
 
 Note that error checking is performed at each stage.  If an error occurs,
-the script is aborted, and no new lis.config file is generated.
+the script is aborted (return code of 1), and no new lis.config file is
+generated.
 
 3. Config file templates
 
@@ -145,8 +131,8 @@ to compiled Fortran binaries; and the path to lis.config file to be updated.
 Also, a list of variable keys is included for use by customize_lis_config.py.
 This is used to identify which variables or data sources (gage vs satellite
 data) are to be updated.  Possible values are rh2m, spd10m, t2m, gage,
-cmorph, geoprecip, imerg, and ssmi.  NOTE:  NO SPACES SHOULD BE USED FOR
-THE VALUES LISTED IN THE varlist: ENTRY.
+and imerg.  NOTE:  NO SPACES SHOULD BE USED FOR THE VALUES LISTED IN THE
+varlist: ENTRY.
 
 (*) blacklist_gage.cfg: A Python config file used by customize_procoba_nwp.py.
 This specifies the maximum number of networks a gage platform (ID) is allowed
@@ -158,7 +144,7 @@ Also specified is the directory containing the OBA files for precipitation;
 the "data_frequency" of the OBA files (i.e., either 6 or 12, indicating
 whether 6 hours or 12 hours of precipitation analyses were generated together
 by LIS); and the valid hours-of-the-day (in UTC) to use when creating
-the blacklist.
+the blacklist. 12 IS RECOMMENDED FOR OPS.
 
 (*) blacklist_rh2m.cfg: A Python config file used by customize_procoba_nwp.py.
 Similar to blacklist_gage.cfg, but intended for 2-m relative humidity. The
@@ -172,32 +158,16 @@ customize_procoba_nwp.py.  Similar to blacklist_rh2m.cfg, but intended for
 Similar to blacklist_rh2m.cfg, but intended for 10-m wind speed.  The
 "data_frequency" of the OBA files should be 1.
 
-(*) gage_cmorph.cfg: A Python config file used by fit_semivariogram.py, and by
+(*) gage_imerg.cfg: A Python config file usd by fit_semivariogram.py, and by
 the utility plot_semivariogram.py.  Intended for fitting or plotting
-semivariogram between gages and nearby CMORPH estimates.  Specifies name
-of text file with empirical semivariogram values; the maximum length (distance)
-of the fitted semivariogram, and the function type of the fitted semivariogram
+semivariogram between gages and nearby IMERG estimates.  Specifies name of text
+file with empirical semivariogram values; the maximum length (distance) of the
+fitted semivariogram, and the function type of the fitted semivariogram
 (currently Gaussian).
 
-Additional settings used by plot_semivariogram.py are: A title label, x-axis
-label, y-axis label, and labels for observations (here gage) and background
-(here CMORPH).
-
-(*) gage_geoprecip.cfg: A Python config file used by fit_semivariogram.py, and
-by the utility plot_semivariogram.py.  Similar to gage_cmorph.cfg, but for
-semivariograms from gauges and GEOPRECIP estimates.
-
-(*) gage_imerg.cfg: A Python config file used by fit_semivariogram.py, and
-by the utility plot_semivariogram.py.  Similar to gage_cmorph.cfg, but for
-semivariograms from gauges and IMERG estimates.
-
 (*) gage_nwp.cfg: A Python config file used by fit_semivariogram.py, and
-by the utility plot_semivariogram.py.  Similar to gage_cmorph.cfg, but for
+by the utility plot_semivariogram.py.  Similar to gage_imerg.cfg, but for
 semivariograms from gauges and NWP background.
-
-(*) gage_ssmi.cfg: A Python config file used by fit_semivariogram.py, and
-by the utility plot_semivariogram.py.  Similar to gage_cmorph.cfg, but for
-semivariograms from gauges and SSMI background.
 
 (*) procOBA_NWP.gage.config: An ESMF input file used by procOBA_NWP. Sets
 maximum number of gage stations to use; the maximum number of semivariogram
@@ -225,9 +195,9 @@ type is "SPD10M".
 to procOBA_NWP.gage.config but for 2-meter temperature. The observation
 type is "T2M".
 
-(*) procOBA_Sat.cmorph.config: An ESMF input file used by procOBA_Sat. Similar
-to procOBA_NWP.gage.config but for semivariogram between gauges and CMORPH
-estimates. The observation type is "CMORPH".
+(*) procOBA_Sat.imerg.config: An ESMF input file used by procOBA_Sat. Similar
+to procOBA_NWP.gage.config but for semivariogram between gauges and IMERG
+estimates. The observation type is "IMERG".
 
 Additional settings are used by procOBA_Sat to construct a lat/lon grid to
 locate gages.  The settings are the maximum number of latitude and longitude
@@ -238,30 +208,18 @@ report with the nearest satellite estimate.
 In addition, the maximum number of satellite estimates must be provided
 for array allocations.
 
-(*) procOBA_Sat.geoprecip.config: An ESMF input file used by procOBA_Sat.
-Similar to procOBA_Sat.cmorph.config but used for GEOPRECIP satellite
-estimates.
-
-(*) procOBA_Sat.imerg.config: An ESMF input file used by procOBA_Sat.
-Similar to procOBA_Sat.cmorph.config but used for IMERG satellite
-estimates.
-
-(*) procOBA_Sat.ssmi.config: An ESMF input file used by procOBA_Sat.
-Similar to procOBA_Sat.cmorph.config but used for SSMI satellite
-estimates.
-
 (*) rh2m.cfg: A Python config file used by fit_semivariogram.py, and by
-the utility plot_semivariogram.py.  Similar to gage_cmorph.cfg, but for
+the utility plot_semivariogram.py.  Similar to gage_imerg.cfg, but for
 semivariograms for 2-meter relative humidity between surface observations
 and NWP background.
 
 (*) spd10m.cfg:  A Python config file used by fit_semivariogram.py, and by
-the utility plot_semivariogram.py.  Similar to gage_cmorph.cfg, but for
+the utility plot_semivariogram.py.  Similar to gage_imerg.cfg, but for
 semivariograms for 10-m wind speed between surface observations and NWP
 background.
 
 (*) t2m.cfg: A Python config file used by fit_semivariogram.py, and by
-the utility plot_semivariogram.py.  Similar to gage_cmorph.cfg, but for
+the utility plot_semivariogram.py.  Similar to gage_imerg.cfg, but for
 semivariograms for 2-m temperature between surface observations and NWP
 background.
 
@@ -273,6 +231,8 @@ below.
 4.1 Top script
 
 (*) run_autotune_discover.sh: Described in Section 3 above.
+
+(*) run_autotune_hpc11.sh: Described in Section 3 above.
 
 4.2  Lower-level scripts
 
@@ -290,9 +250,8 @@ the ESMF input files for ProcOBA_Sat.  Uses the autotune.cfg file.
 
 (*) fit_semivariogram.py: A Python script responsible for creating best-fits
 to empirical semivariograms. Depending on the data to be processed, will
-use either gage_cmorph.cfg, gage_geoprecip.cfg, gage_imerg.cfg, gage_nwp.cfg,
-gage_ssmi.cfg, rh2m.cfg, spd10m.cfg, or t2m.cfg.  Output parameters will
-be written to a file specified on the command line.
+use either gage_imerg.cfg, gage_nwp.cfg, rh2m.cfg, spd10m.cfg, or t2m.cfg.
+Output parameters will be written to a file specified on the command line.
 
 (*) plot_semivariogram.py: A Python script responsible for plotting the
 a best-fit semivariogram developed by fit_semivariogram.py.  THIS IS A
@@ -327,9 +286,8 @@ customized procOBA_NWP.$varname.config file, where $varname is gage, rh2m,
 spd10m, or t2m.
 
 (*) procOBA_Sat.F90: Fortran program to construct semivariograms from gages
-and satellite precipitation estimates. Used for CMORPH, GEOPRECIP, IMERG,
-and SSMI.  The program reads in a customized procOBA_Sat.$varname.config
-file, where $varname is cmorph, geoprecip, imerg, or ssmi.
+and satellite precipitation estimates. Used for IMERG.  The program reads in a
+customized procOBA_Sat.$varname.config file, where $varname is imerg.
 
 5.2 Module files
 
@@ -355,4 +313,9 @@ parent directory.  Once this is run and a make/configure.lis file is created,
 the user should run the 'compile' script in the same directory and include the
 '-u' flag (indicating compilation of utilities).
 
-
+COMMENT FOR OPS:  There needs to be at least one OBA file available for this
+software.  If an OBA file is missing, procOBA_NWP and procOBA_Sat will log
+a warning and move on.  If no OBA files were read in, the output binned files
+are empty, and fit_semivariogram.py will abort.  This error will be detected
+by the batch script, and the job will halt with an error message to standard
+out and a return code of 1.  No customized lis.config file will be produced.

--- a/lis/utils/usaf/retune_bratseth/README
+++ b/lis/utils/usaf/retune_bratseth/README
@@ -1,7 +1,7 @@
 #
 # README for Air Force Bratseth scheme tuning software
 # Eric Kemp, SSAI and NASA GSFC
-# Last modified 9 Jan 2022
+# Last modified 9 Jun 2022
 #
 #------------------------------------------------------------------------------
 

--- a/lis/utils/usaf/retune_bratseth/scripts/run_autotune_discover.sh
+++ b/lis/utils/usaf/retune_bratseth/scripts/run_autotune_discover.sh
@@ -4,7 +4,8 @@
 #SBATCH --account s1189
 #SBATCH --output autotune.slurm.out
 #Adjust node, core, and hardware constraints here
-#SBATCH --ntasks=4 --mem-per-cpu=4G --constraint=hasw
+##SBATCH --ntasks=5 --mem-per-cpu=4G
+#SBATCH --ntasks=5 --ntasks-per-node=1
 #Substitute your e-mail here
 #SBATCH --mail-type=ALL
 #Set quality of service, if needed.
@@ -26,6 +27,7 @@
 # 17 Dec 2020:  Eric Kemp.  Initial specification.
 # 13 Dec 2021:  Eric Kemp.  Updated module, and removed obsolete satellite
 #   data feeds.
+# 09 Jun 2022:  Eric Kemp.  Refactored code to reduce runtime.
 #
 #------------------------------------------------------------------------------
 
@@ -48,257 +50,325 @@ NWPVARS=(gage rh2m spd10m t2m)
 SATVARS=(imerg)
 
 # Paths on local system
-SCRIPTDIR=/discover/nobackup/projects/lis_aist17/emkemp/AFWA/lis74_bratseth_retuning_for_ops/build/LISF/lis/utils/usaf/retune_bratseth/scripts
-CFGDIR=/discover/nobackup/projects/lis_aist17/emkemp/AFWA/lis74_bratseth_retuning_for_ops/build/LISF/lis/utils/usaf/retune_bratseth/cfgs
-BINDIR=/discover/nobackup/projects/lis_aist17/emkemp/AFWA/lis74_bratseth_retuning_for_ops/build/LISF/lis/utils/usaf/retune_bratseth/src
+SCRIPTDIR=/discover/nobackup/projects/usaf_lis/emkemp/AFWA/lis74_oba_runs/build/LISF/lis/utils/usaf/retune_bratseth/scripts
+CFGDIR=/discover/nobackup/projects/usaf_lis/emkemp/AFWA/lis74_oba_runs/build/LISF/lis/utils/usaf/retune_bratseth/cfgs
+BINDIR=/discover/nobackup/projects/usaf_lis/emkemp/AFWA/lis74_oba_runs/build/LISF/lis/utils/usaf/retune_bratseth/src
 
 # Get the command line arguments to specify the training period.
 if [ -z "$1" ] ; then
-    echo "Missing end date time for autotune software!"
+    echo "ERROR, Missing end date time for autotune software!"
     exit 1
 fi
 if [ -z "$2" ] ; then
-    echo "Missing training day range for autotune software!"
+    echo "ERROR, Missing training day range for autotune software!"
     exit 1
 fi
 enddt=$1
 dayrange=$2
 
+echo "INFO, Started autotuning at `date`"
+
 # Customize config files for procOBA_NWP, including blacklist creation.
 # These will be run in the background to parallelize the work.
+echo "---Customizing procOBA config files, and creating blacklists---"
 if [ ! -e $SCRIPTDIR/customize_procoba_nwp.py ] ; then
     echo "ERROR, $SCRIPTDIR/customize_procoba_nwp.py does not exist!" && exit 1
+fi
+if [ ! -e $SCRIPTDIR/customize_procoba_sat.py ] ; then
+    echo "ERROR, $SCRIPTDIR/customize_procoba_sat.py does not exist!" && exit 1
 fi
 if [ ! -e $CFGDIR/autotune.cfg ] ; then
     echo "ERROR, $CFGDIR/autotune.cfg does not exist!" && exit 1
 fi
 i=0
+# We submit the NWP jobs first since they generate blacklists, which is
+# time consuming.
 for varname in "${NWPVARS[@]}" ; do
-    echo "Task $i:  Calling customize_procoba_nwp.py for $varname at `date`"
-    srun --ntasks=1 \
+    echo "INFO, Task $i:  Calling customize_procoba_nwp.py for $varname at `date`"
+    srun --ntasks=1 --nodes=1 --exclusive \
          $SCRIPTDIR/customize_procoba_nwp.py $CFGDIR/autotune.cfg \
          $enddt $dayrange $varname &
     PIDS+=($!)
+    actives+=(1)
     ((i+=1))
     sleep 1
 done
-i=0
-for pid in "${PIDS[@]}"; do
-    wait ${pid}
-    st=($?)
-    if [[ ${st} -ne 0 ]]; then
-        echo "ERROR, Task $i failed, ABORTING..."
-        exit 1
-    else
-        echo "Task $i finished with no reported error"
-    fi
+for varname in "${SATVARS[@]}" ; do
+    echo "INFO, Task $i:  Calling customize_procoba_sat.py for $varname at `date`"
+    srun --ntasks=1 --nodes=1 --exclusive \
+         $SCRIPTDIR/customize_procoba_sat.py $CFGDIR/autotune.cfg \
+         $enddt $dayrange $varname &
+    PIDS+=($!)
+    actives+=(1)
     ((i+=1))
+    sleep 1
+done
+
+count=$i
+echo "INFO, Waiting for $count task(s) to complete..."
+while true; do
+    for i in "${!PIDS[@]}"; do
+        if [ "${actives[$i]}" -eq 0 ]; then
+            continue
+        fi
+        pid="${PIDS[$i]}"
+        # See if pid is still running
+        ps --pid "$pid" > /dev/null
+        if [ "$?" -ne 0 ]; then # ps doesn't see it, so it terminated
+            wait "$pid"
+            return_code="$?"
+            actives[$i]=0
+            count=$((count-1))
+            if [ "${return_code}" -ne 0 ]; then
+                echo "ERROR, Task $i failed, ABORTING at `date`"
+                exit 1
+            else
+                echo "INFO, Task $i finished with no reported error at `date`"
+            fi
+            if [ "$count" -gt 0 ] ; then
+                echo "INFO, Waiting for $count task(s) to complete..."
+            fi
+        fi
+    done
+    alldone=1
+    for i in "${!actives[@]}" ; do
+        if [ "${actives[$i]}" -eq 1 ] ; then
+            alldone=0
+        fi
+    done
+    if [ "${alldone}" -eq 1 ] ; then
+        break
+    fi
 done
 unset PIDS
+unset actives
 
 # Construct empirical semivariograms.
 # These will be run in the background to parallelize the work.
+echo "---Creating empirical semivariograms---"
+if [ ! -e $BINDIR/procOBA_Sat ] ; then
+    echo "ERROR, $BINDIR/procOBA_Sat does not exist!" && exit 1
+fi
 if [ ! -e $BINDIR/procOBA_NWP ] ; then
     echo "ERROR, $BINDIR/procOBA_NWP does not exist!" && exit 1
 fi
 i=0
+for varname in "${SATVARS[@]}" ; do
+    echo "INFO, Task $i:  Calling procOBA_Sat for $varname at `date`"
+    if [ ! -e procOBA_Sat.$varname.config ] ; then
+        echo "ERROR, procOBA_Sat.$varname.config does not exist!" && exit 1
+    fi
+    srun --ntasks=1 --nodes=1 --exclusive \
+         $BINDIR/procOBA_Sat procOBA_Sat.$varname.config \
+         procOBA_Sat.$varname.log &
+    PIDS+=($!)
+    actives+=(1)
+    ((i+=1))
+    sleep 1
+done
 for varname in "${NWPVARS[@]}" ; do
-    echo "Task $i:  Calling procOBA_NWP for $varname at `date`"
+    echo "INFO, Task $i:  Calling procOBA_NWP for $varname at `date`"
     if [ ! -e procOBA_NWP.$varname.config ] ; then
         echo "ERROR, procOBA_NWP.$varname.config does not exist!" && exit 1
     fi
-    srun --ntasks=1 \
+    srun --ntasks=1 --nodes=1 --exclusive \
          $BINDIR/procOBA_NWP procOBA_NWP.$varname.config \
          procOBA_NWP.$varname.log &
         pid=$!
     PIDS+=($!)
+    actives+=(1)
     ((i+=1))
     sleep 1
 done
-i=0
-for pid in "${PIDS[@]}"; do
-    wait ${pid}
-    st=($?)
-    if [[ ${st} -ne 0 ]]; then
-        echo "ERROR, Task $i failed, ABORTING..."
-        exit 1
-    else
-        echo "Task $i finished with no reported error"
+
+count=$i
+echo "INFO, Waiting for $count task(s) to complete..."
+while true; do
+    for i in "${!PIDS[@]}"; do
+        if [ "${actives[$i]}" -eq 0 ]; then
+            continue
+        fi
+        pid="${PIDS[$i]}"
+        # See if pid is still running
+        ps --pid "$pid" > /dev/null
+        if [ "$?" -ne 0 ]; then # ps doesn't see it, so it terminated
+            wait "$pid"
+            return_code="$?"
+            actives[$i]=0
+            count=$((count-1))
+            if [ "${return_code}" -ne 0 ]; then
+                echo "ERROR, Task $i failed, ABORTING at `date`"
+                exit 1
+            else
+                echo "INFO, Task $i finished with no reported error at `date`"
+            fi
+            if [ "$count" -gt 0 ] ; then
+                echo "INFO, Waiting for $count task(s) to complete..."
+            fi
+        fi
+    done
+    alldone=1
+    for i in "${!actives[@]}" ; do
+        if [ "${actives[$i]}" -eq 1 ] ; then
+            alldone=0
+        fi
+    done
+    if [ "${alldone}" -eq 1 ] ; then
+        break
     fi
-    ((i+=1))
 done
 unset PIDS
+unset actives
 
 # Create best-fits to the empirical semivariograms.
 # These will be run in the background to parallelize the work.
+echo "---Estimating best-fit covariance parameters---"
 if [ ! -e $SCRIPTDIR/fit_semivariogram.py ] ; then
     echo "ERROR, $SCRIPTDIR/fit_semivariogram.py does not exist!" && exit 1
 fi
 i=0
+for varname in "${SATVARS[@]}" ; do
+    echo "INFO, Task $i:  Calling fit_semivariogram.py for $varname at `date`"
+    if [ ! -e $CFGDIR/gage_$varname.cfg ] ; then
+        echo "ERROR, $CFGDIR/gage_$varname.cfg does not exist!" && exit 1
+    fi
+    srun --ntasks=1 --nodes=1 --exclusive \
+         $SCRIPTDIR/fit_semivariogram.py $CFGDIR/gage_$varname.cfg \
+         gage_$varname.param &
+    PIDS+=($!)
+    actives+=(1)
+    ((i+=1))
+    sleep 1
+done
 for varname in "${NWPVARS[@]}" ; do
-    echo "Task $i:  Calling fit_semivariogram.py for $varname at `date`"
+    echo "INFO, Task $i:  Calling fit_semivariogram.py for $varname at `date`"
     if [ $varname = gage ] ; then
         if [ ! -e $CFGDIR/${varname}_nwp.cfg ] ; then
             echo "ERROR, $CFGDIR/${varname}_nwp.cfg does not exist!" && exit 1
         fi
-        srun --ntasks=1 \
+        srun --ntasks=1 --nodes=1 --exclusive \
              $SCRIPTDIR/fit_semivariogram.py $CFGDIR/${varname}_nwp.cfg \
             ${varname}_nwp.param &
     else
         if [ ! -e $CFGDIR/${varname}.cfg ] ; then
             echo "ERROR, $CFGDIR/${varname}.cfg does not exist!" && exit 1
         fi
-        srun --ntasks=1 \
+        srun --ntasks=1 --nodes=1 --exclusive \
              $SCRIPTDIR/fit_semivariogram.py $CFGDIR/$varname.cfg \
             $varname.param &
     fi
     PIDS+=($!)
+    actives+=(1)
     ((i+=1))
     sleep 1
 done
-i=0
-for pid in "${PIDS[@]}"; do
-    wait ${pid}
-    st=($?)
-    if [[ ${st} -ne 0 ]]; then
-        echo "ERROR, Task $i failed, ABORTING..."
-        exit 1
-    else
-        echo "Task $i finished with no reported error"
+
+count=$i
+echo "INFO, Waiting for $count task(s) to complete..."
+while true; do
+    for i in "${!PIDS[@]}"; do
+        if [ "${actives[$i]}" -eq 0 ]; then
+            continue
+        fi
+        pid="${PIDS[$i]}"
+        # See if pid is still running
+        ps --pid "$pid" > /dev/null
+        if [ "$?" -ne 0 ]; then # ps doesn't see it, so it terminated
+            wait "$pid"
+            return_code="$?"
+            actives[$i]=0
+            count=$((count-1))
+            if [ "${return_code}" -ne 0 ]; then
+                echo "ERROR, Task $i failed, ABORTING at `date`"
+                exit 1
+            else
+                echo "INFO, Task $i finished with no reported error at `date`"
+            fi
+            if [ "$count" -gt 0 ] ; then
+                echo "INFO, Waiting for $count task(s) to complete..."
+            fi
+        fi
+    done
+    alldone=1
+    for i in "${!actives[@]}" ; do
+        if [ "${actives[$i]}" -eq 1 ] ; then
+            alldone=0
+        fi
+    done
+    if [ "${alldone}" -eq 1 ] ; then
+        break
     fi
-    ((i+=1))
 done
 unset PIDS
-
-# Customize config files for procOBA_Sat.
-# These will be run in the background to parallelize the work.
-if [ ! -e $SCRIPTDIR/customize_procoba_sat.py ] ; then
-    echo "ERROR, $SCRIPTDIR/customize_procoba_sat.py does not exist!" && exit 1
-fi
-i=0
-for varname in "${SATVARS[@]}" ; do
-    echo "Task $i:  Calling customize_procoba_sat.py for $varname at `date`"
-    srun --ntasks=1 \
-         $SCRIPTDIR/customize_procoba_sat.py $CFGDIR/autotune.cfg \
-         $enddt $dayrange $varname &
-    PIDS+=($!)
-    ((i+=1))
-    sleep 1
-done
-i=0
-for pid in "${PIDS[@]}"; do
-    wait ${pid}
-    st=($?)
-    if [[ ${st} -ne 0 ]]; then
-        echo "ERROR, Task $i failed, ABORTING..."
-        exit 1
-    else
-        echo "Task $i finished with no reported error"
-    fi
-    ((i+=1))
-done
-unset PIDS
-
-
-# Construct empirical semivariograms for the satellite data w/r/t gages.
-# These will be run in the background to parallelize the work.
-if [ ! -e $BINDIR/procOBA_Sat ] ; then
-    echo "ERROR, $BINDIR/procOBA_Sat does not exist!" && exit 1
-fi
-i=0
-for varname in "${SATVARS[@]}" ; do
-    echo "Task $i:  Calling procOBA_Sat for $varname at `date`"
-    if [ ! -e procOBA_Sat.$varname.config ] ; then
-        echo "ERROR, procOBA_Sat.$varname.config does not exist!" && exit 1
-    fi
-    srun --ntasks=1 \
-         $BINDIR/procOBA_Sat procOBA_Sat.$varname.config \
-         procOBA_Sat.$varname.log &
-    PIDS+=($!)
-    ((i+=1))
-    sleep 1
-done
-i=0
-for pid in "${PIDS[@]}"; do
-    wait ${pid}
-    st=($?)
-    if [[ ${st} -ne 0 ]]; then
-        echo "ERROR, Task $i failed, ABORTING..."
-        exit 1
-    else
-        echo "Task $i finished with no reported error"
-    fi
-    ((i+=1))
-done
-unset PIDS
-
-# Create best fits to the satellite semivariograms w/r/t gages.
-# These will be run in the background to parallelize the work.
-i=0
-for varname in "${SATVARS[@]}" ; do
-    echo "Task $i:  Calling fit_semivariogram.py for $varname at `date`"
-    if [ ! -e $CFGDIR/gage_$varname.cfg ] ; then
-        echo "ERROR, $CFGDIR/gage_$varname.cfg does not exist!" && exit 1
-    fi
-    srun --ntasks=1 \
-         $SCRIPTDIR/fit_semivariogram.py $CFGDIR/gage_$varname.cfg \
-         gage_$varname.param &
-    PIDS+=($!)
-    ((i+=1))
-    sleep 1
-done
-i=0
-for pid in "${PIDS[@]}"; do
-    wait ${pid}
-    st=($?)
-    if [[ ${st} -ne 0 ]]; then
-        echo "ERROR, Task $i failed, ABORTING..."
-        exit 1
-    else
-        echo "Task $i finished with no reported error"
-    fi
-    ((i+=1))
-done
-unset PIDS
+unset actives
 
 # Rescale the satellite error variances to be w/r/t NWP.
 # These will be run in the background to parallelize the work.
+echo "---Rescaling satellite error variances---"
 if [ ! -e $SCRIPTDIR/rescale_sat_sigma2.py ] ; then
     echo "ERROR, $SCRIPTDIR/rescale_sat_sigma2.py does not exist!" && exit 1
 fi
 i=0
 for varname in "${SATVARS[@]}" ; do
-    echo "Task $i:  Calling rescale_sat_sigma2.py for $varname at `date`"
-    srun --ntasks=1 \
+    echo "INFO, Task $i:  Calling rescale_sat_sigma2.py for $varname at `date`"
+    srun --ntasks=1 --nodes=1 --exclusive \
          $SCRIPTDIR/rescale_sat_sigma2.py $varname &
     PIDS+=($!)
+    actives+=(1)
     ((i+=1))
     sleep 1
 done
-i=0
-for pid in "${PIDS[@]}"; do
-    wait ${pid}
-    st=($?)
-    if [[ ${st} -ne 0 ]]; then
-        echo "ERROR, Task $i failed, ABORTING..."
-        exit 1
-    else
-        echo "Task $i finished with no reported error"
+
+count=$i
+echo "INFO, Waiting for $count task(s) to complete..."
+while true; do
+    for i in "${!PIDS[@]}"; do
+        if [ "${actives[$i]}" -eq 0 ]; then
+            continue
+        fi
+        pid="${PIDS[$i]}"
+        # See if pid is still running
+        ps --pid "$pid" > /dev/null
+        if [ "$?" -ne 0 ]; then # ps doesn't see it, so it terminated
+            wait "$pid"
+            return_code="$?"
+            actives[$i]=0
+            count=$((count-1))
+            if [ "${return_code}" -ne 0 ]; then
+                echo "ERROR, Task $i failed, ABORTING at `date`"
+                exit 1
+            else
+                echo "INFO, Task $i finished with no reported error at `date`"
+            fi
+            if [ "$count" -gt 0 ] ; then
+                echo "INFO, Waiting for $count task(s) to complete..."
+            fi
+        fi
+    done
+    alldone=1
+    for i in "${!actives[@]}" ; do
+        if [ "${actives[$i]}" -eq 1 ] ; then
+            alldone=0
+        fi
+    done
+    if [ "${alldone}" -eq 1 ] ; then
+        break
     fi
-    ((i+=1))
 done
 unset PIDS
+unset actives
 
 # Update the lis.config error settings.
 # Single task, no need to parallelize.
-echo "Calling customize_lis_config.py at `date`"
+echo "---Customizing lis.config file with new error covariances---"
+echo "INFO, Calling customize_lis_config.py at `date`"
 if [ ! -e $SCRIPTDIR/customize_lis_config.py ] ; then
     echo "ERROR, $SCRIPTDIR/customize_lis_config.py does not exist!" && exit 1
 fi
-srun --ntasks=1 --kill-on-bad-exit=1 \
+srun --ntasks=1 --nodes=1 --exclusive --kill-on-bad-exit=1 \
      $SCRIPTDIR/customize_lis_config.py $CFGDIR/autotune.cfg \
      $enddt $dayrange || exit 1
 
 # The end
-echo "INFO, Completed autotuning!"
+echo "INFO, Completed autotuning at `date`"
 exit 0

--- a/lis/utils/usaf/retune_bratseth/scripts/run_autotune_hpc11.sh
+++ b/lis/utils/usaf/retune_bratseth/scripts/run_autotune_hpc11.sh
@@ -1,0 +1,301 @@
+#!/bin/sh
+#SBATCH --job-name=autotune
+#SBATCH --time=1:00:00
+#SBATCH --account=NWP601
+#SBATCH --output autotune.slurm.out
+#Adjust node, core, and hardware constraints here
+#SBATCH --ntasks=4 --ntasks-per-node=1
+#------------------------------------------------------------------------------
+#
+# SCRIPT: run_autotune_discover.sh
+#
+# Batch script for running autotune software to update error covariance
+# settings for LIS Air Force Bratseth scheme.  Customized for NASA Discover
+# supercomputer running SLURM batch queueing system.
+#
+# USAGE:  sbatch run_autotune_discover.sh $YYYYMMDDHH $DD
+#           where $YYYYMMDDHH is the end date/time of the OBA training period
+#           and $DD is the length (in days) of the OBA training period.
+#
+#
+# REVISION HISTORY:
+# 17 Dec 2020:  Eric Kemp.  Initial specification.
+# 13 Dec 2021:  Eric Kemp.  Updated module, and removed obsolete satellite
+#   data feeds.
+#
+#------------------------------------------------------------------------------
+
+ulimit -s unlimited
+
+# When a batch script is started, it starts in the user's home directory.
+# Change to the directory where job was submitted.
+if [ ! -z $SLURM_SUBMIT_DIR ] ; then
+    cd $SLURM_SUBMIT_DIR || exit 1
+fi
+
+# Environment
+#module purge
+#unset LD_LIBRARY_PATH
+module use --append ~emkemp/hpc11/privatemodules
+module load lisf_74_prgenv_cray_8.2.0
+module load afw-python/3.9-202203
+
+# Define the variables to be processed
+NWPVARS=(gage rh2m spd10m t2m)
+SATVARS=(imerg)
+
+# Paths on local system
+SCRIPTDIR=/lustre/active/nwp601/proj-shared/emkemp/build/LISF_557WW_release_7.4.11/lis/utils/usaf/retune_bratseth/scripts
+CFGDIR=/lustre/active/nwp601/proj-shared/emkemp/build/LISF_557WW_release_7.4.11/lis/utils/usaf/retune_bratseth/cfgs
+BINDIR=/lustre/active/nwp601/proj-shared/emkemp/build/LISF_557WW_release_7.4.11/lis/utils/usaf/retune_bratseth/src
+
+# Get the command line arguments to specify the training period.
+if [ -z "$1" ] ; then
+    echo "Missing end date time for autotune software!"
+    exit 1
+fi
+if [ -z "$2" ] ; then
+    echo "Missing training day range for autotune software!"
+    exit 1
+fi
+enddt=$1
+dayrange=$2
+
+# Customize config files for procOBA_NWP, including blacklist creation.
+# These will be run in the background to parallelize the work.
+if [ ! -e $SCRIPTDIR/customize_procoba_nwp.py ] ; then
+    echo "ERROR, $SCRIPTDIR/customize_procoba_nwp.py does not exist!" && exit 1
+fi
+if [ ! -e $CFGDIR/autotune.cfg ] ; then
+    echo "ERROR, $CFGDIR/autotune.cfg does not exist!" && exit 1
+fi
+i=0
+for varname in "${NWPVARS[@]}" ; do
+    echo "Task $i:  Calling customize_procoba_nwp.py for $varname at `date`"
+    srun --ntasks=1 --nodes=1 --exclusive \
+         $SCRIPTDIR/customize_procoba_nwp.py $CFGDIR/autotune.cfg \
+         $enddt $dayrange $varname &
+    PIDS+=($!)
+    ((i+=1))
+    sleep 1
+done
+i=0
+for pid in "${PIDS[@]}"; do
+    wait ${pid}
+    st=($?)
+    if [[ ${st} -ne 0 ]]; then
+        echo "ERROR, Task $i failed, ABORTING..."
+        exit 1
+    else
+        echo "Task $i finished with no reported error"
+    fi
+    ((i+=1))
+done
+unset PIDS
+
+# Construct empirical semivariograms.
+# These will be run in the background to parallelize the work.
+if [ ! -e $BINDIR/procOBA_NWP ] ; then
+    echo "ERROR, $BINDIR/procOBA_NWP does not exist!" && exit 1
+fi
+i=0
+for varname in "${NWPVARS[@]}" ; do
+    echo "Task $i:  Calling procOBA_NWP for $varname at `date`"
+    if [ ! -e procOBA_NWP.$varname.config ] ; then
+        echo "ERROR, procOBA_NWP.$varname.config does not exist!" && exit 1
+    fi
+    srun --ntasks=1 --nodes=1 --exclusive \
+         $BINDIR/procOBA_NWP procOBA_NWP.$varname.config \
+         procOBA_NWP.$varname.log &
+        pid=$!
+    PIDS+=($!)
+    ((i+=1))
+    sleep 1
+done
+i=0
+for pid in "${PIDS[@]}"; do
+    wait ${pid}
+    st=($?)
+    if [[ ${st} -ne 0 ]]; then
+        echo "ERROR, Task $i failed, ABORTING..."
+        exit 1
+    else
+        echo "Task $i finished with no reported error"
+    fi
+    ((i+=1))
+done
+unset PIDS
+
+# Create best-fits to the empirical semivariograms.
+# These will be run in the background to parallelize the work.
+if [ ! -e $SCRIPTDIR/fit_semivariogram.py ] ; then
+    echo "ERROR, $SCRIPTDIR/fit_semivariogram.py does not exist!" && exit 1
+fi
+i=0
+for varname in "${NWPVARS[@]}" ; do
+    echo "Task $i:  Calling fit_semivariogram.py for $varname at `date`"
+    if [ $varname = gage ] ; then
+        if [ ! -e $CFGDIR/${varname}_nwp.cfg ] ; then
+            echo "ERROR, $CFGDIR/${varname}_nwp.cfg does not exist!" && exit 1
+        fi
+        srun --ntasks=1 --nodes=1 --exclusive \
+             $SCRIPTDIR/fit_semivariogram.py $CFGDIR/${varname}_nwp.cfg \
+            ${varname}_nwp.param &
+    else
+        if [ ! -e $CFGDIR/${varname}.cfg ] ; then
+            echo "ERROR, $CFGDIR/${varname}.cfg does not exist!" && exit 1
+        fi
+        srun --ntasks=1 --nodes=1 --exclusive \
+             $SCRIPTDIR/fit_semivariogram.py $CFGDIR/$varname.cfg \
+            $varname.param &
+    fi
+    PIDS+=($!)
+    ((i+=1))
+    sleep 1
+done
+i=0
+for pid in "${PIDS[@]}"; do
+    wait ${pid}
+    st=($?)
+    if [[ ${st} -ne 0 ]]; then
+        echo "ERROR, Task $i failed, ABORTING..."
+        exit 1
+    else
+        echo "Task $i finished with no reported error"
+    fi
+    ((i+=1))
+done
+unset PIDS
+
+# Customize config files for procOBA_Sat.
+# These will be run in the background to parallelize the work.
+if [ ! -e $SCRIPTDIR/customize_procoba_sat.py ] ; then
+    echo "ERROR, $SCRIPTDIR/customize_procoba_sat.py does not exist!" && exit 1
+fi
+i=0
+for varname in "${SATVARS[@]}" ; do
+    echo "Task $i:  Calling customize_procoba_sat.py for $varname at `date`"
+    srun --ntasks=1 --nodes=1 --exclusive \
+         $SCRIPTDIR/customize_procoba_sat.py $CFGDIR/autotune.cfg \
+         $enddt $dayrange $varname &
+    PIDS+=($!)
+    ((i+=1))
+    sleep 1
+done
+i=0
+for pid in "${PIDS[@]}"; do
+    wait ${pid}
+    st=($?)
+    if [[ ${st} -ne 0 ]]; then
+        echo "ERROR, Task $i failed, ABORTING..."
+        exit 1
+    else
+        echo "Task $i finished with no reported error"
+    fi
+    ((i+=1))
+done
+unset PIDS
+
+
+# Construct empirical semivariograms for the satellite data w/r/t gages.
+# These will be run in the background to parallelize the work.
+if [ ! -e $BINDIR/procOBA_Sat ] ; then
+    echo "ERROR, $BINDIR/procOBA_Sat does not exist!" && exit 1
+fi
+i=0
+for varname in "${SATVARS[@]}" ; do
+    echo "Task $i:  Calling procOBA_Sat for $varname at `date`"
+    if [ ! -e procOBA_Sat.$varname.config ] ; then
+        echo "ERROR, procOBA_Sat.$varname.config does not exist!" && exit 1
+    fi
+    srun --ntasks=1 --nodes=1 --exclusive \
+         $BINDIR/procOBA_Sat procOBA_Sat.$varname.config \
+         procOBA_Sat.$varname.log &
+    PIDS+=($!)
+    ((i+=1))
+    sleep 1
+done
+i=0
+for pid in "${PIDS[@]}"; do
+    wait ${pid}
+    st=($?)
+    if [[ ${st} -ne 0 ]]; then
+        echo "ERROR, Task $i failed, ABORTING..."
+        exit 1
+    else
+        echo "Task $i finished with no reported error"
+    fi
+    ((i+=1))
+done
+unset PIDS
+
+# Create best fits to the satellite semivariograms w/r/t gages.
+# These will be run in the background to parallelize the work.
+i=0
+for varname in "${SATVARS[@]}" ; do
+    echo "Task $i:  Calling fit_semivariogram.py for $varname at `date`"
+    if [ ! -e $CFGDIR/gage_$varname.cfg ] ; then
+        echo "ERROR, $CFGDIR/gage_$varname.cfg does not exist!" && exit 1
+    fi
+    srun --ntasks=1 --nodes=1 --exclusive \
+         $SCRIPTDIR/fit_semivariogram.py $CFGDIR/gage_$varname.cfg \
+         gage_$varname.param &
+    PIDS+=($!)
+    ((i+=1))
+    sleep 1
+done
+i=0
+for pid in "${PIDS[@]}"; do
+    wait ${pid}
+    st=($?)
+    if [[ ${st} -ne 0 ]]; then
+        echo "ERROR, Task $i failed, ABORTING..."
+        exit 1
+    else
+        echo "Task $i finished with no reported error"
+    fi
+    ((i+=1))
+done
+unset PIDS
+
+# Rescale the satellite error variances to be w/r/t NWP.
+# These will be run in the background to parallelize the work.
+if [ ! -e $SCRIPTDIR/rescale_sat_sigma2.py ] ; then
+    echo "ERROR, $SCRIPTDIR/rescale_sat_sigma2.py does not exist!" && exit 1
+fi
+i=0
+for varname in "${SATVARS[@]}" ; do
+    echo "Task $i:  Calling rescale_sat_sigma2.py for $varname at `date`"
+    srun --ntasks=1 --nodes=1 --exclusive \
+         $SCRIPTDIR/rescale_sat_sigma2.py $varname &
+    PIDS+=($!)
+    ((i+=1))
+    sleep 1
+done
+i=0
+for pid in "${PIDS[@]}"; do
+    wait ${pid}
+    st=($?)
+    if [[ ${st} -ne 0 ]]; then
+        echo "ERROR, Task $i failed, ABORTING..."
+        exit 1
+    else
+        echo "Task $i finished with no reported error"
+    fi
+    ((i+=1))
+done
+unset PIDS
+
+# Update the lis.config error settings.
+# Single task, no need to parallelize.
+echo "Calling customize_lis_config.py at `date`"
+if [ ! -e $SCRIPTDIR/customize_lis_config.py ] ; then
+    echo "ERROR, $SCRIPTDIR/customize_lis_config.py does not exist!" && exit 1
+fi
+srun --ntasks=1 --nodes=1 --exclusive --kill-on-bad-exit=1 \
+     $SCRIPTDIR/customize_lis_config.py $CFGDIR/autotune.cfg \
+     $enddt $dayrange || exit 1
+
+# The end
+echo "INFO, Completed autotuning!"
+exit 0

--- a/lis/utils/usaf/retune_bratseth/src/Makefile
+++ b/lis/utils/usaf/retune_bratseth/src/Makefile
@@ -27,23 +27,23 @@ procOBA_Sat: procOBA_Sat.o USAF_GridHashMod.o USAF_ReportsMod.o \
 
 procOBA_NWP.o: procOBA_NWP.F90 USAF_GridHashMod.o USAF_ReportsMod.o \
                      USAF_StationsMod.o USAF_sharedMod.o
-	$(FC) -c $(FFLAGS) $< -I$(MOD_ESMF)
+	$(FC) $(FFLAGS) $< -I$(MOD_ESMF)
 
 procOBA_Sat.o: procOBA_Sat.F90 USAF_GridHashMod.o USAF_ReportsMod.o \
                      USAF_StationsMod.o USAF_sharedMod.o
-	$(FC) -c $(FFLAGS) $< -I$(MOD_ESMF)
+	$(FC) $(FFLAGS) $< -I$(MOD_ESMF)
 
 USAF_GridHashMod.o : USAF_GridHashMod.F90
-	$(FC) -c $(FFLAGS) $<
+	$(FC) $(FFLAGS) $<
 
 USAF_ReportsMod.o: USAF_ReportsMod.F90
-	$(FC) -c $(FFLAGS) $<
+	$(FC) $(FFLAGS) $<
 
 USAF_StationsMod.o: USAF_StationsMod.F90
-	$(FC) -c $(FFLAGS) $<
+	$(FC) $(FFLAGS) $<
 
 USAF_sharedMod.o: USAF_sharedMod.F90
-	$(FC) -c $(FFLAGS) $< -I$(MOD_ESMF)
+	$(FC) $(FFLAGS) $< -I$(MOD_ESMF)
 
 .PHONY: clean
 clean:

--- a/lis/utils/usaf/retune_bratseth/src/procOBA_NWP.F90
+++ b/lis/utils/usaf/retune_bratseth/src/procOBA_NWP.F90
@@ -675,7 +675,7 @@ program main
       end if
       call ESMF_LogWrite( &
            "Writing to output file "//trim(outfile), &
-           ESMF_LOGMSG_WARNING)
+           ESMF_LOGMSG_INFO)
       do j = 1, max_vario_bins
          if (icounts_vario(j) .eq. 0) cycle
          write(iunit_out_vario, '(A,f10.0,A,f7.3,A,I14.14)') &


### PR DESCRIPTION


### Description

Updated Bratseth error covariances for GALWEM-17, ending 23 May 2022.  

Also, added new covariance retuning batch script for HPC11; reworked retuning batch script for Discover to reduce wallclock time; updated FOC lis.config files to activate OBA file output; fixed minor bug in procOBA_NWP log output (INFO instead of WARNING for writing output), and removed redundant -c flag in Makefile.

This is intended for USAF operational use.
