### PR TITLE
Update LVT Users' Guide for upcoming LISF Public 7.4.0 release

### DIFF
--- a/docs/LVT_users_guide/LVT_users_guide.adoc
+++ b/docs/LVT_users_guide/LVT_users_guide.adoc
@@ -1,4 +1,4 @@
-= Land surface Verification Toolkit (LVT): LVT {lisfrevision} Users' Guide
+= Land surface Verification Toolkit (LVT): LVT {lisfrevision} Users`' Guide
 :revnumber: 1.9
 :revdate: 06 Dec 2021
 :doctype: book
@@ -9,14 +9,13 @@
 :imagesoutdir: images
 :stem: latexmath
 :devonly:
-:lisfrevision: 7.3
-:lisfurl: http://lis.gsfc.nasa.gov
-:svnurl: http://subversion.apache.org
+:lisfrevision: 7.4
+:lisfurl: https://lis.gsfc.nasa.gov
 :nasalisf: https://github.com/NASA-LIS/LISF
 :githuburl: https://github.com
+:nasalisfpages: https://nasa-lis.github.io/LISF/
 :apachelicense: https://www.apache.org/licenses/LICENSE-2.0
-:lispublicrelease: Initial version - for LDT
-:lvttarball: LISF_public_release_7.3.1.tar.gz
+:lvttarball: LISF_public_release_7.4.0.tar.gz
 :emdash: —
 :endash: –
 :vertellipsis: ⋮

--- a/docs/LVT_users_guide/build.adoc
+++ b/docs/LVT_users_guide/build.adoc
@@ -2,204 +2,13 @@
 [[sec-build]]
 == Building the Executable
 
-This section describes how to build the source code and create LVT`'s executable: named LVT.
+This section describes how to build the source code and create LVT`'s executable: named _LVT_.
 
 Please see Section <<sec-important_note_fs>> for information regarding using a case sensitve file system for compiling/running LVT.
 
-=== Development Tools
+=== LISF Dependencies
 
-This code has been compiled and run on
-Linux PC (Intel/AMD based) systems
-//IBM AIX systems,
-//and SGI Altix systems.
-and Cray systems.
-These instructions expect that you are using such a system.  In particular you need:
-
-==== Linux
-
-===== Compilers
-
-* Intel Fortran Compiler versions 18, 19, or 20 with corresponding Intel C Compiler along with GNU's Compiler Collection version 9.2.0
-* or GNU's Compiler Collection version 4.9.2 or 7.3, both gfortran and gcc.
-
-===== Tools
-
-* GNU's make, gmake, version 3.77 or 3.81
-* Perl, version 5.10
-* Python, version 2.7 or 3.8
-
-IMPORTANT: Support for Python 2.7 is now deprecated.  Future releases will depend on Python 3.
-
-//
-//      *** or Absoft's Pro Fortran Software Developement Kit, version 10.0
-//            with GNU's C and C++ compilers, gcc and g++, version 3.3.3
-//
-//      *** or Lahey/Fujitsu's Fortran 95 Compiler, release L6.00c
-//            with GNU's C and C++ compilers, gcc and g++, version 3.3.3
-//
-
-==== Cray/Linux
-
-===== Compilers
-
-* Intel Fortran Compiler version 18 or 19 with corresponding Intel C Compiler, along with GNU's Compiler Collection version 7.3.0
-
-===== Tools
-
-* GNU's make, gmake, version 3.77 or 3.81
-* Perl, version 5.10
-* Python, version 2.7 or 3.8
-
-IMPORTANT: Support for Python 2.7 is now deprecated.  Future releases will depend on Python 3.
-
-//
-//   * IBM
-//      ** XL Fortran version 10.1.0.6
-//      ** GNU's make, gmake, version 3.77
-//
-//   * SGI Altix
-//      ** Intel Fortran Compiler version 12
-//      ** GNU's make, gmake, version 3.77
-
-[[ssec-requiredlibs]]
-=== Required Software Libraries
-
-In order to build the LVT executable, the following libraries must be installed on your system:
-
-==== Earth System Modeling Framework (ESMF) version 7.1.0r (or higher)
-
-(https://earthsystemmodeling.org/)
-
-//
-//         Please read the ESMF User's Guide for details on installing
-//         ESMF with MPI support and without MPI support (``mpiuni'').
-//
-
-//==== JasPer version 2.0.14 (or higher)
-//
-//(http://www.ece.uvic.ca/{tilde}frodo/jasper/)
-//
-//Note that when running the `configure` command you must include the `--enable-shared` option.
-
-==== OpenJPEG version 2.3.0 (or higher)
-
-(http://www.openjpeg.org/)
-
-==== ecCodes version 2.7.0 (or higher)
-
-(https://confluence.ecmwf.int/display/ECC)
-
-=== Optional Software Libraries
-
-The following libraries are not required to compile LVT. They are used to extend the functionality of LVT.
-
-// ==== Message Passing Interface (MPI)
-//
-// If you wish to run LIS with multiple processes (i.e., in parallel), then you must install an MPI library package.
-//
-// * vendor supplied (e.g., Intel MPI)
-// // * MPICH version 1.2.7p1 (http://www-unix.mcs.anl.gov/mpi/mpich1/)
-// * Open MPI (http://www.open-mpi.org/)
-//
-// Note that LIS does not support OpenMP style parallelization.  There is some experimental support within LIS, but you should not enable it.
-
-==== NetCDF either version 3.6.3 or version 4.5.0 (or higher)
-
-(http://www.unidata.ucar.edu/software/netcdf)
-
-Please read the on-line documentation for details on installing NetCDF.
-
-===== Additional notes for NetCDF 4:
-
-You must also choose whether to compile with compression enabled.  Compiling with compression enabled requires HDF 5 and zlib libraries.  To enable compression, add `--enable-netcdf-4` to the `configure` options.  To disable compression, add `--disable-netcdf-4` to the `configure` options.
-
-An example of installing NetCDF 4 without compression:
-
-....
-% ./configure --prefix=$HOME/local/netcdf-4.5.0 --disable-netcdf-4
-% gmake
-% gmake install
-....
-
-An example of installing NetCDF 4 with compression:
-
-....
-% CPPFLAGS=-I$HOME/local/hdf5/1.10.1/include \
-> LDFLAGS=-L$HOME/local/hdf5/1.10.1/lib \
-> ./configure --prefix=$HOME/local/netcdf/4.5.0 --enable-netcdf-4
-% gmake
-% gmake install
-....
-
-You must also download the _netcdf-fortran-4.4.4.tar.gz_ file.  First install the NetCDF C library, then install the NetCDF Fortran library.  Again, please read the on-line documentation for more details.
-
-An example of installing the NetCDF 4 Fortran library:
-
-....
-% LD_LIBRARY_PATH=$HOME/local/netcdf/4.5.0/lib:$LD_LIBRARY_PATH \
-> CPPFLAGS=-I$HOME/local/netcdf/4.5.0/include \
-> LDFLAGS=-L$HOME/local/netcdf/4.5.0/lib \
-> ./configure --prefix=$HOME/local/netcdf/4.5.0
-% gmake
-% gmake install
-....
-
-==== HDF
-
-You may choose either HDF version 4, HDF version 5, or both.
-
-HDF is used to support a number of remote sensing datasets.
-
-If you wish to use MODIS snow cover area observations or NASA AMSR-E soil moisture observations, then you need HDF 4 support.
-
-If you wish to use ANSA snow cover fraction observations, then you need HDF 5 support.
-
-If you wish to use PMW snow observations, then you need both HDF 4 and HDF 5 support.
-
-===== HDF 4
-
-If you choose to have HDF version 4 support, please download the HDF source for version 4.2.13 (or higher) from https://portal.hdfgroup.org/display/support/Download+HDF4 and compile the source to generate the HDF library.  Make sure that you configure the build process to include the Fortran interfaces by adding the `--enable-fortran` option to the `configure` command.
-
-Note that HDF4 contains its own embedded version of NetCDF.  You must disable this support by adding the `--disable-netcdf` option to the `configure` command.
-
-IMPORTANT: When compiling LVT with HDF 4 support, you must also download and compile HDF-EOS2 version 2.19v1.00 or higher from http://hdfeos.org/software/library.php.
-
-===== HDF 5
-
-If you choose to have HDF version 5 support, please download the HDF source for version 1.10.1 (or higher) from http://www.hdfgroup.org/HDF5/ and compile the source to generate the HDF library.  Make sure that you configure the build process to include the Fortran interfaces by adding the `--enable-fortran` option to the `configure` command.
-
-//Note that when compiling LVT with HDF 5 support, you must also
-//download and compile HDF-EOS5 from http://hdfeos.org/.
-
-==== GDAL version 2.4.1 (or higher)
-
-(https://gdal.org)
-
-IMPORTANT: When compiling LVT with GDAL support, you must also download and compile FortranGIS version 2.4 (or higher) from http://fortrangis.sourceforge.net.
-
-==== Notes
-
-To install these libraries, follow the instructions provided at the various URL listed above. These optional libraries have their own dependencies, which should be documented in their respective documentation.
-
-Please note that your system may have several different compilers installed.  You must verify that you are building these libraries with the correct compiler.  You should review the output from the `configure`, `make`, etc. commands.  If the wrong compiler is being used, you may have to correct your `$PATH` environment variable, or set the `$CC` and `$FC` environment variables, or pass additional settings to the `configure` scripts.  Please consult the installation instructions provided at the various URL listed above for each library.
-
-//If not, review the appropriate _$WORKING/arch/configure.lvt.*_ file
-//for some hints regarding additional low level libraries needed for
-//linking.
-
-//Note that due to an issue involving multiple definitions within the NetCDF 3
-//and HDF 4 libraries, you cannot compile LVT with support for both
-//NetCDF 3 and HDF 4 together.
-
-Note that due to the mix of programing languages (Fortran and C) used by LVT, you may run into linking errors when building the LVT executable.  This is often due to (1) the Fortran compiler and the C compiler using different cases (upper case vs. lower case) for external names, and (2) the Fortran compiler and C compiler using a different number of underscores for external names.
-
-//When compiling code using Absoft's Pro Fortran SDK, set the following compiler options:
-//
-//....
-//-YEXT_NAMES=LCS -s -YEXT_SFX=_ -YCFRL=1
-//....
-//
-//These must be set for each of the above libraries.
+Please first read the companion document "`Installing LISF Dependencies`".  This document describes the required and optional libraries used by LISF.  It also describes the supported development environments.
 
 === Build Instructions
 
@@ -211,7 +20,7 @@ Perform the steps described in Section <<sec-obtain-src>> to obtain the source 
 
 ==== Step 2
 
-Goto the _$WORKING_ directory.  This directory contains two scripts for building the LVT executable: _configure_ and _compile_.
+Go to the _$WORKING_ directory.  This directory contains two scripts for building the LVT executable: _configure_ and _compile_.
 
 ==== Step 3
 
@@ -225,6 +34,21 @@ Set the LVT_ARCH environment variable based on the system you are using.  The fo
 .For a Linux system with the GNU Fortran compiler
 ....
 % export LVT_ARCH=linux_gfortran
+....
+
+.For a Cray system with the Intel Fortran compiler
+....
+% export LVT_ARCH=cray_ifc
+....
+
+.For a Cray system with the Cray Fortran compiler
+....
+% export LVT_ARCH=cray_cray
+....
+
+.For an IBM system with the GNU Fortran compiler
+....
+% export LVT_ARCH=ibm_gfortran
 ....
 
 //.For an AIX system
@@ -242,7 +66,7 @@ Set the LVT_ARCH environment variable based on the system you are using.  The fo
 //% export LVT_ARCH=linux_lf95
 //....
 
-It is suggested that you place this command in your _.profile_ (or equivalent) startup file.
+It is suggested that you set this environment variable in a modulefile footnote:modulefile[See the "`Creating a Custom Modulefile`" document found at {nasalisfpages}] to load or in an environment script to source before compiling and/or running LVT.
 
 ==== Step 4
 
@@ -270,12 +94,13 @@ This script will prompt the user with a series of questions regarding support to
 | `LVT_HDFEOS`     | path to HDFEOS2 library    | optional
 | `LVT_GDAL`       | path to GDAL library       | optional
 | `LVT_FORTRANGIS` | path to FortranGIS library | optional (required by GDAL)
+| `LVT_JPEG`       | path to JPEG library       | optional (use system libjpeg by default)
 |===
 
 //{cpp} is C++
 Note that the `CC` variable must be set to a C compiler, not a {cpp} compiler.  A {cpp} compiler may mangle internal names in a manner that is not consistent with the Fortran compiler.  This will cause errors during linking.
 
-It is suggested that you add these definitions to your _.profile_ (or equivalent) startup file.
+It is suggested that you set these environment variables in a modulefile footnote:modulefile[] to load or in an environment script to source before compiling and/or running LVT.
 
 You may encounter errors either when trying to compile LVT or when trying to run LVT because the compiler or operating system cannot find these libraries.  To fix this, you must add these libraries to your `$LD_LIBRARY_PATH` environment variable.
 For example, say that you are using ESMF, ecCodes, NetCDF, and HDF5.  Then you must execute the following command (written using Bash shell syntax):
@@ -284,7 +109,7 @@ For example, say that you are using ESMF, ecCodes, NetCDF, and HDF5.  Then you m
 % export LD_LIBRARY_PATH=$LVT_HDF5/lib:$LVT_LIBESMF:$LVT_NETCDF/lib:$LVT_ECCODES/lib:$LD_LIBRARY_PATH
 ....
 
-It is also suggested that you add this command to your _.profile_ (or equivalent) startup file.
+It is suggested that you set this environment variable in a modulefile footnote:modulefile[] to load or in an environment script to source before compiling and/or running LVT.
 
 ===== Example
 
@@ -330,14 +155,14 @@ Most of the configure options are be self-explanatory.  Here are a few specific 
 //select the default value of 0.  OpenMP support is
 //experimental.  Please do not use.
 
-* for `Optimization level (-3=strict checks with warnings, -2=strict checks, -1=debug, 0,1,2,3, default=2):`
-+
-[IMPORTANT]
-====
-There is an open issue regarding compiling LVT with the GNU compilers version 7.3 (and higher).  One of the modules takes a long time to compile, and the compilation consumes a lot of memory, often to the point of aborting.
-
-When using the GNU compilers, you should select `0`.
-====
+//* for `Optimization level (-3=strict checks with warnings, -2=strict checks, -1=debug, 0,1,2,3, default=2):`
+//+
+//[IMPORTANT]
+//====
+//There is an open issue regarding compiling LVT with the GNU compilers version 7.3 (and higher).  One of the modules takes a long time to compile, and the compilation consumes a lot of memory, often to the point of aborting.
+//
+//When using the GNU compilers, you should select `0`.
+//====
 
 * for `Assume little/big_endian data format (1-little, 2-big, default=2):`,
 select the default value of 2.  By default, LVT reads and writes binary data in the big endian format.  Only select the value of 1, if you have reformatted all required binary data into the little endian format.

--- a/docs/LVT_users_guide/intro.adoc
+++ b/docs/LVT_users_guide/intro.adoc
@@ -2,9 +2,8 @@
 [[sec-intro]]
 == Introduction
 
-This is the User's Guide for Land surface Verification Toolkit (LVT;<<kumar_etal_gmd_2012>>).
-This document describes how to download and install LVT codes and
-instructions on building an executable.
+This is the Users`' Guide for Land surface Verification Toolkit (LVT; <<kumar_etal_gmd_2012>>).
+This document describes how to download and install the LVT software.  It also describes LVT`'s run-time configuration options (the _lvt.config_ file).
 
 This document consists of 9 sections, described as follows:
 
@@ -37,6 +36,21 @@ This document consists of 9 sections, described as follows:
 
 === What's New
 //\attention{See \file{RELEASE\_NOTES} found in the \file{source.tar.gz} file for more details.  (See Section~\ref{sec-obtain-src}.)}
+
+//==== Version 7.5
+//. utils
+//* s2smetric/
+//* s2spost/
+
+==== Version 7.4
+
+. Includes new runmodes
+* LISpost
+. Supports additional data streams
+* FluxSat GPP
+* MCD15A2H
+* thermal hydraulic disaggregation of soil moisture (THySM)
+* UA SMAP
 
 ==== Version 7.3
 

--- a/docs/LVT_users_guide/lis_refs.bib.adoc
+++ b/docs/LVT_users_guide/lis_refs.bib.adoc
@@ -4,7 +4,7 @@
 
 - [[[kumar_etal_gmd_2012]]] S.V. Kumar, C.D. Peters-Lidard, J.A. Santanello, K. Harrison, Y. Liu, and M. Shaw.  Land surface Verification Toolkit (LVT) - a generalized framework for land surface model evaluation.  _Geosci. Model Dev._, pages 869{endash}886, 2012.
 
-- [[[protex]]] W. Sawyer and A. da Silva.  ProTeX: A sample Fortran 90 source code documentation system.  Technical report, NASA GMAO, 1997.  DAO Office Note 97-11.
+//- [[[protex]]] W. Sawyer and A. da Silva.  ProTeX: A sample Fortran 90 source code documentation system.  Technical report, NASA GMAO, 1997.  DAO Office Note 97-11.
 
 //@Article{kumar_etal_gmd_2012,
 //  author = 	 {Kumar, S.V. and Peters-Lidard, C.D. and Santanello, J.A. and Harrison, K. and Liu, Y. and Shaw, M.},

--- a/docs/LVT_users_guide/obtain-source.adoc
+++ b/docs/LVT_users_guide/obtain-source.adoc
@@ -4,7 +4,7 @@
 
 This section describes how to obtain the source code needed to build the LVT executable.
 
-Beginning with Land Information System Framework (LISF) public release 7.3, the LVT source code is available as open source under the Apache License, version 2.0.  Please see {apachelicense}[Apache`'s web-site] for a copy of the license.
+Beginning with Land Information System Framework (LISF) public release 7.3, the LVT source code is available as open source under the Apache License, version 2.0.  (Please see {apachelicense}[Apache`'s web-site] for a copy of the license.)  LVT is one of the three main components of LISF (LDT, LIS, and LVT).
 
 From LVT public release 7.1rp1 through 7.2, the LVT source code is available as open source under the NASA Open Source Agreement (NOSA).  Please see {lisfurl}[LISF`'s web-site] for a copy of the NOSA.
 
@@ -15,12 +15,12 @@ NOTE: All users are encouraged to go to {lisfurl}[LISF`'s web-site] to fill in t
 [[sec-important_note_fs]]
 === Important Note Regarding File Systems
 
-LVT is developed on Linux/Unix platforms.  Its build process expects a case sensitive file system.  Please make sure that you unpack and/or `git clone` the LVT code into a directory within a case sensitive file system.  In particular, if you are using LVT within a Linux-based virtual machine hosted on a Windows or Macintosh system, do not compile/run LVT from within a shared folder.  Move the LVT source code into a directory within the virtual machine.
+LVT is developed on Linux/Unix platforms.  Its build process expects a case sensitive file system.  Please make sure that you unpack and/or `git clone` the LISF source code into a directory within a case sensitive file system.  In particular, if you are using LVT within a Linux-based virtual machine hosted on a Windows or Macintosh system, do not compile/run LVT from within a shared folder.  Move the LISF source code into a directory within the virtual machine.
 
 [[sec_publicrelease,Public Release Source Code]]
 === Public Release Source Code
 
-The LVT public release {lisfrevision} source code is available both on {lisfurl}[LISF`'s web-site] under the "`Source`" menu and on GitHub under the NASA-LIS organization at {nasalisf} under the "`Releases`" link.
+The LISF public release {lisfrevision} source code is available both on {lisfurl}[LISF`'s web-site] under the "`Source`" menu and on GitHub under the NASA-LIS organization at {nasalisf} under the "`Releases`" link.
 
 After downloading the LISF tar-file:
 
@@ -64,7 +64,7 @@ Unzip and untar the tar-file.
 [[sec-checkoutsrc]]
 === master branch
 
-The LVT source code is maintained in a git repository hosted on GitHub.  If you wish to work with the latest development code (in the master branch), then you must use the `git` client to obtain the LVT source code.  If you need any help regarding `git` or GitHub, please go to {githuburl}.
+The LVT source code is maintained in a git repository hosted on GitHub.  If you wish to work with the latest development code (in the master branch), then you must use the `git` client to obtain the LISF source code.  If you need any help regarding `git` or GitHub, please go to {githuburl}.
 
 :sectnums!: // disable section numbers
 
@@ -99,5 +99,6 @@ NOTE: The directory containing the LVT source code, _LISF/lvt_, will be referred
 
 === Documentation
 
-Processed documentation may be found on {lisfurl}[LISF`'s web-site] under the "`Docs`" menu.
+Processed documentation for each release may be found on {lisfurl}[LISF`'s web-site] under the "`Docs`" menu.  Starting with LISF public release 7.4, processed documentation may also be found on GitHub under the NASA-LIS organization at {nasalisf} under the "`Releases`" link.
 
+Processed documentation for the master branch is available on GitHub under the NASA-LIS organization`'s GitHub pages at {nasalisfpages}.

--- a/lvt/configs/lvt.config.adoc
+++ b/lvt/configs/lvt.config.adoc
@@ -155,7 +155,7 @@ LVT output methodology:                 "2d gridspace"
 | "`SMAP vegetation water content`" | SMAP vegetation water content
 | "`SMAP vegetation optical depth`" | SMAP vegetation optical depth
 | "`LPRM vegetation optical depth`" | LPRM vegetation optical depth
-| "`WG SWRC`"                       | [red]#specifies what?#
+| "`WG SWRC`"                       | Walnut Gulch Southwest Watershed Research Center data
 | "`UA SNOW`"                       | University of Arizona SWE/Snow depth data
 | "`SMAP L3 Tb`"                    | SMAP L3 brightness temperature
 | "`OzFlux`"                        | OzFlux ground measurements
@@ -299,7 +299,7 @@ LVT diagnostic file:                    lvtlog
 [[ssec-domainspec]]
 === Domain specification
 
-LVT expects three sets of domain specification. (1) the domain over which the LVT analysis needs to be carried out (2) the domain in which LIS simulation was carried out (LIS run domain). Section <<ssec-driveropts>> lists the projections that LIS supports.
+LVT expects two sets of domain specifications. (1) the domain over which the LVT analysis needs to be carried out; (2) the domain in which LIS simulation was carried out (LIS run domain). Section <<ssec-driveropts>> lists the projections that LIS supports.
 
 [[sssec-run_latlon]]
 ==== LVT run domain

--- a/lvt/datastreams/UASMAP/UASMAP_obsMod.F90
+++ b/lvt/datastreams/UASMAP/UASMAP_obsMod.F90
@@ -96,7 +96,7 @@ contains
 !
 ! !DESCRIPTION: 
 !  This subroutine initializes and sets up the data structures required
-!  for reading JASMIN AMSRE soil moisture data. 
+!  for reading UA SMAP soil moisture data. 
 ! 
 ! !FILES USED:
 !


### PR DESCRIPTION
### Description

Update LVT Users' Guide for upcoming LISF Public 7.4.0 release.

Note 1: The instructions for building libraries is being moved into a new document.

Note 2: I will update the revision table (revnumber and revdate) when I formally release LISF Public 7.4.0.
