### PR TITLE
Added upscale-by-averaging option for LIS-AGRMET retrospective forcing.

### DIFF
--- a/lis/metforcing/usaf/AGRMET_forcingMod.F90
+++ b/lis/metforcing/usaf/AGRMET_forcingMod.F90
@@ -574,6 +574,8 @@ integer, allocatable   :: n112_sh4(:)
      integer, allocatable   :: n12_anl(:)
      integer, allocatable   :: n21_anl(:)
      integer, allocatable   :: n22_anl(:)
+     integer :: mi111 ! EMK
+     integer, allocatable   :: n111_anl(:) ! EMK
      real, allocatable      :: w11_1_gfs(:)
      real, allocatable      :: w12_1_gfs(:)
      real, allocatable      :: w21_1_gfs(:)
@@ -2274,6 +2276,20 @@ real :: xi14,xj14,xmesh4,orient4,alat14,alon14
                   agrmet_struc(n)%n21_anl,agrmet_struc(n)%n22_anl,&
                   agrmet_struc(n)%w11_anl,agrmet_struc(n)%w12_anl,&
                   agrmet_struc(n)%w21_anl,agrmet_struc(n)%w22_anl)
+          else if(trim(LIS_rc%met_interp(findex)).eq."average") then
+             agrmet_struc(n)%mi111 = agrmet_struc(n)%nrow * &
+                  agrmet_struc(n)%ncol
+             allocate(agrmet_struc(n)%n111_anl(agrmet_struc(n)%mi111))
+             call upscaleByAveraging_input(gridDesci, &
+                  LIS_rc%gridDesc(n,:), agrmet_struc(n)%mi111, &
+                  LIS_rc%lnc(n)*LIS_rc%lnr(n), &
+                  agrmet_struc(n)%n111_anl)
+          else
+             write(LIS_logunit,*) &
+                  '[ERR] Unsupported AGRMET interpolation option ', &
+                  trim(LIS_rc%met_interp(findex))
+             write(LIS_logunit,*) '[ERR] Aborting...'
+             call LIS_endrun()
           endif
        endif
 

--- a/lis/metforcing/usaf/readagrmetforcinganalysis.F90
+++ b/lis/metforcing/usaf/readagrmetforcinganalysis.F90
@@ -27,7 +27,7 @@ subroutine readagrmetforcinganalysis(n,findex, order, agrfile, month)
   use LIS_coreMod, only         : LIS_rc, LIS_domain, LIS_masterproc
   use LIS_timeMgrMod,only       : LIS_get_julhr,LIS_tick,LIS_time2date
   use LIS_logMod, only          : LIS_logunit, LIS_verify, LIS_warning,&
-                                  LIS_endrun
+                                  LIS_endrun, LIS_abort, LIS_alert
   use LIS_spatialDownscalingMod
   use AGRMET_forcingMod,   only : agrmet_struc
 
@@ -83,6 +83,8 @@ subroutine readagrmetforcinganalysis(n,findex, order, agrfile, month)
   integer, save          :: step_count=1
   character(len=10)       :: str_count
   character(len=128)     :: dump_name
+  character(len=100) :: message(20)
+  integer :: mo
 #if(defined USE_GRIBAPI) 
 !--------------------------------------------------------------------------
 ! Set the GRIB parameter specifiers
@@ -271,6 +273,58 @@ subroutine readagrmetforcinganalysis(n,findex, order, agrfile, month)
                     endif
                  enddo
               enddo
+           else if (trim(LIS_rc%met_interp(findex)) .eq. "average") then
+              varfield = -9999.0
+              mo = LIS_rc%lnc(n) * LIS_rc%lnr(n)
+              call upscaleByAveraging(agrmet_struc(n)%mi111, mo, LIS_rc%udef, &
+                   agrmet_struc(n)%n111_anl, lb, f, lo, go)
+              count1 = 0
+              do r = 1, LIS_rc%lnr(n)
+                 do c = 1, LIS_rc%lnc(n)
+                    varfield(c,r) = go(c+count1)
+                 enddo
+                 count1 = count1 + LIS_rc%lnc(n)
+              enddo
+              !call AGRMET_fillgaps(n, 1, varfield)
+
+              if(var_index.eq.1) vid = 1
+              if(var_index.eq.2) vid = 2
+              if(var_index.eq.3) vid = 3
+              if(var_index.eq.4) vid = 4
+              if(var_index.eq.5) vid = 5
+              if(var_index.eq.6) vid = 6  !pressure
+              if(var_index.eq.7) vid = 7  !precip
+
+              do r=1, LIS_rc%lnr(n)
+                 do c=1,LIS_rc%lnc(n)
+                    if(LIS_domain(n)%gindex(c,r).ne.-1) then
+                       if(order.eq.1) then
+                          agrmet_struc(n)%metdata1(vid,&
+                               LIS_domain(n)%gindex(c,r)) = &
+                               varfield(c,r)
+                       else
+                          agrmet_struc(n)%metdata2(vid,&
+                               LIS_domain(n)%gindex(c,r)) = &
+                               varfield(c,r)
+                       endif
+                    endif
+                 enddo
+              enddo
+
+           else ! EMK Handle error
+              write(lis_logunit,*) &
+                   '[ERR] Unsupported AGRMET interpolation option ', &
+                   trim(LIS_rc%met_interp(findex))
+              write(lis_logunit,*)'[ERR] Aborting...'
+              message(:) = ''
+              message(1) = '[ERR] Program: LIS'
+              message(2) = '  Routine: readagrmetforcinganalysis.'
+              message(3) = '  Invalid interpolation selected'
+              if (LIS_masterproc) then
+                 call LIS_alert('LIS.readagrmetforcinganalysis', 1, &
+                      message)
+                 call LIS_abort(message)
+              end if
            endif
         endif
         


### PR DESCRIPTION


### Description

Added upscale-by-averaging option for LIS-AGRMET retrospective forcing.

This is intended to support LISF 7.5 S2S work.

