### PR TITLE
Replace hard-coded value

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/da_snow/noahmp401_qc_snowobs.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/da_snow/noahmp401_qc_snowobs.F90
@@ -94,7 +94,7 @@ subroutine noahmp401_qc_snowobs(n,k,OBS_State)
            snowobs(t) = LIS_rc%udef
         elseif(vegt_obs(t).le.4) then !forest types
            snowobs(t) = LIS_rc%udef
-        elseif(vegt_obs(t).eq.15) then !TML: Eliminate Glaciers
+        elseif(vegt_obs(t).eq.LIS_rc%glacierclass) then !TML: Eliminate Glaciers
            snowobs(t) = LIS_rc%udef
 !assume that snow will not form at 5 deg. celcius or higher ground temp. 
        elseif(tv_obs(t).ge.278.15) then


### PR DESCRIPTION
### Description

Use the generic value LIS_rc%glacierclass to check whether a tile is
a glacier type.  The hard-coded value 15 is specific to only one of our
land-cover classifications.