### PR TITLE
Removes unused variables from NoahMP restart

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
@@ -428,13 +428,13 @@ subroutine NoahMP401_readrst()
                                      varname="PGS", wformat=wformat)
  
             ! read: optional gecros crop
-            do l=1, 60 ! TODO: check loop
-                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="GECROS_STATE", &
-                                         dim=l, vlevels = 60, wformat=wformat)
-                do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-                    NOAHMP401_struc(n)%noahmp401(t)%gecros_state(l) = tmptilen(t)
-                enddo
-            enddo
+!            do l=1, 60 ! TODO: check loop
+!                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="GECROS_STATE", &
+!                                         dim=l, vlevels = 60, wformat=wformat)
+!                do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+!                    NOAHMP401_struc(n)%noahmp401(t)%gecros_state(l) = tmptilen(t)
+!                enddo
+!            enddo
         
             ! close restart file
             if(wformat .eq. "binary") then

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
@@ -776,12 +776,12 @@ subroutine NoahMP401_dump_restart(n, ftn, wformat)
                               varid=pgs_ID, dim=1, wformat=wformat)
 
     ! optional gecros crop
-    do l=1, 60  ! TODO: check loop
-        tmptilen = 0
-        do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-            tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%gecros_state(l)
-        enddo
-        call LIS_writevar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, &
-                                  varid=gecros_state_ID, dim=l, wformat=wformat)
-    enddo
+!    do l=1, 60  ! TODO: check loop
+!        tmptilen = 0
+!        do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+!            tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%gecros_state(l)
+!        enddo
+!        call LIS_writevar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, &
+!                                  varid=gecros_state_ID, dim=l, wformat=wformat)
+!    enddo
 end subroutine NoahMP401_dump_restart


### PR DESCRIPTION
The NoahMP.4.0.1 writes 60 variables related to GECROS_STATE, which are not currently used.
These variables are removed from the NoahMP restart files.

Note that this update will break the ability to read existing restart files. In such instances, the
following steps can be employed:

* Edit the NoahMP401_readrst.F90 file and uncomment lines 431 to 437:
!            do l=1, 60 ! TODO: check loop
!                call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="GECROS_STATE", &
!                                         dim=l, vlevels = 60, wformat=wformat)
!                do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
!                    NOAHMP401_struc(n)%noahmp401(t)%gecros_state(l) = tmptilen(t)
!                enddo
!            enddo

* Recompile the code and use the new executable to read the existing restart file.
* The updated code will write restart files without these additional variables.
* For the next execution of the code, comment out the lines 431-437 in NoahMP401_readrst.F90,  so that
 the restart files WITHOUT the gecros_state variables can be processed. Recompile the code and
 use the new executable

Resolves #1171

<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Replace this text with a concise description of *what* was changed and *why*.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->


