### PR TITLE
Fixed typo in the README.adoc file.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,7 +32,7 @@ Please visit our website for more information: {url-lis-website}
 
 == Documentation
 
-Online documentation is available link:https://nasa-lis.github.io/LISF/['here'].
+Online documentation is available link:https://nasa-lis.github.io/LISF/[here].
 
 Navigate into the link:https://github.com/NASA-LIS/LISF/tree/master/docs[`docs/`] subdirectory of this repository to view our documentation. See the `docs/README` file for instructions.
 


### PR DESCRIPTION
### Description

Fixed a typo that was made in the README.adoc file when adding the LISF Documentation URL. 


