### PR TITLE
Removed Brendan's name from the Working with Github guide.

### DIFF
--- a/docs/working_with_github/working_with_github.adoc
+++ b/docs/working_with_github/working_with_github.adoc
@@ -618,7 +618,7 @@ NOTE: Submitting a pull request causes GitHub to jump to the NASA-LIS/LISF page.
 
 Your pull request will be reviewed for code quality, proper documentation, and relevant testcase.
 
-Sujay, Eric, David, Jim, or Brendan will review code and documentation.  Brendan will perform testing.  (Reviewers please do not merge your own pull requests.)  This process may require some additional commits from you to resolve any issues that arise from the pull request review.
+Sujay, Eric, David, or Jim will review code and documentation.  Testing will be performed.  (Reviewers please do not merge your own pull requests.)  This process may require some additional commits from you to resolve any issues that arise from the pull request review.
 
 When addressing issues raised by a reviewer, simply push your new updates back to origin:
 


### PR DESCRIPTION
### Description

Brendan's name was removed from the Working with GitHub guide since he is no longer in the group and will not be reviewing code or documentation.  When a new person is assigned to perform testing, their name should be added to the guide.




