### PR TITLE
Add new option to the lis/testcases/dataassim/smos_nrt_nn_l2sm testcase

### DIFF
--- a/lis/testcases/dataassim/smos_nrt_nn_l2sm/lis.config
+++ b/lis/testcases/dataassim/smos_nrt_nn_l2sm/lis.config
@@ -234,7 +234,7 @@ AGRMET skip superstatQC : 0
 
 
 AGRMET WWMCA GRIB1 read option: 0
-
+AGRMET PPT Background bias correction option: 0
 #-----------------------LAND SURFACE MODELS--------------------------
 Noah.3.9 model timestep:                  15mn
 Noah.3.9 restart output interval:         1mo


### PR DESCRIPTION
### Description

Add missing option `AGRMET PPT Background bias correction option: 0` to the  lis/testcases/dataassim/smos_nrt_nn_l2sm testcase.





