### PR TITLE
Fixes to LIS log message directory lengths and reduced the NoahMP401 restart GECROS dimension

### DIFF
--- a/lis/core/LIS_histDataMod.F90
+++ b/lis/core/LIS_histDataMod.F90
@@ -1142,8 +1142,8 @@ contains
     call LIS_verify(rc,'Model output attributes file: not specified')
 
     call ESMF_ConfigGetAttribute(LIS_config,LIS_rc%outputSpecFile(n),rc=rc)
-    write(LIS_logunit,*) '[INFO] Opening Model Output Attributes File', &
-                         LIS_rc%outputSpecFile(n)
+    write(LIS_logunit,*) '[INFO] Opening Model Output Attributes File, ', &
+                         trim(LIS_rc%outputSpecFile(n))
 
     inquire(file=LIS_rc%outputSpecFile(n),exist=file_exists)
     if(.not.file_exists) then 

--- a/lis/core/LIS_metforcingMod.F90
+++ b/lis/core/LIS_metforcingMod.F90
@@ -283,8 +283,8 @@ contains
        call LIS_endrun()
     endif
 
-    write(LIS_logunit,*) "[INFO] Opening Forcing Variables list file ",&
-         LIS_rc%forcvarlistfile
+    write(LIS_logunit,*) "[INFO] Opening Forcing Variables list file: ",&
+         trim(LIS_rc%forcvarlistfile)
 
     forcConfig = ESMF_ConfigCreate(rc=status)
 
@@ -517,8 +517,8 @@ contains
        call LIS_endrun()
     endif
 
-    write(LIS_logunit,*) "[INFO] Opening Forcing Variables list file ",&
-         LIS_rc%forcvarlistfile
+    write(LIS_logunit,*) "[INFO] Opening Forcing Variables list file: ",&
+         trim(LIS_rc%forcvarlistfile)
     
     forcConfig = ESMF_ConfigCreate(rc=status)
     

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
@@ -273,7 +273,8 @@ subroutine NoahMP401_dump_restart(n, ftn, wformat)
                                        dim1=NOAHMP401_struc(n)%nsoil+NOAHMP401_struc(n)%nsnow, &
                                        dim2=NOAHMP401_struc(n)%nsoil,                          &
                                        dim3=NOAHMP401_struc(n)%nsnow,                          &
-                                       dim4=60,                                                &
+!                                       dim4=60,                                                & ! GECROS
+                                       dim4=1,                                                 &
                                        dimID=dimID,                                            &
                                        output_format = trim(wformat))
 


### PR DESCRIPTION
Added the trim function for a couple of LIS log file entries that adhere to the 256 character length.  With the long length, it can create several blank lines in the LIS log files.

Also, reduced the dimension number of 60 to 1 for the GECROS states, which were commented out in the NoahMP401 write restart file routine.