### PR TITLE
Add new option to Ensemble Forecast Readers in LIS

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -6105,11 +6105,17 @@ ensemble members desired for the user-generated ensemble forecast dataset.
 the generated ensemble-based forecast forcing files being read in.
 Default setting is GEOS5, but options include GEOS5 and CFSv2.
 
+`Generic ensemble forecast initial date:` specifies the initial forecast
+date, such as YYYYMMDD. This option enables the user to be able to
+run from restart conditions if a forecast run stops or times out
+during runtime. This is an optional entry.
+
 .Example _lis.config_ entry
 ....
 Generic ensemble forecast directory:     ./GEOS5_BiasCorrected/
 Generic ensemble forecast number of ensemble members:  11
-Name of base forecast model:              GEOS5
+Name of base forecast model:               GEOS5
+Generic ensemble forecast initial date:    20200501
 ....
 
 
@@ -6126,11 +6132,17 @@ ensemble members desired for the user-generated precipitation ensemble forecast 
 the generated ensemble-based forecast forcing files being read in.
 Default setting is GEOS5, but options include GEOS5 and CFSv2.
 
+`Precipitation ensemble forecast initial date:` specifies the initial forecast
+date, such as YYYYMMDD. This option enables the user to be able to
+run from restart conditions if a forecast run stops or times out
+during runtime. This is an optional entry.
+
 .Example _lis.config_ entry
 ....
-Precipitation ensemble forecast directory:     ./GEOS5_BiasCorrected/
+Precipitation ensemble forecast directory:    ./GEOS5_BiasCorrected/
 Precipitation ensemble forecast number of ensemble members:  11
-Name of base forecast model:              GEOS5
+Name of base forecast model:                   GEOS5
+Precipitation ensemble forecast initial date:  20200501
 ....
 
 

--- a/lis/core/LIS_histDataMod.F90
+++ b/lis/core/LIS_histDataMod.F90
@@ -1142,8 +1142,8 @@ contains
     call LIS_verify(rc,'Model output attributes file: not specified')
 
     call ESMF_ConfigGetAttribute(LIS_config,LIS_rc%outputSpecFile(n),rc=rc)
-    write(LIS_logunit,*) '[INFO] Opening Model Output Attributes File', &
-                         LIS_rc%outputSpecFile(n)
+    write(LIS_logunit,*) '[INFO] Opening Model Output Attributes File, ', &
+                         trim(LIS_rc%outputSpecFile(n))
 
     inquire(file=LIS_rc%outputSpecFile(n),exist=file_exists)
     if(.not.file_exists) then 

--- a/lis/core/LIS_metforcingMod.F90
+++ b/lis/core/LIS_metforcingMod.F90
@@ -283,8 +283,8 @@ contains
        call LIS_endrun()
     endif
 
-    write(LIS_logunit,*) "[INFO] Opening Forcing Variables list file ",&
-         LIS_rc%forcvarlistfile
+    write(LIS_logunit,*) "[INFO] Opening Forcing Variables list file: ",&
+         trim(LIS_rc%forcvarlistfile)
 
     forcConfig = ESMF_ConfigCreate(rc=status)
 
@@ -517,8 +517,8 @@ contains
        call LIS_endrun()
     endif
 
-    write(LIS_logunit,*) "[INFO] Opening Forcing Variables list file ",&
-         LIS_rc%forcvarlistfile
+    write(LIS_logunit,*) "[INFO] Opening Forcing Variables list file: ",&
+         trim(LIS_rc%forcvarlistfile)
     
     forcConfig = ESMF_ConfigCreate(rc=status)
     

--- a/lis/metforcing/genEnsFcst/genEnsFcst_forcingMod.F90
+++ b/lis/metforcing/genEnsFcst/genEnsFcst_forcingMod.F90
@@ -60,7 +60,13 @@ module genEnsFcst_forcingMod
      logical        :: zterp_flags      !(:) Allocatable later?
 
      character(20)  :: fcst_type        ! Forecast type name
+     character(40)  :: user_spec        ! Forecast file, user-specified naming convention
      integer        :: max_ens_members  ! Max number of forecast ensemble members
+   
+     ! Specify forecast initialization date:
+     integer        :: fcst_inityr      ! Forecast initial year
+     integer        :: fcst_initmo      ! Forecast initial month
+     integer        :: fcst_initda      ! Forecast initial day
 
      real, allocatable :: metdata1(:,:,:)  ! Metforcing data from file/bookend 1
      real, allocatable :: metdata2(:,:,:)  ! Metforcing data from file/bookend 2
@@ -157,7 +163,9 @@ contains
    ! Locate starting genEnsFcst file: 
    fullfilename = "none"
    call get_genEnsFcst_filename( genensfcst_struc%fcst_type, &
-      LIS_rc%syr, LIS_rc%smo, &
+      genensfcst_struc%user_spec, &
+!      LIS_rc%syr, LIS_rc%smo, &    ! (Original code prior to 09-02-2022)
+      genensfcst_struc%fcst_inityr, genensfcst_struc%fcst_initmo, &  ! New config entry
       1, LIS_rc%syr, LIS_rc%smo, &
       genensfcst_struc%directory, fullfilename )
 

--- a/lis/metforcing/genEnsFcst/get_genEnsFcst.F90
+++ b/lis/metforcing/genEnsFcst/get_genEnsFcst.F90
@@ -126,7 +126,9 @@ subroutine get_genEnsFcst(n, findex)
       do m = 1, genensfcst_struc%max_ens_members
          ensnum = m
          call get_genEnsFcst_filename( genensfcst_struc%fcst_type, &
-            LIS_rc%syr, LIS_rc%smo, &
+            genensfcst_struc%user_spec, &
+!            LIS_rc%syr, LIS_rc%smo, &   ! Original code (prior to 09-02-2022)
+            genensfcst_struc%fcst_inityr, genensfcst_struc%fcst_initmo, &  ! New config file entry
             ensnum, LIS_rc%yr, LIS_rc%mo, &
             genensfcst_struc%directory, fullfilename )
 
@@ -144,9 +146,6 @@ subroutine get_genEnsFcst(n, findex)
         genensfcst_struc%findtime1 = 0
         retrieve_file = .false.
 
-!        print *, " Getting Ensemble Forecast file: ",&
-!                trim(fullfilename)
-
         ! Read in GenEnsFcst Forcing File:
         !  Also, spatially reproject/reinterpolate genEnsFcst file.
         call genEnsFcst_Variables_read( findex, fullfilename, &
@@ -160,9 +159,6 @@ subroutine get_genEnsFcst(n, findex)
                 gindex = LIS_domain(n)%gindex(c,r)
  
                 if( forcopts%read_airtmp ) then
-!                  if( c==10 .and. r==10 ) then
-!                     print *, c,r,tindex,ensfcstvars_struc(n)%airtmp(c,r)
-!                  endif
                   genensfcst_struc%metdata2(forcopts%index_airtmp,m,gindex) = &
                      ensfcstvars_struc(n)%airtmp(c,r)
                 endif

--- a/lis/metforcing/genEnsFcst/get_genEnsFcst_filename.F90
+++ b/lis/metforcing/genEnsFcst/get_genEnsFcst_filename.F90
@@ -13,9 +13,11 @@
 !
 ! !REVISION HISTORY:
 !  27 Sep 2016: K. Arsenault; Initial Implementation
+!  21 Jul 2022: K. Arsenault; Updated to support long-term reanalysis
 !
 ! !INTERFACE:
- subroutine get_genEnsFcst_filename( fcsttype, fcstyr, fcstmo,&
+ subroutine get_genEnsFcst_filename( fcsttype, userspec, &
+                fcstyr, fcstmo,&
                 ensnum, yr, mo, & 
                 directory, filename)
 ! !USES:
@@ -24,11 +26,12 @@
    implicit none
 ! !ARGUMENTS: 
    character*20,  intent(in)  :: fcsttype        ! Forecast file of origin
+   character*40,  intent(in)  :: userspec        ! Forecast file, user-specified convention
    integer,       intent(in)  :: fcstyr          ! Forecast year
    integer,       intent(in)  :: fcstmo          ! Forecast month - Need to convert to "3-letter month"
    integer,       intent(in)  :: ensnum          ! Forecast ensemble number
    integer,       intent(in)  :: yr, mo          ! Lead-time year, month
-   character(len=*), intent(in)  :: directory       ! Dataset Directory
+   character(len=*), intent(in)  :: directory    ! Dataset Directory
    character(len=*), intent(out) :: filename        
 !
 ! !DESCRIPTION:
@@ -89,8 +92,15 @@
       filename = trim(directory)//"/"//fyr//"/"//fmo3//"01/ens"//&
           trim(fensnum)//"/"//trim(fcsttype)//"."//lyr//lmo//".nc4"
 
+    case( "user-specified" )
+     ! User specified entry ...
+      if( trim(userspec) .ne. "none" ) then
+         filename = trim(directory)//"/ens"//trim(fensnum)//"/"&
+                 //lyr//"/"//trim(userspec)//"_"//lyr//lmo//".nc4"
+      endif
+
     case default
-      write(*,*) " No other forecast datasets supported at this time "
+      write(*,*) "[ERR] GenEnsFcst: No other forecast datasets supported at this time "
 
     end select
 

--- a/lis/metforcing/genEnsFcst/readcrd_genEnsFcst.F90
+++ b/lis/metforcing/genEnsFcst/readcrd_genEnsFcst.F90
@@ -34,6 +34,9 @@ subroutine readcrd_genEnsFcst()
   implicit none
 
   integer :: n, rc
+  character(8) :: fcstinitdate
+  character(4) :: chyr
+  character(2) :: chmo, chda
 
   call ESMF_ConfigFindLabel(LIS_config,"Generic ensemble forecast directory:",rc=rc)
   call ESMF_ConfigGetAttribute(LIS_config,genensfcst_struc%directory,rc=rc)
@@ -42,11 +45,37 @@ subroutine readcrd_genEnsFcst()
   call LIS_verify(rc, 'Generic ensemble forecast number of ensemble members: not defined')
   call ESMF_ConfigGetAttribute(LIS_config,genensfcst_struc%max_ens_members,rc=rc)
 
+! Option to select forecast year and month in LIS config file:
+  call ESMF_ConfigGetAttribute(LIS_config, fcstinitdate, &
+       label="Generic ensemble forecast initial date:",&
+       default="none",rc=rc)
+  call LIS_verify(rc,'Generic ensemble forecast initial date: not defined')
+  ! If default option is set to "none":
+  if( trim(fcstinitdate) == "none" ) then
+     genensfcst_struc%fcst_inityr = LIS_rc%syr
+     genensfcst_struc%fcst_initmo = LIS_rc%smo
+     genensfcst_struc%fcst_initda = LIS_rc%sda
+  ! Initial forecast date set:
+  else
+    ! Convert readin 8-char date to integer based entries:
+    chyr = fcstinitdate(1:4)
+    read( chyr, '(i4)' ) genensfcst_struc%fcst_inityr
+    chmo = fcstinitdate(5:6)
+    read( chmo, '(i2)' ) genensfcst_struc%fcst_initmo
+    chda = fcstinitdate(7:8)
+    read( chda, '(i2)' ) genensfcst_struc%fcst_initda
+  endif
+
 ! Option to select base forecast dataset
   call ESMF_ConfigGetAttribute(LIS_config,genensfcst_struc%fcst_type,&
        label="Name of base forecast model:",&
        default="GEOS5",rc=rc)
   call LIS_verify(rc,'Name of base forecast model: not defined')
+
+  call ESMF_ConfigGetAttribute(LIS_config,genensfcst_struc%user_spec,&
+       label="User-specified name of forcing:",&
+       default="none",rc=rc)
+  call LIS_verify(rc,'User-specified name of forcing: not defined')
 
   write(LIS_logunit,*) "[INFO] "
   write(LIS_logunit,*) "[INFO] Using the GenEnsFcst forcing dataset"

--- a/lis/metforcing/genEnsFcst/timeinterp_genEnsFcst.F90
+++ b/lis/metforcing/genEnsFcst/timeinterp_genEnsFcst.F90
@@ -173,8 +173,6 @@ subroutine timeinterp_genEnsFcst(n, findex)
     endif
 #endif
 
-!    do t = 1, LIS_rc%ntiles(n)
-!       index1 = LIS_domain(n)%tile(t)%index
   do t=1,LIS_rc%ntiles(n)/LIS_rc%nensem(n)
      do m=1,genensfcst_struc%max_ens_members
         do k=1,mfactor
@@ -201,19 +199,13 @@ subroutine timeinterp_genEnsFcst(n, findex)
           swd(tid) = genensfcst_struc%metdata1(forcopts%index_swdown,m,index1)
        endif
 #endif
-
          swd(tid) = genensfcst_struc%metdata2(forcopts%index_swdown,m,index1)
-!         if(t==100) then
-!            print *, 'swd: ', swd(t)
-!         endif
         end do
       end do
     end do
   endif
 
 !- Time Averaged Longwave, Block Interpolation
-!   do t = 1, LIS_rc%ntiles(n)
-!      index1 = LIS_domain(n)%tile(t)%index
   do t=1,LIS_rc%ntiles(n)/LIS_rc%nensem(n)
      do m=1,genensfcst_struc%max_ens_members
         do k=1,mfactor
@@ -237,7 +229,6 @@ subroutine timeinterp_genEnsFcst(n, findex)
           if( forcopts%read_psurf ) then 
             if((genensfcst_struc%metdata1(forcopts%index_psurf,m,index1).ne.LIS_rc%udef).and.&
                (genensfcst_struc%metdata2(forcopts%index_psurf,m,index1).ne.LIS_rc%udef)) then
- 
               psurf(tid) = genensfcst_struc%metdata2(forcopts%index_psurf,m,index1) 
             endif
           endif
@@ -259,8 +250,7 @@ subroutine timeinterp_genEnsFcst(n, findex)
           if( forcopts%read_vwind ) then 
             if((genensfcst_struc%metdata1(forcopts%index_vwind,m,index1).ne.LIS_rc%udef).and.&
                (genensfcst_struc%metdata2(forcopts%index_vwind,m,index1).ne.LIS_rc%udef)) then
-             vwind(tid) = genensfcst_struc%metdata2(forcopts%index_vwind,m,index1) 
-!         if(t==100) then; print *, 'vwind: ',vwind(t); endif
+              vwind(tid) = genensfcst_struc%metdata2(forcopts%index_vwind,m,index1) 
             endif
           endif
 
@@ -268,7 +258,9 @@ subroutine timeinterp_genEnsFcst(n, findex)
             if((genensfcst_struc%metdata1(forcopts%index_rainf,m,index1).ne.LIS_rc%udef).and.&
                (genensfcst_struc%metdata2(forcopts%index_rainf,m,index1).ne.LIS_rc%udef)) then
               prcp(tid) = genensfcst_struc%metdata2(forcopts%index_rainf,m,index1)
-!         if(t==100) then; print *, 'prcp: ',prcp(t); endif
+              if( prcp(tid) < 0.0 ) then
+                prcp(tid) = 0.0
+              endif
             endif
           endif
  
@@ -276,6 +268,9 @@ subroutine timeinterp_genEnsFcst(n, findex)
             if((genensfcst_struc%metdata1(forcopts%index_cpcp,m,index1).ne.LIS_rc%udef).and.&
                (genensfcst_struc%metdata2(forcopts%index_cpcp,m,index1).ne.LIS_rc%udef)) then
               cpcp(tid) = genensfcst_struc%metdata2(forcopts%index_cpcp,m,index1)
+              if( cpcp(tid) < 0.0 ) then
+                cpcp(tid) = 0.0
+              endif
             endif     
           endif
 

--- a/lis/metforcing/pptEnsFcst/get_pptEnsFcst.F90
+++ b/lis/metforcing/pptEnsFcst/get_pptEnsFcst.F90
@@ -126,7 +126,8 @@ subroutine get_pptEnsFcst(n, findex)
       do m = 1, pptensfcst_struc%max_ens_members
          ensnum = m
          call get_pptEnsFcst_filename( pptensfcst_struc%fcst_type,&
-               LIS_rc%syr, LIS_rc%smo, &
+!               LIS_rc%syr, LIS_rc%smo, &   ! Original code (prior to 09-02-2022)
+               pptensfcst_struc%fcst_inityr, pptensfcst_struc%fcst_initmo, &  ! New config file entry
                ensnum, LIS_rc%yr, LIS_rc%mo, &
                pptensfcst_struc%directory, fullfilename  )
 

--- a/lis/metforcing/pptEnsFcst/pptEnsFcst_forcingMod.F90
+++ b/lis/metforcing/pptEnsFcst/pptEnsFcst_forcingMod.F90
@@ -62,6 +62,11 @@ module pptEnsFcst_forcingMod
      character(20)  :: fcst_type        ! Forecast type name
      integer        :: max_ens_members  ! Max number of forecast ensemble members
 
+     ! Specify forecast initialization date:
+     integer        :: fcst_inityr      ! Forecast initial year
+     integer        :: fcst_initmo      ! Forecast initial month
+     integer        :: fcst_initda      ! Forecast initial day
+
      real, allocatable :: metdata1(:,:,:)  ! Metforcing data from file/bookend 1
      real, allocatable :: metdata2(:,:,:)  ! Metforcing data from file/bookend 2
      
@@ -157,7 +162,8 @@ contains
    ! Locate starting pptEnsFcst file: 
    fullfilename = "none"
    call get_pptEnsFcst_filename( pptensfcst_struc%fcst_type, &
-              LIS_rc%syr, LIS_rc%smo, &
+        !      LIS_rc%syr, LIS_rc%smo, &    ! (Original code prior to 09-02-2022)
+              pptensfcst_struc%fcst_inityr, pptensfcst_struc%fcst_initmo, &  ! New config entry
               1, LIS_rc%syr, LIS_rc%smo, &
               pptensfcst_struc%directory, fullfilename  )
 

--- a/lis/metforcing/pptEnsFcst/readcrd_pptEnsFcst.F90
+++ b/lis/metforcing/pptEnsFcst/readcrd_pptEnsFcst.F90
@@ -34,6 +34,9 @@ subroutine readcrd_pptEnsFcst()
   implicit none
 
   integer :: n, rc
+  character(8) :: fcstinitdate
+  character(4) :: chyr
+  character(2) :: chmo, chda
 
   call ESMF_ConfigFindLabel(LIS_config,"Precipitation ensemble forecast directory:",rc=rc)
   call ESMF_ConfigGetAttribute(LIS_config,pptensfcst_struc%directory,rc=rc)
@@ -41,6 +44,27 @@ subroutine readcrd_pptEnsFcst()
   call ESMF_ConfigFindLabel(LIS_config,"Precipitation ensemble forecast number of ensemble members:",rc=rc)
   call LIS_verify(rc, 'Precipitation ensemble forecast number of ensemble members: not defined')
   call ESMF_ConfigGetAttribute(LIS_config,pptensfcst_struc%max_ens_members,rc=rc)
+
+! Option to select forecast year and month in LIS config file:
+  call ESMF_ConfigGetAttribute(LIS_config, fcstinitdate, &
+       label="Precipitation ensemble forecast initial date:",&
+       default="none",rc=rc)
+  call LIS_verify(rc,'Precipitation ensemble forecast initial date: not defined')
+  ! If default option is set to "none":
+  if( trim(fcstinitdate) == "none" ) then
+     pptensfcst_struc%fcst_inityr = LIS_rc%syr
+     pptensfcst_struc%fcst_initmo = LIS_rc%smo
+     pptensfcst_struc%fcst_initda = LIS_rc%sda
+  ! Initial forecast date set:
+  else
+    ! Convert readin 8-char date to integer based entries:
+    chyr = fcstinitdate(1:4)
+    read( chyr, '(i4)' ) pptensfcst_struc%fcst_inityr
+    chmo = fcstinitdate(5:6)
+    read( chmo, '(i2)' ) pptensfcst_struc%fcst_initmo
+    chda = fcstinitdate(7:8)
+    read( chda, '(i2)' ) pptensfcst_struc%fcst_initda
+  endif
 
 ! Option to select base forecast dataset
   call ESMF_ConfigGetAttribute(LIS_config,pptensfcst_struc%fcst_type,&

--- a/lis/metforcing/pptEnsFcst/timeinterp_pptEnsFcst.F90
+++ b/lis/metforcing/pptEnsFcst/timeinterp_pptEnsFcst.F90
@@ -66,73 +66,11 @@ subroutine timeinterp_pptEnsFcst(n, findex)
   integer :: status
 
 ! ESMF Fields and Pointer Arrays:
-  type(ESMF_Field)   :: airtmpField, spechumField
-  type(ESMF_Field)   :: swdField, lwdField
-  type(ESMF_Field)   :: uwindField, vwindField
-  type(ESMF_Field)   :: psurfField, prcpField, cpcpField
-  real,pointer       :: airtmp(:), spechum(:)
-  real,pointer       :: swd(:), lwd(:)
-  real,pointer       :: uwind(:), vwind(:)
-  real,pointer       :: psurf(:), prcp(:), cpcp(:)
+  type(ESMF_Field)   :: prcpField, cpcpField
+  real,pointer       :: prcp(:), cpcp(:)
 ! __________________________________________________________
 
 ! Get Meteorological Field  - ESMF State Get:
-  if( forcopts%read_airtmp ) then
-    call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Tair%varname(1),airtmpField,&
-         rc=status)
-    call LIS_verify(status, 'Error: Enable Tair in the forcing variables list')
-    call ESMF_FieldGet(airtmpField,localDE=0,farrayPtr=airtmp,rc=status)
-    call LIS_verify(status)
-  endif
-
-  if( forcopts%read_spechum ) then
-    call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Qair%varname(1),spechumField,&
-         rc=status)
-    call LIS_verify(status, 'Error: Enable Qair in the forcing variables list')
-    call ESMF_FieldGet(spechumField,localDE=0,farrayPtr=spechum,rc=status)
-    call LIS_verify(status)
-  endif
-
-  if( forcopts%read_swdown ) then
-    call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_SWdown%varname(1),swdField,&
-         rc=status)
-    call LIS_verify(status, 'Error: Enable SWdown in the forcing variables list')
-    call ESMF_FieldGet(swdField,localDE=0,farrayPtr=swd,rc=status)
-    call LIS_verify(status)
-  endif
-
-  if( forcopts%read_lwdown ) then
-    call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_LWdown%varname(1),lwdField,&
-         rc=status)
-    call LIS_verify(status, 'Error: Enable LWdown in the forcing variables list')
-    call ESMF_FieldGet(lwdField,localDE=0,farrayPtr=lwd,rc=status)
-    call LIS_verify(status)
-  endif
-
-  if( forcopts%read_uwind ) then
-    call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Wind_E%varname(1),uwindField,&
-         rc=status)
-    call LIS_verify(status, 'Error: Enable Uwind in the forcing variables list')
-    call ESMF_FieldGet(uwindField,localDE=0,farrayPtr=uwind,rc=status)
-    call LIS_verify(status)
-  endif
-
-  if( forcopts%read_vwind ) then
-    call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Wind_N%varname(1),vwindField,&
-         rc=status)
-    call LIS_verify(status, 'Error: Enable Vwind in the forcing variables list')
-    call ESMF_FieldGet(vwindField,localDE=0,farrayPtr=vwind,rc=status)
-    call LIS_verify(status)
-  endif
-
-  if( forcopts%read_psurf ) then
-    call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Psurf%varname(1),psurfField,&
-         rc=status)
-    call LIS_verify(status, 'Error: Enable Psurf in the forcing variables list')
-    call ESMF_FieldGet(psurfField,localDE=0,farrayPtr=psurf,rc=status)
-    call LIS_verify(status)
-  endif
-
   if( forcopts%read_rainf ) then
     call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Rainf%varname(1),prcpField,&
          rc=status)
@@ -161,114 +99,26 @@ subroutine timeinterp_pptEnsFcst(n, findex)
   ! Ensemble member factor for this ensemble forcing dataset:
   mfactor = LIS_rc%nensem(n)/pptensfcst_struc%max_ens_members
 
-! --- SWDown ---
-!- Perform zenith interpolation on solar radiation fields: 
-  if( forcopts%read_swdown ) then
-#if 0
-    if( pptensfcst_struc%zterp_flags ) then
-      btime = pptensfcst_struc%metforc_time1
-      call LIS_time2date(btime,bdoy,gmt1,byr,bmo,bda,bhr,bmn)
-      btime = pptensfcst_struc%metforc_time2
-      call LIS_time2date(btime,bdoy,gmt2,byr,bmo,bda,bhr,bmn)
-    endif
-#endif
-
-!    do t = 1, LIS_rc%ntiles(n)
-!       index1 = LIS_domain(n)%tile(t)%index
-  do t=1,LIS_rc%ntiles(n)/LIS_rc%nensem(n)
-     do m=1,pptensfcst_struc%max_ens_members
-        do k=1,mfactor
-           tid = (t-1)*LIS_rc%nensem(n)+(m-1)*mfactor+k
-           index1 = LIS_domain(n)%tile(tid)%index
-#if 0
-       if( pptensfcst_struc%zterp_flags ) then
-         zdoy = LIS_rc%doy
-         call zterp( 0, LIS_domain(n)%grid(index1)%lat,&
-              LIS_domain(n)%grid(index1)%lon, gmt1, gmt2, &
-              LIS_rc%gmt,zdoy,zw1,zw2,czb,cze,czm,LIS_rc)
-         swd(t) = pptensfcst_struc%metdata1(forcopts%index_swdown,m,index1)*zw1
-       else
-         swd(t) = pptensfcst_struc%metdata1(forcopts%index_swdown,m,index1)
-       endif
-       if( swd(t) < 0 ) then
-          write(LIS_logunit,*) "[ERR] SW radiation is negative!!"
-          write(LIS_logunit,*) "[ERR] sw=", swd(t), "... negative"
-          write(LIS_logunit,*) "[ERR] PPTEnsFcst SWdown=", &
-                pptensfcst_struc%metdata2(forcopts%index_swdown,m,index1)
-          call LIS_endrun
-       end if
-       if( swd(tid).gt.LIS_CONST_SOLAR ) then
-          swd(tid) = pptensfcst_struc%metdata1(forcopts%index_swdown,m,index1)
-       endif
-#endif
-
-         swd(tid) = pptensfcst_struc%metdata2(forcopts%index_swdown,m,index1)
-!         if(t==100) then
-!            print *, 'swd: ', swd(t)
-!         endif
-        end do
-      end do
-    end do
-  endif
-
 !- Time Averaged Longwave, Block Interpolation
-!   do t = 1, LIS_rc%ntiles(n)
-!      index1 = LIS_domain(n)%tile(t)%index
+
   do t=1,LIS_rc%ntiles(n)/LIS_rc%nensem(n)
      do m=1,pptensfcst_struc%max_ens_members
         do k=1,mfactor
            tid = (t-1)*LIS_rc%nensem(n)+(m-1)*mfactor+k
            index1 = LIS_domain(n)%tile(tid)%index
-
-          if( forcopts%read_airtmp ) then 
-            if((pptensfcst_struc%metdata1(forcopts%index_airtmp,m,index1).ne.LIS_rc%udef).and.&
-               (pptensfcst_struc%metdata2(forcopts%index_airtmp,m,index1).ne.LIS_rc%udef)) then
-              airtmp(tid) = pptensfcst_struc%metdata2(forcopts%index_airtmp,m,index1)
-            endif
-          endif
- 
-          if( forcopts%read_spechum ) then 
-            if((pptensfcst_struc%metdata1(forcopts%index_spechum,m,index1).ne.LIS_rc%udef).and.&
-               (pptensfcst_struc%metdata2(forcopts%index_spechum,m,index1).ne.LIS_rc%udef)) then
-              spechum(tid) = pptensfcst_struc%metdata2(forcopts%index_spechum,m,index1)
-            endif
-          endif
-
-          if( forcopts%read_psurf ) then 
-            if((pptensfcst_struc%metdata1(forcopts%index_psurf,m,index1).ne.LIS_rc%udef).and.&
-               (pptensfcst_struc%metdata2(forcopts%index_psurf,m,index1).ne.LIS_rc%udef)) then
- 
-              psurf(tid) = pptensfcst_struc%metdata2(forcopts%index_psurf,m,index1) 
-            endif
-          endif
-
-          if( forcopts%read_lwdown ) then
-            if((pptensfcst_struc%metdata1(forcopts%index_lwdown,m,index1).ne.LIS_rc%udef).and.&
-               (pptensfcst_struc%metdata2(forcopts%index_lwdown,m,index1).ne.LIS_rc%udef)) then
-              lwd(tid) = pptensfcst_struc%metdata2(forcopts%index_lwdown,m,index1)
-            endif
-          endif
-
-          if( forcopts%read_uwind ) then 
-            if((pptensfcst_struc%metdata1(forcopts%index_uwind,m,index1).ne.LIS_rc%udef).and.&
-               (pptensfcst_struc%metdata2(forcopts%index_uwind,m,index1).ne.LIS_rc%udef)) then
-              uwind(tid) = pptensfcst_struc%metdata2(forcopts%index_uwind,m,index1) 
-            endif
-          endif
-
-          if( forcopts%read_vwind ) then 
-            if((pptensfcst_struc%metdata1(forcopts%index_vwind,m,index1).ne.LIS_rc%udef).and.&
-               (pptensfcst_struc%metdata2(forcopts%index_vwind,m,index1).ne.LIS_rc%udef)) then
-             vwind(tid) = pptensfcst_struc%metdata2(forcopts%index_vwind,m,index1) 
-!         if(t==100) then; print *, 'vwind: ',vwind(t); endif
-            endif
-          endif
 
           if( forcopts%read_rainf ) then 
             if((pptensfcst_struc%metdata1(forcopts%index_rainf,m,index1).ne.LIS_rc%udef).and.&
                (pptensfcst_struc%metdata2(forcopts%index_rainf,m,index1).ne.LIS_rc%udef)) then
               prcp(tid) = pptensfcst_struc%metdata2(forcopts%index_rainf,m,index1)
-!         if(t==100) then; print *, 'prcp: ',prcp(t); endif
+
+              if( prcp(tid) < 0.0 ) then ! mm/s
+                prcp(tid) = 0.0
+              endif
+              if( prcp(tid) > 1.0 ) then ! mm/s
+                prcp(tid) = 0.025
+              endif
+
             endif
           endif
  
@@ -276,6 +126,11 @@ subroutine timeinterp_pptEnsFcst(n, findex)
             if((pptensfcst_struc%metdata1(forcopts%index_cpcp,m,index1).ne.LIS_rc%udef).and.&
                (pptensfcst_struc%metdata2(forcopts%index_cpcp,m,index1).ne.LIS_rc%udef)) then
               cpcp(tid) = pptensfcst_struc%metdata2(forcopts%index_cpcp,m,index1)
+
+              if( cpcp(tid) < 0.0 ) then
+                cpcp(tid) = 0.0
+              endif
+
             endif     
           endif
 

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
@@ -273,7 +273,8 @@ subroutine NoahMP401_dump_restart(n, ftn, wformat)
                                        dim1=NOAHMP401_struc(n)%nsoil+NOAHMP401_struc(n)%nsnow, &
                                        dim2=NOAHMP401_struc(n)%nsoil,                          &
                                        dim3=NOAHMP401_struc(n)%nsnow,                          &
-                                       dim4=60,                                                &
+!                                       dim4=60,                                                & ! GECROS
+                                       dim4=1,                                                 &
                                        dimID=dimID,                                            &
                                        output_format = trim(wformat))
 


### PR DESCRIPTION
Updated the ensemble forecast forcing readers in LIS with a new optional entry in the LIS config file.

### Description:

The user can now specify an initial forecast date, which supports the use of restarts in the middle of forecast run (for large domain and long-term forecast runs).  If not specified in the LIS config file, LIS resorts to default settings of the LIS start year and month.

Additional code cleanup of the "generic" and precipitation forecast readers included.

If a use case is required to complete the merge of this pull request, I can provide one.  Otherwise, the new code added does not impact any users currently using the readers and has been tested for a suite of different conditions.