### PR TITLE
Add support to specify RPC library

### DIFF
--- a/ldt/arch/Config.pl
+++ b/ldt/arch/Config.pl
@@ -586,6 +586,13 @@ else{
    $libjpeg = "-ljpeg";
 }
 
+if(defined($ENV{LDT_RPC})){
+   $librpc = "-ltirpc";
+}
+else{
+   $librpc = "";
+}
+
 if($sys_arch eq "linux_ifc") {
    if($use_omp == 1) {
       if($use_endian == 1) {
@@ -704,7 +711,7 @@ if($use_hdfeos == 1){
 if($use_hdf4 == 1){
    $fflags77 = $fflags77." -I\$(INC_HDF4) ";
    $fflags = $fflags." -I\$(INC_HDF4) ";
-   $ldflags = $ldflags." -L\$(LIB_HDF4) -lmfhdf -ldf ".$libjpeg." -lz ";
+   $ldflags = $ldflags." -L\$(LIB_HDF4) -lmfhdf -ldf ".$libjpeg." -lz ".$librpc;
 }
 if($use_hdf5 == 1){
    $fflags77 = $fflags77." -I\$(INC_HDF5) ";

--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -770,6 +770,13 @@ else{
    $libjpeg = "-ljpeg";
 }
 
+if(defined($ENV{LIS_RPC})){
+   $librpc = "-ltirpc";
+}
+else{
+   $librpc = "";
+}
+
 if($ENV{ESMF_TRACE} > 0){
    $use_esmf_trace = 1 
 }
@@ -869,7 +876,7 @@ if($use_hdfeos == 1){
 if($use_hdf4 == 1){
    $fflags77 = $fflags77." -I\$(INC_HDF4)";
    $fflags = $fflags." -I\$(INC_HDF4)";
-   $ldflags = $ldflags." -L\$(LIB_HDF4) -lmfhdf -ldf ".$libjpeg." -lz";
+   $ldflags = $ldflags." -L\$(LIB_HDF4) -lmfhdf -ldf ".$libjpeg." -lz ".$librpc;
 }
 if($use_hdf5 == 1){
    $fflags77 = $fflags77." -I\$(INC_HDF5)";

--- a/lvt/arch/Config.pl
+++ b/lvt/arch/Config.pl
@@ -520,6 +520,13 @@ else{
    $libjpeg = "-ljpeg";
 }
 
+if(defined($ENV{LVT_RPC})){
+   $librpc = "-ltirpc";
+}
+else{
+   $librpc = "";
+}
+
 if($sys_arch eq "linux_ifc") {
    if ($use_endian == 1 ) {
       $cflags = "-c ".$sys_c_opt." -traceback -DIFC";
@@ -611,7 +618,7 @@ if($use_hdfeos == 1){
 if($use_hdf4 == 1){
    $fflags77 = $fflags77." -I\$(INC_HDF4) ";
    $fflags = $fflags." -I\$(INC_HDF4) ";
-   $ldflags = $ldflags." -L\$(LIB_HDF4) -lmfhdf -ldf ".$libjpeg." -lz ";
+   $ldflags = $ldflags." -L\$(LIB_HDF4) -lmfhdf -ldf ".$libjpeg." -lz ".$librpc;
 }
 if($use_hdf5 == 1){
    $fflags77 = $fflags77." -I\$(INC_HDF5) ";


### PR DESCRIPTION
### Description

The OS upgrade on HPC-11 changed the available low level RPC library. The system no longer has a static version to compile into the HDF4 library.  You must now specify the RPC library in the LDFLAGS variable (both when building the HDF4 library itself and when compiling LISF).

This commit adds LDT_RPC, LIS_RPC, and LVT_RPC environment variables. If these environment variables are defined, then the build scripts add "-ltirpc" to the LDFLAGS variable for HDF4.  If these environment variables are not defined, then the build scripts function as before (nothing new is added to the LDFLAGS variable for HDF4).