### PR TITLE
Address errors raised by GNU compilers

### DIFF
--- a/ldt/make/Makefile
+++ b/ldt/make/Makefile
@@ -124,6 +124,17 @@ version.F90:
 	@echo "Building version file $@"
 	sh build_version.sh
 
+ifeq ($(LIS_ARCH),linux_gfortran)
+# For MPI
+LDT_historyMod.o: LDT_historyMod.F90
+	$(FC) $(FFLAGS) -fallow-argument-mismatch $(HEADER_DIRS) $<
+# For HDF-EOS2
+readGLASSlaiObs.o: readGLASSlaiObs.F90
+	$(FC) $(FFLAGS) -fallow-argument-mismatch $(HEADER_DIRS) $<
+readNASA_AMSREsmObs.o: readNASA_AMSREsmObs.F90
+	$(FC) $(FFLAGS) -fallow-argument-mismatch $(HEADER_DIRS) $<
+endif
+
 .PHONY: help
 help:
 	@echo ""

--- a/lis/make/Makefile
+++ b/lis/make/Makefile
@@ -163,6 +163,27 @@ soil_htc_jls_mod.o: soil_htc_jls_mod.F90
 	$(FC) $(FFLAGS) -O0 $(HEADER_DIRS) $<
 endif
 
+ifeq ($(LIS_ARCH),linux_gfortran)
+# For MPI
+LIS_historyMod.o: LIS_historyMod.F90
+	$(FC) $(FFLAGS) -fallow-argument-mismatch $(HEADER_DIRS) $<
+LIS_DAobservationsMod.o: LIS_DAobservationsMod.F90
+	$(FC) $(FFLAGS) -fallow-argument-mismatch $(HEADER_DIRS) $<
+USAF_bratsethMod.o: USAF_bratsethMod.F90
+	$(FC) $(FFLAGS) -fallow-argument-mismatch $(HEADER_DIRS) $<
+gmaopert_Mod.o: gmaopert_Mod.F90
+	$(FC) $(FFLAGS) -fallow-argument-mismatch $(HEADER_DIRS) $<
+HYMAP2_routingMod.o: HYMAP2_routingMod.F90
+	$(FC) $(FFLAGS) -fallow-argument-mismatch $(HEADER_DIRS) $<
+read_SMOSNRTNNL2sm.o: read_SMOSNRTNNL2sm.F90
+	$(FC) $(FFLAGS) -fallow-argument-mismatch $(HEADER_DIRS) $<
+HYMAP2_model.o: HYMAP2_model.F90
+	$(FC) $(FFLAGS) -fallow-argument-mismatch $(HEADER_DIRS) $<
+# For HDF-EOS2
+read_GLASSlai.o: read_GLASSlai.F90
+	$(FC) $(FFLAGS) -fallow-argument-mismatch $(HEADER_DIRS) $<
+endif
+
 .PHONY: help
 help:
 	@echo ""

--- a/lvt/make/Makefile
+++ b/lvt/make/Makefile
@@ -124,6 +124,14 @@ version.F90:
 	@echo "Building version file $@"
 	sh build_version.sh
 
+ifeq ($(LIS_ARCH),linux_gfortran)
+# For HDF-EOS2
+readGLASSlaiObs.o: readGLASSlaiObs.F90
+	$(FC) $(FFLAGS) -fallow-argument-mismatch $(HEADER_DIRS) $<
+readNASA_AMSREsmObs.o: readNASA_AMSREsmObs.F90
+	$(FC) $(FFLAGS) -fallow-argument-mismatch $(HEADER_DIRS) $<
+endif
+
 .PHONY: help
 help:
 	@echo ""


### PR DESCRIPTION
### Description

The GNU Fortran compiler raised errors when compiling source code that included mpif.h (needed when compiling with gfortran while using the Intel MPI library) or used the HDF-EOS2 library.

The workaround is to add `-fallow-argument-mismatch` to the gfortran compiler flags.

Note: On some systems, this compiler option is already added by the mpif90 wrapper script.


### Testcase

I compiled on narwhal and in my virtual machine.  To test compiling on discover, compile serially.  `mpif90` on discover adds `-fallow-argument-mismatch` to the compiler options.

