### PR TITLE
Clean up build scripts

### DIFF
--- a/lis/make/default.cfg
+++ b/lis/make/default.cfg
@@ -66,7 +66,6 @@
 #                  Tau Omega,
 #                  virtual_optue,
 #                  virtual_da,
-#                  virtual_da_obs_snodep,
 #                  virtual_routing,
 #                  virtual_irrigation
 # WRF coupling path: surfacemodels/land/noah.3.3/cpl_wrf_noesmf
@@ -79,8 +78,8 @@
 #                     surfacemodels/land/noah.3.3/pe/obspred/USDA_ARSsm,
 #                     surfacemodels/land/noah.3.3/pe/obspred/FLUXNET
 # virtual_da path: surfacemodels/land/noah.3.3/da_snow,
-#                  surfacemodels/land/noah.3.3/da_soilm
-# virtual_da_obs_snodep path: surfacemodels/land/noah.3.3/da_snodep
+#                  surfacemodels/land/noah.3.3/da_soilm,
+#                  surfacemodels/land/noah.3.3/da_snodep
 # virtual_routing path: surfacemodels/land/noah.3.3/routing
 # virtual_irrigation path: surfacemodels/land/noah.3.3/irrigation
 
@@ -1026,10 +1025,10 @@ enabled: True
 macro: SM_NOAH_2_7_1
 path: surfacemodels/land/noah.2.7.1
 dependent_comps: WRF coupling,
-                 virtual_da_obs_snodep,
+                 virtual_da,
                  virtual_routing
 WRF coupling path: surfacemodels/land/noah.2.7.1/cpl_wrf_noesmf
-virtual_da_obs_snodep path: surfacemodels/land/noah.2.7.1/da_snodep
+virtual_da path: surfacemodels/land/noah.2.7.1/da_snodep
 virtual_routing path: surfacemodels/land/noah.2.7.1/routing
 
 [Noah.3.2]
@@ -1051,7 +1050,6 @@ dependent_comps: WRF coupling,
                  Tau Omega,
                  virtual_optue,
                  virtual_da,
-                 virtual_da_obs_snodep,
                  virtual_routing,
                  virtual_irrigation
 WRF coupling path: surfacemodels/land/noah.3.3/cpl_wrf_noesmf
@@ -1064,8 +1062,8 @@ virtual_optue path: surfacemodels/land/noah.3.3/pe,
             surfacemodels/land/noah.3.3/pe/obspred/USDA_ARSsm,
             surfacemodels/land/noah.3.3/pe/obspred/FLUXNET
 virtual_da path: surfacemodels/land/noah.3.3/da_snow,
-                 surfacemodels/land/noah.3.3/da_soilm
-virtual_da_obs_snodep path: surfacemodels/land/noah.3.3/da_snodep
+                 surfacemodels/land/noah.3.3/da_soilm,
+                 surfacemodels/land/noah.3.3/da_snodep
 virtual_routing path: surfacemodels/land/noah.3.3/routing
 virtual_irrigation path: surfacemodels/land/noah.3.3/irrigation
 
@@ -1077,14 +1075,13 @@ dependent_comps: WRF coupling,
                  CMEM,
                  virtual_optue,
                  virtual_da,
-                 virtual_da_obs_snodep,
                  virtual_routing
 WRF coupling path: surfacemodels/land/noah.3.6/cpl_wrf_noesmf
 CMEM path: surfacemodels/land/noah.3.6/sfc_cmem3
 virtual_optue path: surfacemodels/land/noah.3.6/pe
 virtual_da path: surfacemodels/land/noah.3.6/da_snow,
-                 surfacemodels/land/noah.3.6/da_soilm
-virtual_da_obs_snodep path: surfacemodels/land/noah.3.6/da_snodep
+                 surfacemodels/land/noah.3.6/da_soilm,
+                 surfacemodels/land/noah.3.6/da_snodep
 virtual_routing path: surfacemodels/land/noah.3.6/routing
 
 [Noah.3.9]
@@ -1093,13 +1090,11 @@ macro: SM_NOAH_3_9
 path: surfacemodels/land/noah.3.9, 
       surfacemodels/land/noah.3.9/phys
 dependent_comps: virtual_da,
-                 virtual_routing,
-                 virtual_da_obs_usafsi,
-                 virtual_da_obs_snodep
+                 virtual_routing
 virtual_da path: surfacemodels/land/noah.3.9/da_soilm,
-                 surfacemodels/land/noah.3.9/da_snow
-virtual_da_obs_usafsi path: surfacemodels/land/noah.3.9/da_usafsi
-virtual_da_obs_snodep path: surfacemodels/land/noah.3.9/da_snodep
+                 surfacemodels/land/noah.3.9/da_snow,
+                 surfacemodels/land/noah.3.9/da_usafsi,
+                 surfacemodels/land/noah.3.9/da_snodep
 virtual_routing path: surfacemodels/land/noah.3.9/routing
 
 [NoahMP.3.6]
@@ -1109,7 +1104,6 @@ path: surfacemodels/land/noahmp.3.6
 dependent_comps: WRF coupling,
                  CMEM,
                  virtual_da,
-                 virtual_da_obs_snodep,
                  virtual_optue,
                  virtual_routing,
                  virtual_irrigation
@@ -1120,8 +1114,8 @@ virtual_da path: surfacemodels/land/noahmp.3.6/da_soilm,
                  surfacemodels/land/noahmp.3.6/da_snowSVM,
                  surfacemodels/land/noahmp.3.6/da_LAI,
                  surfacemodels/land/noahmp.3.6/da_albedo,
-                 surfacemodels/land/noahmp.3.6/da_tws
-virtual_da_obs_snodep path: surfacemodels/land/noahmp.3.6/da_snodep
+                 surfacemodels/land/noahmp.3.6/da_tws,
+                 surfacemodels/land/noahmp.3.6/da_snodep
 virtual_routing path: surfacemodels/land/noahmp.3.6/routing
 virtual_optue path: surfacemodels/land/noahmp.3.6/pe,
             surfacemodels/land/noahmp.3.6/pe/obspred/ARSsm,
@@ -1137,8 +1131,6 @@ path: surfacemodels/land/noahmp.4.0.1,
       surfacemodels/land/noahmp.4.0.1/cplsubLSM
 dependent_comps: WRF coupling,
                  virtual_da,
-                 virtual_da_obs_snodep,
-                 virtual_da_obs_usafsi,
                  virtual_optue,
                  virtual_routing,
                  virtual_irrigation
@@ -1146,12 +1138,12 @@ WRF coupling path: surfacemodels/land/noahmp.4.0.1/cpl_wrf_noesmf
 virtual_da path: surfacemodels/land/noahmp.4.0.1/da_soilm,
                  surfacemodels/land/noahmp.4.0.1/da_snow,
                  surfacemodels/land/noahmp.4.0.1/da_LAI,
-                 surfacemodels/land/noahmp.4.0.1/da_tws
+                 surfacemodels/land/noahmp.4.0.1/da_tws,
+                 surfacemodels/land/noahmp.4.0.1/da_snodep,
+                 surfacemodels/land/noahmp.4.0.1/da_usafsi
 virtual_optue path: surfacemodels/land/noahmp.4.0.1/pe,
             surfacemodels/land/noahmp.4.0.1/pe/obspred/UAsnow
 virtual_routing path: surfacemodels/land/noahmp.4.0.1/routing
-virtual_da_obs_snodep path: surfacemodels/land/noahmp.4.0.1/da_snodep
-virtual_da_obs_usafsi path: surfacemodels/land/noahmp.4.0.1/da_usafsi
 virtual_irrigation path: surfacemodels/land/noahmp.4.0.1/irrigation
 
 [RUC.3.7]
@@ -1293,11 +1285,10 @@ path: surfacemodels/land/jules.5.0,
       surfacemodels/land/jules.5.0/src/util/grid,
       surfacemodels/land/jules.5.0/src/util/cube
 dependent_comps: virtual_da,
-                 virtual_da_obs_snodep,
                  virtual_routing
 virtual_da path: surfacemodels/land/jules.5.0/da_soilm,
-                 surfacemodels/land/jules.5.0/da_usafsi
-virtual_da_obs_snodep path: surfacemodels/land/jules.5.0/da_snodep
+                 surfacemodels/land/jules.5.0/da_usafsi,
+                 surfacemodels/land/jules.5.0/da_snodep
 virtual_routing path: surfacemodels/land/jules.5.0/routing
 
 
@@ -1362,11 +1353,10 @@ path: surfacemodels/land/jules.5.1,
       surfacemodels/land/jules.5.1/src/util/grid,
       surfacemodels/land/jules.5.1/src/util/cube
 #dependent_comps: virtual_da,
-#                 virtual_da_obs_snodep,
 #                 virtual_routing
 #virtual_da path: surfacemodels/land/jules.5.1/da_soilm,
-#                 surfacemodels/land/jules.5.1/da_ldtsi
-#virtual_da_obs_snodep path: surfacemodels/land/jules.5.1/da_snodep
+#                 surfacemodels/land/jules.5.1/da_ldtsi,
+#                 surfacemodels/land/jules.5.1/da_snodep
 #virtual_routing path: surfacemodels/land/jules.5.1/routing
 
 [JULES.5.2]
@@ -1643,11 +1633,10 @@ path: surfacemodels/land,
 
 dependent_comps:  virtual_da,
                   virtual_routing,
-                  virtual_da_obs_snodep
 virtual_routing path: surfacemodels/land/jules.5.x/routing
 virtual_da path: surfacemodels/land/jules.5.x/da_soilm,
-                 surfacemodels/land/jules.5.x/da_usafsi
-virtual_da_obs_snodep path: surfacemodels/land/jules.5.x/da_snodep
+                 surfacemodels/land/jules.5.x/da_usafsi,
+                 surfacemodels/land/jules.5.x/da_snodep
 
 [CABLE]
 enabled: True

--- a/lis/make/plugins.py
+++ b/lis/make/plugins.py
@@ -124,19 +124,6 @@ if (config.getboolean('OPTUE ES', 'enabled') or
         config.getboolean('OPTUE DEMCz', 'enabled')):
     config.set('virtual_optue', 'enabled', 'true')
 
-config.add_section('virtual_da_obs_snodep')
-config.set('virtual_da_obs_snodep', 'enabled', 'false')
-config.set('virtual_da_obs_snodep', 'virtual', 'true')
-if (config.getboolean('virtual_da', 'enabled') and
-        config.getboolean('DA OBS SNODEP', 'enabled')):
-    config.set('virtual_da_obs_snodep', 'enabled', 'true')
-
-config.add_section('virtual_da_obs_usafsi')
-config.set('virtual_da_obs_usafsi', 'enabled', 'false')
-config.set('virtual_da_obs_usafsi', 'virtual', 'true')
-if (config.getboolean('virtual_da', 'enabled') and
-        config.getboolean('DA OBS USAFSI', 'enabled')):
-    config.set('virtual_da_obs_usafsi', 'enabled', 'true')
 
 #
 # Write Filepath and LIS_plugins.h


### PR DESCRIPTION
### Description

The SNODEP reader has been available for a while.  We no longer need the virtual_da_obs_snodep special case.

The USAFSI reader is also available.  We do not need the virtual_da_obs_usafsi special case.

I noticed that these unneeded special cases were  causing some confusion.

### Testcase

I cleanly compiled LIS before and after this update.  The exact same files in the exact same order were compiled.
