### PR TITLE
Changed length of dir vars in Noah_parmsMod.F90

### DIFF
--- a/ldt/params/Noah/Noah_parmsMod.F90
+++ b/ldt/params/Noah/Noah_parmsMod.F90
@@ -66,11 +66,11 @@ module Noah_parmsMod
      character*50   :: tbot_proj
      character*50   :: slopetype_proj
 
-     character*140  :: mmf_fdepth_dir
-     character*140  :: mmf_rechclim_dir
-     character*140  :: mmf_riverbed_dir
-     character*140  :: mmf_eqwtd_dir
-     character*140  :: mmf_hgtm_dir
+     character(len=LDT_CONST_PATH_LEN)  :: mmf_fdepth_dir
+     character(len=LDT_CONST_PATH_LEN)  :: mmf_rechclim_dir
+     character(len=LDT_CONST_PATH_LEN)  :: mmf_riverbed_dir
+     character(len=LDT_CONST_PATH_LEN)  :: mmf_eqwtd_dir
+     character(len=LDT_CONST_PATH_LEN)  :: mmf_hgtm_dir
      character*50   :: mmf_transform
       
      real           :: pblh_value


### PR DESCRIPTION
This is an edit to PR #1038.  In the file /params/Noah/Noah_parmsMod.F90, directory variable character lengths were edited to be equal to the constant, LVT_CONST_PATH_LEN.

The PR #1038 testcase can be used to confirm this minor edit does not break any functionality.  A copy of the testcase is stored in /discover/nobackup/cmclaug2/github/PR_mmf-edits/mmfldttest
