### PR TITLE
Update MODEL_OUTPUT_LIST.TBL files for Jules specific snow variables

### DIFF
--- a/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.ActSnowNL_inst.3hr
+++ b/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.ActSnowNL_inst.3hr
@@ -1,1 +1,0 @@
-ActSnowNL:    1  "-"    -    0 0 0 1  255 1000 0 1   # Actual number of snow layers

--- a/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.GrndSnow_inst.3hr
+++ b/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.GrndSnow_inst.3hr
@@ -1,1 +1,0 @@
-GrndSnow:    1  "kg m-2"    -    0 0 0 1  66 1000 0 1   # Snow on ground beneath canopy

--- a/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.LayerSnowDensity_inst.3hr
+++ b/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.LayerSnowDensity_inst.3hr
@@ -1,2 +1,0 @@
-LayerSnowDensity: 1  "kg m-3"    -    0 0 0 3  61 1000 0 1   # Snow density for each layer
-

--- a/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.LayerSnowDepth_inst.3hr
+++ b/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.LayerSnowDepth_inst.3hr
@@ -1,2 +1,0 @@
-LayerSnowDepth: 1  "m"    -    0 0 0 3  11 1000 0 1   # Snow depth for each layer
-

--- a/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.LayerSnowGrain_inst.3hr
+++ b/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.LayerSnowGrain_inst.3hr
@@ -1,2 +1,0 @@
-LayerSnowGrain: 1  "micron"    -    0 0 0 3  255 1000 0 1   # Snow grain size for each layer
-

--- a/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.PS41Snow_inst.3hr
+++ b/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.PS41Snow_inst.3hr
@@ -1,7 +1,7 @@
-ActSnowNL:        1  "-"      - 0 0 0 1 255 1000 0 1 # Actual number of snow layers
+ActSnowNL:        1  "-"      - 0 0 0 1 198 1000 0 1 # Actual number of snow layers
 LayerSnowDepth:   1  "m"      - 0 0 0 3 11 1000 0 1  # Snow depth for each layer
-LayerSnowGrain:   1  "micron" - 0 0 0 3 255 1000 0 1 # Snow grain size for each layer
-SnowIce:          1  "kg/m2"  - 0 0 0 3 255 1000 0 1 # Snow layer ice
+LayerSnowGrain:   1  "micron" - 0 0 0 3 199 1000 0 1 # Snow grain size for each layer
+SnowIce:          1  "kg/m2"  - 0 0 0 3 200 1000 0 1 # Snow layer ice
 SnowLiq:          1  "kg/m2"  - 0 0 0 3 16 1000 0 1  # Snow layer liquid water
-SnowTProf:        1  "K"      - 0 0 0 3 1 1000 0 1   # Snow temperature profile
+SnowTProf:        1  "K"      - 0 0 0 3 201 1000 0 1 # Snow temperature profile
 

--- a/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SnowDensity_inst.3hr
+++ b/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SnowDensity_inst.3hr
@@ -1,1 +1,0 @@
-SnowDensity:    1  "kg m-3"    -    0 0 0 1  255 1000 0 1   # Snow density

--- a/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SnowGrain_inst.3hr
+++ b/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SnowGrain_inst.3hr
@@ -1,1 +1,0 @@
-SnowGrain:    1  "micron"    -    0 0 0 1  255 1000 0 1   # Snow grain size

--- a/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SnowIce_inst.3hr
+++ b/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SnowIce_inst.3hr
@@ -1,2 +1,0 @@
-SnowIce: 1  "kg/m2"    -    0 0 0 3  255 1000 0 1   # Snow layer ice
-

--- a/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SnowLiq_inst.3hr
+++ b/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SnowLiq_inst.3hr
@@ -1,2 +1,0 @@
-SnowLiq: 1  "kg/m2"    -    0 0 0 3  16 1000 0 1   # Snow layer liquid water
-

--- a/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SnowSoot_inst.3hr
+++ b/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SnowSoot_inst.3hr
@@ -1,1 +1,0 @@
-SnowSoot:    1  "kg kg-1"    -    0 0 0 1  255 1000 0 1   # Snow soot content

--- a/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SnowTProf_inst.3hr
+++ b/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SnowTProf_inst.3hr
@@ -1,1 +1,0 @@
-SnowTProf:    1  "K"    -    0 0 0 3  1 1000 0 1   # Snow temperature profile

--- a/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SurftSnow_inst.3hr
+++ b/lvt/utils/usaf/templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.SurftSnow_inst.3hr
@@ -1,1 +1,0 @@
-SurftSnow:    1  "kg/m2"    -    0 0 0 1  66 1000 0 1   # Snow amount on tile


### PR DESCRIPTION


### Description

Updated several parameter numbers for Jules specific PS41 snow variables, based on latest 557 WW GRIB2 manual.

Also removed obsolete standalone MODEL_OUTPUT_LIST.TBL files for additional Jules specific snow variables, as these are either handled by PS41Snow mode, or still lack valid GRIB2 parameters (and are not required for GRIB2 distribution anyway).


