### PR TITLE
Fix/micromet metreaders

### DIFF
--- a/lis/metforcing/gdas/get_gdas.F90
+++ b/lis/metforcing/gdas/get_gdas.F90
@@ -224,10 +224,13 @@ subroutine get_gdas(n, findex)
      gridDesci(10) = 95
      gridDesci(20) = 0
 
-! EMK Bug fix
-!     if(LIS_rc%met_ecor(findex).eq."lapse-rate") then 
-     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
-          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then 
+! KRA - Previous:
+!     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
+!          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then 
+! Including MicroMet downscaling:
+     if(LIS_rc%met_ecor(findex) == "lapse-rate" .or. &
+          LIS_rc%met_ecor(findex) == "lapse-rate and slope-aspect" .or. &
+          LIS_rc%met_ecor(findex) == "micromet" ) then
         call read_gdas_elev(n,findex, 1)
      endif
 
@@ -260,10 +263,13 @@ subroutine get_gdas(n, findex)
      gridDesci(10) = 128
      gridDesci(20) = 0.0
 
-! EMK Bug fix
-!     if(LIS_rc%met_ecor(findex).eq."lapse-rate") then 
-     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
-          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then 
+! KRA - Previous:
+!     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
+!          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then 
+! Including MicroMet downscaling:
+     if(LIS_rc%met_ecor(findex) == "lapse-rate" .or. &
+          LIS_rc%met_ecor(findex) == "lapse-rate and slope-aspect" .or. &
+          LIS_rc%met_ecor(findex) == "micromet" ) then
         call read_gdas_elev(n,findex, 2)
      endif
 
@@ -296,10 +302,13 @@ subroutine get_gdas(n, findex)
      gridDesci(10) = 192
      gridDesci(20) = 0.0
 
-! EMK Bug fix
-!     if(LIS_rc%met_ecor(findex).eq."lapse-rate") then 
-     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
-          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then 
+! KRA - Previous:
+!     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
+!          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then 
+! Including MicroMet downscaling:
+     if(LIS_rc%met_ecor(findex) == "lapse-rate" .or. &
+          LIS_rc%met_ecor(findex) == "lapse-rate and slope-aspect" .or. &
+          LIS_rc%met_ecor(findex) == "micromet" ) then
         call read_gdas_elev(n,findex, 3)
      endif
 
@@ -332,10 +341,13 @@ subroutine get_gdas(n, findex)
      gridDesci(10) = 288
      gridDesci(20) = 0.0
 
-! EMK Bug fix
-!     if(LIS_rc%met_ecor(findex).eq."lapse-rate") then 
-     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
-          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then 
+! KRA - Previous:
+!     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
+!          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then 
+! Including MicroMet downscaling:
+     if(LIS_rc%met_ecor(findex) == "lapse-rate" .or. &
+          LIS_rc%met_ecor(findex) == "lapse-rate and slope-aspect" .or. &
+          LIS_rc%met_ecor(findex) == "micromet" ) then
         call read_gdas_elev(n,findex, 4)
      endif
 
@@ -368,10 +380,13 @@ subroutine get_gdas(n, findex)
      gridDesci(10) = 440
      gridDesci(20) = 0.0
 
-! EMK Bug fix
-!     if(LIS_rc%met_ecor(findex).eq."lapse-rate") then 
-     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
-          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then 
+! KRA - Previous:
+!     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
+!          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then 
+! Including MicroMet downscaling:
+     if(LIS_rc%met_ecor(findex) == "lapse-rate" .or. &
+          LIS_rc%met_ecor(findex) == "lapse-rate and slope-aspect" .or. &
+          LIS_rc%met_ecor(findex) == "micromet" ) then
         call read_gdas_elev(n,findex, 5)
      endif
 
@@ -403,10 +418,13 @@ subroutine get_gdas(n, findex)
      gridDesci(10) = 768.0
      gridDesci(20) = 0.0
 
-! EMK Bug fix
-!     if(LIS_rc%met_ecor(findex).eq."lapse-rate") then
-     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
-          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then 
+! KRA - Previous:
+!     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
+!          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then 
+! Including MicroMet downscaling:
+     if(LIS_rc%met_ecor(findex) == "lapse-rate" .or. &
+          LIS_rc%met_ecor(findex) == "lapse-rate and slope-aspect" .or. &
+          LIS_rc%met_ecor(findex) == "micromet" ) then
         call read_gdas_elev(n,findex, 6)
      endif
 

--- a/lis/metforcing/gdas/read_gdas_elev.F90
+++ b/lis/metforcing/gdas/read_gdas_elev.F90
@@ -53,10 +53,14 @@ subroutine read_gdas_elev(n, findex, change)
   integer :: c,r
   real :: go(LIS_rc%lnc(n),LIS_rc%lnr(n))
 
-! EMK TEST
-!  if ( LIS_rc%met_ecor(findex).eq."lapse-rate") then 
-     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
-          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then
+! KRA - previous:
+!     if(LIS_rc%met_ecor(findex).eq."lapse-rate" .or. &
+!          LIS_rc%met_ecor(findex) .eq. "lapse-rate and slope-aspect") then
+! Addition of Micromet topographic downscaling:
+     if(LIS_rc%met_ecor(findex) == "lapse-rate" .or. &
+          LIS_rc%met_ecor(findex) == "lapse-rate and slope-aspect" .or. &
+          LIS_rc%met_ecor(findex) == "micromet" ) then
+
      write(LIS_logunit,*) 'Reading the GDAS elevation'
      if ( change == 0 ) then ! period 1980--1991
         ! Note that for this time period we have a difference file

--- a/lis/metforcing/merra2/merra2_forcingMod.F90
+++ b/lis/metforcing/merra2/merra2_forcingMod.F90
@@ -330,7 +330,8 @@ contains
        merra2_struc(n)%merraforc2 = LIS_rc%udef
 
        if ( LIS_rc%met_ecor(findex) == "lapse-rate" .or. &
-            LIS_rc%met_ecor(findex) == "lapse-rate and slope-aspect" ) then
+            LIS_rc%met_ecor(findex) == "lapse-rate and slope-aspect" .or. &
+            LIS_rc%met_ecor(findex) == "micromet" ) then
           call read_merra2_elev(n,findex)
        endif
 

--- a/lis/metforcing/merra2/read_merra2_elev.F90
+++ b/lis/metforcing/merra2/read_merra2_elev.F90
@@ -59,7 +59,7 @@ subroutine read_merra2_elev(n,findex)
 
   if ( trim(LIS_rc%met_ecor(findex)) .ne. "none") then 
 
-     write(LIS_logunit,*) 'Reading the MERRA2 elevation map ...'
+     write(LIS_logunit,*) '[INFO] Reading the MERRA2 elevation map ...'
      
      call LIS_read_param(n,"ELEV_MERRA2",go)
 

--- a/lis/metforcing/merra2/read_merra2_elev.F90
+++ b/lis/metforcing/merra2/read_merra2_elev.F90
@@ -57,9 +57,12 @@ subroutine read_merra2_elev(n,findex)
   integer :: c,r
   real    :: go(LIS_rc%lnc(n),LIS_rc%lnr(n))
 
-  if ( trim(LIS_rc%met_ecor(findex)) .ne. "none") then 
+!  if ( trim(LIS_rc%met_ecor(findex)) .ne. "none") then 
+  if ( LIS_rc%met_ecor(findex) == "lapse-rate" .or. &
+        LIS_rc%met_ecor(findex) == "lapse-rate and slope-aspect" .or. &
+        LIS_rc%met_ecor(findex) == "micromet" ) then
 
-     write(LIS_logunit,*) '[INFO] Reading the MERRA2 elevation map ...'
+     write(LIS_logunit,*) '[INFO] Reading the MERRA2 elevation map '
      
      call LIS_read_param(n,"ELEV_MERRA2",go)
 


### PR DESCRIPTION
Replace this text with a concise description of *what* was changed and *why*.
 Two of the LIS met forcing readers did not support the new
  MicroMet topographic downscaling option, which included:

  GDAS and MERRA2

 This MicroMet option has been included and tested into those
  two readers.

If you would like a test case for this, I would be happy to provide one.

This addresses issue #1264 

