### PR TITLE
Fix/lisf75 lvt grib filenames

### DIFF
--- a/lvt/core/LVT_DataStreamsMod.F90
+++ b/lvt/core/LVT_DataStreamsMod.F90
@@ -440,6 +440,8 @@ contains
     type(LVT_lismetadataEntry), target :: SnowGrain
     type(LVT_lismetadataEntry), target :: SurftSnow
 
+    character*20 :: model_name ! EMK
+
     ! EMK...This is only used when LVT is run in "557 post" mode.
     if (trim(LVT_rc%runmode) .ne. "557 post") return
 
@@ -563,55 +565,78 @@ contains
           write(unit=cdate3, fmt='(i2.2,i2.2)') &
                LVT_rc%hr, LVT_rc%mn
 
+          ! EMK...Include LSM in GP section
+          if (trim(LVT_LIS_rc(1)%model_name) == "NOAH.3.9") then
+             model_name = "LIS-NOAH"
+          else if (trim(LVT_LIS_rc(1)%model_name) == "NOAHMP.4.0.1") then
+             model_name = "LIS-NOAHMP"
+          else if (trim(LVT_LIS_rc(1)%model_name) == "JULES.5.0") then
+             model_name = "LIS-JULES"
+          else
+             write(LVT_logunit,*)'[ERR] Unknown LSM selected'
+             write(LVT_logunit,*)&
+                  '[ERR] Must be NOAH.3.9, NOAHMP.4.0.1, or JULES.5.0'
+             write(LVT_logunit,*) &
+                  "[ERR] Update 'LIS output model name:' in lis.config" // &
+                  " and try again!"
+             call LVT_endrun()
+          end if
+
           ! EMK...Different file name convention for 24-hr data
           if (LVT_rc%tavgInterval == 86400) then
-             fname_mean = trim(LVT_rc%statsodir)// &
-                  '/PS.557WW_SC.' &
-                  //trim(LVT_rc%security_class)//'_DI.' &
-                  //trim(LVT_rc%data_category)//'_GP.' &
-                  //'LIS_GR.C0P09DEG_AR.'// &
-                  trim(LVT_rc%area_of_data)//'_PA.'&
-                  //'LIS24_DD.'// &
-                  trim(cdate2)//'_DT.' &
-                  //trim(cdate3)//'_DF.GR1'
 
-             fname_ssdev = trim(LVT_rc%statsodir)// &
-                  '/PS.557WW_SC.' &
-                  //trim(LVT_rc%security_class)//'_DI.' &
-                  //trim(LVT_rc%data_category)//'_GP.' &
-                  //'LIS_GR.C0P09DEG_AR.'// &
-                  trim(LVT_rc%area_of_data)//'_PA.' &
-                  //'LIS24_DD.'// &
-                  trim(cdate2)//'_DT.'//trim(cdate3)//'_DF_SSDEV.GR1'
+             fname_mean = trim(LVT_rc%statsodir) &
+                  //'/PS.557WW' &
+                  //'_SC.'//trim(LVT_rc%security_class) &
+                  //'_DI.'//trim(LVT_rc%data_category) &
+                  //'_GP.'//trim(model_name) &
+                  //'_GR.C0P09DEG' &
+                  //'_AR.'//trim(LVT_rc%area_of_data) &
+                  //'_PA.LIS24' &
+                  //'_DD.'//trim(cdate2) &
+                  //'_DT.'//trim(cdate3) &
+                  //'_DF.GR1'
+
+             ! FIXME:  Where to add SSDEV in filename?
+             fname_ssdev = trim(LVT_rc%statsodir) &
+                  //'/PS.557WW' &
+                  //'_SC.'//trim(LVT_rc%security_class) &
+                  //'_DI.'//trim(LVT_rc%data_category) &
+                  //'_GP.'//trim(model_name) &
+                  //'_GR.C0P09DEG' &
+                  //'_AR.'//trim(LVT_rc%area_of_data) &
+                  //'_PA.LIS24' &
+                  //'_DD.'//trim(cdate2) &
+                  //'_DT.'//trim(cdate3) &
+                  //'_DF_SSDEV.GR1'
           else
 
-             fname_mean = trim(LVT_rc%statsodir)// &
-                  ! '/PS.AFWA_SC.'//trim(LVT_rc%security_class)//&
-                  ! '_DI.'//trim(LVT_rc%distribution_class)//&
-                  ! '_DC.'//trim(LVT_rc%data_category)//&
-                  ! '_GP.LIS_GR.C0P25DEG_AR.'//&
+             fname_mean = trim(LVT_rc%statsodir) &
                   ! EMK...Update name convention
-                  '/PS.557WW_SC.'//trim(LVT_rc%security_class)// &
-                  '_DI.'//trim(LVT_rc%data_category)// &
-                  '_GP.LIS_GR.C0P09DEG_AR.'// &
-                  trim(LVT_rc%area_of_data)// &
-                  ! '_PA.03-HR-SUM_DD.'//&
-                  '_PA.LIS_DD.'// &
-                  trim(cdate2)//'_DT.'//trim(cdate3)//'_DF.GR1'
+                  //'/PS.557WW' &
+                  //'_SC.'//trim(LVT_rc%security_class) &
+                  //'_DI.'//trim(LVT_rc%data_category) &
+                  //'_GP.'//trim(model_name) &
+                  //'_GR.C0P09DEG' &
+                  //'_AR.'//trim(LVT_rc%area_of_data) &
+                  //'_PA.LIS' &
+                  //'_DD.'//trim(cdate2) &
+                  //'_DT.'//trim(cdate3) &
+                  //'_DF.GR1'
 
-             fname_ssdev = trim(LVT_rc%statsodir)//&
-                  ! '/PS.AFWA_SC.'//trim(LVT_rc%security_class)//&
-                  ! '_DI.'//trim(LVT_rc%distribution_class)//&
-                  ! '_DC.'//trim(LVT_rc%data_category)//&
-                  ! '_GP.LIS_GR.C0P25DEG_AR.'//&
+             fname_ssdev = trim(LVT_rc%statsodir) &
                   ! EMK...Update name convention
-                  '/PS.557WW_SC.'//trim(LVT_rc%security_class)// &
-                  '_DI.'//trim(LVT_rc%data_category)// &
-                  '_GP.LIS_GR.C0P09DEG_AR.'// &
-                  trim(LVT_rc%area_of_data)// &
-                  ! '_PA.03-HR-SUM_DD.'// &
-                  '_PA.LIS_DD.'// &
-                  trim(cdate2)//'_DT.'//trim(cdate3)//'_DF_SSDEV.GR1'
+                  ! FIXME Where to put SSDEV in filename?
+                  //'/PS.557WW' &
+                  //'_SC.'//trim(LVT_rc%security_class) &
+                  //'_DI.'//trim(LVT_rc%data_category) &
+                  //'_GP.'//trim(model_name) &
+                  //'_GR.C0P09DEG' &
+                  //'_AR.'//trim(LVT_rc%area_of_data) &
+                  //'_PA.LIS' &
+                  //'_DD.'//trim(cdate2) &
+                  //'_DT.'//trim(cdate3) &
+                  //'_DF_SSDEV.GR1'
 
           end if
 
@@ -689,58 +714,80 @@ contains
           write(unit=cdate3, fmt='(i2.2,i2.2)') &
                LVT_rc%hr, LVT_rc%mn
 
+          ! EMK...Include LSM in GP section
+          if (trim(LVT_LIS_rc(1)%model_name) == "NOAH.3.9") then
+             model_name = "LIS-NOAH"
+          else if (trim(LVT_LIS_rc(1)%model_name) == "NOAHMP.4.0.1") then
+             model_name = "LIS-NOAHMP"
+          else if (trim(LVT_LIS_rc(1)%model_name) == "JULES.5.0") then
+             model_name = "LIS-JULES"
+          else
+             write(LVT_logunit,*)'[ERR] Unknown LSM selected'
+             write(LVT_logunit,*)&
+                  '[ERR] Must be NOAH.3.9, NOAHMP.4.0.1, or JULES.5.0'
+             write(LVT_logunit,*) &
+                  "[ERR] Update 'LIS output model name:' in lis.config" // &
+                  " and try again!"
+             call LVT_endrun()
+          end if
+
           ! EMK...Different file name convention for 24-hr data
           if (LVT_rc%tavgInterval == 86400) then
-             fname_mean = trim(LVT_rc%statsodir)// &
-                  '/PS.557WW_SC.' &
-                  //trim(LVT_rc%security_class)//'_DI.' &
-                  //trim(LVT_rc%data_category)//'_GP.' &
-                  //'LIS_GR.C0P09DEG_AR.'// &
-                  trim(LVT_rc%area_of_data)//'_PA.' &
-                  //'LIS24_DD.'// &
-                  trim(cdate2)//'_DT.' &
-                  //trim(cdate3)//'_DF.GR2'
+             fname_mean = trim(LVT_rc%statsodir) &
+                  //'/PS.557WW' &
+                  //'_SC.'//trim(LVT_rc%security_class) &
+                  //'_DI.'//trim(LVT_rc%data_category) &
+                  //'_GP.'//trim(model_name) &
+                  //'_GR.C0P09DEG' &
+                  //'_AR.'//trim(LVT_rc%area_of_data) &
+                  //'_PA.LIS24' &
+                  //'_DD.'//trim(cdate2) &
+                  //'_DT.'//trim(cdate3) &
+                  //'_DF.GR2'
 
              if (LVT_rc%nensem > 1) then
-                fname_ssdev = trim(LVT_rc%statsodir)// &
-                     '/PS.557WW_SC.' &
-                     //trim(LVT_rc%security_class)//'_DI.' &
-                     //trim(LVT_rc%data_category)//'_GP.' &
-                     //'LIS_GR.C0P09DEG_AR.'// &
-                     trim(LVT_rc%area_of_data)//'_PA.' &
-                     //'LIS24_DD.'// &
-                     trim(cdate2)//'_DT.'//trim(cdate3)//'_DF_SSDEV.GR2'
+                ! FIXME Where to put SSDEV in filename?
+                fname_ssdev = trim(LVT_rc%statsodir) &
+                     //'/PS.557WW' &
+                     //'_SC.'//trim(LVT_rc%security_class) &
+                     //'_DI.'//trim(LVT_rc%data_category) &
+                     //'_GP.'//trim(model_name) &
+                     //'_GR.C0P09DEG' &
+                     //'_AR.'//trim(LVT_rc%area_of_data) &
+                     //'_PA.LIS24' &
+                     //'_DD.'//trim(cdate2) &
+                     //'_DT.'//trim(cdate3) &
+                     //'_DF_SSDEV.GR2'
              end if
           else
              ! EMK...Assume 3-hr
-             fname_mean = trim(LVT_rc%statsodir)// &
-                  ! '/PS.AFWA_SC.'//trim(LVT_rc%security_class)//&
-                  ! '_DI.'//trim(LVT_rc%distribution_class)//&
-                  ! '_DC.'//trim(LVT_rc%data_category)//&
-                  ! '_GP.LIS_GR.C0P25DEG_AR.'//&
+             fname_mean = trim(LVT_rc%statsodir) &
                   ! EMK...Update name convention
-                  '/PS.557WW_SC.'//trim(LVT_rc%security_class)// &
-                  '_DI.'//trim(LVT_rc%data_category)// &
-                  '_GP.LIS_GR.C0P09DEG_AR.'// &
-                  trim(LVT_rc%area_of_data)// &
-                  ! '_PA.03-HR-SUM_DD.'//&
-                  '_PA.LIS_DD.'// &
-                  trim(cdate2)//'_DT.'//trim(cdate3)//'_DF.GR2'
+                  //'/PS.557WW' &
+                  //'_SC.'//trim(LVT_rc%security_class) &
+                  //'_DI.'//trim(LVT_rc%data_category) &
+                  //'_GP.'//trim(model_name) &
+                  //'_GR.C0P09DEG' &
+                  //'_AR.'//trim(LVT_rc%area_of_data) &
+                  //'_PA.LIS' &
+                  //'_DD.'//trim(cdate2) &
+                  //'_DT.'//trim(cdate3) &
+                  //'_DF.GR2'
 
              if (LVT_rc%nensem > 1) then
-                fname_ssdev = trim(LVT_rc%statsodir)// &
-                     ! '/PS.AFWA_SC.'//trim(LVT_rc%security_class)//&
-                     ! '_DI.'//trim(LVT_rc%distribution_class)//&
-                     ! '_DC.'//trim(LVT_rc%data_category)//&
-                     ! '_GP.LIS_GR.C0P25DEG_AR.'//&
+                fname_ssdev = trim(LVT_rc%statsodir) &
                      ! EMK...Update name convention
-                     '/PS.557WW_SC.'//trim(LVT_rc%security_class)// &
-                     '_DI.'//trim(LVT_rc%data_category)// &
-                     '_GP.LIS_GR.C0P09DEG_AR.'// &
-                     trim(LVT_rc%area_of_data)// &
-                     ! '_PA.03-HR-SUM_DD.'//&
-                     '_PA.LIS_DD.'// &
-                     trim(cdate2)//'_DT.'//trim(cdate3)//'_DF_SSDEV.GR2'
+                     ! FIXME Where to put SSDEV in filename?
+                     //'/PS.557WW' &
+                     //'_SC.'//trim(LVT_rc%security_class) &
+                     //'_DI.'//trim(LVT_rc%data_category) &
+                     //'_GP.'//trim(model_name) &
+                     //'_GR.C0P09DEG' &
+                     //'_AR.'//trim(LVT_rc%area_of_data) &
+                     //'_PA.LIS' &
+                     //'_DD.'//trim(cdate2) &
+                     //'_DT.'//trim(cdate3) &
+                     //'_DF_SSDEV.GR2'
              end if
           end if
           ! Setup of GRIB-1 and GRIB-2 Metadata Section
@@ -821,58 +868,80 @@ contains
           write(unit=cdate3, fmt='(i2.2,i2.2)') &
                LVT_rc%hr, LVT_rc%mn
 
+                    ! EMK...Include LSM in GP section
+          if (trim(LVT_LIS_rc(1)%model_name) == "NOAH.3.9") then
+             model_name = "LIS-NOAH"
+          else if (trim(LVT_LIS_rc(1)%model_name) == "NOAHMP.4.0.1") then
+             model_name = "LIS-NOAHMP"
+          else if (trim(LVT_LIS_rc(1)%model_name) == "JULES.5.0") then
+             model_name = "LIS-JULES"
+          else
+             write(LVT_logunit,*)'[ERR] Unknown LSM selected'
+             write(LVT_logunit,*)&
+                  '[ERR] Must be NOAH.3.9, NOAHMP.4.0.1, or JULES.5.0'
+             write(LVT_logunit,*) &
+                  "[ERR] Update 'LIS output model name:' in lis.config" // &
+                  " and try again!"
+             call LVT_endrun()
+          end if
+
           ! EMK...Different file name convention for 24-hr data
           if (LVT_rc%tavgInterval == 86400) then
-             fname_mean = trim(LVT_rc%statsodir)// &
-                  '/PS.557WW_SC.' &
-                  //trim(LVT_rc%security_class)//'_DI.' &
-                  //trim(LVT_rc%data_category)//'_GP.' &
-                  //'LIS_GR.C0P09DEG_AR.'// &
-                  trim(LVT_rc%area_of_data)//'_PA.' &
-                  //'LIS24_DD.'// &
-                  trim(cdate2)//'_DT.' &
-                  //trim(cdate3)//'_DF.nc'
+             fname_mean = trim(LVT_rc%statsodir) &
+                  //'/PS.557WW' &
+                  //'_SC.'//trim(LVT_rc%security_class) &
+                  //'_DI.'//trim(LVT_rc%data_category) &
+                  //'_GP.'//trim(model_name) &
+                  //'_GR.C0P09DEG' &
+                  //'_AR.'//trim(LVT_rc%area_of_data) &
+                  //'_PA.LIS24' &
+                  //'_DD.'//trim(cdate2) &
+                  //'_DT.'//trim(cdate3) &
+                  //'_DF.nc'
 
              if (LVT_rc%nensem > 1) then
-                fname_ssdev = trim(LVT_rc%statsodir)// &
-                     '/PS.557WW_SC.' &
-                     //trim(LVT_rc%security_class)//'_DI.' &
-                     //trim(LVT_rc%data_category)//'_GP.' &
-                     //'LIS_GR.C0P09DEG_AR.'// &
-                     trim(LVT_rc%area_of_data)//'_PA.' &
-                     //'LIS24_DD.'// &
-                     trim(cdate2)//'_DT.'//trim(cdate3)//'_DF_SSDEV.nc'
+                ! FIXME Where to put SSDEV in filename?
+                fname_ssdev = trim(LVT_rc%statsodir) &
+                     //'/PS.557WW' &
+                     //'_SC.'//trim(LVT_rc%security_class) &
+                     //'_DI.'//trim(LVT_rc%data_category) &
+                     //'_GP.'//trim(model_name) &
+                     //'_GR.C0P09DEG' &
+                     //'_AR.'//trim(LVT_rc%area_of_data) &
+                     //'_PA.LIS24' &
+                     //'_DD.'//trim(cdate2) &
+                     //'_DT.'//trim(cdate3) &
+                     //'_DF_SSDEV.nc'
              end if
           else
 
-             fname_mean = trim(LVT_rc%statsodir)// &
-                  ! '/PS.AFWA_SC.'//trim(LVT_rc%security_class)//&
-                  ! '_DI.'//trim(LVT_rc%distribution_class)//&
-                  ! '_DC.'//trim(LVT_rc%data_category)//&
-                  ! '_GP.LIS_GR.C0P25DEG_AR.'//&
+             fname_mean = trim(LVT_rc%statsodir) &
                   ! EMK...Update name convention
-                  '/PS.557WW_SC.'//trim(LVT_rc%security_class)// &
-                  '_DI.'//trim(LVT_rc%data_category)// &
-                  '_GP.LIS_GR.C0P09DEG_AR.'// &
-                  trim(LVT_rc%area_of_data)// &
-                  ! '_PA.03-HR-SUM_DD.'//&
-                  '_PA.LIS_DD.'// &
-                  trim(cdate2)//'_DT.'//trim(cdate3)//'_DF.nc'
+                  //'/PS.557WW' &
+                  //'_SC.'//trim(LVT_rc%security_class) &
+                  //'_DI.'//trim(LVT_rc%data_category) &
+                  //'_GP.'//trim(model_name) &
+                  //'_GR.C0P09DEG' &
+                  //'_AR.'//trim(LVT_rc%area_of_data) &
+                  //'_PA.LIS' &
+                  //'_DD.'//trim(cdate2) &
+                  //'_DT.'//trim(cdate3) &
+                  //'_DF.nc'
 
              if (LVT_rc%nensem > 1) then
-                fname_ssdev = trim(LVT_rc%statsodir)// &
-                     ! '/PS.AFWA_SC.'//trim(LVT_rc%security_class)//&
-                     ! '_DI.'//trim(LVT_rc%distribution_class)//&
-                     ! '_DC.'//trim(LVT_rc%data_category)//&
-                     ! '_GP.LIS_GR.C0P25DEG_AR.'//&
+                ! FIXME Where to put SSDEV in filename?
+                fname_ssdev = trim(LVT_rc%statsodir) &
                      ! EMK...Update name convention
-                     '/PS.557WW_SC.'//trim(LVT_rc%security_class)// &
-                     '_DI.'//trim(LVT_rc%data_category)// &
-                     '_GP.LIS_GR.C0P09DEG_AR.'// &
-                     trim(LVT_rc%area_of_data)// &
-                     ! '_PA.03-HR-SUM_DD.'//&
-                     '_PA.LIS_DD.'// &
-                     trim(cdate2)//'_DT.'//trim(cdate3)//'_DF_SSDEV.nc'
+                     //'/PS.557WW' &
+                     //'_SC.'//trim(LVT_rc%security_class) &
+                     //'_DI.'//trim(LVT_rc%data_category) &
+                     //'_GP.'//trim(model_name) &
+                     //'_GR.C0P09DEG' &
+                     //'_AR.'//trim(LVT_rc%area_of_data) &
+                     //'_PA.LIS' &
+                     //'_DD.'//trim(cdate2) &
+                     //'_DT.'//trim(cdate3) &
+                     //'_DF_SSDEV.nc'
              end if
           end if
           ! Setup of GRIB-1 and GRIB-2 Metadata Section

--- a/lvt/core/LVT_DataStreamsMod.F90
+++ b/lvt/core/LVT_DataStreamsMod.F90
@@ -597,7 +597,6 @@ contains
                   //'_DT.'//trim(cdate3) &
                   //'_DF.GR1'
 
-             ! FIXME:  Where to add SSDEV in filename?
              fname_ssdev = trim(LVT_rc%statsodir) &
                   //'/PS.557WW' &
                   //'_SC.'//trim(LVT_rc%security_class) &
@@ -605,14 +604,13 @@ contains
                   //'_GP.'//trim(model_name) &
                   //'_GR.C0P09DEG' &
                   //'_AR.'//trim(LVT_rc%area_of_data) &
-                  //'_PA.LIS24' &
+                  //'_PA.LIS24-SSDEV' &
                   //'_DD.'//trim(cdate2) &
                   //'_DT.'//trim(cdate3) &
-                  //'_DF_SSDEV.GR1'
+                  //'_DF.GR1'
           else
 
              fname_mean = trim(LVT_rc%statsodir) &
-                  ! EMK...Update name convention
                   //'/PS.557WW' &
                   //'_SC.'//trim(LVT_rc%security_class) &
                   //'_DI.'//trim(LVT_rc%data_category) &
@@ -625,18 +623,16 @@ contains
                   //'_DF.GR1'
 
              fname_ssdev = trim(LVT_rc%statsodir) &
-                  ! EMK...Update name convention
-                  ! FIXME Where to put SSDEV in filename?
                   //'/PS.557WW' &
                   //'_SC.'//trim(LVT_rc%security_class) &
                   //'_DI.'//trim(LVT_rc%data_category) &
                   //'_GP.'//trim(model_name) &
                   //'_GR.C0P09DEG' &
                   //'_AR.'//trim(LVT_rc%area_of_data) &
-                  //'_PA.LIS' &
+                  //'_PA.SSDEV' &
                   //'_DD.'//trim(cdate2) &
                   //'_DT.'//trim(cdate3) &
-                  //'_DF_SSDEV.GR1'
+                  //'_DF.GR1'
 
           end if
 
@@ -746,7 +742,6 @@ contains
                   //'_DF.GR2'
 
              if (LVT_rc%nensem > 1) then
-                ! FIXME Where to put SSDEV in filename?
                 fname_ssdev = trim(LVT_rc%statsodir) &
                      //'/PS.557WW' &
                      //'_SC.'//trim(LVT_rc%security_class) &
@@ -754,15 +749,14 @@ contains
                      //'_GP.'//trim(model_name) &
                      //'_GR.C0P09DEG' &
                      //'_AR.'//trim(LVT_rc%area_of_data) &
-                     //'_PA.LIS24' &
+                     //'_PA.LIS24-SSDEV' &
                      //'_DD.'//trim(cdate2) &
                      //'_DT.'//trim(cdate3) &
-                     //'_DF_SSDEV.GR2'
+                     //'_DF.GR2'
              end if
           else
              ! EMK...Assume 3-hr
              fname_mean = trim(LVT_rc%statsodir) &
-                  ! EMK...Update name convention
                   //'/PS.557WW' &
                   //'_SC.'//trim(LVT_rc%security_class) &
                   //'_DI.'//trim(LVT_rc%data_category) &
@@ -776,18 +770,16 @@ contains
 
              if (LVT_rc%nensem > 1) then
                 fname_ssdev = trim(LVT_rc%statsodir) &
-                     ! EMK...Update name convention
-                     ! FIXME Where to put SSDEV in filename?
                      //'/PS.557WW' &
                      //'_SC.'//trim(LVT_rc%security_class) &
                      //'_DI.'//trim(LVT_rc%data_category) &
                      //'_GP.'//trim(model_name) &
                      //'_GR.C0P09DEG' &
                      //'_AR.'//trim(LVT_rc%area_of_data) &
-                     //'_PA.LIS' &
+                     //'_PA.SSDEV' &
                      //'_DD.'//trim(cdate2) &
                      //'_DT.'//trim(cdate3) &
-                     //'_DF_SSDEV.GR2'
+                     //'_DF.GR2'
              end if
           end if
           ! Setup of GRIB-1 and GRIB-2 Metadata Section
@@ -868,7 +860,7 @@ contains
           write(unit=cdate3, fmt='(i2.2,i2.2)') &
                LVT_rc%hr, LVT_rc%mn
 
-                    ! EMK...Include LSM in GP section
+          ! EMK...Include LSM in GP section
           if (trim(LVT_LIS_rc(1)%model_name) == "NOAH.3.9") then
              model_name = "LIS-NOAH"
           else if (trim(LVT_LIS_rc(1)%model_name) == "NOAHMP.4.0.1") then
@@ -900,7 +892,6 @@ contains
                   //'_DF.nc'
 
              if (LVT_rc%nensem > 1) then
-                ! FIXME Where to put SSDEV in filename?
                 fname_ssdev = trim(LVT_rc%statsodir) &
                      //'/PS.557WW' &
                      //'_SC.'//trim(LVT_rc%security_class) &
@@ -908,15 +899,14 @@ contains
                      //'_GP.'//trim(model_name) &
                      //'_GR.C0P09DEG' &
                      //'_AR.'//trim(LVT_rc%area_of_data) &
-                     //'_PA.LIS24' &
+                     //'_PA.LIS24-SSDEV' &
                      //'_DD.'//trim(cdate2) &
                      //'_DT.'//trim(cdate3) &
-                     //'_DF_SSDEV.nc'
+                     //'_DF.nc'
              end if
           else
 
              fname_mean = trim(LVT_rc%statsodir) &
-                  ! EMK...Update name convention
                   //'/PS.557WW' &
                   //'_SC.'//trim(LVT_rc%security_class) &
                   //'_DI.'//trim(LVT_rc%data_category) &
@@ -929,19 +919,17 @@ contains
                   //'_DF.nc'
 
              if (LVT_rc%nensem > 1) then
-                ! FIXME Where to put SSDEV in filename?
                 fname_ssdev = trim(LVT_rc%statsodir) &
-                     ! EMK...Update name convention
                      //'/PS.557WW' &
                      //'_SC.'//trim(LVT_rc%security_class) &
                      //'_DI.'//trim(LVT_rc%data_category) &
                      //'_GP.'//trim(model_name) &
                      //'_GR.C0P09DEG' &
                      //'_AR.'//trim(LVT_rc%area_of_data) &
-                     //'_PA.LIS' &
+                     //'_PA.SSDEV' &
                      //'_DD.'//trim(cdate2) &
                      //'_DT.'//trim(cdate3) &
-                     //'_DF_SSDEV.nc'
+                     //'_DF.nc'
              end if
           end if
           ! Setup of GRIB-1 and GRIB-2 Metadata Section

--- a/lvt/utils/usaf/cat_lvt_grib2.py
+++ b/lvt/utils/usaf/cat_lvt_grib2.py
@@ -34,6 +34,7 @@
 # 05 Aug 2020:  Eric Kemp (SSAI), added Albedo_tavg and SmLiqFrac_inst for
 #               JULES.
 # 05 Dec 2022:  Eric Kemp (SSAI), updates to improve pylint score.
+# 24 Jan 2023:  Eric Kemp (SSAI), updates to GRIB file names.
 #
 #------------------------------------------------------------------------------
 """
@@ -237,7 +238,7 @@ def _get_gr2_mean_files(validdt, lsm, period):
     # Collect input files
     for invocation in invocation_list:
         path = f"OUTPUT/STATS.{invocation}.{period}hr"
-        path += "/PS.557WW_SC.U_DI.C_GP.LIS_GR.C0P09DEG_AR.GLOBAL_PA"
+        path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
         if period == 24:
             path += ".LIS24_DD."
         else:
@@ -255,7 +256,7 @@ def _get_gr2_mean_files(validdt, lsm, period):
     path = f"OUTPUT/STATS_merged_{period}hr"
     if not os.path.exists(path):
         os.mkdir(path)
-    path += "/PS.557WW_SC.U_DI.C_GP.LIS_GR.C0P09DEG_AR.GLOBAL_PA"
+    path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
     if period == 24:
         path += ".LIS24_DD."
     else:
@@ -279,7 +280,7 @@ def _get_gr2_ssdev_files(validdt, lsm, period):
     # Collect input files
     for invocation in invocation_list:
         path = f"OUTPUT/STATS.{invocation}.{period}hr"
-        path += "/PS.557WW_SC.U_DI.C_GP.LIS_GR.C0P09DEG_AR.GLOBAL_PA"
+        path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
         if period == 24:
             path += ".LIS24_DD."
         else:
@@ -297,7 +298,7 @@ def _get_gr2_ssdev_files(validdt, lsm, period):
     path = f"OUTPUT/STATS_merged_{period}hr"
     if not os.path.exists(path):
         os.mkdir(path)
-    path += "/PS.557WW_SC.U_DI.C_GP.LIS_GR.C0P09DEG_AR.GLOBAL_PA"
+    path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
     if period == 24:
         path += ".LIS24_DD."
     else:
@@ -322,7 +323,7 @@ def _get_gr2_latest_files(validdt, lsm):
     # Collect input files
     for invocation in invocation_list:
         path = f"OUTPUT/STATS.{invocation}.3hr" # Always use 3hr processing
-        path += "/PS.557WW_SC.U_DI.C_GP.LIS_GR.C0P09DEG_AR.GLOBAL_PA"
+        path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
         path += ".LIS_DD."
         path += f"{validdt.year:04}{validdt.month:02}{validdt.day:02}_DT"
         path += f".{validdt.hour:02}00_DF"

--- a/lvt/utils/usaf/cat_lvt_grib2.py
+++ b/lvt/utils/usaf/cat_lvt_grib2.py
@@ -282,13 +282,13 @@ def _get_gr2_ssdev_files(validdt, lsm, period):
         path = f"OUTPUT/STATS.{invocation}.{period}hr"
         path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
         if period == 24:
-            path += ".LIS24_DD."
+            path += ".LIS24-SSDEV_DD."
         else:
-            path += ".LIS_DD."
+            path += ".SSDEV_DD."
         path += f"{validdt.year:04}{validdt.month:02}{validdt.day:02}_DT"
         path += f".{validdt.hour:02}00_DF"
 
-        ssdev_path = path + "_SSDEV.GR2"
+        ssdev_path = path + ".GR2"
         if not os.path.exists(ssdev_path):
             print(f"[ERR], {ssdev_path} does not exist!")
             sys.exit(1)
@@ -300,13 +300,13 @@ def _get_gr2_ssdev_files(validdt, lsm, period):
         os.mkdir(path)
     path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
     if period == 24:
-        path += ".LIS24_DD."
+        path += ".LIS24-SSDEV_DD."
     else:
-        path += ".LIS_DD."
+        path += ".SSDEV_DD."
     path += f"{validdt.year:04}{validdt.month:02}{validdt.day:02}_DT"
     path += f".{validdt.hour:02}00_DF"
 
-    ssdev_gr2_outfile = path + "_SSDEV.GR2"
+    ssdev_gr2_outfile = path + ".GR2"
 
     # All done
     return ssdev_gr2_infiles, ssdev_gr2_outfile

--- a/lvt/utils/usaf/run_ncks.py
+++ b/lvt/utils/usaf/run_ncks.py
@@ -424,13 +424,13 @@ def _get_nc_ssdev_files(validdt, lsm, period):
         path = f"OUTPUT/STATS.{invocation}.{period}hr"
         path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
         if period == 24:
-            path += ".LIS24_DD."
+            path += ".LIS24-SSDEV_DD."
         else:
-            path += ".LIS_DD."
+            path += ".SSDEV_DD."
         path += f"{validdt.year:04}{validdt.month:02}{validdt.day:02}_DT"
         path += f".{validdt.hour:02}00_DF"
 
-        ssdev_path = path + "_SSDEV.nc"
+        ssdev_path = path + ".nc"
         if not os.path.exists(ssdev_path):
             print(f"[ERR], {ssdev_path} does not exist!")
             sys.exit(1)
@@ -443,13 +443,13 @@ def _get_nc_ssdev_files(validdt, lsm, period):
         os.mkdir(path)
     path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
     if period == 24:
-        path += ".LIS24_DD."
+        path += ".LIS24-SSDEV_DD."
     else:
-        path += ".LIS_DD."
+        path += ".SSDEV_DD."
     path += f"{validdt.year:04}{validdt.month:02}{validdt.day:02}_DT"
     path += f".{validdt.hour:02}00_DF"
 
-    ssdev_nc_outfile = path + "_SSDEV.nc"
+    ssdev_nc_outfile = path + ".nc"
 
     # All done
     return ssdev_nc_infiles, ssdev_nc_outfile

--- a/lvt/utils/usaf/run_ncks.py
+++ b/lvt/utils/usaf/run_ncks.py
@@ -50,6 +50,7 @@
 # 23 Mar 2021:  Eric Kemp (SSAI), revised JULES multi-layer snow variables
 #               for PS41 physics.
 # 05 Dec 2022:  Eric Kemp (SSAI), revised to improve pylint score.
+# 24 Jan 2023:  Eric Kemp (SSAI), updated filenames.
 #
 #------------------------------------------------------------------------------
 """
@@ -63,8 +64,6 @@ import sys
 #------------------------------------------------------------------------------
 
 # Path to NCO ncks program
-# _NCKS_PATH = "/app/nco/4.5.2-gnu/bin/ncks" # On Conrad
-# _NCKS_PATH = "/app/nco/4.7.7-gnu/bin/ncks" # On Koehr
 _NCKS_PATH = "/usr/local/other/nco/4.8.1/bin/ncks" # On Discover
 
 # Supported LIS LSMs
@@ -380,7 +379,7 @@ def _get_nc_mean_files(validdt, lsm, period):
 
         path = f"OUTPUT/STATS.{invocation}.{period}hr"
 
-        path += "/PS.557WW_SC.U_DI.C_GP.LIS_GR.C0P09DEG_AR.GLOBAL_PA"
+        path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
         if period == 24:
             path += ".LIS24_DD."
         else:
@@ -399,7 +398,7 @@ def _get_nc_mean_files(validdt, lsm, period):
     path = f"OUTPUT/STATS_merged_{period}hr"
     if not os.path.exists(path):
         os.mkdir(path)
-    path += "/PS.557WW_SC.U_DI.C_GP.LIS_GR.C0P09DEG_AR.GLOBAL_PA"
+    path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
     if period == 24:
         path += ".LIS24_DD."
     else:
@@ -423,7 +422,7 @@ def _get_nc_ssdev_files(validdt, lsm, period):
     # Collect input files
     for invocation in invocation_list:
         path = f"OUTPUT/STATS.{invocation}.{period}hr"
-        path += "/PS.557WW_SC.U_DI.C_GP.LIS_GR.C0P09DEG_AR.GLOBAL_PA"
+        path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
         if period == 24:
             path += ".LIS24_DD."
         else:
@@ -442,7 +441,7 @@ def _get_nc_ssdev_files(validdt, lsm, period):
     path = f"OUTPUT/STATS_merged_{period}hr"
     if not os.path.exists(path):
         os.mkdir(path)
-    path += "/PS.557WW_SC.U_DI.C_GP.LIS_GR.C0P09DEG_AR.GLOBAL_PA"
+    path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
     if period == 24:
         path += ".LIS24_DD."
     else:
@@ -466,7 +465,7 @@ def _get_nc_latest_files(validdt, lsm):
     # Collect input files
     for invocation in invocation_list:
         path = f"OUTPUT/STATS.{invocation}.3hr"# Always use 3hr processing
-        path += "/PS.557WW_SC.U_DI.C_GP.LIS_GR.C0P09DEG_AR.GLOBAL_PA"
+        path += f"/PS.557WW_SC.U_DI.C_GP.LIS-{lsm}_GR.C0P09DEG_AR.GLOBAL_PA"
         path += ".LIS_DD."  # Always use 3-hr output for latest fields
         path += f"{validdt.year:04}{validdt.month:02}{validdt.day:02}_DT"
         path += f".{validdt.hour:02}00_DF"

--- a/lvt/utils/usaf/templates/make_lvt_config_24hr_noah.py
+++ b/lvt/utils/usaf/templates/make_lvt_config_24hr_noah.py
@@ -20,11 +20,11 @@ import os
 
 _TEMPLATE = "templates/lvt.config.template.noah39"
 
-_STARTDT = datetime.datetime(2007, 12, 1, 12)
-_ENDDT = datetime.datetime(2007, 12, 2, 12)
+_STARTDT = datetime.datetime(2022, 8, 1, 12)
+_ENDDT = datetime.datetime(2022, 8, 2, 12)
 
-_OUTPUT = "netcdf"
-#_OUTPUT = "grib2"
+#_OUTPUT = "netcdf"
+_OUTPUT = "grib2"
 
 # Most variables are processed independently, and are listed below.
 _VAR_ATTRIBUTES = {
@@ -119,7 +119,7 @@ def _main():
                 else:
                     line += f"{_VAR_ATTRIBUTES[var]}\n"
             elif "Metrics attributes file:" in line:
-                line = 'Metrics attributes file: "tables/METRICS.TBL"\n'
+                line = 'Metrics attributes file: "templates/METRICS.TBL"\n'
             elif "Metrics computation frequency:" in line:
                 line = 'Metrics computation frequency: "24hr"\n'
             elif "Metrics output directory:" in line:
@@ -128,7 +128,8 @@ def _main():
                 line = 'Metrics output frequency: "24hr"\n'
             elif "LIS output attributes file:" in line:
                 line = "LIS output attributes file:"
-                line += f" ./tables/MODEL_OUTPUT_LIST.TBL.lvt_557post.{var}.24hr\n"
+                line += \
+                 f" ./templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.{var}.24hr\n"
 
             newlines.append(line)
 

--- a/lvt/utils/usaf/templates/make_lvt_config_24hr_noahmp.py
+++ b/lvt/utils/usaf/templates/make_lvt_config_24hr_noahmp.py
@@ -21,11 +21,11 @@ import os
 
 _TEMPLATE = "templates/lvt.config.template.noahmp401"
 
-_STARTDT = datetime.datetime(2007, 12, 1, 12)
-_ENDDT = datetime.datetime(2007, 12, 2, 12)
+_STARTDT = datetime.datetime(2022, 8, 1, 12)
+_ENDDT = datetime.datetime(2022, 8, 2, 12)
 
-_OUTPUT = "netcdf"
-#_OUTPUT = "grib2"
+#_OUTPUT = "netcdf"
+_OUTPUT = "grib2"
 
 # Most variables are processed independently, and are listed below.
 _VAR_ATTRIBUTES = {
@@ -117,7 +117,7 @@ def _main():
                 else:
                     line += f"{_VAR_ATTRIBUTES[var]}\n"
             elif "Metrics attributes file:" in line:
-                line = 'Metrics attributes file: "tables/METRICS.TBL"\n'
+                line = 'Metrics attributes file: "templates/METRICS.TBL"\n'
             elif "Metrics computation frequency:" in line:
                 line = 'Metrics computation frequency: "24hr"\n'
             elif "Metrics output directory:" in line:
@@ -126,7 +126,7 @@ def _main():
                 line = 'Metrics output frequency: "24hr"\n'
             elif "LIS output attributes file:" in line:
                 line = "LIS output attributes file:"
-                line += f" ./tables/MODEL_OUTPUT_LIST.TBL.lvt_557post.{var}.24hr\n"
+                line += f" ./templates/MODEL_OUTPUT_LIST.TBL.lvt_557post.{var}.24hr\n"
 
             newlines.append(line)
 

--- a/lvt/utils/usaf/templates/make_lvt_config_3hr_jules.py
+++ b/lvt/utils/usaf/templates/make_lvt_config_3hr_jules.py
@@ -20,8 +20,8 @@ import os
 
 _TEMPLATE = "templates/lvt.config.template.jules50"
 
-_STARTDT = datetime.datetime(2021, 4, 13,  9)
-_ENDDT = datetime.datetime(2021, 4, 13,  12)
+_STARTDT = datetime.datetime(2022, 8, 2,  9)
+_ENDDT = datetime.datetime(2022, 8, 2,  12)
 
 _OUTPUT = "netcdf" # For 557 Ops (Fields file)
 #_OUTPUT = "grib2"

--- a/lvt/utils/usaf/templates/make_lvt_config_3hr_noah.py
+++ b/lvt/utils/usaf/templates/make_lvt_config_3hr_noah.py
@@ -20,8 +20,8 @@ import os
 
 _TEMPLATE = "templates/lvt.config.template.noah39"
 
-_STARTDT = datetime.datetime(2021, 4, 13, 0)
-_ENDDT = datetime.datetime(2021, 4, 13, 12)
+_STARTDT = datetime.datetime(2022, 8, 2, 6)
+_ENDDT = datetime.datetime(2022, 8, 2, 12)
 
 _OUTPUT = "grib2" # For 557 operations
 #_OUTPUT = "netcdf" # For testing

--- a/lvt/utils/usaf/templates/make_lvt_config_3hr_noahmp.py
+++ b/lvt/utils/usaf/templates/make_lvt_config_3hr_noahmp.py
@@ -20,8 +20,8 @@ import os
 
 _TEMPLATE = "templates/lvt.config.template.noahmp401"
 
-_STARTDT = datetime.datetime(2021, 4, 13, 0)
-_ENDDT = datetime.datetime(2021, 4, 13, 12)
+_STARTDT = datetime.datetime(2022, 8, 2, 6)
+_ENDDT = datetime.datetime(2022, 8, 2, 12)
 
 _OUTPUT = "grib2"  # For 557 ops
 #_OUTPUT = "netcdf" # For debugging

--- a/lvt/utils/usaf/templates/submit_lvt_discover_24hr_noah.py
+++ b/lvt/utils/usaf/templates/submit_lvt_discover_24hr_noah.py
@@ -49,9 +49,8 @@ if [ ! -z $SLURM_SUBMIT_DIR ] ; then
 fi
 
 module purge
-module use --append ~/privatemodules
-module load lisf_7.5_intel_2021.4.0
-
+module use --append /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf75_lvt_grib_filenames/LISF/env/discover
+module load lisf_7_intel_2021.4.0_petsc
 
 if [ ! -e ./LVT ] ; then
    echo "ERROR, LVT does not exist!" && exit 1

--- a/lvt/utils/usaf/templates/submit_lvt_discover_24hr_noahmp.py
+++ b/lvt/utils/usaf/templates/submit_lvt_discover_24hr_noahmp.py
@@ -52,8 +52,8 @@ if [ ! -z $SLURM_SUBMIT_DIR ] ; then
 fi
 
 module purge
-module use --append ~/privatemodules
-module load lisf_7.5_intel_2021.4.0
+module use --append /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf75_lvt_grib_filenames/LISF/env/discover
+module load lisf_7_intel_2021.4.0_petsc
 
 if [ ! -e ./LVT ] ; then
    echo "ERROR, LVT does not exist!" && exit 1

--- a/lvt/utils/usaf/templates/submit_lvt_discover_3hr_jules.py
+++ b/lvt/utils/usaf/templates/submit_lvt_discover_3hr_jules.py
@@ -72,8 +72,8 @@ if [ ! -z $SLURM_SUBMIT_DIR ] ; then
 fi
 
 module purge
-module use --append ~/privatemodules
-module load lisf_7.5_intel_2021.4.0
+module use --append /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf75_lvt_grib_filenames/LISF/env/discover
+module load lisf_7_intel_2021.4.0_petsc
 
 if [ ! -e ./LVT ] ; then
    echo "ERROR, LVT does not exist!" && exit 1

--- a/lvt/utils/usaf/templates/submit_lvt_discover_3hr_noah.py
+++ b/lvt/utils/usaf/templates/submit_lvt_discover_3hr_noah.py
@@ -63,8 +63,8 @@ if [ ! -z $SLURM_SUBMIT_DIR ] ; then
 fi
 
 module purge
-module use --append ~/privatemodules
-module load lisf_7.5_intel_2021.4.0
+module use --append /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf75_lvt_grib_filenames/LISF/env/discover
+module load lisf_7_intel_2021.4.0_petsc
 
 if [ ! -e ./LVT ] ; then
    echo "ERROR, LVT does not exist!" && exit 1

--- a/lvt/utils/usaf/templates/submit_lvt_discover_3hr_noahmp.py
+++ b/lvt/utils/usaf/templates/submit_lvt_discover_3hr_noahmp.py
@@ -64,8 +64,8 @@ if [ ! -z $SLURM_SUBMIT_DIR ] ; then
 fi
 
 module purge
-module use --append ~/privatemodules
-module load lisf_7.5_intel_2021.4.0
+module use --append /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf75_lvt_grib_filenames/LISF/env/discover
+module load lisf_7_intel_2021.4.0_petsc
 
 
 if [ ! -e ./LVT ] ; then


### PR DESCRIPTION


### Description

Updates to LVT and postprocessing scripts to use new file names for postprocessed data.  Based on requirements issued by 557 WW.


