### PR TITLE
Correct dimensions of tmp_sfcheadrt, tmp_infxs1rt, and tmp_soldrain1rt

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
@@ -242,9 +242,9 @@ subroutine NoahMP401_main(n)
     ! Code added by David Mocko 04/25/2019
     real                 :: startsm, startswe, startint, startgw, endsm
    
-    real                 :: tmp_sfcheadrt          ! extra input  for WRF-HYDRO [m]
-    real                 :: tmp_infxs1rt           ! extra output for WRF-HYDRO [m]
-    real                 :: tmp_soldrain1rt        ! extra output for WRF-HYDRO [m]
+    real, dimension(1,1) :: tmp_sfcheadrt          ! extra input  for WRF-HYDRO [m]
+    real, dimension(1,1) :: tmp_infxs1rt           ! extra output for WRF-HYDRO [m]
+    real, dimension(1,1) :: tmp_soldrain1rt        ! extra output for WRF-HYDRO [m]
 
         !ag (05Jan2021)
     real                 :: tmp_rivsto
@@ -866,8 +866,8 @@ subroutine NoahMP401_main(n)
             NOAHMP401_struc(n)%noahmp401(t)%chuc      = tmp_chuc
             NOAHMP401_struc(n)%noahmp401(t)%chv2      = tmp_chv2
             NOAHMP401_struc(n)%noahmp401(t)%chb2      = tmp_chb2
-            NOAHMP401_struc(n)%noahmp401(t)%infxs1rt  = tmp_infxs1rt
-            NOAHMP401_struc(n)%noahmp401(t)%soldrain1rt  = tmp_soldrain1rt
+            NOAHMP401_struc(n)%noahmp401(t)%infxs1rt  = tmp_infxs1rt(1,1)
+            NOAHMP401_struc(n)%noahmp401(t)%soldrain1rt  = tmp_soldrain1rt(1,1)
 
             ! EMK Update RHMin for 557WW
             if (tmp_tair .lt. &


### PR DESCRIPTION
### Description

This patch fixes an error that resulted in glaciers melting.  Here variables tmp_sfcheadrt, tmp_infxs1rt, and tmp_soldrain1rt were declared to be scalars, but within the NoahMP 4.0.1 physics, they are 2-d arrays sized 1x1.  Technically, these are not equivalent.  I resolved this issue by declaring tmp_sfcheadrt, tmp_infxs1rt, and tmp_soldrain1rt to be "real, dimension(1,1)".