### PR TITLE
Fix garbage in SNODEP filename lislog message

### DIFF
--- a/lis/dataassim/obs/SNODEP/read_SNODEPobs.F90
+++ b/lis/dataassim/obs/SNODEP/read_SNODEPobs.F90
@@ -96,6 +96,8 @@ subroutine read_SNODEPobs(n, k, OBS_State,OBS_Pert_State)
 
   file_exists1 = .false.
   file_exists2 = .false.
+  name_nh = ''
+  name_sh = ''
 
   alarmCheck = LIS_isAlarmRinging(LIS_rc, "SNODEP read alarm")    
 
@@ -112,8 +114,8 @@ subroutine read_SNODEPobs(n, k, OBS_State,OBS_Pert_State)
      call SNODEP_filename(name_sh, SNODEP_obs_obj(n)%mesh, hemi, obsdir,&
           yr, mo, da, hr, mn, SNODEP_obs_obj(n)%conv)
      
-     inquire(file=name_nh,exist=file_exists1)
-     inquire(file=name_sh,exist=file_exists2)
+     inquire(file=trim(name_nh),exist=file_exists1)
+     inquire(file=trim(name_sh),exist=file_exists2)
   endif
 
   if(file_exists1.and.file_exists2) then 

--- a/lis/dataassim/obs/SNODEP/read_SNODEPobs.F90
+++ b/lis/dataassim/obs/SNODEP/read_SNODEPobs.F90
@@ -114,8 +114,8 @@ subroutine read_SNODEPobs(n, k, OBS_State,OBS_Pert_State)
      call SNODEP_filename(name_sh, SNODEP_obs_obj(n)%mesh, hemi, obsdir,&
           yr, mo, da, hr, mn, SNODEP_obs_obj(n)%conv)
      
-     inquire(file=trim(name_nh),exist=file_exists1)
-     inquire(file=trim(name_sh),exist=file_exists2)
+     inquire(file=name_nh,exist=file_exists1)
+     inquire(file=name_sh,exist=file_exists2)
   endif
 
   if(file_exists1.and.file_exists2) then 


### PR DESCRIPTION
This fix will correct garbage being included in SNODEP filenames as output to the lislog files.  The character string is set to an empty string before the filename is written into it.

