### PR TITLE
Correct intent error

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/phys/module_sf_noahmp_glacier_401.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/phys/module_sf_noahmp_glacier_401.F90
@@ -1208,7 +1208,7 @@ contains
     REAL,              INTENT(INOUT) :: FH2    !sen heat stability correction, weighted by prior iters
 
 ! outputs
-    REAL,                INTENT(OUT) :: FV     !friction velocity (m/s)
+    REAL,                INTENT(INOUT) :: FV     !friction velocity (m/s)
     REAL,                INTENT(OUT) :: CM     !drag coefficient for momentum
     REAL,                INTENT(OUT) :: CH     !drag coefficient for heat
     REAL,                INTENT(OUT) :: CH2    !drag coefficient for heat


### PR DESCRIPTION
### Description

This patch fixes an intent(out) vs intent(inout) error that resulted in glaciers melting.

In SFCDIF1_GLACIER, the variable FV was declared as intent(out). Technically, this means that FV was uninitialized.  FV was initialized for the first iteration (ITER=1), but it was not initialized for subsequent calls (iterations 2 through 5).