### PR TITLE
Removing 'Apply perturbation bias correction:' as an option

### DIFF
--- a/lis/core/LIS_readConfig.F90
+++ b/lis/core/LIS_readConfig.F90
@@ -754,11 +754,12 @@ subroutine LIS_readConfig()
   
   call LIS_parseTimeString(time,LIS_rc%pertrestartInterval)
 
-  if(npert_forc.ne.0.or.npert_state.ne.0) then 
-     call ESMF_ConfigGetAttribute(LIS_config,LIS_rc%pert_bias_corr,&
-          label="Apply perturbation bias correction:",rc=rc)
-     call LIS_verify(rc,'Apply perturbation bias correction: not specified')
-  endif
+  LIS_rc%pert_bias_corr = 1
+!  if(npert_forc.ne.0.or.npert_state.ne.0) then 
+!     call ESMF_ConfigGetAttribute(LIS_config,LIS_rc%pert_bias_corr,&
+!          label="Apply perturbation bias correction:",rc=rc)
+!     call LIS_verify(rc,'Apply perturbation bias correction: not specified')
+!  endif
 
 !  if(npert_forc.ne.0.or.npert_state.ne.0.or.npert_obs.ne.0) then 
   call ESMF_ConfigFindLabel(LIS_config,"Perturbations restart filename:",rc=rc)


### PR DESCRIPTION
The code has been updated to always employ perturbation bias correciton. Turning this off (mostly inadvertently) leads to biases in ensemble simulations

Resolves #1299

<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Replace this text with a concise description of *what* was changed and *why*.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->


