### PR TITLE
Bugfix: issue in grid finding period (Issue #1301). The number of day…

### DIFF
--- a/ldt/DAobs/SMOS_NRTNN_L2sm/readSMOSNRTNNL2smObs.F90
+++ b/ldt/DAobs/SMOS_NRTNN_L2sm/readSMOSNRTNNL2smObs.F90
@@ -19,7 +19,9 @@
 !                not work with optimization level -1 and -2
 !  21 Feb. 2021: Mahdi Navari, code modified to write the DGG 
 !                lookup table into a netCDF file
-!
+!  3  Apr. 2023: Mahdi Navari, Bugfix: issue in grid finding 
+!                period (Issue #1301)
+! 
 ! !INTERFACE:
 subroutine readSMOSNRTNNL2smObs(n)
 ! !USES:
@@ -279,11 +281,12 @@ subroutine read_SMOSNRTL2sm_data(n, fname, smobs_inp)
                    lat2d(c,r)-dy/2 <= max_lat_dgg) then
 
 
-                  if (SMOSNRTNNsmobs(n)%count_day <= 30) then
-                     ! assume that during 30 days after the simulation start date
+                  if (SMOSNRTNNsmobs(n)%count_day <= 150) then
+                     ! assume that during 150 days after the simulation start date
                      ! all land grids have assigned dgg_id_number
                      ! in order to avoid looping over ocean grids for every files
-
+                     ! originally count_day was set to 30 days, but it seems that this 
+                     ! period was not enough to assign all SMOS grids to the LIS grids.  
                      if (.not. SMOSNRTNNsmobs(n)%SMOS_lookup(c,r)%dgg_assign) then 
                         call find_SMOS_Dgg_id_number(n,c,r, lon_dgg, lat_dgg, &
                                                      dgg_length, i_dgg, DGG_id_number, &
@@ -381,9 +384,10 @@ subroutine read_SMOSNRTL2sm_data(n, fname, smobs_inp)
    call LDT_verify(ios,'Error closing file '//trim(fname))
 
 
-  ! assume that during 30 days after the simulation start date
+  ! assume that during 150 days after the simulation start date
   ! all land grids have assigned dgg_id_number
-   if (SMOSNRTNNsmobs(n)%count_day .eq. 31) then
+
+   if (SMOSNRTNNsmobs(n)%count_day .eq. 151) then
 
      total_length = 0
        do r = 1, LDT_rc%lnr(n)


### PR DESCRIPTION

### Description

Bugfix: issue in grid finding period (Issue #1301). The number of days to assign all SMOS grids to the LIS grids changes from 30 to 150

Resolves #1301


### Testcase

I do not have a test case for this issue. I can create a test case if needed. But, Yonghwan confirmed that he did not fix the bug in the code prior to his departure.

See the following email exchange
Hi Mahdi,
Yes. You are right.
Thanks,
Yonghwan

From: "Navari, Mahdi (GSFC-617.0)[UNIV OF MARYLAND COLLEGE PARK]" <[mahdi.navari@nasa.gov](mailto:mahdi.navari@nasa.gov)>
Date: Friday, March 24, 2023 at 12:20 PM
To: LIS-557WW <[LIS-557WW@nasa.onmicrosoft.com](mailto:LIS-557WW@nasa.onmicrosoft.com)>, Yonghwan Kwon <[yhkwon@umd.edu](mailto:yhkwon@umd.edu)>
Subject: Re: [update] SMOS DA

Hi Yonghwan,
We were discussing the SMOS NRT DA and I just remembered an old conversation between us (see previous emails below).
Do we need to change the “grid finding period” from 30 days to 150 days?

[https://github.com/NASA-LIS/LISF/blob/48a8c51aa15c49031be45342ed8b441cc27e18c0/ldt/DAobs/SMOS_NRTNN_L2sm/readSMOSNRTNNL2smObs.F90#L281](https://gcc02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FNASA-LIS%2FLISF%2Fblob%2F48a8c51aa15c49031be45342ed8b441cc27e18c0%2Fldt%2FDAobs%2FSMOS_NRTNN_L2sm%2FreadSMOSNRTNNL2smObs.F90%23L281&data=05%7C01%7Cmahdi.navari%40nasa.gov%7Cd3ed2b0d01cc4dadc39f08db2e73c78a%7C7005d45845be48ae8140d43da96dd17b%7C0%7C0%7C638154847074297287%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=0Co3lz5wXl2OgFTuvDPnhd8AWGX4a2ReIQn7h78Ie%2FM%3D&reserved=0)

If that is the case, is this the right and only places we need to change?

Thanks
Mahdi

