### PR TITLE
[GHI] Update code to fit new GALWEM-GE format

### DIFF
--- a/lis/metforcing/galwem_ge/galwemge_forcingMod.F90
+++ b/lis/metforcing/galwem_ge/galwemge_forcingMod.F90
@@ -19,6 +19,7 @@ module galwemge_forcingMod
 
 ! REVISION HISTORY:
 ! 09 May 2022; Yeosang Yoon; Initial Specification
+! 05 Apr 2023; Yeosang Yoon; Update code to fit new format
 
 ! !USES:
   use LIS_constantsMod, only : LIS_CONST_PATH_LEN
@@ -125,8 +126,8 @@ contains
     enddo
 
     do n=1, LIS_rc%nnest
-       galwemge_struc(:)%nc = 640  ! galwem-ge
-       galwemge_struc(:)%nr = 480
+       galwemge_struc(:)%nc = 720  ! galwem-ge
+       galwemge_struc(:)%nr = 361
     enddo
 
     ! 8 - key met field
@@ -165,13 +166,13 @@ contains
        gridDesci(n,1)  = 0
        gridDesci(n,2)  = galwemge_struc(n)%nc !gnc
        gridDesci(n,3)  = galwemge_struc(n)%nr !gnr
-       gridDesci(n,4)  = -89.8125    !lat(1,1)
-       gridDesci(n,5)  = -179.7188   !lon(1,1)
+       gridDesci(n,4)  = -89.750    !lat(1,1)
+       gridDesci(n,5)  = -179.750   !lon(1,1)
        gridDesci(n,6)  = 128
-       gridDesci(n,7)  = 89.8125     !lat(gnc,gnr)
-       gridDesci(n,8)  = 179.7188    !lon(gnc,gnr)
-       gridDesci(n,9)  = 0.5625      !dx
-       gridDesci(n,10) = 0.3750      !dy
+       gridDesci(n,7)  = 89.750     !lat(gnc,gnr)
+       gridDesci(n,8)  = 179.750    !lon(gnc,gnr)
+       gridDesci(n,9)  = 0.500      !dx
+       gridDesci(n,10) = 0.500      !dy
        gridDesci(n,20) = 0           !for 0 to 360?
 
        galwemge_struc(n)%mi = galwemge_struc(n)%nc*galwemge_struc(n)%nr

--- a/lis/metforcing/galwem_ge/get_galwemge.F90
+++ b/lis/metforcing/galwem_ge/get_galwemge.F90
@@ -15,6 +15,7 @@
 !
 ! !REVISION HISTORY:
 ! 15 Mar 2022: Yeosang Yoon, initial code
+! 04 Apr 2023: Yeosang Yoon, Update code to fit new format
 !
 ! !INTERFACE:
 subroutine get_galwemge(n, findex)
@@ -109,11 +110,7 @@ subroutine get_galwemge(n, findex)
       openfile == 1)  then
 
      ! Forecast hour condition within each file:
-     if(galwemge_struc(n)%fcst_hour < 192) then
-        galwemge_struc(n)%fcst_hour = galwemge_struc(n)%fcst_hour + fcsthr_intv
-     elseif(galwemge_struc(n)%fcst_hour >= 192) then
-        galwemge_struc(n)%fcst_hour = galwemge_struc(n)%fcst_hour + fcsthr_intv
-     endif
+      galwemge_struc(n)%fcst_hour = galwemge_struc(n)%fcst_hour + fcsthr_intv
  
      ! Check if local forecast hour exceeds max grib file forecast hour:
      if(galwemge_struc(n)%fcst_hour > 384 ) then
@@ -148,7 +145,7 @@ subroutine get_galwemge(n, findex)
           ! Obtain filenames   
            call get_galwemge_filename(galwemge_struc(n)%odir,galwemge_struc(n)%init_yr,&
                 galwemge_struc(n)%init_mo,galwemge_struc(n)%init_da,galwemge_struc(n)%init_hr,&
-                hr1,m,fname)
+                0,m,fname)
 
            write(LIS_logunit,*)'[INFO] Getting GALWEM-GE forecast file1 ... ',trim(fname)
            call read_galwemge(n, m, findex, order, fname, ferror)
@@ -206,17 +203,27 @@ subroutine get_galwemge_filename(rootdir,yr,mo,da,hr,fc_hr,ens_id,filename)
   character(3) :: fchr
   character(3) :: ens 
 
-  character(len=36) :: fname
+  character(len=37) :: fname
 
   write (UNIT=chr, FMT='(i2.2)') hr
   write (UNIT=fchr, FMT='(i3.3)') fc_hr
-  write (UNIT=ens, FMT='(i3.3)') ens_id-1  ! start 0
   write (UNIT=ftime, FMT='(i4, i2.2, i2.2)') yr, mo, da
 
   fname = 'PS.557WW_SC.U_DI.C_GP.GALWEM-GE-MEMB'
 
+  !TODO: need to check, 12z cycle memebers 00,28-44
+  if (hr == 0) then
+       write (UNIT=ens, FMT='(i3.3)') ens_id-1   ! start 00, 01 - 17
+  else
+     if (ens_id == 1) then
+        write (UNIT=ens, FMT='(i3.3)') ens_id-1  ! start 00
+     else
+        write (UNIT=ens, FMT='(i3.3)') ens_id+26 ! start 28-44
+     endif
+  endif
+
   filename = trim(rootdir)//'/'//ftime//'T'//chr//'00Z'//'/'// &
-             trim(fname) //ens//'_GR.C40KM_AR.GLOBAL_DD.'//   &
+             trim(fname)//ens//'_GR.C0P5DEG_AR.GLOBAL_DD.'//   &
              ftime//'_CY.'//chr//'_FH.'//fchr//'_DF.GR2'
 end subroutine get_galwemge_filename
 

--- a/lis/metforcing/galwem_ge/timeinterp_galwemge.F90
+++ b/lis/metforcing/galwem_ge/timeinterp_galwemge.F90
@@ -188,7 +188,7 @@ subroutine timeinterp_galwemge(n,findex)
               galwemge_struc(n)%metdata2(3,m,index1).ne.LIS_rc%udef) then
               !swd(tid) = galwemge_struc(n)%metdata1(3,m,index1)*zw1+&
               !         galwemge_struc(n)%metdata2(3,m,index1)*zw2
-             
+
               swd(tid) = zw1 * galwemge_struc(n)%metdata2(3,m,index1)
               ! In cases of small cos(zenith) angles, use linear weighting
               !  to avoid overly large weights
@@ -198,7 +198,7 @@ subroutine timeinterp_galwemge(n,findex)
               !   swd(tid) = galwemge_struc(n)%metdata1(3,m,index1)*swt1+ &
               !            galwemge_struc(n)%metdata2(3,m,index1)*swt2
               !endif
-          
+
               if(swd(tid).lt.0.0) then
                  write(unit=LIS_logunit,fmt=*)'[ERR] SW radiation is unphysical'
                  write(unit=LIS_logunit,fmt=*)'[ERR] it is', LIS_localPet, tid, swd(tid)

--- a/lis/routing/RAPID_router/RAPID_routingMod.F90
+++ b/lis/routing/RAPID_router/RAPID_routingMod.F90
@@ -332,10 +332,13 @@ contains
     enddo
 
     ! ensemble mode 0: open loop, ensemble mode 1: ensemble mean 
-    if(RAPID_routing_struc(n)%useens>1) then
-       write(LIS_logunit,*) "[ERR] Currently RAPID only supports ensemble modes 0 or 1" 
-       call LIS_endrun()
-    endif
+    ! EMK...Add do loop
+    do n=1, LIS_rc%nnest
+       if(RAPID_routing_struc(n)%useens>1) then
+          write(LIS_logunit,*) "[ERR] Currently RAPID only supports ensemble modes 0 or 1" 
+          call LIS_endrun()
+       endif
+    end do
 
     ! checks the size of static data for RAPID
     do n=1, LIS_rc%nnest

--- a/lis/routing/RAPID_router/src/rapid_Vlat.F90
+++ b/lis/routing/RAPID_router/src/rapid_Vlat.F90
@@ -66,7 +66,11 @@ do i=1,n_weight_table
 
      ! check if all npoints points correspond to the same streamID
      if (npt(i) > 1) then
-        if (i > 1 .AND. (rivid(i-1) == rivid(i)))  CYCLE
+        ! EMK Avoid array bounds read error
+        !if (i > 1 .AND. (rivid(i-1) == rivid(i)))  CYCLE
+        if (i > 1) then
+           if (rivid(i-1) == rivid(i)) cycle
+        end if
 
         do j=1,npt(i)
            col=idx_i(i+j-1)+1


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Update GALWEM-GE (Global Air-Land Weather Exploitation Model-Global Ensemble) medium-range forecasts reader to fit the new format ([#1230](https://github.com/NASA-LIS/LISF/issues/1230)):

Spatial resolution: 40 km -> 0.5 deg 
Number of ensembles: 21 -> 18

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->

6 test cases are here:
There are 3 LSMs (Noah39, NoahMP401, JULES50) with 2 routings each (HyMAP and RAPID).

Note: Currently, JULES50 is in a queue on Discover.

/discover/nobackup/projects/usaf_lis/yyoon4/Hydro/MRF/LISF_7.5_Use_Case_all/GALWEM-GE-new

