### PR TITLE
Update the LISF AppImage workflow for the master branch

### DIFF
--- a/.github/scripts/appimage/compile_lisf
+++ b/.github/scripts/appimage/compile_lisf
@@ -54,9 +54,10 @@ printf '%s\n' "0" "2" "2" "2" "4" "1" "1" "1" "1" "1" "1" "1" "1" "1" | ./config
 # Use LIS-CMEM? (1-yes, 0-no, default=0): 0
 # Use LIS-LAPACK? (1-yes, 0-no, default=0): 0
 # Use LIS-MKL-LAPACK? (1-yes, 0-no, default=0): 0
+# Use PETSc? (1-yes, 0-no, default=0): 0
 
 cd ../lis
-printf '%s\n' "1" "2" "2" "2" "0" "1" "4" "1" "1" "1" "1" "1" "1" "0" "0" "0" "0" "0" | ./configure
+printf '%s\n' "1" "2" "2" "2" "0" "1" "4" "1" "1" "1" "1" "1" "1" "0" "0" "0" "0" "0" "0" | ./configure
 ./compile -j 2
 
 #


### PR DESCRIPTION
### Description

This adds PETSc to the compile_lisf script.  PETSc support is disabled because this library has not yet been installed into the lisf_libraries image.

