### PR TITLE
Address error raised by Cray compilers (CPE 23.02 / CCE 15.0.1)

### DIFF
--- a/lis/dataassim/obs/SMAP_NRTsm/create_filelist.c
+++ b/lis/dataassim/obs/SMAP_NRTsm/create_filelist.c
@@ -57,7 +57,7 @@ int FTN(create_filelist) (const char *regexp,
     /* Use the POSIX glob function to assemble list of files matching the
        provided regular expression. */
     globbuf.gl_offs = 0;
-    ierr = glob(regexp, NULL, NULL, &globbuf);
+    ierr = glob(regexp, 0, NULL, &globbuf);
 
     if (ierr == GLOB_NOMATCH) {
 	/* No files were found by glob.  So just create an empty outfile. */


### PR DESCRIPTION
### Description

The Cray C compiler raised this error:

incompatible pointer to integer conversion passing 'void *' to parameter of type 'int'

In C (Cray, Intel, and GNU compilers), NULL is defined to be '((void *)0)'. In create_filelist.c, we were using NULL to represent 0.