### PR TITLE
Add non-zero exit status to LISF endrun routines

### DIFF
--- a/ldt/core/LDT_logMod.F90
+++ b/ldt/core/LDT_logMod.F90
@@ -186,7 +186,7 @@ contains
     
     call LDT_releaseUnitNumber(ftn)
     
-    call abort ()
+    call LDT_endrun
       
 !     ----------------------------------------------------------------
 !     format statements.
@@ -208,7 +208,7 @@ contains
 
 9000 write (6, 8000) iofunc, istat
       
-    call abort ()
+    call LDT_endrun
   
   end subroutine LDT_abort
 
@@ -464,7 +464,7 @@ contains
 !    call mpi_abort (MPI_COMM_WORLD, 1)         ! LDT
     call mpi_abort (MPI_COMM_WORLD, 1, ierr)   ! LIS-7
 #else
-    stop
+    error stop 1
 #endif   
    end subroutine LDT_endrun
 

--- a/ldt/main/LDTmain.F90
+++ b/ldt/main/LDTmain.F90
@@ -38,7 +38,7 @@ program LDTmain
   if(i.ne.1) then 
      print*, 'Usage: '
      print*, 'LDT <ldtconfigfile>'
-     stop
+     error stop 1
   endif
   
   call getarg(1, configfile)

--- a/lis/core/LIS_logMod.F90
+++ b/lis/core/LIS_logMod.F90
@@ -218,7 +218,7 @@ contains
 
 9000 write (6, 8000) iofunc, istat
       
-    call abort ()
+    call LIS_endrun
   
   end subroutine LIS_abort
 
@@ -474,7 +474,7 @@ contains
 #if (defined SPMD) 
     call mpi_abort (LIS_mpi_comm, 1, ierr)
 #else
-    call abort
+    error stop 1
 #endif   
   end subroutine LIS_endrun
   end module LIS_logMod

--- a/lvt/core/LVT_logMod.F90
+++ b/lvt/core/LVT_logMod.F90
@@ -258,7 +258,7 @@ contains
     
     call LVT_releaseUnitNumber(ftn)
     
-    call abort ()
+    call LVT_endrun
       
 !     ----------------------------------------------------------------
 !     format statements.
@@ -280,7 +280,7 @@ contains
 
 9000 write (6, 8000) iofunc, istat
       
-    call abort ()
+    call LVT_endrun
   
   end subroutine LVT_abort
 
@@ -562,7 +562,7 @@ contains
 #if (defined SPMD) 
     call mpi_abort (MPI_COMM_WORLD, 1)  
 #else
-    stop
+    error stop 1
 #endif   
   end subroutine LVT_endrun
 

--- a/lvt/main/LVTmain.F90
+++ b/lvt/main/LVTmain.F90
@@ -45,7 +45,7 @@ program LVTmain
   if(i.ne.1) then 
      print*, 'Usage: '
      print*, 'LVT <lvtconfigfile>'
-     stop
+     error stop 1
   endif
   
   call getarg(1, configfile)


### PR DESCRIPTION
### Description

Add non-zero exit status to LISF endrun routines.

