### PR TITLE
[GHI] Bug fixes for Medium Range Forecasts

### DIFF
--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.hymap.galwem-ge
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.hymap.galwem-ge
@@ -22,7 +22,7 @@ Forcing variables list file:            ./input/forcing_variables.txt
 Output methodology:                     "2d ensemble gridspace"
 Output model restart files:             1
 Output data format:                     netcdf
-Output naming style:                    "557WW streamflow convention"
+Output naming style:      "557WW medium range forecast convention"
 AGRMET security classification:            U
 AGRMET distribution classification:        C
 AGRMET data category:                      FCST

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.hymap.galwem-ge
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.hymap.galwem-ge
@@ -4,7 +4,7 @@ Map projection of the LIS domain:       latlon
 Number of nests:                        1
 Number of surface model types:          2
 Surface model types:                    "LSM"  "Openwater"
-Surface model output interval:          1da
+Surface model output interval:          3hr
 Land surface model:                     "JULES.5.0"
 Open water model:                       "template open water"
 Number of met forcing sources:          1
@@ -176,7 +176,7 @@ Routing model:                  "HYMAP2 router"
 
 HYMAP2 routing model time step:              "15mn"
 TEMPLATE model timestep:                     "15mn"
-HYMAP2 routing model output interval:        "1da"
+HYMAP2 routing model output interval:        "3hr"
 HYMAP2 routing model restart interval:       "1mo"
 
 HYMAP2 routing model start mode:             restart

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.hymap.galwem.0p25deg
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.hymap.galwem.0p25deg
@@ -4,7 +4,7 @@ Map projection of the LIS domain:       latlon
 Number of nests:                        1
 Number of surface model types:          2
 Surface model types:                    "LSM"  "Openwater"
-Surface model output interval:          1da
+Surface model output interval:          3hr
 Land surface model:                     "JULES.5.0"
 Open water model:                       "template open water"
 Number of met forcing sources:          1
@@ -169,7 +169,7 @@ Model output attributes file:           ./input/tables/MODEL_OUTPUT_LIST.TBL.noa
 Routing model:                          "HYMAP2 router"
 
 HYMAP2 routing model time step:         "15mn"
-HYMAP2 routing model output interval:   "1da"
+HYMAP2 routing model output interval:   "3hr"
 HYMAP2 routing model restart interval:  "1mo"
 HYMAP2 enable 2-way coupling:            0
 HYMAP2 run in ensemble mode:             0      # Run HYMAP in single member mode

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.hymap.galwem.0p25deg
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.hymap.galwem.0p25deg
@@ -22,7 +22,7 @@ Forcing variables list file:            ./input/forcing_variables.txt
 Output methodology:                     "2d gridspace"
 Output model restart files:             1
 Output data format:                     netcdf
-Output naming style:                    "3 level hierarchy"
+Output naming style:                    "557WW medium range forecast convention"
 Start mode:                             restart
 Starting year:                          2022
 Starting month:                            8
@@ -32,9 +32,9 @@ Starting minute:                           0
 Starting second:                           0
 Ending year:                            2022
 Ending month:                              8
-Ending day:                               28
-Ending hour:                              23
-Ending minute:                            45
+Ending day:                               29
+Ending hour:                               0
+Ending minute:                             0
 Ending second:                             0
 Undefined value:                       -9999
 Output directory:                       "output/2022082300Z/hymap/jules50/"

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.rapid.galwem-ge
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.rapid.galwem-ge
@@ -4,7 +4,7 @@ Map projection of the LIS domain:       latlon
 Number of nests:                        1
 Number of surface model types:          2
 Surface model types:                    "LSM"  "Openwater"
-Surface model output interval:          1da
+Surface model output interval:          3hr
 Land surface model:                     "JULES.5.0"
 Open water model:                       "template open water"
 Number of met forcing sources:          1
@@ -176,7 +176,7 @@ Routing model:                               "RAPID router"
 
 RAPID routing model time step:               "1da"
 RAPID river routing time step:               "15mn"   # less than routing model time step
-RAPID routing model output interval:         "1da"
+RAPID routing model output interval:         "3hr"
 RAPID routing model restart interval:        "1mo"
 
 RAPID routing model start mode:         restart

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.rapid.galwem-ge
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.rapid.galwem-ge
@@ -22,7 +22,7 @@ Forcing variables list file:            ./input/forcing_variables.txt
 Output methodology:                     "2d ensemble gridspace"
 Output model restart files:             1
 Output data format:                     netcdf
-Output naming style:                    "557WW streamflow convention"
+Output naming style:    "557WW medium range forecast convention"
 AGRMET security classification:            U
 AGRMET distribution classification:        C
 AGRMET data category:                      FCST

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.rapid.galwem.0p25deg
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.rapid.galwem.0p25deg
@@ -4,7 +4,7 @@ Map projection of the LIS domain:       latlon
 Number of nests:                        1
 Number of surface model types:          2
 Surface model types:                    "LSM"  "Openwater"
-Surface model output interval:          1da
+Surface model output interval:          3hr
 Land surface model:                     "JULES.5.0"
 Open water model:                       "template open water"
 Number of met forcing sources:          1
@@ -170,7 +170,7 @@ Routing model:                               "RAPID router"
 
 RAPID routing model time step:               "1da"
 RAPID river routing time step:               "15mn"   # less than routing model time step
-RAPID routing model output interval:         "1da"
+RAPID routing model output interval:         "3hr"
 RAPID routing model restart interval:        "1mo"
 
 RAPID routing model start mode:         restart

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.rapid.galwem.0p25deg
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.jules50.rapid.galwem.0p25deg
@@ -22,7 +22,7 @@ Forcing variables list file:            ./input/forcing_variables.txt
 Output methodology:                     "2d gridspace"
 Output model restart files:             1
 Output data format:                     netcdf
-Output naming style:                    "3 level hierarchy"
+Output naming style:              "557WW medium range forecast convention"
 Start mode:                             restart
 Starting year:                          2022
 Starting month:                            8
@@ -32,9 +32,9 @@ Starting minute:                           0
 Starting second:                           0
 Ending year:                            2022
 Ending month:                              8
-Ending day:                               28
-Ending hour:                              23
-Ending minute:                            45
+Ending day:                               29
+Ending hour:                               0
+Ending minute:                             0
 Ending second:                             0
 Undefined value:                       -9999
 Output directory:                       "output/2022082300Z/rapid/jules50/"

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.hymap.galwem-ge
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.hymap.galwem-ge
@@ -4,7 +4,7 @@ Map projection of the LIS domain:       latlon
 Number of nests:                        1
 Number of surface model types:          2
 Surface model types:                    "LSM"  "Openwater"
-Surface model output interval:          1da
+Surface model output interval:          3hr
 Land surface model:                     "Noah.3.9"
 Open water model:                       "template open water"
 Number of met forcing sources:          1
@@ -207,7 +207,7 @@ Routing model:                  "HYMAP2 router"
 
 HYMAP2 routing model time step:              "15mn"
 TEMPLATE model timestep:                     "15mn"
-HYMAP2 routing model output interval:        "1da"
+HYMAP2 routing model output interval:        "3hr"
 HYMAP2 routing model restart interval:       "1mo"
 
 HYMAP2 routing model start mode:             restart

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.hymap.galwem-ge
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.hymap.galwem-ge
@@ -22,7 +22,7 @@ Forcing variables list file:            ./input/forcing_variables.txt
 Output methodology:                     "2d ensemble gridspace"
 Output model restart files:             1
 Output data format:                     netcdf
-Output naming style:                    "557WW streamflow convention"
+Output naming style:       "557WW medium range forecast convention"
 AGRMET security classification:            U
 AGRMET distribution classification:        C
 AGRMET data category:                      FCST

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.hymap.galwem.0p25deg
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.hymap.galwem.0p25deg
@@ -22,7 +22,7 @@ Forcing variables list file:            ./input/forcing_variables.txt
 Output methodology:                     "2d gridspace"
 Output model restart files:             1
 Output data format:                     netcdf
-Output naming style:                    "3 level hierarchy"
+Output naming style:              "557WW medium range forecast convention"
 Start mode:                             restart
 Starting year:                          2022
 Starting month:                            8
@@ -32,9 +32,9 @@ Starting minute:                           0
 Starting second:                           0
 Ending year:                            2022
 Ending month:                              8
-Ending day:                               28
-Ending hour:                              23
-Ending minute:                            45
+Ending day:                               29
+Ending hour:                               0
+Ending minute:                             0
 Ending second:                             0
 Undefined value:                       -9999
 Output directory:                       "output/2022082300Z/hymap/noah39/"

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.hymap.galwem.0p25deg
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.hymap.galwem.0p25deg
@@ -4,7 +4,7 @@ Map projection of the LIS domain:       latlon
 Number of nests:                        1
 Number of surface model types:          2
 Surface model types:                    "LSM"  "Openwater"
-Surface model output interval:          1da
+Surface model output interval:          3hr
 Land surface model:                     "Noah.3.9"
 Open water model:                       "template open water"
 Number of met forcing sources:          1
@@ -199,7 +199,7 @@ Model output attributes file:           ./input/tables/MODEL_OUTPUT_LIST.TBL.noa
 Routing model:                          "HYMAP2 router"
 
 HYMAP2 routing model time step:         "15mn"
-HYMAP2 routing model output interval:   "1da"
+HYMAP2 routing model output interval:   "3hr"
 HYMAP2 routing model restart interval:  "1mo"
 HYMAP2 enable 2-way coupling:            0
 HYMAP2 run in ensemble mode:             0      # Run HYMAP in single member mode

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.rapid.galwem-ge
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.rapid.galwem-ge
@@ -4,7 +4,7 @@ Map projection of the LIS domain:       latlon
 Number of nests:                        1
 Number of surface model types:          2
 Surface model types:                    "LSM"  "Openwater"
-Surface model output interval:          1da
+Surface model output interval:          3hr
 Land surface model:                     "Noah.3.9"
 Open water model:                       "template open water"
 Number of met forcing sources:          1
@@ -207,7 +207,7 @@ Routing model:                               "RAPID router"
 
 RAPID routing model time step:               "1da"
 RAPID river routing time step:               "15mn"   # less than routing model time step
-RAPID routing model output interval:         "1da"
+RAPID routing model output interval:         "3hr"
 RAPID routing model restart interval:        "1mo"
 
 RAPID routing model start mode:         restart

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.rapid.galwem-ge
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.rapid.galwem-ge
@@ -22,7 +22,7 @@ Forcing variables list file:            ./input/forcing_variables.txt
 Output methodology:                     "2d ensemble gridspace"
 Output model restart files:             1
 Output data format:                     netcdf
-Output naming style:                    "557WW streamflow convention"
+Output naming style:        "557WW medium range forecast convention"
 AGRMET security classification:            U
 AGRMET distribution classification:        C
 AGRMET data category:                      FCST

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.rapid.galwem.0p25deg
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.rapid.galwem.0p25deg
@@ -4,7 +4,7 @@ Map projection of the LIS domain:       latlon
 Number of nests:                        1
 Number of surface model types:          2
 Surface model types:                    "LSM"  "Openwater"
-Surface model output interval:          1da
+Surface model output interval:          3hr
 Land surface model:                     "Noah.3.9"
 Open water model:                       "template open water"
 Number of met forcing sources:          1
@@ -200,7 +200,7 @@ Routing model:                               "RAPID router"
 
 RAPID routing model time step:               "1da"
 RAPID river routing time step:               "15mn"   # less than routing model time step
-RAPID routing model output interval:         "1da"
+RAPID routing model output interval:         "3hr"
 RAPID routing model restart interval:        "1mo"
 
 RAPID routing model start mode:         restart

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.rapid.galwem.0p25deg
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noah39.rapid.galwem.0p25deg
@@ -22,7 +22,7 @@ Forcing variables list file:            ./input/forcing_variables.txt
 Output methodology:                     "2d gridspace"
 Output model restart files:             1
 Output data format:                     netcdf
-Output naming style:                    "3 level hierarchy"
+Output naming style:    "557WW medium range forecast convention"
 Start mode:                             restart
 Starting year:                          2022
 Starting month:                            8
@@ -32,9 +32,9 @@ Starting minute:                           0
 Starting second:                           0
 Ending year:                            2022
 Ending month:                              8
-Ending day:                               28
-Ending hour:                              23
-Ending minute:                            45
+Ending day:                               29
+Ending hour:                               0
+Ending minute:                             0
 Ending second:                             0
 Undefined value:                       -9999
 Output directory:                       "output/2022082300Z/rapid/noah39/"

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.hymap.galwem-ge
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.hymap.galwem-ge
@@ -4,7 +4,7 @@ Map projection of the LIS domain:       latlon
 Number of nests:                        1
 Number of surface model types:          2
 Surface model types:                    "LSM"  "Openwater"
-Surface model output interval:          1da
+Surface model output interval:          3hr
 Land surface model:                     "Noah-MP.4.0.1"
 Open water model:                       "template open water"
 Number of met forcing sources:          1
@@ -209,7 +209,7 @@ Routing model:                  "HYMAP2 router"
 
 HYMAP2 routing model time step:              "15mn"
 TEMPLATE model timestep:                     "15mn"
-HYMAP2 routing model output interval:        "1da"
+HYMAP2 routing model output interval:        "3hr"
 HYMAP2 routing model restart interval:       "1mo"
 
 HYMAP2 routing model start mode:             restart

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.hymap.galwem-ge
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.hymap.galwem-ge
@@ -22,7 +22,7 @@ Forcing variables list file:            ./input/forcing_variables.txt
 Output methodology:                     "2d ensemble gridspace"
 Output model restart files:             1
 Output data format:                     netcdf
-Output naming style:                    "557WW streamflow convention"
+Output naming style:       "557WW medium range forecast convention"
 AGRMET security classification:            U
 AGRMET distribution classification:        C
 AGRMET data category:                      FCST

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.hymap.galwem.0p25deg
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.hymap.galwem.0p25deg
@@ -22,7 +22,7 @@ Forcing variables list file:            ./input/forcing_variables.txt
 Output methodology:                     "2d gridspace"
 Output model restart files:             1
 Output data format:                     netcdf
-Output naming style:                    "3 level hierarchy"
+Output naming style:         "557WW medium range forecast convention"
 Start mode:                             restart
 Starting year:                          2022
 Starting month:                            8
@@ -32,9 +32,9 @@ Starting minute:                           0
 Starting second:                           0
 Ending year:                            2022
 Ending month:                              8
-Ending day:                               28
-Ending hour:                              23
-Ending minute:                            45
+Ending day:                               29
+Ending hour:                               0
+Ending minute:                             0
 Ending second:                             0
 Undefined value:                       -9999
 Output directory:                       "output/2022082300Z/hymap/noahmp401/"

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.hymap.galwem.0p25deg
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.hymap.galwem.0p25deg
@@ -4,7 +4,7 @@ Map projection of the LIS domain:       latlon
 Number of nests:                        1
 Number of surface model types:          2
 Surface model types:                    "LSM"  "Openwater"
-Surface model output interval:          1da
+Surface model output interval:          3hr
 Land surface model:                     "Noah-MP.4.0.1"
 Open water model:                       "template open water"
 Number of met forcing sources:          1
@@ -201,7 +201,7 @@ Model output attributes file:           ./input/tables/MODEL_OUTPUT_LIST.TBL.noa
 Routing model:                          "HYMAP2 router"
 
 HYMAP2 routing model time step:         "15mn"
-HYMAP2 routing model output interval:   "1da"
+HYMAP2 routing model output interval:   "3hr"
 HYMAP2 routing model restart interval:  "1mo"
 HYMAP2 enable 2-way coupling:            0
 HYMAP2 run in ensemble mode:             0      # Run HYMAP in single member mode

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.rapid.galwem-ge
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.rapid.galwem-ge
@@ -4,7 +4,7 @@ Map projection of the LIS domain:       latlon
 Number of nests:                        1
 Number of surface model types:          2
 Surface model types:                    "LSM"  "Openwater"
-Surface model output interval:          1da
+Surface model output interval:          3hr
 Land surface model:                     "Noah-MP.4.0.1"
 Open water model:                       "template open water"
 Number of met forcing sources:          1
@@ -209,7 +209,7 @@ Routing model:                               "RAPID router"
 
 RAPID routing model time step:               "1da"
 RAPID river routing time step:               "15mn"   # less than routing model time step
-RAPID routing model output interval:         "1da"
+RAPID routing model output interval:         "3hr"
 RAPID routing model restart interval:        "1mo"
 
 RAPID routing model start mode:         restart

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.rapid.galwem-ge
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.rapid.galwem-ge
@@ -22,7 +22,7 @@ Forcing variables list file:            ./input/forcing_variables.txt
 Output methodology:                     "2d ensemble gridspace"
 Output model restart files:             1
 Output data format:                     netcdf
-Output naming style:                    "557WW streamflow convention"
+Output naming style:       "557WW medium range forecast convention"
 AGRMET security classification:            U
 AGRMET distribution classification:        C
 AGRMET data category:                      FCST

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.rapid.galwem.0p25deg
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.rapid.galwem.0p25deg
@@ -4,7 +4,7 @@ Map projection of the LIS domain:       latlon
 Number of nests:                        1
 Number of surface model types:          2
 Surface model types:                    "LSM"  "Openwater"
-Surface model output interval:          1da
+Surface model output interval:          3hr
 Land surface model:                     "Noah-MP.4.0.1"
 Open water model:                       "template open water"
 Number of met forcing sources:          1
@@ -202,7 +202,7 @@ Routing model:                               "RAPID router"
 
 RAPID routing model time step:               "1da"
 RAPID river routing time step:               "15mn"   # less than routing model time step
-RAPID routing model output interval:         "1da"
+RAPID routing model output interval:         "3hr"
 RAPID routing model restart interval:        "1mo"
 
 RAPID routing model start mode:         restart

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.rapid.galwem.0p25deg
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/lis.config.mr.noahmp401.rapid.galwem.0p25deg
@@ -22,7 +22,7 @@ Forcing variables list file:            ./input/forcing_variables.txt
 Output methodology:                     "2d gridspace"
 Output model restart files:             1
 Output data format:                     netcdf
-Output naming style:                    "3 level hierarchy"
+Output naming style:     "557WW medium range forecast convention"
 Start mode:                             restart
 Starting year:                          2022
 Starting month:                            8
@@ -32,9 +32,9 @@ Starting minute:                           0
 Starting second:                           0
 Ending year:                            2022
 Ending month:                              8
-Ending day:                               28
-Ending hour:                              23
-Ending minute:                            45
+Ending day:                               29
+Ending hour:                               0
+Ending minute:                             0
 Ending second:                             0
 Undefined value:                       -9999
 Output directory:                       "output/2022082300Z/rapid/noahmp401/"

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -604,6 +604,8 @@ Acceptable values are:
 |"`4 level hierarchy`" | 4 levels of hierarchy
 |"`WMO convention`"    | WMO convention for weather codes
 |"`557WW streamflow convention`" | 557WW convention for streamflow output
+|"`557WW medium range forecast convention`" | 557WW convention for medium range forecast output
+
 |====
 .Example _lis.config_ entry
 ....
@@ -612,15 +614,15 @@ Output naming style: "3 level hierarchy"
 
 [NOTE]
 ====
-The "`557WW streamflow convention`" has 4 additional settings:
+The "`557WW streamflow convention`" and "`557WW medium range forecast convention`" have 4 additional settings:
 
-`AGRMET security classification:` used with 557WW streamflow convention or AGRMET Ops runmode.
+`AGRMET security classification:` used with 557WW streamflow convention, 557WW medium range forecast convention, or AGRMET Ops runmode.
 
-`AGRMET distribution classification:` used with 557WW streamflow convention or AGRMET Ops runmode.
+`AGRMET distribution classification:` used with 557WW streamflow convention, 557WW medium range forecast convention, or AGRMET Ops runmode.
 
-`AGRMET data category:` used with 557WW streamflow convention or AGRMET Ops runmode.
+`AGRMET data category:` used with 557WW streamflow convention, 557WW medium range forecast convention, or AGRMET Ops runmode.
 
-`AGRMET area of data:` used with 557WW streamflow convention or AGRMET Ops runmode.
+`AGRMET area of data:` used with 557WW streamflow convention, 557WW medium range forecast convention, or AGRMET Ops runmode.
 
 See Section <<sssec_forcings_afwa,AFWA/AGRMET>> for more information.
 

--- a/lis/core/LIS_fileIOMod.F90
+++ b/lis/core/LIS_fileIOMod.F90
@@ -25,6 +25,8 @@ module LIS_fileIOMod
 !  18 Oct 2019    David Mocko, corrected creation of sub-directories for "WMO convention"
 !  26 Apr 2023    Eric Kemp, added new output naming style for 557 WW for
 !                 streamflow output.
+!  22 May 2023    Eric Kemp, added new output naming style for 557 WW for
+!                 medium range forecasts.
 ! !USES: 
   use ESMF
   use LIS_constantsMod, only : LIS_CONST_PATH_LEN
@@ -266,7 +268,8 @@ subroutine LIS_create_output_directory(mname)
          write(unit=cdate1, fmt='(i4.4, i2.2)') LIS_rc%yr, LIS_rc%mo
          out_dname = trim(out_dname)//trim(cdate1)
       endif
-   elseif(LIS_rc%wstyle.eq."557WW streamflow convention") then ! EMK
+   elseif(LIS_rc%wstyle.eq."557WW streamflow convention" .or. &
+        LIS_rc%wstyle .eq. "557WW medium range forecast convention") then ! EMK
       out_dname = trim(LIS_rc%odir)
       if (trim(mname).eq."SURFACEMODEL") then
          continue
@@ -394,6 +397,14 @@ subroutine create_output_filename(n, fname, model_name, odir, writeint)
    character(len=LIS_CONST_PATH_LEN), save :: out_fname
    character(len=LIS_CONST_PATH_LEN)       :: odir_temp
    integer                  :: i, c
+
+   character(len=8) :: initdate
+   character(len=2) :: inithr
+   character(len=3) :: fhr
+   integer :: hr
+   integer :: rc
+   type(ESMF_Time) :: starttime, curtime
+   type(ESMF_TimeInterval) :: deltatime
 
    if ( present(odir) ) then
       odir_temp = odir
@@ -755,11 +766,150 @@ subroutine create_output_filename(n, fname, model_name, odir, writeint)
       case ("grib1")
          out_fname = trim(dname)//'.GR1'
       case ("netcdf")
-         out_fname = trim(dname)//'.nc'
+         out_fname = trim(dname)//'.NC' ! EMK
       case ("grib2")
          out_fname = trim(dname)//'.GR2'
       case default            
       end select
+
+   elseif(LIS_rc%wstyle.eq."557WW medium range forecast convention") then ! EMK
+      write(unit=fint,fmt='(i2.2)') nint(writeint)/3600
+      write(unit=cdate1, fmt='(i4.4, i2.2, i2.2)') &
+           LIS_rc%yr, LIS_rc%mo, LIS_rc%da
+
+      write(unit=cdate, fmt='(i2.2, i2.2)') LIS_rc%hr, LIS_rc%mn
+
+      if(LIS_rc%lis_map_proj.eq."polar") then
+         fproj = 'P'
+         if (LIS_rc%gridDesc(n, 9) .ge. 10.) then
+            write(unit=fres, fmt='(i2)') nint(LIS_rc%gridDesc(n, 9))
+         else
+            write(unit=fres, fmt='(i1)') nint(LIS_rc%gridDesc(n, 9))
+         endif
+         fres2 = trim(fres)//'KM'
+      elseif(LIS_rc%lis_map_proj.eq."lambert") then
+         fproj = 'L'
+         write(unit=fres, fmt='(f2.0)') LIS_rc%gridDesc(n, 9)
+         if (LIS_rc%gridDesc(n, 9) .ge. 10.) then
+            write(unit=fres, fmt='(i2)') nint(LIS_rc%gridDesc(n, 9))
+         else
+            write(unit=fres, fmt='(i1)') nint(LIS_rc%gridDesc(n, 9))
+         endif
+         fres2 = trim(fres)//'KM'
+      elseif(LIS_rc%lis_map_proj.eq."mercator") then
+         fproj = 'M'
+         write(unit=fres, fmt='(i2.2)') LIS_rc%gridDesc(n, 9)
+         fres = trim(fres)//'KM'
+      elseif(LIS_rc%lis_map_proj.eq."gaussian") then
+         fproj = 'G'
+         write(unit=fres, fmt='(i2.2)') LIS_rc%gridDesc(n, 9)*100
+         fres = '0P'//trim(fres)//'DEG'
+      else
+         fproj = 'C'
+         write(unit=fres, fmt='(i10)') nint(LIS_rc%gridDesc(n,10)*100)
+         read(unit=fres,fmt='(10a1)') (fres1(i),i=1,10)
+         c = 0
+         do i=1,10
+            if(fres1(i).ne.' '.and.c==0) c = i
+         enddo
+         if (LIS_rc%gridDesc(n,10) .lt. 0.1) then
+            fres3 = '0P0'
+         else
+            fres3 = '0P'
+         end if
+         fres2 = fres3
+         do i=c,10
+            fres2 = trim(fres2)//trim(fres1(i))
+         enddo
+         fres2 = trim(fres2)//'DEG'
+      endif
+
+      dname = trim(odir_temp) &
+           //'/PS.557WW' &
+           //'_SC.'//trim(LIS_rc%security_class) &
+           //'_DI.'//trim(LIS_rc%distribution_class)
+      if (LIS_rc%lsm .eq. "Noah.3.9") then
+         dname = trim(dname) &
+           //'_GP.'//'LIS-MR-NOAH'
+      else if (LIS_rc%lsm .eq. "Noah-MP.4.0.1") then
+         dname = trim(dname) &
+           //'_GP.'//'LIS-MR-NOAHMP'
+      else if (LIS_rc%lsm .eq. "JULES.5.0") then
+         dname = trim(dname) &
+           //'_GP.'//'LIS-MR-JULES'
+      else
+         write(LIS_logunit,*) &
+              '[ERR] Invalid Land surface model for ', &
+              '557WW medium range forecast convention ', &
+              trim(LIS_rc%lsm)
+         call LIS_endrun()
+      end if
+      if (LIS_rc%routingmodel .eq. "HYMAP2 router") then
+         dname = trim(dname) &
+           //'-HYMAP'
+      else if (LIS_rc%routingmodel .eq. "RAPID router") then
+         dname = trim(dname) &
+           //'-RAPID'
+      else if (LIS_rc%routingmodel .eq. "none") then
+         continue
+      else
+         write(LIS_logunit,*) &
+              '[ERR] Invalid Routing model for ', &
+              '557WW medium range forecast convention ', &
+              trim(LIS_rc%routingmodel)
+         call LIS_endrun()
+      end if
+
+      write(unit=initdate, fmt='(i4.4, i2.2, i2.2)') &
+           LIS_rc%syr, LIS_rc%smo, LIS_rc%sda
+      write(unit=inithr, fmt='(i2.2)') LIS_rc%shr
+      call ESMF_TimeSet(starttime, &
+           yy=LIS_rc%syr, mm=LIS_rc%smo, dd=LIS_rc%sda, &
+           h=LIS_rc%shr, m=LIS_rc%smn, s=LIS_rc%sss, rc=rc)
+      if (rc .ne. ESMF_SUCCESS) then
+         write(LIS_logunit,*)'[ERR] Cannot set starttime object!'
+         call LIS_endrun()
+      end if
+      call ESMF_TimeSet(curtime, &
+           yy=LIS_rc%yr, mm=LIS_rc%mo, dd=LIS_rc%da, &
+           h=LIS_rc%hr, m=LIS_rc%mn, s=LIS_rc%ss, rc=rc)
+      if (rc .ne. ESMF_SUCCESS) then
+         write(LIS_logunit,*)'[ERR] Cannot set curtime object!'
+         call LIS_endrun()
+      end if
+      deltatime = curtime - starttime
+      call ESMF_TimeIntervalGet(deltatime, h=hr, rc=rc)
+      if (rc .ne. ESMF_SUCCESS) then
+         write(LIS_logunit,*)'[ERR] Cannot get hr from deltatime!'
+         call LIS_endrun()
+      end if
+      write(unit=fhr, fmt='(i3.3)') hr
+      dname = trim(dname) &
+           //'_GR.'//trim(fproj)//trim(fres2) &
+           //'_AR.'//trim(LIS_rc%area_of_data) &
+           //'_PA.'//'LIS-'//trim(model_name) &
+           //'_DD.'//trim(initdate) &
+           //'_CY.'//trim(inithr) &
+           //'_FH.'//trim(fhr)
+
+      select case (LIS_rc%wout)
+      case ("binary")
+         if(LIS_rc%wopt.eq."1d tilespace") then 
+            out_fname = trim(dname)//'_DF.DAT'
+         elseif(LIS_rc%wopt.eq."2d gridspace") then 
+            out_fname = trim(dname)//'_DF.DAT'
+         elseif(LIS_rc%wopt.eq."1d gridspace") then 
+            out_fname = trim(out_fname)//'_DF.DAT'
+         endif
+      case ("grib1")
+         out_fname = trim(dname)//'_DF.GR1'
+      case ("netcdf")
+         out_fname = trim(dname)//'_DF.NC'
+      case ("grib2")
+         out_fname = trim(dname)//'_DF.GR2'
+      case default            
+      end select
+
    endif
    fname = out_fname
  end subroutine create_output_filename
@@ -857,6 +1007,12 @@ subroutine create_output_filename_expected(n, fname, wout, flag, model_name, odi
    character*1             :: fres1(10)
    character(len=1)        :: fproj
    integer                 :: curr_mo = 0
+   character(len=8) :: initdate
+   character(len=2) :: inithr
+   character(len=3) :: fhr
+   integer :: rc
+   type(ESMF_Time) :: starttime, curtime
+   type(ESMF_TimeInterval) :: deltatime
    character(len=LIS_CONST_PATH_LEN)       :: dname
    character(len=LIS_CONST_PATH_LEN), save :: out_fname
    character(len=LIS_CONST_PATH_LEN)       :: odir_temp
@@ -1302,12 +1458,150 @@ subroutine create_output_filename_expected(n, fname, wout, flag, model_name, odi
       case ("grib1")
          out_fname = trim(dname)//'.GR1'
       case ("netcdf")
-         out_fname = trim(dname)//'.nc'
+         out_fname = trim(dname)//'.NC'
       case ("grib2")
          out_fname = trim(dname)//'.GR2'
       case default
       end select
 
+   elseif(LIS_rc%wstyle.eq. &
+        "557WW medium range forecast convention") then ! EMK
+      write(unit=fint,fmt='(i2.2)') nint(writeint)/3600
+      write(unit=cdate1, fmt='(i4.4, i2.2, i2.2)') &
+           yr, mo, da
+
+      write(unit=cdate, fmt='(i2.2, i2.2)') hr, mn
+
+      if(LIS_rc%lis_map_proj.eq."polar") then
+         fproj = 'P'
+         if (LIS_rc%gridDesc(n, 9) .ge. 10.) then
+            write(unit=fres, fmt='(i2)') nint(LIS_rc%gridDesc(n, 9))
+         else
+            write(unit=fres, fmt='(i1)') nint(LIS_rc%gridDesc(n, 9))
+         endif
+         fres2 = trim(fres)//'KM'
+      elseif(LIS_rc%lis_map_proj.eq."lambert") then
+         fproj = 'L'
+         write(unit=fres, fmt='(f2.0)') LIS_rc%gridDesc(n, 9)
+         if (LIS_rc%gridDesc(n, 9) .ge. 10.) then
+            write(unit=fres, fmt='(i2)') nint(LIS_rc%gridDesc(n, 9))
+         else
+            write(unit=fres, fmt='(i1)') nint(LIS_rc%gridDesc(n, 9))
+         endif
+         fres2 = trim(fres)//'KM'
+      elseif(LIS_rc%lis_map_proj.eq."mercator") then
+         fproj = 'M'
+         write(unit=fres, fmt='(i2.2)') LIS_rc%gridDesc(n, 9)
+         fres = trim(fres)//'KM'
+      elseif(LIS_rc%lis_map_proj.eq."gaussian") then
+         fproj = 'G'
+         write(unit=fres, fmt='(i2.2)') LIS_rc%gridDesc(n, 9)*100
+         fres = '0P'//trim(fres)//'DEG'
+      else
+         fproj = 'C'
+         write(unit=fres, fmt='(i10)') nint(LIS_rc%gridDesc(n,10)*100)
+         read(unit=fres,fmt='(10a1)') (fres1(i),i=1,10)
+         c = 0
+         do i=1,10
+            if(fres1(i).ne.' '.and.c==0) c = i
+         enddo
+         if (LIS_rc%gridDesc(n,10) .lt. 0.1) then
+            fres3 = '0P0'
+         else
+            fres3 = '0P'
+         end if
+         fres2 = fres3
+         do i=c,10
+            fres2 = trim(fres2)//trim(fres1(i))
+         enddo
+         fres2 = trim(fres2)//'DEG'
+      endif
+
+      dname = trim(odir_temp) &
+           //'/PS.557WW' &
+           //'_SC.'//trim(LIS_rc%security_class) &
+           //'_DI.'//trim(LIS_rc%distribution_class)
+      if (LIS_rc%lsm .eq. "Noah.3.9") then
+         dname = trim(dname) &
+           //'_GP.'//'LIS-MR-NOAH'
+      else if (LIS_rc%lsm .eq. "Noah-MP.4.0.1") then
+         dname = trim(dname) &
+           //'_GP.'//'LIS-MR-NOAHMP'
+      else if (LIS_rc%lsm .eq. "JULES.5.0") then
+         dname = trim(dname) &
+           //'_GP.'//'LIS-MR-JULES'
+      else
+         write(LIS_logunit,*) &
+              '[ERR] Invalid Land surface model for ', &
+              '557WW medium range forecast convention ', &
+              trim(LIS_rc%lsm)
+         call LIS_endrun()
+      end if
+      if (LIS_rc%routingmodel .eq. "HYMAP2 router") then
+         dname = trim(dname) &
+           //'-HYMAP'
+      else if (LIS_rc%routingmodel .eq. "RAPID router") then
+         dname = trim(dname) &
+           //'-RAPID'
+      else if (LIS_rc%routingmodel .eq. "none") then
+         continue
+      else
+         write(LIS_logunit,*) &
+              '[ERR] Invalid Routing model for ', &
+              '557WW medium range convention ', &
+              trim(LIS_rc%routingmodel)
+         call LIS_endrun()
+      end if
+
+      write(unit=initdate, fmt='(i4.4, i2.2, i2.2)') &
+           LIS_rc%syr, LIS_rc%smo, LIS_rc%sda
+      write(unit=inithr, fmt='(i2.2)') LIS_rc%shr
+      call ESMF_TimeSet(starttime, &
+           yy=LIS_rc%syr, mm=LIS_rc%smo, dd=LIS_rc%sda, &
+           h=LIS_rc%shr, m=LIS_rc%smn, s=LIS_rc%sss, rc=rc)
+      if (rc .ne. ESMF_SUCCESS) then
+         write(LIS_logunit,*)'[ERR] Cannot set starttime object!'
+         call LIS_endrun()
+      end if
+      call ESMF_TimeSet(curtime, &
+           yy=LIS_rc%yr, mm=LIS_rc%mo, dd=LIS_rc%da, &
+           h=LIS_rc%hr, m=LIS_rc%mn, s=LIS_rc%ss, rc=rc)
+      if (rc .ne. ESMF_SUCCESS) then
+         write(LIS_logunit,*)'[ERR] Cannot set curtime object!'
+         call LIS_endrun()
+      end if
+      deltatime = curtime - starttime
+      call ESMF_TimeIntervalGet(deltatime, h=hr, rc=rc)
+      if (rc .ne. ESMF_SUCCESS) then
+         write(LIS_logunit,*)'[ERR] Cannot get hr from deltatime!'
+         call LIS_endrun()
+      end if
+      write(unit=fhr, fmt='(i3.3)') hr
+      dname = trim(dname) &
+           //'_GR.'//trim(fproj)//trim(fres2) &
+           //'_AR.'//trim(LIS_rc%area_of_data) &
+           //'_PA.'//'LIS-'//trim(model_name) &
+           //'_DD.'//trim(initdate) &
+           //'_CY.'//trim(inithr) &
+           //'_FH.'//trim(fhr)
+
+      select case (wout)
+      case ("binary")
+         if(LIS_rc%wopt.eq."1d tilespace") then
+            out_fname = trim(dname)//'_DF.DAT'
+         elseif(LIS_rc%wopt.eq."2d gridspace") then
+            out_fname = trim(dname)//'_DF.DAT'
+         elseif(LIS_rc%wopt.eq."1d gridspace") then
+            out_fname = trim(out_fname)//'_DF.DAT'
+         endif
+      case ("grib1")
+         out_fname = trim(dname)//'_DF.GR1'
+      case ("netcdf")
+         out_fname = trim(dname)//'_DF.NC'
+      case ("grib2")
+         out_fname = trim(dname)//'_DF.GR2'
+      case default
+      end select
 
    endif
    fname = out_fname
@@ -1441,7 +1735,8 @@ subroutine create_dapert_filename(n, fname)
       out_fname = trim(out_fname)//'.bin'
    elseif(LIS_rc%wstyle.eq."2 level hierarchy".or.&
         LIS_rc%wstyle.eq."WMO convention" .or. &
-        LIS_rc%wstyle.eq."557WW streamflow convention") then
+        LIS_rc%wstyle.eq."557WW streamflow convention" .or. &
+        LIS_rc%wstyle.eq."557WW medium range forecast convention") then
       write(unit=cdate1, fmt='(i4.4, i2.2, i2.2, i2.2, i2.2)') &
            LIS_rc%yr, LIS_rc%mo, &
            LIS_rc%da, LIS_rc%hr,LIS_rc%mn
@@ -1587,7 +1882,8 @@ subroutine create_dapert_filename_withtime(n, fname, yr, mo, da, hr, mn, ss)
       out_fname = trim(out_fname)//'.bin'
    elseif(LIS_rc%wstyle.eq."2 level hierarchy".or.&
         LIS_rc%wstyle.eq."WMO convention" .or. &
-        LIS_rc%wstyle.eq."557WW streamflow convention") then
+        LIS_rc%wstyle.eq."557WW streamflow convention" .or. &
+        LIS_rc%wstyle.eq."557WW medium range forecast convention") then
       write(unit=cdate1, fmt='(i4.4, i2.2, i2.2, i2.2, i2.2)') &
            yr, mo, &
            da, hr,mn
@@ -1768,7 +2064,8 @@ subroutine create_dapert_filename_withtime(n, fname, yr, mo, da, hr, mn, ss)
       fname = out_fname
       
    elseif(LIS_rc%wstyle.eq."WMO convention" .or. &
-        LIS_rc%wstyle.eq."557WW streamflow convention") then 
+        LIS_rc%wstyle.eq."557WW streamflow convention" .or. &
+        LIS_rc%wstyle.eq."557WW medium range forecast convention") then 
 
       write(unit=cdate1, fmt='(i4.4, i2.2, i2.2, i2.2,i2.2)') &
            yr,mo,da,hr,mn
@@ -1961,7 +2258,8 @@ subroutine create_dapert_filename_withtime(n, fname, yr, mo, da, hr, mn, ss)
       fname = out_fname
       
    elseif(LIS_rc%wstyle.eq."WMO convention" .or. &
-        LIS_rc%wstyle.eq."557WW streamflow convention") then 
+        LIS_rc%wstyle.eq."557WW streamflow convention" .or. &
+        LIS_rc%wstyle.eq."557WW medium range forecast convention") then 
 
       write(unit=cdate1, fmt='(i4.4, i2.2, i2.2, i2.2,i2.2)') &
            yr,mo,da,hr,mn
@@ -2201,7 +2499,8 @@ subroutine LIS_create_innov_filename(n, k, fname, mname)
       
       out_fname = trim(out_fname)//'.nc'
    elseif(LIS_rc%wstyle.eq."WMO convention" .or. &
-        LIS_rc%wstyle.eq."557WW streamflow convention") then
+        LIS_rc%wstyle.eq."557WW streamflow convention" .or. &
+        LIS_rc%wstyle.eq."557WW medium range forecast convention") then
       write(unit=cdate1, fmt='(i4.4, i2.2, i2.2, i2.2, i2.2)') &
            LIS_rc%yr, LIS_rc%mo, &
            LIS_rc%da, LIS_rc%hr,LIS_rc%mn
@@ -2379,7 +2678,8 @@ subroutine LIS_create_incr_filename(n, k, fname, mname)
       
       out_fname = trim(out_fname)//'.nc'
    elseif(LIS_rc%wstyle.eq."WMO convention" .or. &
-        LIS_rc%wstyle.eq."557WW streamflow convention") then
+        LIS_rc%wstyle.eq."557WW streamflow convention" .or. &
+        LIS_rc%wstyle.eq."557WW medium range forecast convention") then
       write(unit=cdate1, fmt='(i4.4, i2.2, i2.2, i2.2, i2.2)') &
            LIS_rc%yr, LIS_rc%mo, &
            LIS_rc%da, LIS_rc%hr,LIS_rc%mn
@@ -2539,7 +2839,8 @@ subroutine LIS_create_daspread_filename(n, k, fname, mname)
       out_fname = trim(out_fname)//'.nc'
    elseif(LIS_rc%wstyle.eq."2 level hierarchy".or.&
         LIS_rc%wstyle.eq."WMO convention" .or. &
-        LIS_rc%wstyle.eq."557WW streamflow convention") then
+        LIS_rc%wstyle.eq."557WW streamflow convention" .or. &
+        LIS_rc%wstyle.eq."557WW medium range forecast convention") then
       write(unit=cdate1, fmt='(i4.4, i2.2, i2.2, i2.2, i2.2)') &
            LIS_rc%yr, LIS_rc%mo, &
            LIS_rc%da, LIS_rc%hr,LIS_rc%mn
@@ -3024,7 +3325,8 @@ subroutine LIS_create_gain_filename(n, fname, mname)
       out_fname = trim(out_fname)//'.nc'
    elseif(LIS_rc%wstyle.eq."2 level hierarchy".or.&
         LIS_rc%wstyle.eq."WMO convention" .or. &
-        LIS_rc%wstyle.eq."557WW streamflow convention") then
+        LIS_rc%wstyle.eq."557WW streamflow convention" .or. &
+        LIS_rc%wstyle.eq."557WW medium range forecast convention") then
       write(unit=cdate1, fmt='(i4.4, i2.2, i2.2, i2.2, i2.2)') &
            LIS_rc%yr, LIS_rc%mo, &
            LIS_rc%da, LIS_rc%hr,LIS_rc%mn

--- a/lis/core/LIS_fileIOMod.F90
+++ b/lis/core/LIS_fileIOMod.F90
@@ -887,7 +887,7 @@ subroutine create_output_filename(n, fname, model_name, odir, writeint)
       dname = trim(dname) &
            //'_GR.'//trim(fproj)//trim(fres2) &
            //'_AR.'//trim(LIS_rc%area_of_data) &
-           //'_PA.'//'LIS-'//trim(model_name) &
+           //'_PA.'//trim(model_name) &
            //'_DD.'//trim(initdate) &
            //'_CY.'//trim(inithr) &
            //'_FH.'//trim(fhr)
@@ -1548,7 +1548,7 @@ subroutine create_output_filename_expected(n, fname, wout, flag, model_name, odi
       else
          write(LIS_logunit,*) &
               '[ERR] Invalid Routing model for ', &
-              '557WW medium range convention ', &
+              '557WW medium range forecast convention ', &
               trim(LIS_rc%routingmodel)
          call LIS_endrun()
       end if
@@ -1580,7 +1580,7 @@ subroutine create_output_filename_expected(n, fname, wout, flag, model_name, odi
       dname = trim(dname) &
            //'_GR.'//trim(fproj)//trim(fres2) &
            //'_AR.'//trim(LIS_rc%area_of_data) &
-           //'_PA.'//'LIS-'//trim(model_name) &
+           //'_PA.'//trim(model_name) &
            //'_DD.'//trim(initdate) &
            //'_CY.'//trim(inithr) &
            //'_FH.'//trim(fhr)

--- a/lis/core/LIS_readConfig.F90
+++ b/lis/core/LIS_readConfig.F90
@@ -468,7 +468,8 @@ subroutine LIS_readConfig()
        rc=rc)
   call LIS_verify(rc,'Output naming style: not defined')
   !EMK Extra info required
-  if (LIS_rc%wstyle == "557WW streamflow convention") then
+  if (LIS_rc%wstyle == "557WW streamflow convention" .or. &
+       LIS_rc%wstyle == "557WW medium range forecast convention") then
      call ESMF_ConfigGetAttribute(LIS_config, LIS_rc%security_class, &
           label="AGRMET security classification:", rc=rc)
      call LIS_verify(rc, 'AGRMET security classification: option not specified in the config file')


### PR DESCRIPTION

### Description

Bug fixes for Medium Range Forecasts

* Fixed GALWEM-GD reader to increase maximum run length to 240 hours; allow runs as 06Z, 12Z, and 18Z; and correct intervals between GALWEM-GD output files.
* Added 557WW medium range forecast convention for output files.
* Updated FOC files.
* Updated documentation.


