### PR TITLE
Disable AWRAL in user_557ww.cfg and user_ghis2s_557ww.cfg

### DIFF
--- a/lis/make/user_557ww.cfg
+++ b/lis/make/user_557ww.cfg
@@ -7,3 +7,4 @@ VIC.4.1.2: Off
 CLM.2: Off
 LSM RDHM.3.5.6: Off
 RAPID router: On
+AWRAL: Off

--- a/lis/make/user_ghis2s_557ww.cfg
+++ b/lis/make/user_ghis2s_557ww.cfg
@@ -57,3 +57,4 @@ GeoWRSI.2: Off
 SUMMA.1.0: Off
 ESP boot: Off
 GLS: Off
+AWRAL: Off


### PR DESCRIPTION
### Description

SonarQube reports an "Out of bound memory access" finding for AWRAL. A review of the code showed that that was a false positive finding. However, to remove this finding from the SonarQube report, I am disabling compiling AWRAL in LIS for the USAF configurations.  USAF does not run AWRAL in operations.