### PR TITLE
Disabled AWRAL.6.0.0 LSM from 557WW builds.

### DIFF
--- a/lis/make/user_557ww.cfg
+++ b/lis/make/user_557ww.cfg
@@ -8,3 +8,4 @@ CLM.2: Off
 LSM RDHM.3.5.6: Off
 RAPID router: On
 AWRAL: Off
+AWRAL.6.0.0: Off

--- a/lis/make/user_ghis2s_557ww.cfg
+++ b/lis/make/user_ghis2s_557ww.cfg
@@ -58,3 +58,4 @@ SUMMA.1.0: Off
 ESP boot: Off
 GLS: Off
 AWRAL: Off
+AWRAL.6.0.0: Off


### PR DESCRIPTION

### Description

This corrects an oversight in disabling AWRAL compilation to address SonarQube "Out of bound memory access" finding on AWRAL.  Prior edits to 557WW user build config files only disabled the AWRAL metforcing reader, not the LSM.


