### PR TITLE
Fixed the LVT percentile issue

### DIFF
--- a/lvt/metrics/LVT_percentileMod.F90
+++ b/lvt/metrics/LVT_percentileMod.F90
@@ -717,7 +717,7 @@ contains
           elseif(trim(model%short_name).eq."TWS") then 
              min_value = -10000
           else
-             min_value = 0.0 !soil moisture
+             min_value = -100.0 
           endif
 
           do t=1,LVT_rc%ngrid
@@ -926,7 +926,7 @@ contains
           elseif(trim(model%short_name).eq."TWS") then
              min_value = -10000
           else
-             min_value = 0.0 !soil moisture
+             min_value = -100.0
           endif
           
           do t=1,LVT_rc%ngrid


### PR DESCRIPTION
Fixed the issue where LVT percentiles are undefined for valid input values. This was occurring due to the use of a minimum value of 0.0 for certain variables. In such cases, valid input values were being screened out.

Resolves #1386

<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Replace this text with a concise description of *what* was changed and *why*.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->


