### PR TITLE
Updated IMERG version to V06D in FOC files

### DIFF
--- a/lis/configs/557WW-7.5-FOC/NRT_GLOBAL/lis.config.global.jules50.galwem17
+++ b/lis/configs/557WW-7.5-FOC/NRT_GLOBAL/lis.config.global.jules50.galwem17
@@ -237,7 +237,7 @@ AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
 AGRMET IMERG data directory:               ./input/USAF_FORCING/IMERG/Early_V06B
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V06B            # V06B released in 2019
+AGRMET IMERG version:                      V06D            # V06D released 2 Jul 2023
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings

--- a/lis/configs/557WW-7.5-FOC/NRT_GLOBAL/lis.config.global.noah39.galwem17
+++ b/lis/configs/557WW-7.5-FOC/NRT_GLOBAL/lis.config.global.noah39.galwem17
@@ -235,9 +235,9 @@ AGRMET CMORPH minimum temperature threshold:      273
 # Use IMERG rainfall data
 AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
-AGRMET IMERG data directory:               ./input/USAF_FORCING/IMERG/Early_V06C
+AGRMET IMERG data directory:               ./input/USAF_FORCING/IMERG/Early_V06B
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V06C            # V06B released in 2019
+AGRMET IMERG version:                      V06D            # V06D released 2 Jul 2023
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings

--- a/lis/configs/557WW-7.5-FOC/NRT_GLOBAL/lis.config.global.noahmp401.galwem17
+++ b/lis/configs/557WW-7.5-FOC/NRT_GLOBAL/lis.config.global.noahmp401.galwem17
@@ -236,9 +236,9 @@ AGRMET CMORPH minimum temperature threshold:      273
 # Use IMERG rainfall data
 AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
-AGRMET IMERG data directory:               ./input/USAF_FORCING/IMERG/Early_V06C
+AGRMET IMERG data directory:               ./input/USAF_FORCING/IMERG/Early_V06B
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V06C            # V06B released in 2019
+AGRMET IMERG version:                      V06D            # V06D released 2 Jul 2023
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings

--- a/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.jules50.hymap
+++ b/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.jules50.hymap
@@ -238,7 +238,7 @@ AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
 AGRMET IMERG data directory:               ./input/IMERG/Early_V06B
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V06B            # V06B released in 2019
+AGRMET IMERG version:                      V06D            # V06D released 2 Jul 2023
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings

--- a/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.jules50.rapid
+++ b/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.jules50.rapid
@@ -239,7 +239,7 @@ AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
 AGRMET IMERG data directory:               ./input/IMERG/Early_V06B
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V06B            # V06B released in 2019
+AGRMET IMERG version:                      V06D            # V06D released 2 Jul 2023
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings

--- a/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.noah39.hymap
+++ b/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.noah39.hymap
@@ -237,7 +237,7 @@ AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
 AGRMET IMERG data directory:               ./input/IMERG/Early_V06B
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V06B            # V06B released in 2019
+AGRMET IMERG version:                      V06D            # V06D released 2 Jul 2023
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings

--- a/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.noah39.rapid
+++ b/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.noah39.rapid
@@ -237,7 +237,7 @@ AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
 AGRMET IMERG data directory:               ./input/IMERG/Early_V06B
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V06B            # V06B released in 2019
+AGRMET IMERG version:                      V06D            # V06D released 2 Jul 2023
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings

--- a/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.noahmp401.hymap
+++ b/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.noahmp401.hymap
@@ -236,7 +236,7 @@ AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
 AGRMET IMERG data directory:               ./input/IMERG/Early_V06B
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V06B            # V06B released in 2019
+AGRMET IMERG version:                      V06D            # V06D released 2 Jul 2023
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings

--- a/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.noahmp401.rapid
+++ b/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.noahmp401.rapid
@@ -236,7 +236,7 @@ AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
 AGRMET IMERG data directory:               ./input/IMERG/Early_V06B
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V06B            # V06B released in 2019
+AGRMET IMERG version:                      V06D            # V06D released 2 Jul 2023
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings

--- a/lis/utils/usaf/s2s/global_usaf_forc/input/lis.config.template
+++ b/lis/utils/usaf/s2s/global_usaf_forc/input/lis.config.template
@@ -248,7 +248,7 @@ AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
 AGRMET IMERG data directory:               ./input/IMERG
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V06C            # V06C started 9 May 2022
+AGRMET IMERG version:                      V06D            # V06D started 2 Jul 2023
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings


### PR DESCRIPTION

### Description

Updated IMERG version to V06D in FOC files. V06D went live on 2 Jul 2023.

These changes were requested by the TADS contractor.



