### PR TITLE
Modify IMERG reader to ingest V07A Final products

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5973,8 +5973,18 @@ default to the "`final`" product of GPM IMERG.
 
 `IMERG version:` specifies the version of the GPM IMERG
 precipitation forcing files. If no version is specified, 
-the reader will default to the latest version of GPM IMERG.
-(Currently V06B).
+the reader will default to "`V06B`".
+
+The supported versions of GPM IMERG are:
+
+|====
+|Version  | Product
+
+|V06B     | early, late, final
+|V06C     | early, late, final
+|V06D     | early, late, final
+|V07A     | preliminary support for final
+|====
 
 .Example _lis.config_ entry
 ....

--- a/lis/metforcing/imerg/read_imerg.F90
+++ b/lis/metforcing/imerg/read_imerg.F90
@@ -22,7 +22,7 @@
 ! !INTERFACE:
 subroutine read_imerg (n, kk, name_imerg, findex, order, ferror_imerg )
 ! !USES:
-  use LIS_coreMod,only : LIS_rc, LIS_domain, LIS_masterproc
+  use LIS_coreMod,only : LIS_rc, LIS_domain
   use LIS_logMod, only : LIS_logunit, LIS_getNextUnitNumber, &
                          LIS_releaseUnitNumber
   use LIS_metforcingMod,only : LIS_forc
@@ -93,16 +93,16 @@ subroutine read_imerg (n, kk, name_imerg, findex, order, ferror_imerg )
  ferror_imerg = 1
  inquire(file=fname, EXIST=file_exists)
  if (file_exists) then
-   if(LIS_masterproc) write(LIS_logunit,*) &
+   write(LIS_logunit,*) &
         "[INFO] Reading HDF5 IMERG precipitation data from ", trim(fname)
    call read_imerghdf(n, fname, xd, yd, realprecip, ireaderr)
    if (ireaderr .ne. 0) then
-     if(LIS_masterproc) write(LIS_logunit,*) &
+     write(LIS_logunit,*) &
         "[WARN] Error reading IMERG file ",trim(fname)
      ferror_imerg = 0
    endif
  else
-   if(LIS_masterproc) write(LIS_logunit,*) &
+   write(LIS_logunit,*) &
       "[WARN] Missing IMERG precipitation data:: ",trim(fname)
    ferror_imerg = 0
  endif
@@ -126,8 +126,7 @@ subroutine read_imerg (n, kk, name_imerg, findex, order, ferror_imerg )
           endif
        enddo
     enddo
-    if (LIS_masterproc) &
-      write(LIS_logunit,*) "Obtained IMERG precipitation data from ", trim(fname)
+    write(LIS_logunit,*) "Obtained IMERG precipitation data from ", trim(fname)
  endif
 
  deallocate (precip_regrid)
@@ -141,7 +140,7 @@ subroutine read_imerghdf(n, filename, xsize, ysize, precipout, istatus)
 #if (defined USE_HDF5)
   use hdf5
 #endif
-  use LIS_coreMod, only : LIS_rc, LIS_domain, LIS_masterproc
+  use LIS_coreMod, only : LIS_rc, LIS_domain
   use LIS_logMod, only : LIS_logunit, LIS_getNextUnitNumber
   use imerg_forcingMod, only : imerg_struc
 
@@ -211,7 +210,7 @@ subroutine read_imerghdf(n, filename, xsize, ysize, precipout, istatus)
   call h5dread_f(dsetid, H5T_NATIVE_REAL, precipin, dims, istatus)
   if (istatus .ne. 0) then
      ! We can't read the dataset.  Close the dataset, the file, and
-     ! the Fortran interface.  Don't overwrite the istatus values.
+     ! the Fortran interface.  Don't overwrite the istatus value.
      write (LIS_logunit,*) '[WARN] Error reading IMERG dataset', &
              trim(dsetname)
      call h5dclose_f(dsetid, ierr)

--- a/lis/metforcing/imerg/read_imerg.F90
+++ b/lis/metforcing/imerg/read_imerg.F90
@@ -15,6 +15,9 @@
 ! !REVISION HISTORY:
 !  17 Jul 2001: Jon Gottschalck; Initial code
 !  09 Mar 2015: Jon Case;  Added IMERG precipitation reader
+!  07 Aug 2023: Jessica Erlingas; Added support for IMERG V07
+!  16 Aug 2023: Eric Kemp; Improved graceful HDF5 library cleanup if
+!               error is detected.
 !
 ! !INTERFACE:
 subroutine read_imerg (n, kk, name_imerg, findex, order, ferror_imerg )
@@ -150,82 +153,94 @@ subroutine read_imerghdf(n, filename, xsize, ysize, precipout, istatus)
   character(len=40) :: dsetname
   real :: precipin(ysize,xsize)
   real :: precipout(xsize,ysize)
-  logical :: bIsError
   integer :: istatus,i
   character(len=4) :: vlname
   integer         :: vnum, n
 #if (defined USE_HDF5)
   integer(HSIZE_T), dimension(2) :: dims
-  integer(HID_T) :: fileid,dsetid
+  integer(HID_T) :: fileid, dsetid
+  integer :: ierr
 
   dims(1) = xsize
   dims(2) = ysize
 
-  bIsError=.false.
-
   ! Variable names changed in IMERG V07
-
   vlname = trim(imerg_struc(n)%imergver)
-  read( vlname(3:3), *) vnum
-
-  if(vnum.ge.7) then
+  read( vlname(3:3), '(I)') vnum
+  if (vnum .ge. 7) then
      dsetname='/Grid/precipitation'
   else
      dsetname='/Grid/precipitationCal'
   endif
-!open fortran interface
+
+  istatus = 0 ! istatus is returned from this subroutine
+  ierr = 0    ! ierr is strictly a local variable
+
+  ! Open Fortran interface
   call h5open_f(istatus)
-  if(istatus.ne.0) then
-    bIsError=.true.
-    if (LIS_masterproc) write (LIS_logunit,*) 'Error opening HDF5 fortran interface'
-    return
-  endif
-!open hdf5 file
-  call h5fopen_f(filename,H5F_ACC_RDONLY_F,fileid,istatus)
-  if(istatus.ne.0) then
-    bIsError=.true.
-    if (LIS_masterproc) write (LIS_logunit,*) 'Error opening IMERG file',trim(filename)
-    return
-  endif
-!open dataset
-  call h5dopen_f(fileid,dsetname,dsetid,istatus)
-  if(istatus.ne.0) then
-    bIsError=.true.
-    if (LIS_masterproc) write (LIS_logunit,*) 'Error opening IMERG dataset',trim(dsetname)
-    return
-  endif
-!read dataset 
-  call h5dread_f(dsetid,H5T_NATIVE_REAL,precipin,dims,istatus)
-  if(istatus.ne.0) then
-    bIsError=.true.
-    if (LIS_masterproc) write (LIS_logunit,*) 'Error reading IMERG dataset',trim(dsetname)
-    return
-  endif
-!Put the real(1:,1:) on the precipout(0:,0:)
-!precipin is (ysize,xsize) starting at (lon=-179.9,lat=-89.9)
+  if (istatus .ne. 0) then
+     ! No need to proceed, something is wrong with HDF5.
+     write (LIS_logunit,*) '[WARN] Error opening HDF5 Fortran interface'
+     return
+  end if
+
+  ! Open HDF5 file.
+  call h5fopen_f(filename, H5F_ACC_RDONLY_F, fileid, istatus)
+  if (istatus .ne. 0) then
+     ! We couldn't open the file.  Close the Fortran interface and return.
+     ! Don't overwrite the istatus value.
+     write (LIS_logunit,*) '[WARN] Error opening IMERG file', &
+          trim(filename)
+     call h5close_f(ierr)
+     return
+  end if
+
+  ! Open dataset
+  call h5dopen_f(fileid, dsetname, dsetid, istatus)
+  if (istatus .ne. 0) then
+     ! We can't open the dataset.  Close the file and Fortran interface.
+     ! Don't overwrite the istatus value.
+     write (LIS_logunit,*) '[WARN] Error opening IMERG dataset', &
+             trim(dsetname)
+     call h5fclose_f(fileid, ierr)
+     call h5close_f(ierr)
+     return
+  end if
+
+  ! Read dataset
+  call h5dread_f(dsetid, H5T_NATIVE_REAL, precipin, dims, istatus)
+  if (istatus .ne. 0) then
+     ! We can't read the dataset.  Close the dataset, the file, and
+     ! the Fortran interface.  Don't overwrite the istatus values.
+     write (LIS_logunit,*) '[WARN] Error reading IMERG dataset', &
+             trim(dsetname)
+     call h5dclose_f(dsetid, ierr)
+     call h5fclose_f(fileid, ierr)
+     call h5close_f(ierr)
+     return
+  end if
+
+  ! Put the real(1:,1:) on the precipout(0:,0:)
+  ! precipin is (ysize,xsize) starting at (lon=-179.9,lat=-89.9)
   precipout(1:xsize,1:ysize)=transpose(precipin)
 
-!close dataset
-  call h5dclose_f(dsetid,istatus)
-  if(istatus.ne.0) then
-    bIsError=.true.
-    if (LIS_masterproc) write (LIS_logunit,*) 'Error closing IMERG dataset',trim(dsetname)
-    return
-  endif
-!close file
-  call h5fclose_f(fileid,istatus)
-  if(istatus.ne.0) then
-    bIsError=.true.
-    if (LIS_masterproc) write (LIS_logunit,*) 'Error closing IMERG file',trim(filename)
-    return
-  endif
-!close fortran interface
-  call h5close_f(istatus)
-  if(istatus.ne.0) then
-    bIsError=.true.
-    if (LIS_masterproc) write (LIS_logunit,*) 'Error closing HDF5 fortran interface'
-    return
-  endif
+  ! Close the dataset, file, and Fortran interface.  We already have
+  ! the IMERG data in the array, so we don't need to overwrite the
+  ! istatus value.  But we'll still log problems.
+  call h5dclose_f(dsetid, ierr)
+  if (ierr .ne. 0) then
+     write (LIS_logunit,*) '[WARN] Error closing IMERG dataset', &
+          trim(dsetname)
+  end if
+  call h5fclose_f(fileid, ierr)
+  if (ierr .ne. 0) then
+     write (LIS_logunit,*) '[WARN] Error closing IMERG file', &
+          trim(filename)
+  end if
+  call h5close_f(ierr)
+  if (ierr .ne. 0) then
+     write (LIS_logunit,*) '[WARN] Error closing HDF5 Fortran interface'
+  end if
 
 #endif
 


### PR DESCRIPTION
### Description

The IMERG reader was modified to read the newly released V07 products. Only Final IMERG V07A products are available at this time (August 2023), but Early and Late products are anticipated in Fall 2023. In V07 and subsequent versions, variable names have changed. Please see https://gpm.nasa.gov/sites/default/files/2023-07/IMERG_V07_ReleaseNotes_final_230713.pdf for more documentation. 

Resolves #1394 

### Testcase

A testcase is available at /discover/nobackup/projects/lais/sharespace/imergv07_forcing_testcase


