### PR TITLE
Fix ISRIC soil texture water point index value in LDT

### DIFF
--- a/ldt/core/LDT_paramOptCheckMod.F90
+++ b/ldt/core/LDT_paramOptCheckMod.F90
@@ -483,8 +483,8 @@ contains
           endif
 
         case( "ISRIC")
-          if (nt.ne.13) then 
-            write(LDT_logunit,*) "Param_Check: ISRIC has 13 types (includes water) for tiling."
+          if (nt.ne.16) then
+            write(LDT_logunit,*) "Param_Check: ISRIC has 16 types (includes water) for tiling."
             write(LDT_logunit,*) "             The current value is: ",nt
             write(LDT_logunit,*) " Stopping ..."
             call LDT_endrun

--- a/ldt/core/LDT_soilsMod.F90
+++ b/ldt/core/LDT_soilsMod.F90
@@ -782,7 +782,7 @@ module LDT_soilsMod
             elseif(INDEX(LDT_LSMparam_struc(n)%texture%source,"ZOBLER") >0) then 
                soiltext%watervalue = 1.0
             elseif(INDEX(LDT_LSMparam_struc(n)%texture%source,"ISRIC") >0) then 
-               soiltext%watervalue = 13.
+               soiltext%watervalue = 14.
             else
                soiltext%watervalue = LDT_rc%udef
             endif
@@ -1484,7 +1484,7 @@ module LDT_soilsMod
             elseif(INDEX(LDT_LSMparam_struc(n)%texture%source,"ZOBLER") >0) then 
                soiltext%watervalue = 1.0
             elseif(INDEX(LDT_LSMparam_struc(n)%texture%source,"ISRIC") >0) then 
-               soiltext%watervalue = 13.
+               soiltext%watervalue = 14.
             else
                soiltext%watervalue = LDT_rc%udef
             endif
@@ -1814,7 +1814,7 @@ module LDT_soilsMod
               14))
       elseif( LDT_rc%soil_classification(1) == "ISRIC" ) then
          call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"NUMBER_SOILTYPES", &
-              13))
+              19))
       else
          call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"NUMBER_SOILTYPES", &
               19))
@@ -1972,7 +1972,7 @@ module LDT_soilsMod
               14))
       elseif( LDT_rc%soil_classification(1) == "ISRIC" ) then
          call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"NUMBER_SOILTYPES", &
-              13))
+              19))
       else
          call LDT_verify(nf90_put_att(ftn,NF90_GLOBAL,"NUMBER_SOILTYPES", &
               19))

--- a/ldt/params/soils/read_ISRIC_texture.F90
+++ b/ldt/params/soils/read_ISRIC_texture.F90
@@ -94,7 +94,7 @@ subroutine read_ISRIC_texture( n, num_bins, fgrd, texture_layers )
 
 ! ___________________________________________________________________
   
-   water_class = 13    ! Water class for ISRIC soil texture class
+   water_class = 14    ! Water class for ISRIC soil texture class
 
    temp = LDT_rc%udef
    gridcnt = 0.

--- a/ldt/params/soils/set_ISRIC_texture_attribs.F90
+++ b/ldt/params/soils/set_ISRIC_texture_attribs.F90
@@ -34,7 +34,7 @@ subroutine set_ISRIC_texture_attribs()
 !  \end{description}
 !EOP      
 !
-  LDT_LSMparam_struc(:)%texture%num_bins = 13
+  LDT_LSMparam_struc(:)%texture%num_bins = 16
   LDT_LSMparam_struc(:)%texture%vlevels = 1
 
   LDT_soils_struc(:)%texture_nlyrs%num_bins = 1


### PR DESCRIPTION
This pull request fixes the water point index values when using the ISRIC soil texture maps in LDT.  LDT re-maps the ISRIC soil texture map onto the STATSGO soil classification index.  However, the water points were incorrectly assigned a value of 13, when it should be 14 in the STATSGO soil texture classification.

Resolves: #1406
