### PR TITLE
Enable compiling LISF on Cray/SLES 15.4/PrgEnv 8.3.3 using Intel 2022.2.1 compilers

### DIFF
--- a/env/narwhal/lisf_7.5_prgenv_intel_8.3.3
+++ b/env/narwhal/lisf_7.5_prgenv_intel_8.3.3
@@ -1,0 +1,198 @@
+#%Module1.0###################################################################
+
+proc ModulesHelp { } {
+    puts stderr "\t[module-info name] - loads the LISF_7.5_PRGENV_INTEL_8.3.3 (22.09) env"
+    puts stderr ""
+    puts stderr "This is for use on Navy's narwhal system running Cray/SUSE 15.4."
+    puts stderr ""
+    puts stderr "\tThe following env variables are set:"
+    puts stderr "\t\tDEV_ENV"
+    puts stderr "\t\tCRAYPE_LINK_TYPE"
+    puts stderr "\t\tLIS_ARCH"
+    puts stderr "\t\tLIS_SPMD"
+    puts stderr "\t\tLIS_FC"
+    puts stderr "\t\tLIS_CC"
+    puts stderr "\t\tLIS_OPENJPEG"
+    puts stderr "\t\tLIS_ECCODES"
+    puts stderr "\t\tLIS_NETCDF"
+    puts stderr "\t\tLIS_HDF4"
+    puts stderr "\t\tLIS_HDFEOS"
+    puts stderr "\t\tLIS_HDF5"
+    puts stderr "\t\tLIS_MODESMF"
+    puts stderr "\t\tLIS_LIBESMF"
+    puts stderr "\t\tLIS_MINPACK"
+    puts stderr "\t\tLIS_CRTM"
+    puts stderr "\t\tLIS_CRTM_PROF"
+    puts stderr "\t\tLIS_CMEM"
+    puts stderr "\t\tLIS_LAPACK"
+    puts stderr "\t\tLIS_PETSC"
+    puts stderr "\t\tLDT_ARCH"
+    puts stderr "\t\tLDT_FC"
+    puts stderr "\t\tLDT_CC"
+    puts stderr "\t\tLDT_JPEG"
+    puts stderr "\t\tLDT_OPENJPEG"
+    puts stderr "\t\tLDT_ECCODES"
+    puts stderr "\t\tLDT_NETCDF"
+    puts stderr "\t\tLDT_HDF4"
+    puts stderr "\t\tLDT_HDFEOS"
+    puts stderr "\t\tLDT_HDF5"
+    puts stderr "\t\tLDT_MODESMF"
+    puts stderr "\t\tLDT_LIBESMF"
+    puts stderr "\t\tLDT_GDAL"
+    puts stderr "\t\tLDT_FORTRANGIS"
+    puts stderr "\t\tLDT_LIBGEOTIFF"
+    puts stderr "\t\tLVT_ARCH"
+    puts stderr "\t\tLVT_FC"
+    puts stderr "\t\tLVT_CC"
+    puts stderr "\t\tLVT_JPEG"
+    puts stderr "\t\tLVT_OPENJPEG"
+    puts stderr "\t\tLVT_ECCODES"
+    puts stderr "\t\tLVT_NETCDF"
+    puts stderr "\t\tLVT_HDF4"
+    puts stderr "\t\tLVT_HDFEOS"
+    puts stderr "\t\tLVT_HDF5"
+    puts stderr "\t\tLVT_MODESMF"
+    puts stderr "\t\tLVT_LIBESMF"
+    puts stderr "\t\tLVT_GDAL"
+    puts stderr "\t\tLVT_FORTRANGIS"
+    puts stderr ""
+    puts stderr "\tThe following modules are loaded:"
+    puts stderr "\t\taPrgEnv-intel"
+    puts stderr ""
+}
+
+#
+# Original default modules
+#
+#  Currently Loaded Modulefiles:
+#  1) cce/15.0.0             
+#  2) craype/2.7.19          
+#  3) craype-x86-rome        
+#  4) libfabric/1.12.1.2.2.1 
+#  5) craype-network-ofi     
+#  6) cray-dsmml/0.2.2       
+#  7) perftools-base/22.09.0
+#  8) cray-mpich/8.1.21
+#  9) cray-libsci/22.11.1.2
+# 10) cray-pals/1.2.12
+# 11) bct-env/0.1
+# 12) mpscp/1.3a
+# 13) PrgEnv-cray/8.3.3
+
+module purge
+module load PrgEnv-intel/8.3.3
+module load gcc/12.1.0
+
+#  Currently Loaded Modulefiles:
+#  1) intel/2022.2.1            
+#  2) craype/2.7.19             
+#  3) craype-x86-rome           
+#  4) libfabric/1.12.1.2.2.1    
+#  5) craype-network-ofi        
+#  6) cray-dsmml/0.2.2          
+#  7) perftools-base/22.09.0    
+#  8) cray-mpich/8.1.21
+#  9) cray-libsci/22.11.1.2
+# 10) cray-pals/1.2.12
+# 11) bct-env/0.1
+# 12) mpscp/1.3a
+# 13) PrgEnv-intel/8.3.3
+# 14) gcc/12.1.0
+
+conflict comp mpi
+
+
+module-whatis	"loads the [module-info name] environment"
+
+
+set modname     [module-info name]
+set modmode     [module-info mode]
+
+setenv CRAYPE_LINK_TYPE dynamic
+
+set   def_lis_rpc         /lib64/libtirpc.so.3
+set   def_lis_hdf5        /p/home/jim/local/lib/sles-15.4/prgenv-intel-8.3.3_2022.2.1/hdf5/1.14.2_intel-2022.2.1
+set   def_lis_netcdf      /p/home/jim/local/lib/sles-15.4/prgenv-intel-8.3.3_2022.2.1/netcdf/4.9.2_intel-2022.2.1
+set   def_lis_openjpeg    /p/home/jim/local/lib/sles-15.4/prgenv-intel-8.3.3_2022.2.1/openjpeg/2.4.0_intel-2022.2.1
+set   def_lis_eccodes     /p/home/jim/local/lib/sles-15.4/prgenv-intel-8.3.3_2022.2.1/eccodes/2.32.0_intel-2022.2.1
+set   def_lis_modesmf     /p/home/jim/local/lib/sles-15.4/prgenv-intel-8.3.3_2022.2.1/esmf/8.5.0_intel-2022.2.1_cray-mpich-8.1.12/mod/modO/Unicos.intel.64.mpi.default
+set   def_lis_libesmf     /p/home/jim/local/lib/sles-15.4/prgenv-intel-8.3.3_2022.2.1/esmf/8.5.0_intel-2022.2.1_cray-mpich-8.1.12/lib/libO/Unicos.intel.64.mpi.default/
+set   def_lis_hdf4        /p/home/jim/local/lib/sles-15.4/prgenv-intel-8.3.3_2022.2.1/hdf4/4.2.16-2_intel-2022.2.1
+set   def_lis_hdfeos      /p/home/jim/local/lib/sles-15.4/prgenv-intel-8.3.3_2022.2.1/hdfeos2/3.0_intel-2022.2.1
+set   def_ldt_libgeotiff  /p/home/jim/local/lib/sles-15.4/prgenv-intel-8.3.3_2022.2.1/geotiff/1.7.1_intel-2022.2.1
+set   def_lvt_proj        /p/home/jim/local/lib/sles-15.4/prgenv-intel-8.3.3_2022.2.1/proj/9.3.0_intel-2022.2.1
+set   def_lvt_gdal        /p/home/jim/local/lib/sles-15.4/prgenv-intel-8.3.3_2022.2.1/gdal/3.5.2_intel-2022.2.1
+set   def_lvt_fortrangis  /p/home/jim/local/lib/sles-15.4/prgenv-intel-8.3.3_2022.2.1/fortrangis/2.6_intel-2022.2.1
+set   def_lis_minpack     ""
+set   def_lis_crtm        ""
+set   def_lis_crtm_prof   ""
+set   def_lis_cmem        ""
+set   def_lis_lapack      ""
+set   def_lis_petsc       /p/home/jim/local/lib/sles-15.4/prgenv-intel-8.3.3_2022.2.1/petsc/3.20.0_intel-2022.2.1
+
+setenv   DEV_ENV         LISF_7.5_PRGENV_INTEL_8.3.3
+setenv   LIS_ARCH        linux_ifc
+setenv   LIS_SPMD        parallel
+setenv   LIS_FC          ftn
+setenv   LIS_CC          cc
+setenv   LIS_RPC         $def_lis_rpc
+setenv   LIS_HDF5        $def_lis_hdf5
+setenv   LIS_NETCDF      $def_lis_netcdf
+setenv   LIS_OPENJPEG    $def_lis_openjpeg
+setenv   LIS_ECCODES     $def_lis_eccodes
+setenv   LIS_MODESMF     $def_lis_modesmf
+setenv   LIS_LIBESMF     $def_lis_libesmf
+setenv   LIS_HDF4        $def_lis_hdf4
+setenv   LIS_HDFEOS      $def_lis_hdfeos
+setenv   LIS_MINPACK     $def_lis_minpack
+setenv   LIS_CRTM        $def_lis_crtm
+setenv   LIS_CRTM_PROF   $def_lis_crtm_prof
+setenv   LIS_CMEM        $def_lis_cmem
+setenv   LIS_LAPACK      $def_lis_lapack
+setenv   LIS_PETSC       $def_lis_petsc
+
+
+setenv   LDT_ARCH        linux_ifc
+setenv   LDT_FC          ftn
+setenv   LDT_CC          cc
+setenv   LDT_RPC         $def_lis_rpc
+setenv   LDT_HDF5        $def_lis_hdf5
+setenv   LDT_NETCDF      $def_lis_netcdf
+setenv   LDT_OPENJPEG    $def_lis_openjpeg
+setenv   LDT_ECCODES     $def_lis_eccodes
+setenv   LDT_MODESMF     $def_lis_modesmf
+setenv   LDT_LIBESMF     $def_lis_libesmf
+setenv   LDT_HDF4        $def_lis_hdf4
+setenv   LDT_HDFEOS      $def_lis_hdfeos
+setenv   LDT_LIBGEOTIFF  $def_ldt_libgeotiff
+setenv   LDT_GDAL        $def_lvt_gdal
+setenv   LDT_FORTRANGIS  $def_lvt_fortrangis
+
+
+setenv   LVT_ARCH        linux_ifc
+setenv   LVT_FC          ftn
+setenv   LVT_CC          cc
+setenv   LVT_RPC         $def_lis_rpc
+setenv   LVT_HDF5        $def_lis_hdf5
+setenv   LVT_NETCDF      $def_lis_netcdf
+setenv   LVT_OPENJPEG    $def_lis_openjpeg
+setenv   LVT_ECCODES     $def_lis_eccodes
+setenv   LVT_MODESMF     $def_lis_modesmf
+setenv   LVT_LIBESMF     $def_lis_libesmf
+setenv   LVT_HDF4        $def_lis_hdf4
+setenv   LVT_HDFEOS      $def_lis_hdfeos
+setenv   LVT_GDAL        $def_lvt_gdal
+setenv   LVT_FORTRANGIS  $def_lvt_fortrangis
+
+
+prepend-path   LD_LIBRARY_PATH   "$def_lis_openjpeg/lib"
+prepend-path   LD_LIBRARY_PATH   "$def_ldt_libgeotiff/lib"
+prepend-path   LD_LIBRARY_PATH   "$def_lvt_proj/lib64"
+prepend-path   LD_LIBRARY_PATH   "$def_lvt_gdal/lib"
+prepend-path   LD_LIBRARY_PATH   "$def_lis_hdf4/lib"
+prepend-path   LD_LIBRARY_PATH   "$def_lis_hdf5/lib"
+prepend-path   LD_LIBRARY_PATH   "$def_lis_libesmf"
+prepend-path   LD_LIBRARY_PATH   "$def_lis_netcdf/lib"
+prepend-path   LD_LIBRARY_PATH   "$def_lis_eccodes/lib"
+prepend-path   LD_LIBRARY_PATH   "$def_lis_petsc/lib"
+prepend-path   PATH   "$def_lis_netcdf/bin:$def_lis_eccodes/bin"

--- a/ldt/arch/Config.pl
+++ b/ldt/arch/Config.pl
@@ -608,25 +608,25 @@ else{
 if($sys_arch eq "linux_ifc") {
    if($use_omp == 1) {
       if($use_endian == 1) {
-         $fflags77= "-c -openmp ".$sys_opt."-nomixed_str_len_arg -names lowercase -convert little_endian -assume byterecl ".$sys_par." -DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
-         $fflags =" -c -openmp ".$sys_opt."-u -traceback -fpe0  -nomixed_str_len_arg -names lowercase -convert little_endian -assume byterecl ".$sys_par."-DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
+         $fflags77= "-c -openmp ".$sys_opt."-nomixed-str-len-arg -names lowercase -convert little_endian -assume byterecl ".$sys_par." -DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
+         $fflags =" -c -openmp ".$sys_opt."-u -traceback -fpe0  -nomixed-str-len-arg -names lowercase -convert little_endian -assume byterecl ".$sys_par."-DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
          $ldflags= " -openmp -L\$(LIB_ESMF) -lesmf -lstdc++ -limf -lm -lrt -lz";
       }
       else {
-         $fflags77= "-c -openmp ".$sys_opt."-nomixed_str_len_arg -names lowercase -convert big_endian -assume byterecl ".$sys_par." -DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
-         $fflags =" -c -openmp ".$sys_opt."-u -traceback -fpe0  -nomixed_str_len_arg -names lowercase -convert big_endian -assume byterecl ".$sys_par."-DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
+         $fflags77= "-c -openmp ".$sys_opt."-nomixed-str-len-arg -names lowercase -convert big_endian -assume byterecl ".$sys_par." -DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
+         $fflags =" -c -openmp ".$sys_opt."-u -traceback -fpe0  -nomixed-str-len-arg -names lowercase -convert big_endian -assume byterecl ".$sys_par."-DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
          $ldflags= " -openmp -L\$(LIB_ESMF) -lesmf -lstdc++ -limf -lm -lrt -lz";
       }
    }
    else {
       if($use_endian == 1) {
-         $fflags77= "-c ".$sys_opt."-nomixed_str_len_arg -names lowercase -convert little_endian -assume byterecl ".$sys_par." -DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
-         $fflags =" -c ".$sys_opt."-u -traceback -fpe0  -nomixed_str_len_arg -names lowercase -convert little_endian -assume byterecl ".$sys_par."-DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
+         $fflags77= "-c ".$sys_opt."-nomixed-str-len-arg -names lowercase -convert little_endian -assume byterecl ".$sys_par." -DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
+         $fflags =" -c ".$sys_opt."-u -traceback -fpe0  -nomixed-str-len-arg -names lowercase -convert little_endian -assume byterecl ".$sys_par."-DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
          $ldflags= " -L\$(LIB_ESMF) -lesmf -lstdc++ -limf -lm -lrt -lz";
       }
       else {
-         $fflags77= "-c ".$sys_opt."-nomixed_str_len_arg -names lowercase -convert big_endian -assume byterecl ".$sys_par." -DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
-         $fflags =" -c ".$sys_opt."-u -traceback -fpe0  -nomixed_str_len_arg -names lowercase -convert big_endian -assume byterecl ".$sys_par."-DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
+         $fflags77= "-c ".$sys_opt."-nomixed-str-len-arg -names lowercase -convert big_endian -assume byterecl ".$sys_par." -DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
+         $fflags =" -c ".$sys_opt."-u -traceback -fpe0  -nomixed-str-len-arg -names lowercase -convert big_endian -assume byterecl ".$sys_par."-DIFC -I\$(MOD_ESMF) -DUSE_INCLUDE_MPI";
          $ldflags= " -L\$(LIB_ESMF) -lesmf -lstdc++ -limf -lm -lrt -lz";
       }
    }

--- a/ldt/arch/Config.pl
+++ b/ldt/arch/Config.pl
@@ -599,7 +599,7 @@ else{
 }
 
 if(defined($ENV{LDT_RPC})){
-   $librpc = "-ltirpc";
+   $librpc = $ENV{LDT_RPC};
 }
 else{
    $librpc = "";

--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -897,7 +897,7 @@ if ($ENV{MPDECOMP2} eq '1') {
 }
 
 if(defined($ENV{LIS_RPC})){
-   $librpc = "-ltirpc";
+   $librpc = $ENV{LIS_RPC};
 }
 else{
    $librpc = "";

--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -910,8 +910,8 @@ else{
 
 if($sys_arch eq "linux_ifc") {
    $cflags = "-c ".$sys_omp." ".$sys_c_opt." -traceback -DIFC -DLINUX";
-   $fflags77= "-c ".$sys_omp." ".$sys_opt." -traceback -nomixed_str_len_arg -names lowercase ".$sys_endian." -assume byterecl ".$sys_par." -DHIDE_SHR_MSG -DNO_SHR_VMATH -DIFC -DLINUX -I\$(MOD_ESMF) ".$sys_par_d;
-   $fflags ="-c ".$sys_omp." ".$sys_opt." -u -traceback -fpe0 -nomixed_str_len_arg -names lowercase ".$sys_endian." -assume byterecl ".$sys_par." -DHIDE_SHR_MSG -DNO_SHR_VMATH -DIFC -DLINUX -I\$(MOD_ESMF) ".$sys_par_d;
+   $fflags77= "-c ".$sys_omp." ".$sys_opt." -traceback -nomixed-str-len-arg -names lowercase ".$sys_endian." -assume byterecl ".$sys_par." -DHIDE_SHR_MSG -DNO_SHR_VMATH -DIFC -DLINUX -I\$(MOD_ESMF) ".$sys_par_d;
+   $fflags ="-c ".$sys_omp." ".$sys_opt." -u -traceback -fpe0 -nomixed-str-len-arg -names lowercase ".$sys_endian." -assume byterecl ".$sys_par." -DHIDE_SHR_MSG -DNO_SHR_VMATH -DIFC -DLINUX -I\$(MOD_ESMF) ".$sys_par_d;
    $ldflags= $sys_omp." -L\$(LIB_ESMF) -lesmf -lstdc++ -limf -lrt";
    $lib_flags= "-lesmf -lstdc++ -limf -lrt";
    $lib_paths= "-L\$(LIB_ESMF)";

--- a/lis/make/Makefile
+++ b/lis/make/Makefile
@@ -8,7 +8,7 @@ RM := rm -f
 make-clean := $(RM) *.o *.mod LIS
 make-real-clean := $(RM) *.o *.mod LIS *.d Filepath
 COUPLED:=$(shell grep -E '^\#[[:space:]]*define[[:space:]]+COUPLED' LIS_misc.h)
-append_offline := $(if $(COUPLED),,vim -N -u NONE -i NONE -e -s -c '$$s;$$; ../offline;|wq' Filepath)
+append_offline := $(if $(COUPLED),,vim -X -N -u NONE -i NONE -e -s -c '$$s;$$; ../offline;|wq' Filepath)
 
 # Ensure that Filepath exists and/or is up to date.
 #

--- a/lvt/arch/Config.pl
+++ b/lvt/arch/Config.pl
@@ -530,13 +530,13 @@ else{
 if($sys_arch eq "linux_ifc") {
    if ($use_endian == 1 ) {
       $cflags = "-c ".$sys_c_opt." -traceback -DIFC";
-      $fflags77= "-c ".$sys_opt." -traceback -nomixed_str_len_arg -names lowercase -convert little_endian -assume byterecl ".$sys_par." -DIFC -I\$(MOD_ESMF) ";
-      $fflags =" -c ".$sys_opt." -u -traceback -fpe0  -nomixed_str_len_arg -names lowercase -convert little_endian -assume byterecl ".$sys_par."-DIFC -I\$(MOD_ESMF) ";
+      $fflags77= "-c ".$sys_opt." -traceback -nomixed-str-len-arg -names lowercase -convert little_endian -assume byterecl ".$sys_par." -DIFC -I\$(MOD_ESMF) ";
+      $fflags =" -c ".$sys_opt." -u -traceback -fpe0  -nomixed-str-len-arg -names lowercase -convert little_endian -assume byterecl ".$sys_par."-DIFC -I\$(MOD_ESMF) ";
    }
    else {
       $cflags = "-c ".$sys_c_opt." -traceback -DIFC";
-      $fflags77= "-c ".$sys_opt." -traceback -nomixed_str_len_arg -names lowercase -convert big_endian -assume byterecl ".$sys_par." -DIFC -I\$(MOD_ESMF) ";
-      $fflags =" -c ".$sys_opt." -u -traceback -fpe0  -nomixed_str_len_arg -names lowercase -convert big_endian -assume byterecl ".$sys_par."-DIFC -I\$(MOD_ESMF) ";
+      $fflags77= "-c ".$sys_opt." -traceback -nomixed-str-len-arg -names lowercase -convert big_endian -assume byterecl ".$sys_par." -DIFC -I\$(MOD_ESMF) ";
+      $fflags =" -c ".$sys_opt." -u -traceback -fpe0  -nomixed-str-len-arg -names lowercase -convert big_endian -assume byterecl ".$sys_par."-DIFC -I\$(MOD_ESMF) ";
    }
    $ldflags= " -L\$(LIB_ESMF) -lesmf -lstdc++ -limf -lm -lrt ";
 }

--- a/lvt/arch/Config.pl
+++ b/lvt/arch/Config.pl
@@ -521,7 +521,7 @@ else{
 }
 
 if(defined($ENV{LVT_RPC})){
-   $librpc = "-ltirpc";
+   $librpc = $ENV{LVT_RPC};
 }
 else{
    $librpc = "";

--- a/lvt/core/LVT_create_subdirs.c
+++ b/lvt/core/LVT_create_subdirs.c
@@ -7,6 +7,7 @@
 // Administrator of the National Aeronautics and Space Administration.
 // All Rights Reserved.
 //-------------------------END NOTICE -- DO NOT EDIT-----------------------
+
 /*****************************************************************************/
 /* NASA/GSFC, Software Systems Support Office, Code 610.3                    */
 /*****************************************************************************/
@@ -24,6 +25,7 @@
 
 /* ANSI C Standard Headers */
 #include <errno.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
### Description

These changes address issues encountered when compiling LISF on narwhal after its upgrade to Cray/SLES 15.4/PrgEnv 8.3.3.
