### PR TITLE
add distributed binary option for LIS_RST and LIS_DAPERT files

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -7993,7 +7993,7 @@ of how to specify a time interval.
 `Noah-MP.4.0.1 restart file:` specifies the Noah-MP-4.0.1 LSM restart file.
  
 `Noah-MP.4.0.1 restart file format:` specifies the Noah-MP-4.0.1 restart
-file format (default = netcdf).
+file format.  Acceptable values are: "`binary`", "`netcdf`", or "`distributed binary`".
  
 `Noah-MP.4.0.1 soil parameter table:` specifies the filename of the
 Noah-MP-4.0.1 soil parameter table.

--- a/lis/dataassim/perturb/gmaopert/gmaopert_Mod.F90
+++ b/lis/dataassim/perturb/gmaopert/gmaopert_Mod.F90
@@ -1841,7 +1841,6 @@ module gmaopert_Mod
       character*20 :: wformat
 
       wformat = "distributed binary"
-      
 
       if(wformat.eq."binary") then 
          if ( LIS_masterproc ) then
@@ -2210,6 +2209,7 @@ module gmaopert_Mod
       integer, allocatable      :: pertdata1d_obs_int(:)
       integer, allocatable      :: pertdata1d_patch_int(:)
       real, allocatable         :: dummy_var(:,:,:)
+      logical                   :: file_exists
       character*20              :: wformat
 
       wformat = "distributed binary"
@@ -2239,7 +2239,14 @@ module gmaopert_Mod
                   LIS_rc%pertRestartFile(n) = filen
                endif
             endif
-            
+           
+            inquire( file=trim(LIS_rc%pertRestartFile(n)), exist=file_exists ) 
+            if(file_exists .neqv. .true.) then
+               write(LIS_logunit,*) '[ERR] Reading perturbations restart file MISSING: ',&
+                     trim(LIS_rc%pertRestartFile(n))
+               call LIS_endrun()
+            endif
+
             open(ftn,file=trim(LIS_rc%pertRestartFile(n)), form='unformatted')
             write(LIS_logunit,*) '[INFO] Reading perturbations restart file ',&
                  trim(LIS_rc%pertRestartFile(n))

--- a/lis/dataassim/perturb/gmaopert/gmaopert_Mod.F90
+++ b/lis/dataassim/perturb/gmaopert/gmaopert_Mod.F90
@@ -1842,39 +1842,39 @@ module gmaopert_Mod
 
       wformat = "distributed binary"
 
-      if(wformat.eq."binary") then 
+      if(wformat.eq."binary") then
          if ( LIS_masterproc ) then
-            
-            call LIS_create_output_directory('DAPERT')         
+
+            call LIS_create_output_directory('DAPERT')
             call LIS_create_dapert_filename(n,filen)
-            
+
             ftn = LIS_getNextUnitNumber()
             write(LIS_logunit,*) '[INFO] Writing Perturbations restart ', &
                  trim(filen)
             open(ftn, file = trim(filen), form='unformatted')
             
          endif
-         if(LIS_rc%perturb_forcing .ne."none") then 
-            if(.not. f_xyCorr) then 
+         if(LIS_rc%perturb_forcing .ne."none") then
+            if(.not. f_xyCorr) then
                allocate(pertdata1d(LIS_rc%ntiles(n)))
                
                k = 1
                do i=1,LIS_rc%nforcepert
-                  
+
                   do t=1,LIS_rc%ntiles(n)
                      col = LIS_domain(n)%tile(t)%col
                      row = LIS_domain(n)%tile(t)%row
                      ensem = LIS_domain(n)%tile(t)%ensem
                      pertdata1d(t) = forcpert(n,k)%forcepert_ntrmdt(i,col,row,ensem)
                   enddo
-                  
-                  call LIS_writevar_restart(ftn,n,pertdata1d)         
+
+                  call LIS_writevar_restart(ftn,n,pertdata1d)
                enddo
-               
+
                deallocate(pertdata1d)
                allocate(pertdata1d_int(LIS_rc%ntiles(n)))
-               
-               do i=1,NRANDSEED            
+
+               do i=1,NRANDSEED
                   do t=1,LIS_rc%ntiles(n)
                      col = LIS_domain(n)%tile(t)%col
                      row = LIS_domain(n)%tile(t)%row
@@ -1882,30 +1882,30 @@ module gmaopert_Mod
                      pertdata1d_int(t) = &
                           forcpert(n,k)%forcepert_rseed(i,col,row,ensem)
                   enddo
-                  call LIS_writevar_restart(ftn,n,pertdata1d_int)         
+                  call LIS_writevar_restart(ftn,n,pertdata1d_int)
                enddo
                deallocate(pertdata1d_int)
-               
+
             else
-               if(LIS_masterproc) then 
+               if(LIS_masterproc) then
                   k = 1
-                  do i=1,LIS_rc%nforcepert               
+                  do i=1,LIS_rc%nforcepert
                      write(ftn) forcpert(n,k)%forcepert_ntrmdt(i,:,:,:)
                   enddo
-                  
+
                   do i=1,NRANDSEED
                      write(ftn) forcpert(n,k)%forcepert_rseed(i,:,:,:)
                   enddo
                endif
             endif
          endif
-         
-         if(.not. p_xyCorr) then 
-            
+
+         if(.not. p_xyCorr) then
+
             do k=1,LIS_rc%nperts
                allocate(pertdata1d_patch(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-               
-               if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+
+               if(trim(LIS_rc%perturb_state(k)).ne."none") then
                   do i =1, LIS_rc%nstvars(k)
                      do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
                         col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
@@ -1914,15 +1914,15 @@ module gmaopert_Mod
                         pertdata1d_patch(t) =  &
                              progpert(n,k)%progpert_ntrmdt(i,col,row,ensem)
                      enddo
-                     
-                     call LIS_writevar_restart(ftn,n,1,pertdata1d_patch)   
+
+                     call LIS_writevar_restart(ftn,n,1,pertdata1d_patch)
                   enddo
                endif
-               
+
                deallocate(pertdata1d_patch)
                allocate(pertdata1d_patch_int(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-               
-               if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+
+               if(trim(LIS_rc%perturb_state(k)).ne."none") then
                   do i =1, NRANDSEED
                      do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
                         col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
@@ -1931,23 +1931,23 @@ module gmaopert_Mod
                         pertdata1d_patch_int(t) =  &
                              progpert(n,k)%progpert_rseed(i,col,row,ensem)
                      enddo
-                     
-                     call LIS_writevar_restart(ftn,n,1,pertdata1d_patch_int)   
+
+                     call LIS_writevar_restart(ftn,n,1,pertdata1d_patch_int)
                   enddo
                endif
-               
+
                deallocate(pertdata1d_patch_int)
             enddo
-            
+
          else
-            if(LIS_masterproc) then 
+            if(LIS_masterproc) then
                do k=1,LIS_rc%nperts
-                  if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+                  if(trim(LIS_rc%perturb_state(k)).ne."none") then
                      do i =1, LIS_rc%nstvars(k)
                         write(ftn) &
                              progpert(n,k)%progpert_ntrmdt(i,:,:,:)
                      enddo
-                     
+
                      do i =1, NRANDSEED
                         write(ftn) &
                              progpert(n,k)%progpert_rseed(i,:,:,:)
@@ -1956,10 +1956,10 @@ module gmaopert_Mod
                enddo
             endif
          endif
-         
-         if(.not. o_xyCorr) then 
+
+         if(.not. o_xyCorr) then
             do k=1,LIS_rc%ndas
-               if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
+               if(trim(LIS_rc%perturb_obs(k)).ne."none") then
                   allocate(pertdata1d(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
                   do i=1, nobs(n,k)
                      do t=1,LIS_rc%obs_ngrid(k)
@@ -1970,11 +1970,11 @@ module gmaopert_Mod
                                 obspert(n,k)%obspert_ntrmdt(i,col,row,kk)
                         enddo
                      enddo
-                     
-                     call writevar_obspert_restart(ftn,n,k,pertdata1d)   
+
+                     call writevar_obspert_restart(ftn,n,k,pertdata1d)
                   enddo
                   deallocate(pertdata1d)
-                  
+
                   allocate(pertdata1d_int(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
                   do i=1, NRANDSEED
                      do t=1,LIS_rc%obs_ngrid(k)
@@ -1985,17 +1985,17 @@ module gmaopert_Mod
                                 obspert(n,k)%obspert_rseed(i,col,row,kk)
                         enddo
                      enddo
-                     
-                     call writevar_obspert_restart_int(ftn,n,k,pertdata1d_int)   
+
+                     call writevar_obspert_restart_int(ftn,n,k,pertdata1d_int)
                   enddo
                   deallocate(pertdata1d_int)
-                  
+
                endif
             enddo
          else
-            if(LIS_masterproc) then 
+            if(LIS_masterproc) then
                do k=1,LIS_rc%ndas
-                  if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
+                  if(trim(LIS_rc%perturb_obs(k)).ne."none") then
                      do i=1, nobs(n,k)
                         write(ftn) obspert(n,k)%obspert_ntrmdt(i,:,:,:)
                      enddo
@@ -2006,15 +2006,15 @@ module gmaopert_Mod
                enddo
             endif
          endif
-         if(LIS_masterproc) then 
+         if(LIS_masterproc) then
             call LIS_releaseUnitNumber(ftn)
             write(LIS_logunit,*) '[INFO] Done writing Perturbations restart ', &
                  trim(filen)
          endif
-      elseif(wformat.eq."distributed binary") then 
+      elseif(wformat.eq."distributed binary") then
 
-         call LIS_create_output_directory('DAPERT')         
-                     
+         call LIS_create_output_directory('DAPERT')
+
          ftn = LIS_getNextUnitNumber()
          call LIS_create_dapert_filename(n,filen)
 
@@ -2025,13 +2025,13 @@ module gmaopert_Mod
 
          open(ftn,file=trim(filenp),form='unformatted')
 
-         if(LIS_rc%perturb_forcing .ne."none") then 
-            if(.not. f_xyCorr) then 
+         if(LIS_rc%perturb_forcing .ne."none") then
+            if(.not. f_xyCorr) then
                allocate(pertdata1d(LIS_rc%ntiles(n)))
-               
+
                k = 1
                do i=1,LIS_rc%nforcepert
-                  
+
                   do t=1,LIS_rc%ntiles(n)
                      col = LIS_domain(n)%tile(t)%col
                      row = LIS_domain(n)%tile(t)%row
@@ -2041,11 +2041,11 @@ module gmaopert_Mod
 
                   write(ftn) pertdata1d
                enddo
-               
+
                deallocate(pertdata1d)
                allocate(pertdata1d_int(LIS_rc%ntiles(n)))
-               
-               do i=1,NRANDSEED            
+
+               do i=1,NRANDSEED
                   do t=1,LIS_rc%ntiles(n)
                      col = LIS_domain(n)%tile(t)%col
                      row = LIS_domain(n)%tile(t)%row
@@ -2056,25 +2056,25 @@ module gmaopert_Mod
                   write(ftn) pertdata1d_int
                enddo
                deallocate(pertdata1d_int)
-               
+
             else
                k = 1
-               do i=1,LIS_rc%nforcepert               
+               do i=1,LIS_rc%nforcepert
                   write(ftn) forcpert(n,k)%forcepert_ntrmdt(i,:,:,:)
                enddo
-               
+
                do i=1,NRANDSEED
                   write(ftn) forcpert(n,k)%forcepert_rseed(i,:,:,:)
                enddo
 
             endif
          endif
-         if(.not. p_xyCorr) then 
-            
+         if(.not. p_xyCorr) then
+
             do k=1,LIS_rc%nperts
                allocate(pertdata1d_patch(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-               
-               if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+
+               if(trim(LIS_rc%perturb_state(k)).ne."none") then
                   do i =1, LIS_rc%nstvars(k)
                      do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
                         col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
@@ -2088,11 +2088,11 @@ module gmaopert_Mod
 
                   enddo
                endif
-               
+
                deallocate(pertdata1d_patch)
                allocate(pertdata1d_patch_int(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-               
-               if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+
+               if(trim(LIS_rc%perturb_state(k)).ne."none") then
                   do i =1, NRANDSEED
                      do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
                         col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
@@ -2105,18 +2105,18 @@ module gmaopert_Mod
                      write(ftn) pertdata1d_patch_int
                   enddo
                endif
-               
+
                deallocate(pertdata1d_patch_int)
             enddo
-            
+
          else
             do k=1,LIS_rc%nperts
-               if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+               if(trim(LIS_rc%perturb_state(k)).ne."none") then
                   do i =1, LIS_rc%nstvars(k)
                      write(ftn) &
                           progpert(n,k)%progpert_ntrmdt(i,:,:,:)
                   enddo
-                  
+
                   do i =1, NRANDSEED
                      write(ftn) &
                           progpert(n,k)%progpert_rseed(i,:,:,:)
@@ -2124,10 +2124,10 @@ module gmaopert_Mod
                endif
             enddo
          endif
-         
-         if(.not. o_xyCorr) then 
+
+         if(.not. o_xyCorr) then
             do k=1,LIS_rc%ndas
-               if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
+               if(trim(LIS_rc%perturb_obs(k)).ne."none") then
                   allocate(pertdata1d(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
                   do i=1, nobs(n,k)
                      do t=1,LIS_rc%obs_ngrid(k)
@@ -2141,7 +2141,7 @@ module gmaopert_Mod
                      write(ftn) pertdata1d
                   enddo
                   deallocate(pertdata1d)
-                  
+
                   allocate(pertdata1d_int(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
                   do i=1, NRANDSEED
                      do t=1,LIS_rc%obs_ngrid(k)
@@ -2155,12 +2155,12 @@ module gmaopert_Mod
                      write(ftn) pertdata1d_int
                   enddo
                   deallocate(pertdata1d_int)
-                  
+
                endif
             enddo
          else
             do k=1,LIS_rc%ndas
-               if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
+               if(trim(LIS_rc%perturb_obs(k)).ne."none") then
                   do i=1, nobs(n,k)
                      write(ftn) obspert(n,k)%obspert_ntrmdt(i,:,:,:)
                   enddo
@@ -2174,7 +2174,7 @@ module gmaopert_Mod
          call LIS_releaseUnitNumber(ftn)
          write(LIS_logunit,*) '[INFO] Done writing Perturbations restart ', &
               trim(filenp)
-         
+
       endif
     end subroutine gmaopert_writerestart
 
@@ -2201,7 +2201,7 @@ module gmaopert_Mod
       character*100             :: temp1
       real*8                    :: time
       real                      :: gmt
-      character*1               :: fproc(4)      
+      character*1               :: fproc(4)
       real, allocatable         :: pertdata1d(:)
       real, allocatable         :: pertdata1d_obs(:)
       real, allocatable         :: pertdata1d_patch(:)
@@ -2214,33 +2214,33 @@ module gmaopert_Mod
 
       wformat = "distributed binary"
 
-      if(wformat.eq."binary") then 
+      if(wformat.eq."binary") then
          do n = 1, LIS_rc%nnest
-            
+
             ftn = LIS_getNextUnitNumber()
-            
-            if(LIS_rc%runmode.eq."ensemble smoother") then 
-               if(LIS_rc%iterationid(n).gt.1) then 
+
+            if(LIS_rc%runmode.eq."ensemble smoother") then
+               if(LIS_rc%iterationid(n).gt.1) then
                   if(LIS_rc%pertrestartInterval.eq.2592000) then
                      call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
                           dd=da,calendar=LIS_calendar,rc=status)
-                     hr = 0 
-                     mn = 0 
-                     ss = 0 
+                     hr = 0
+                     mn = 0
+                     ss = 0
                      call LIS_tick(time,doy,gmt,yr,mo,da,hr,mn,ss,(-1)*LIS_rc%ts)
                   else
                      call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
                           dd=da,calendar=LIS_calendar,rc=status)
-                     hr = 0 
-                     mn = 0 
-                     ss = 0 
+                     hr = 0
+                     mn = 0
+                     ss = 0
                   endif
                   call LIS_create_dapert_filename(n,filen, yr, mo, da, hr, mn, ss)
                   LIS_rc%pertRestartFile(n) = filen
                endif
             endif
-           
-            inquire( file=trim(LIS_rc%pertRestartFile(n)), exist=file_exists ) 
+
+            inquire( file=trim(LIS_rc%pertRestartFile(n)), exist=file_exists )
             if(file_exists .neqv. .true.) then
                write(LIS_logunit,*) '[ERR] Reading perturbations restart file MISSING: ',&
                      trim(LIS_rc%pertRestartFile(n))
@@ -2250,16 +2250,16 @@ module gmaopert_Mod
             open(ftn,file=trim(LIS_rc%pertRestartFile(n)), form='unformatted')
             write(LIS_logunit,*) '[INFO] Reading perturbations restart file ',&
                  trim(LIS_rc%pertRestartFile(n))
-            
-            if(LIS_rc%perturb_forcing .ne."none") then 
-               if(.not. f_xyCorr) then 
+
+            if(LIS_rc%perturb_forcing .ne."none") then
+               if(.not. f_xyCorr) then
                   allocate(pertdata1d(LIS_rc%ntiles(n)))
-                  
+
                   k = 1
                   do i=1,LIS_rc%nforcepert
-                     
+
                      call LIS_readvar_restart(ftn,n,pertdata1d)
-                     
+
                      do t=1,LIS_rc%ntiles(n)
                         col = LIS_domain(n)%tile(t)%col
                         row = LIS_domain(n)%tile(t)%row
@@ -2267,15 +2267,15 @@ module gmaopert_Mod
                         forcpert(n,k)%forcepert_ntrmdt(i,col,row,ensem) = pertdata1d(t)
                      enddo
                   enddo
-                  
+
                   deallocate(pertdata1d)
-                  
+
                   allocate(pertdata1d_int(LIS_rc%ntiles(n)))
-                  
+
                   do i=1,NRANDSEED
-                     
+
                      call LIS_readvar_restart(ftn,n,pertdata1d_int)
-                     
+
                      do t=1,LIS_rc%ntiles(n)
                         col = LIS_domain(n)%tile(t)%col
                         row = LIS_domain(n)%tile(t)%row
@@ -2284,11 +2284,11 @@ module gmaopert_Mod
                      enddo
                   enddo
                   deallocate(pertdata1d_int)
-                  
+
                else
                   if(LIS_masterproc) then
                      k = 1
-                     do i=1,LIS_rc%nforcepert                  
+                     do i=1,LIS_rc%nforcepert
                         read(ftn) forcpert(n,k)%forcepert_ntrmdt(i,:,:,:)
                      enddo
                      do i=1,NRANDSEED
@@ -2296,7 +2296,7 @@ module gmaopert_Mod
                      enddo
                   else
 ! to keep the binary reading in sync when there is a mix of file reading that
-! happens only on one processor and across processors. 
+! happens only on one processor and across processors.
                      allocate(dummy_var(&
                           LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n)))
                      do i =1, LIS_rc%nforcepert
@@ -2307,53 +2307,53 @@ module gmaopert_Mod
                      enddo
                      deallocate(dummy_var)
                   endif
-                  
+
                endif
             endif
-            if(.not. p_xyCorr) then 
+            if(.not. p_xyCorr) then
                do k=1, LIS_rc%nperts
-                  
-                  if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+
+                  if(trim(LIS_rc%perturb_state(k)).ne."none") then
                      allocate(pertdata1d_patch(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-                     
-                     do i =1, LIS_rc%nstvars(k)                  
-                        call LIS_readvar_restart(ftn,n,1,pertdata1d_patch)   
-                        
+
+                     do i =1, LIS_rc%nstvars(k)
+                        call LIS_readvar_restart(ftn,n,1,pertdata1d_patch)
+
                         do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
                            col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
                            row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
                            ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
                            progpert(n,k)%progpert_ntrmdt(i,col,row,ensem) = &
-                                pertdata1d_patch(t) 
+                                pertdata1d_patch(t)
                         enddo
-                        
+
                      enddo
                      deallocate(pertdata1d_patch)
-                     
+
                      allocate(pertdata1d_patch_int(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-                     
+
                      do i =1, NRANDSEED
-                        call LIS_readvar_restart(ftn,n,1,pertdata1d_patch_int)   
-                        
+                        call LIS_readvar_restart(ftn,n,1,pertdata1d_patch_int)
+
                         do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
                            col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
                            row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
                            ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
                            progpert(n,k)%progpert_rseed(i,col,row,ensem) = &
-                                pertdata1d_patch_int(t) 
+                                pertdata1d_patch_int(t)
                         enddo
-                        
+
                      enddo
                      deallocate(pertdata1d_patch_int)
-                     
+
                   endif
                enddo
             else
-               if(LIS_masterproc) then 
+               if(LIS_masterproc) then
                   do k=1, LIS_rc%nperts
-                     if(trim(LIS_rc%perturb_state(k)).ne."none") then 
-                        
-                        do i =1, LIS_rc%nstvars(k)                  
+                     if(trim(LIS_rc%perturb_state(k)).ne."none") then
+
+                        do i =1, LIS_rc%nstvars(k)
                            read(ftn) progPert(n,k)%progpert_ntrmdt(i,:,:,:)
                         enddo
                         do i =1, NRANDSEED
@@ -2363,13 +2363,13 @@ module gmaopert_Mod
                   enddo
                else
 ! to keep the binary reading in sync when there is a mix of file reading that
-! happens only on one processor and across processors. 
+! happens only on one processor and across processors.
                   allocate(dummy_var(&
                        LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n)))
                   do k=1, LIS_rc%nperts
                      if(trim(LIS_rc%perturb_state(k)).ne."none") then 
-                        
-                        do i =1, LIS_rc%nstvars(k)                  
+
+                        do i =1, LIS_rc%nstvars(k)
                            read(ftn) dummy_var
                         enddo
                         do i =1, NRANDSEED
@@ -2380,52 +2380,52 @@ module gmaopert_Mod
                   deallocate(dummy_var)
                endif
             endif
-            
-            if(.not. o_xyCorr) then       
+
+            if(.not. o_xyCorr) then
                do k=1, LIS_rc%ndas
-                  
-                  if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
+
+                  if(trim(LIS_rc%perturb_obs(k)).ne."none") then
                      allocate(pertdata1d_obs(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
-                     
+
                      do i=1, nobs(n,k)
-                        call readvar_obspert_restart(ftn,n,k,pertdata1d_obs)   
-                        
+                        call readvar_obspert_restart(ftn,n,k,pertdata1d_obs)
+
                         do t=1,LIS_rc%obs_ngrid(k)
                            col = LIS_obs_domain(n,k)%col(t)
                            row = LIS_obs_domain(n,k)%row(t)
                            do kk=1,LIS_rc%nensem(n)
-                              obspert(n,k)%obspert_ntrmdt(i,col,row,kk) = & 
+                              obspert(n,k)%obspert_ntrmdt(i,col,row,kk) = &
                                    pertdata1d_obs(kk+(t-1)*LIS_rc%nensem(n))
-                               
+
                            enddo
                         enddo
                      enddo
                      deallocate(pertdata1d_obs)
-                  
+
                      allocate(pertdata1d_obs_int(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
-                     
-                     
+
+
                      do i=1, NRANDSEED
-                        call readvar_obspert_restart_int(ftn,n,k,pertdata1d_obs_int)   
-                        
+                        call readvar_obspert_restart_int(ftn,n,k,pertdata1d_obs_int)
+
                         do t=1,LIS_rc%obs_ngrid(k)
                            col = LIS_obs_domain(n,k)%col(t)
                            row = LIS_obs_domain(n,k)%row(t)
                            do kk=1,LIS_rc%nensem(n)
-                              obspert(n,k)%obspert_rseed(i,col,row,kk) = & 
+                              obspert(n,k)%obspert_rseed(i,col,row,kk) = &
                                    pertdata1d_obs_int(kk+(t-1)*LIS_rc%nensem(n))
-                              
+
                            enddo
                         enddo
                      enddo
                   endif
                   deallocate(pertdata1d_obs_int)
-                  
+
                enddo
             else
-               if(LIS_masterproc) then 
+               if(LIS_masterproc) then
                   do k=1, LIS_rc%ndas
-                     if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
+                     if(trim(LIS_rc%perturb_obs(k)).ne."none") then
                         do i=1, nobs(n,k)
                            read(ftn) obsPert(n,k)%obspert_ntrmdt(i,:,:,:)
                         enddo
@@ -2438,7 +2438,7 @@ module gmaopert_Mod
                   do k=1, LIS_rc%nperts
                      allocate(dummy_var(&
                           LIS_rc%obs_gnc(k),LIS_rc%obs_gnr(k),LIS_rc%nensem(n)))
-                     if(trim(LIS_rc%perturb_obs(k)).ne."none") then  
+                     if(trim(LIS_rc%perturb_obs(k)).ne."none") then
                         do i =1, nobs(n,k)
                            read(ftn) dummy_var
                         enddo
@@ -2447,37 +2447,37 @@ module gmaopert_Mod
                         enddo
                      endif
                      deallocate(dummy_var)
-                     
+
                   enddo
 
                endif
             endif
-         
+
             call LIS_releaseUnitNumber(ftn)
             write(LIS_logunit,*) '[INFO] Finished reading perturbations restart file ',&
                  trim(LIS_rc%pertRestartFile(n))
-            
+
          enddo
-      elseif(wformat.eq."distributed binary") then 
+      elseif(wformat.eq."distributed binary") then
          do n = 1, LIS_rc%nnest
-            
+
             ftn = LIS_getNextUnitNumber()
-            
-            if(LIS_rc%runmode.eq."ensemble smoother") then 
-               if(LIS_rc%iterationid(n).gt.1) then 
+
+            if(LIS_rc%runmode.eq."ensemble smoother") then
+               if(LIS_rc%iterationid(n).gt.1) then
                   if(LIS_rc%pertrestartInterval.eq.2592000) then
                      call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
                           dd=da,calendar=LIS_calendar,rc=status)
-                     hr = 0 
-                     mn = 0 
-                     ss = 0 
+                     hr = 0
+                     mn = 0
+                     ss = 0
                      call LIS_tick(time,doy,gmt,yr,mo,da,hr,mn,ss,(-1)*LIS_rc%ts)
                   else
                      call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
                           dd=da,calendar=LIS_calendar,rc=status)
-                     hr = 0 
-                     mn = 0 
-                     ss = 0 
+                     hr = 0
+                     mn = 0
+                     ss = 0
                   endif
                   call LIS_create_dapert_filename(n,filen, yr, mo, da, hr, mn, ss)
                   LIS_rc%pertRestartFile(n) = filen
@@ -2486,21 +2486,21 @@ module gmaopert_Mod
 
             write(temp1,'(i4.4)') LIS_localPet
             read(temp1,fmt='(4a1)') fproc
-            
+
             open(ftn,file=trim(LIS_rc%pertRestartFile(n))//&
                  '.'//fproc(1)//fproc(2)//fproc(3)//fproc(4), form='unformatted')
             write(LIS_logunit,*) '[INFO] Reading perturbations restart file ',&
                  trim(LIS_rc%pertRestartFile(n))
-            
-            if(LIS_rc%perturb_forcing .ne."none") then 
-               if(.not. f_xyCorr) then 
+
+            if(LIS_rc%perturb_forcing .ne."none") then
+               if(.not. f_xyCorr) then
                   allocate(pertdata1d(LIS_rc%ntiles(n)))
-                  
+
                   k = 1
                   do i=1,LIS_rc%nforcepert
 
                      read(ftn) pertdata1d
-                     
+
                      do t=1,LIS_rc%ntiles(n)
                         col = LIS_domain(n)%tile(t)%col
                         row = LIS_domain(n)%tile(t)%row
@@ -2508,15 +2508,15 @@ module gmaopert_Mod
                         forcpert(n,k)%forcepert_ntrmdt(i,col,row,ensem) = pertdata1d(t)
                      enddo
                   enddo
-                  
+
                   deallocate(pertdata1d)
-                  
+
                   allocate(pertdata1d_int(LIS_rc%ntiles(n)))
-                  
+
                   do i=1,NRANDSEED
 
                      read(ftn) pertdata1d_int
-                     
+
                      do t=1,LIS_rc%ntiles(n)
                         col = LIS_domain(n)%tile(t)%col
                         row = LIS_domain(n)%tile(t)%row
@@ -2525,52 +2525,52 @@ module gmaopert_Mod
                      enddo
                   enddo
                   deallocate(pertdata1d_int)
-                  
+
                else
                   print*, 'Restart read with horizontal correlations not supported '
                   print*, 'for distributed binary writing format '
                   call LIS_endrun()
-                                   
+
                endif
             endif
-            if(.not. p_xyCorr) then 
+            if(.not. p_xyCorr) then
                do k=1, LIS_rc%nperts
-                  
-                  if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+
+                  if(trim(LIS_rc%perturb_state(k)).ne."none") then
                      allocate(pertdata1d_patch(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-                     
+
                      do i =1, LIS_rc%nstvars(k)
 
                         read(ftn) pertdata1d_patch
-                        
+
                         do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
                            col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
                            row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
                            ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
                            progpert(n,k)%progpert_ntrmdt(i,col,row,ensem) = &
-                                pertdata1d_patch(t) 
+                                pertdata1d_patch(t)
                         enddo
-                        
+
                      enddo
                      deallocate(pertdata1d_patch)
-                     
+
                      allocate(pertdata1d_patch_int(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-                     
+
                      do i =1, NRANDSEED
 
                         read(ftn) pertdata1d_patch_int
-                        
+
                         do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
                            col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
                            row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
                            ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
                            progpert(n,k)%progpert_rseed(i,col,row,ensem) = &
-                                pertdata1d_patch_int(t) 
+                                pertdata1d_patch_int(t)
                         enddo
-                        
+
                      enddo
                      deallocate(pertdata1d_patch_int)
-                     
+
                   endif
                enddo
             else
@@ -2579,62 +2579,62 @@ module gmaopert_Mod
                call LIS_endrun()
 
             endif
-            
-            if(.not. o_xyCorr) then       
+
+            if(.not. o_xyCorr) then
                do k=1, LIS_rc%ndas
-                  
-                  if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
+
+                  if(trim(LIS_rc%perturb_obs(k)).ne."none") then
                      allocate(pertdata1d_obs(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
-                     
+
                      do i=1, nobs(n,k)
                         read(ftn) pertdata1d_obs
-                        
+
                         do t=1,LIS_rc%obs_ngrid(k)
                            col = LIS_obs_domain(n,k)%col(t)
                            row = LIS_obs_domain(n,k)%row(t)
                            do kk=1,LIS_rc%nensem(n)
-                              obspert(n,k)%obspert_ntrmdt(i,col,row,kk) = & 
+                              obspert(n,k)%obspert_ntrmdt(i,col,row,kk) = &
                                    pertdata1d_obs(kk+(t-1)*LIS_rc%nensem(n))
-                               
+
                            enddo
                         enddo
                      enddo
                      deallocate(pertdata1d_obs)
-                  
+
                      allocate(pertdata1d_obs_int(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
-                     
-                     
+
+
                      do i=1, NRANDSEED
                         read(ftn) pertdata1d_obs_int
-                        
+
                         do t=1,LIS_rc%obs_ngrid(k)
                            col = LIS_obs_domain(n,k)%col(t)
                            row = LIS_obs_domain(n,k)%row(t)
                            do kk=1,LIS_rc%nensem(n)
-                              obspert(n,k)%obspert_rseed(i,col,row,kk) = & 
+                              obspert(n,k)%obspert_rseed(i,col,row,kk) = &
                                    pertdata1d_obs_int(kk+(t-1)*LIS_rc%nensem(n))
-                              
+
                            enddo
                         enddo
                      enddo
                   endif
                   deallocate(pertdata1d_obs_int)
-                  
+
                enddo
             else
                print*, 'Restart read with horizontal correlations not supported '
                print*, 'for distributed binary writing format '
                call LIS_endrun()
             endif
-         
+
             call LIS_releaseUnitNumber(ftn)
             write(LIS_logunit,*) '[INFO] Finished reading perturbations restart file ',&
                  trim(LIS_rc%pertRestartFile(n))
-            
+
          enddo
-         
+
       endif
-      
+
     end subroutine gmaopert_readrestart
 
 !BOP

--- a/lis/dataassim/perturb/gmaopert/gmaopert_Mod.F90
+++ b/lis/dataassim/perturb/gmaopert/gmaopert_Mod.F90
@@ -1834,53 +1834,231 @@ module gmaopert_Mod
       real, allocatable        :: pertdata1d_patch(:)
       integer, allocatable     :: pertdata1d_int(:)
       integer, allocatable     :: pertdata1d_patch_int(:)
-      character(len=LIS_CONST_PATH_LEN) :: filen
-      integer                  :: ftn 
+      character(len=LIS_CONST_PATH_LEN) :: filen,filenp
+      character*100            :: temp1
+      character*1              :: fproc(4)
+      integer                  :: ftn
+      character*20 :: wformat
 
-      if ( LIS_masterproc ) then
-         
-         call LIS_create_output_directory('DAPERT')         
-         call LIS_create_dapert_filename(n,filen)
-         
-         ftn = LIS_getNextUnitNumber()
-         write(LIS_logunit,*) '[INFO] Writing Perturbations restart ', &
-              trim(filen)
-         open(ftn, file = trim(filen), form='unformatted')
-         
-      endif
-      if(LIS_rc%perturb_forcing .ne."none") then 
-         if(.not. f_xyCorr) then 
-            allocate(pertdata1d(LIS_rc%ntiles(n)))
+      wformat = "distributed binary"
+      
+
+      if(wformat.eq."binary") then 
+         if ( LIS_masterproc ) then
             
-            k = 1
-            do i=1,LIS_rc%nforcepert
+            call LIS_create_output_directory('DAPERT')         
+            call LIS_create_dapert_filename(n,filen)
+            
+            ftn = LIS_getNextUnitNumber()
+            write(LIS_logunit,*) '[INFO] Writing Perturbations restart ', &
+                 trim(filen)
+            open(ftn, file = trim(filen), form='unformatted')
+            
+         endif
+         if(LIS_rc%perturb_forcing .ne."none") then 
+            if(.not. f_xyCorr) then 
+               allocate(pertdata1d(LIS_rc%ntiles(n)))
                
-               do t=1,LIS_rc%ntiles(n)
-                  col = LIS_domain(n)%tile(t)%col
-                  row = LIS_domain(n)%tile(t)%row
-                  ensem = LIS_domain(n)%tile(t)%ensem
-                  pertdata1d(t) = forcpert(n,k)%forcepert_ntrmdt(i,col,row,ensem)
+               k = 1
+               do i=1,LIS_rc%nforcepert
+                  
+                  do t=1,LIS_rc%ntiles(n)
+                     col = LIS_domain(n)%tile(t)%col
+                     row = LIS_domain(n)%tile(t)%row
+                     ensem = LIS_domain(n)%tile(t)%ensem
+                     pertdata1d(t) = forcpert(n,k)%forcepert_ntrmdt(i,col,row,ensem)
+                  enddo
+                  
+                  call LIS_writevar_restart(ftn,n,pertdata1d)         
                enddo
                
-               call LIS_writevar_restart(ftn,n,pertdata1d)         
-            enddo
-            deallocate(pertdata1d)
-            allocate(pertdata1d_int(LIS_rc%ntiles(n)))
-            
-            do i=1,NRANDSEED            
-               do t=1,LIS_rc%ntiles(n)
-                  col = LIS_domain(n)%tile(t)%col
-                  row = LIS_domain(n)%tile(t)%row
-                  ensem = LIS_domain(n)%tile(t)%ensem
-                  pertdata1d_int(t) = &
-                       forcpert(n,k)%forcepert_rseed(i,col,row,ensem)
+               deallocate(pertdata1d)
+               allocate(pertdata1d_int(LIS_rc%ntiles(n)))
+               
+               do i=1,NRANDSEED            
+                  do t=1,LIS_rc%ntiles(n)
+                     col = LIS_domain(n)%tile(t)%col
+                     row = LIS_domain(n)%tile(t)%row
+                     ensem = LIS_domain(n)%tile(t)%ensem
+                     pertdata1d_int(t) = &
+                          forcpert(n,k)%forcepert_rseed(i,col,row,ensem)
+                  enddo
+                  call LIS_writevar_restart(ftn,n,pertdata1d_int)         
                enddo
-               call LIS_writevar_restart(ftn,n,pertdata1d_int)         
+               deallocate(pertdata1d_int)
+               
+            else
+               if(LIS_masterproc) then 
+                  k = 1
+                  do i=1,LIS_rc%nforcepert               
+                     write(ftn) forcpert(n,k)%forcepert_ntrmdt(i,:,:,:)
+                  enddo
+                  
+                  do i=1,NRANDSEED
+                     write(ftn) forcpert(n,k)%forcepert_rseed(i,:,:,:)
+                  enddo
+               endif
+            endif
+         endif
+         
+         if(.not. p_xyCorr) then 
+            
+            do k=1,LIS_rc%nperts
+               allocate(pertdata1d_patch(LIS_rc%npatch(n,LIS_rc%lsm_index)))
+               
+               if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+                  do i =1, LIS_rc%nstvars(k)
+                     do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+                        col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
+                        row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
+                        ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
+                        pertdata1d_patch(t) =  &
+                             progpert(n,k)%progpert_ntrmdt(i,col,row,ensem)
+                     enddo
+                     
+                     call LIS_writevar_restart(ftn,n,1,pertdata1d_patch)   
+                  enddo
+               endif
+               
+               deallocate(pertdata1d_patch)
+               allocate(pertdata1d_patch_int(LIS_rc%npatch(n,LIS_rc%lsm_index)))
+               
+               if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+                  do i =1, NRANDSEED
+                     do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+                        col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
+                        row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
+                        ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
+                        pertdata1d_patch_int(t) =  &
+                             progpert(n,k)%progpert_rseed(i,col,row,ensem)
+                     enddo
+                     
+                     call LIS_writevar_restart(ftn,n,1,pertdata1d_patch_int)   
+                  enddo
+               endif
+               
+               deallocate(pertdata1d_patch_int)
             enddo
-            deallocate(pertdata1d_int)
-
+            
          else
             if(LIS_masterproc) then 
+               do k=1,LIS_rc%nperts
+                  if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+                     do i =1, LIS_rc%nstvars(k)
+                        write(ftn) &
+                             progpert(n,k)%progpert_ntrmdt(i,:,:,:)
+                     enddo
+                     
+                     do i =1, NRANDSEED
+                        write(ftn) &
+                             progpert(n,k)%progpert_rseed(i,:,:,:)
+                     enddo
+                  endif
+               enddo
+            endif
+         endif
+         
+         if(.not. o_xyCorr) then 
+            do k=1,LIS_rc%ndas
+               if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
+                  allocate(pertdata1d(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
+                  do i=1, nobs(n,k)
+                     do t=1,LIS_rc%obs_ngrid(k)
+                        col = LIS_obs_domain(n,k)%col(t)
+                        row = LIS_obs_domain(n,k)%row(t)
+                        do kk=1,LIS_rc%nensem(n)
+                           pertdata1d(kk+(t-1)*LIS_rc%nensem(n)) =  &
+                                obspert(n,k)%obspert_ntrmdt(i,col,row,kk)
+                        enddo
+                     enddo
+                     
+                     call writevar_obspert_restart(ftn,n,k,pertdata1d)   
+                  enddo
+                  deallocate(pertdata1d)
+                  
+                  allocate(pertdata1d_int(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
+                  do i=1, NRANDSEED
+                     do t=1,LIS_rc%obs_ngrid(k)
+                        col = LIS_obs_domain(n,k)%col(t)
+                        row = LIS_obs_domain(n,k)%row(t)
+                        do kk=1,LIS_rc%nensem(n)
+                           pertdata1d_int(kk+(t-1)*LIS_rc%nensem(n)) =  &
+                                obspert(n,k)%obspert_rseed(i,col,row,kk)
+                        enddo
+                     enddo
+                     
+                     call writevar_obspert_restart_int(ftn,n,k,pertdata1d_int)   
+                  enddo
+                  deallocate(pertdata1d_int)
+                  
+               endif
+            enddo
+         else
+            if(LIS_masterproc) then 
+               do k=1,LIS_rc%ndas
+                  if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
+                     do i=1, nobs(n,k)
+                        write(ftn) obspert(n,k)%obspert_ntrmdt(i,:,:,:)
+                     enddo
+                     do i=1, NRANDSEED
+                        write(ftn) obspert(n,k)%obspert_rseed(i,:,:,:)
+                     enddo
+                  endif
+               enddo
+            endif
+         endif
+         if(LIS_masterproc) then 
+            call LIS_releaseUnitNumber(ftn)
+            write(LIS_logunit,*) '[INFO] Done writing Perturbations restart ', &
+                 trim(filen)
+         endif
+      elseif(wformat.eq."distributed binary") then 
+
+         call LIS_create_output_directory('DAPERT')         
+                     
+         ftn = LIS_getNextUnitNumber()
+         call LIS_create_dapert_filename(n,filen)
+
+         write(temp1,'(i4.4)') LIS_localPet
+         read(temp1,fmt='(4a1)') fproc
+
+         filenp = trim(filen)//'.'//fproc(1)//fproc(2)//fproc(3)//fproc(4)
+
+         open(ftn,file=trim(filenp),form='unformatted')
+
+         if(LIS_rc%perturb_forcing .ne."none") then 
+            if(.not. f_xyCorr) then 
+               allocate(pertdata1d(LIS_rc%ntiles(n)))
+               
+               k = 1
+               do i=1,LIS_rc%nforcepert
+                  
+                  do t=1,LIS_rc%ntiles(n)
+                     col = LIS_domain(n)%tile(t)%col
+                     row = LIS_domain(n)%tile(t)%row
+                     ensem = LIS_domain(n)%tile(t)%ensem
+                     pertdata1d(t) = forcpert(n,k)%forcepert_ntrmdt(i,col,row,ensem)
+                  enddo
+
+                  write(ftn) pertdata1d
+               enddo
+               
+               deallocate(pertdata1d)
+               allocate(pertdata1d_int(LIS_rc%ntiles(n)))
+               
+               do i=1,NRANDSEED            
+                  do t=1,LIS_rc%ntiles(n)
+                     col = LIS_domain(n)%tile(t)%col
+                     row = LIS_domain(n)%tile(t)%row
+                     ensem = LIS_domain(n)%tile(t)%ensem
+                     pertdata1d_int(t) = &
+                          forcpert(n,k)%forcepert_rseed(i,col,row,ensem)
+                  enddo
+                  write(ftn) pertdata1d_int
+               enddo
+               deallocate(pertdata1d_int)
+               
+            else
                k = 1
                do i=1,LIS_rc%nforcepert               
                   write(ftn) forcpert(n,k)%forcepert_ntrmdt(i,:,:,:)
@@ -1889,58 +2067,57 @@ module gmaopert_Mod
                do i=1,NRANDSEED
                   write(ftn) forcpert(n,k)%forcepert_rseed(i,:,:,:)
                enddo
+
             endif
          endif
-      endif
+         if(.not. p_xyCorr) then 
+            
+            do k=1,LIS_rc%nperts
+               allocate(pertdata1d_patch(LIS_rc%npatch(n,LIS_rc%lsm_index)))
+               
+               if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+                  do i =1, LIS_rc%nstvars(k)
+                     do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+                        col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
+                        row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
+                        ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
+                        pertdata1d_patch(t) =  &
+                             progpert(n,k)%progpert_ntrmdt(i,col,row,ensem)
+                     enddo
 
-      if(.not. p_xyCorr) then 
+                     write(ftn) pertdata1d_patch
 
-         do k=1,LIS_rc%nperts
-            allocate(pertdata1d_patch(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-
-            if(trim(LIS_rc%perturb_state(k)).ne."none") then 
-               do i =1, LIS_rc%nstvars(k)
-                  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
-                     col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
-                     row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
-                     ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
-                     pertdata1d_patch(t) =  &
-                          progpert(n,k)%progpert_ntrmdt(i,col,row,ensem)
                   enddo
-                  
-                  call LIS_writevar_restart(ftn,n,1,pertdata1d_patch)   
-               enddo
-            endif
+               endif
+               
+               deallocate(pertdata1d_patch)
+               allocate(pertdata1d_patch_int(LIS_rc%npatch(n,LIS_rc%lsm_index)))
+               
+               if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+                  do i =1, NRANDSEED
+                     do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+                        col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
+                        row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
+                        ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
+                        pertdata1d_patch_int(t) =  &
+                             progpert(n,k)%progpert_rseed(i,col,row,ensem)
+                     enddo
 
-            deallocate(pertdata1d_patch)
-            allocate(pertdata1d_patch_int(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-
-            if(trim(LIS_rc%perturb_state(k)).ne."none") then 
-               do i =1, NRANDSEED
-                  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
-                     col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
-                     row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
-                     ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
-                     pertdata1d_patch_int(t) =  &
-                          progpert(n,k)%progpert_rseed(i,col,row,ensem)
+                     write(ftn) pertdata1d_patch_int
                   enddo
-                  
-                  call LIS_writevar_restart(ftn,n,1,pertdata1d_patch_int)   
-               enddo
-            endif
-
-            deallocate(pertdata1d_patch_int)
-         enddo
-
-      else
-         if(LIS_masterproc) then 
+               endif
+               
+               deallocate(pertdata1d_patch_int)
+            enddo
+            
+         else
             do k=1,LIS_rc%nperts
                if(trim(LIS_rc%perturb_state(k)).ne."none") then 
                   do i =1, LIS_rc%nstvars(k)
                      write(ftn) &
                           progpert(n,k)%progpert_ntrmdt(i,:,:,:)
                   enddo
-
+                  
                   do i =1, NRANDSEED
                      write(ftn) &
                           progpert(n,k)%progpert_rseed(i,:,:,:)
@@ -1948,45 +2125,41 @@ module gmaopert_Mod
                endif
             enddo
          endif
-      endif
-
-      if(.not. o_xyCorr) then 
-         do k=1,LIS_rc%ndas
-            if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
-               allocate(pertdata1d(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
-               do i=1, nobs(n,k)
-                  do t=1,LIS_rc%obs_ngrid(k)
-                     col = LIS_obs_domain(n,k)%col(t)
-                     row = LIS_obs_domain(n,k)%row(t)
-                     do kk=1,LIS_rc%nensem(n)
-                        pertdata1d(kk+(t-1)*LIS_rc%nensem(n)) =  &
-                             obspert(n,k)%obspert_ntrmdt(i,col,row,kk)
+         
+         if(.not. o_xyCorr) then 
+            do k=1,LIS_rc%ndas
+               if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
+                  allocate(pertdata1d(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
+                  do i=1, nobs(n,k)
+                     do t=1,LIS_rc%obs_ngrid(k)
+                        col = LIS_obs_domain(n,k)%col(t)
+                        row = LIS_obs_domain(n,k)%row(t)
+                        do kk=1,LIS_rc%nensem(n)
+                           pertdata1d(kk+(t-1)*LIS_rc%nensem(n)) =  &
+                                obspert(n,k)%obspert_ntrmdt(i,col,row,kk)
+                        enddo
                      enddo
+                     write(ftn) pertdata1d
                   enddo
-
-                  call writevar_obspert_restart(ftn,n,k,pertdata1d)   
-               enddo
-               deallocate(pertdata1d)
-
-               allocate(pertdata1d_int(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
-               do i=1, NRANDSEED
-                  do t=1,LIS_rc%obs_ngrid(k)
-                     col = LIS_obs_domain(n,k)%col(t)
-                     row = LIS_obs_domain(n,k)%row(t)
-                     do kk=1,LIS_rc%nensem(n)
-                        pertdata1d_int(kk+(t-1)*LIS_rc%nensem(n)) =  &
-                             obspert(n,k)%obspert_rseed(i,col,row,kk)
+                  deallocate(pertdata1d)
+                  
+                  allocate(pertdata1d_int(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
+                  do i=1, NRANDSEED
+                     do t=1,LIS_rc%obs_ngrid(k)
+                        col = LIS_obs_domain(n,k)%col(t)
+                        row = LIS_obs_domain(n,k)%row(t)
+                        do kk=1,LIS_rc%nensem(n)
+                           pertdata1d_int(kk+(t-1)*LIS_rc%nensem(n)) =  &
+                                obspert(n,k)%obspert_rseed(i,col,row,kk)
+                        enddo
                      enddo
+                     write(ftn) pertdata1d_int
                   enddo
-
-                  call writevar_obspert_restart_int(ftn,n,k,pertdata1d_int)   
-               enddo
-               deallocate(pertdata1d_int)
-
-            endif
-         enddo
-      else
-         if(LIS_masterproc) then 
+                  deallocate(pertdata1d_int)
+                  
+               endif
+            enddo
+         else
             do k=1,LIS_rc%ndas
                if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
                   do i=1, nobs(n,k)
@@ -1997,14 +2170,13 @@ module gmaopert_Mod
                   enddo
                endif
             enddo
+
          endif
-      endif
-      if(LIS_masterproc) then 
          call LIS_releaseUnitNumber(ftn)
          write(LIS_logunit,*) '[INFO] Done writing Perturbations restart ', &
-              trim(filen)
+              trim(filenp)
+         
       endif
-
     end subroutine gmaopert_writerestart
 
 !BOP
@@ -2027,8 +2199,10 @@ module gmaopert_Mod
       integer                   :: yr,mo,da,hr,mn,ss, doy
       integer                   :: status
       character(len=LIS_CONST_PATH_LEN) :: filen
+      character*100             :: temp1
       real*8                    :: time
       real                      :: gmt
+      character*1               :: fproc(4)      
       real, allocatable         :: pertdata1d(:)
       real, allocatable         :: pertdata1d_obs(:)
       real, allocatable         :: pertdata1d_patch(:)
@@ -2036,251 +2210,424 @@ module gmaopert_Mod
       integer, allocatable      :: pertdata1d_obs_int(:)
       integer, allocatable      :: pertdata1d_patch_int(:)
       real, allocatable         :: dummy_var(:,:,:)
-      logical                   :: file_exists
+      character*20              :: wformat
 
-      do n = 1, LIS_rc%nnest
+      wformat = "distributed binary"
 
-         ftn = LIS_getNextUnitNumber()
-
-         if(LIS_rc%runmode.eq."ensemble smoother") then 
-            if(LIS_rc%iterationid(n).gt.1) then 
-               if(LIS_rc%pertrestartInterval.eq.2592000) then
-                  call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
-                       dd=da,calendar=LIS_calendar,rc=status)
-                  hr = 0 
-                  mn = 0 
-                  ss = 0 
-                  call LIS_tick(time,doy,gmt,yr,mo,da,hr,mn,ss,(-1)*LIS_rc%ts)
-               else
-                  call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
-                       dd=da,calendar=LIS_calendar,rc=status)
-                  hr = 0 
-                  mn = 0 
-                  ss = 0 
+      if(wformat.eq."binary") then 
+         do n = 1, LIS_rc%nnest
+            
+            ftn = LIS_getNextUnitNumber()
+            
+            if(LIS_rc%runmode.eq."ensemble smoother") then 
+               if(LIS_rc%iterationid(n).gt.1) then 
+                  if(LIS_rc%pertrestartInterval.eq.2592000) then
+                     call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
+                          dd=da,calendar=LIS_calendar,rc=status)
+                     hr = 0 
+                     mn = 0 
+                     ss = 0 
+                     call LIS_tick(time,doy,gmt,yr,mo,da,hr,mn,ss,(-1)*LIS_rc%ts)
+                  else
+                     call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
+                          dd=da,calendar=LIS_calendar,rc=status)
+                     hr = 0 
+                     mn = 0 
+                     ss = 0 
+                  endif
+                  call LIS_create_dapert_filename(n,filen, yr, mo, da, hr, mn, ss)
+                  LIS_rc%pertRestartFile(n) = filen
                endif
-               call LIS_create_dapert_filename(n,filen, yr, mo, da, hr, mn, ss)
-               LIS_rc%pertRestartFile(n) = filen
             endif
-         endif
-         
-         inquire( file=trim(LIS_rc%pertRestartFile(n)), exist=file_exists ) 
-         if(file_exists .neqv. .true.) then
-            write(LIS_logunit,*) '[ERR] Reading perturbations restart file MISSING: ',&
-                  trim(LIS_rc%pertRestartFile(n))
-            call LIS_endrun()
-         endif
-
-         open(ftn,file=trim(LIS_rc%pertRestartFile(n)), form='unformatted')
-         write(LIS_logunit,*) '[INFO] Reading perturbations restart file ',&
-              trim(LIS_rc%pertRestartFile(n))
-         
-         if(LIS_rc%perturb_forcing .ne."none") then 
-            if(.not. f_xyCorr) then 
-               allocate(pertdata1d(LIS_rc%ntiles(n)))
-               
-               k = 1
-               do i=1,LIS_rc%nforcepert
+            
+            open(ftn,file=trim(LIS_rc%pertRestartFile(n)), form='unformatted')
+            write(LIS_logunit,*) '[INFO] Reading perturbations restart file ',&
+                 trim(LIS_rc%pertRestartFile(n))
+            
+            if(LIS_rc%perturb_forcing .ne."none") then 
+               if(.not. f_xyCorr) then 
+                  allocate(pertdata1d(LIS_rc%ntiles(n)))
                   
-                  call LIS_readvar_restart(ftn,n,pertdata1d)
-                  
-                  do t=1,LIS_rc%ntiles(n)
-                     col = LIS_domain(n)%tile(t)%col
-                     row = LIS_domain(n)%tile(t)%row
-                     ensem = LIS_domain(n)%tile(t)%ensem
-                     forcpert(n,k)%forcepert_ntrmdt(i,col,row,ensem) = pertdata1d(t)
-                  enddo
-               enddo
-               
-               deallocate(pertdata1d)
-               
-               allocate(pertdata1d_int(LIS_rc%ntiles(n)))
-               
-               do i=1,NRANDSEED
-                  
-                  call LIS_readvar_restart(ftn,n,pertdata1d_int)
-                  
-                  do t=1,LIS_rc%ntiles(n)
-                     col = LIS_domain(n)%tile(t)%col
-                     row = LIS_domain(n)%tile(t)%row
-                     ensem = LIS_domain(n)%tile(t)%ensem
-                     forcpert(n,k)%forcepert_rseed(i,col,row,ensem) = pertdata1d_int(t)
-                  enddo
-               enddo
-               deallocate(pertdata1d_int)
-               
-            else
-               if(LIS_masterproc) then
                   k = 1
-                  do i=1,LIS_rc%nforcepert                  
-                     read(ftn) forcpert(n,k)%forcepert_ntrmdt(i,:,:,:)
+                  do i=1,LIS_rc%nforcepert
+                     
+                     call LIS_readvar_restart(ftn,n,pertdata1d)
+                     
+                     do t=1,LIS_rc%ntiles(n)
+                        col = LIS_domain(n)%tile(t)%col
+                        row = LIS_domain(n)%tile(t)%row
+                        ensem = LIS_domain(n)%tile(t)%ensem
+                        forcpert(n,k)%forcepert_ntrmdt(i,col,row,ensem) = pertdata1d(t)
+                     enddo
                   enddo
+                  
+                  deallocate(pertdata1d)
+                  
+                  allocate(pertdata1d_int(LIS_rc%ntiles(n)))
+                  
                   do i=1,NRANDSEED
-                     read(ftn) forcpert(n,k)%forcepert_rseed(i,:,:,:)
+                     
+                     call LIS_readvar_restart(ftn,n,pertdata1d_int)
+                     
+                     do t=1,LIS_rc%ntiles(n)
+                        col = LIS_domain(n)%tile(t)%col
+                        row = LIS_domain(n)%tile(t)%row
+                        ensem = LIS_domain(n)%tile(t)%ensem
+                        forcpert(n,k)%forcepert_rseed(i,col,row,ensem) = pertdata1d_int(t)
+                     enddo
+                  enddo
+                  deallocate(pertdata1d_int)
+                  
+               else
+                  if(LIS_masterproc) then
+                     k = 1
+                     do i=1,LIS_rc%nforcepert                  
+                        read(ftn) forcpert(n,k)%forcepert_ntrmdt(i,:,:,:)
+                     enddo
+                     do i=1,NRANDSEED
+                        read(ftn) forcpert(n,k)%forcepert_rseed(i,:,:,:)
+                     enddo
+                  else
+! to keep the binary reading in sync when there is a mix of file reading that
+! happens only on one processor and across processors. 
+                     allocate(dummy_var(&
+                          LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n)))
+                     do i =1, LIS_rc%nforcepert
+                        read(ftn) dummy_var
+                     enddo
+                     do i =1, NRANDSEED
+                        read(ftn) dummy_var
+                     enddo
+                     deallocate(dummy_var)
+                  endif
+                  
+               endif
+            endif
+            if(.not. p_xyCorr) then 
+               do k=1, LIS_rc%nperts
+                  
+                  if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+                     allocate(pertdata1d_patch(LIS_rc%npatch(n,LIS_rc%lsm_index)))
+                     
+                     do i =1, LIS_rc%nstvars(k)                  
+                        call LIS_readvar_restart(ftn,n,1,pertdata1d_patch)   
+                        
+                        do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+                           col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
+                           row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
+                           ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
+                           progpert(n,k)%progpert_ntrmdt(i,col,row,ensem) = &
+                                pertdata1d_patch(t) 
+                        enddo
+                        
+                     enddo
+                     deallocate(pertdata1d_patch)
+                     
+                     allocate(pertdata1d_patch_int(LIS_rc%npatch(n,LIS_rc%lsm_index)))
+                     
+                     do i =1, NRANDSEED
+                        call LIS_readvar_restart(ftn,n,1,pertdata1d_patch_int)   
+                        
+                        do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+                           col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
+                           row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
+                           ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
+                           progpert(n,k)%progpert_rseed(i,col,row,ensem) = &
+                                pertdata1d_patch_int(t) 
+                        enddo
+                        
+                     enddo
+                     deallocate(pertdata1d_patch_int)
+                     
+                  endif
+               enddo
+            else
+               if(LIS_masterproc) then 
+                  do k=1, LIS_rc%nperts
+                     if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+                        
+                        do i =1, LIS_rc%nstvars(k)                  
+                           read(ftn) progPert(n,k)%progpert_ntrmdt(i,:,:,:)
+                        enddo
+                        do i =1, NRANDSEED
+                           read(ftn) progPert(n,k)%progpert_rseed(i,:,:,:)
+                        enddo
+                     endif
                   enddo
                else
 ! to keep the binary reading in sync when there is a mix of file reading that
 ! happens only on one processor and across processors. 
                   allocate(dummy_var(&
                        LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n)))
-                  do i =1, LIS_rc%nforcepert
-                     read(ftn) dummy_var
-                  enddo
-                  do i =1, NRANDSEED
-                     read(ftn) dummy_var
+                  do k=1, LIS_rc%nperts
+                     if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+                        
+                        do i =1, LIS_rc%nstvars(k)                  
+                           read(ftn) dummy_var
+                        enddo
+                        do i =1, NRANDSEED
+                           read(ftn) dummy_var
+                        enddo
+                     endif
                   enddo
                   deallocate(dummy_var)
                endif
-               
             endif
-         endif
-         if(.not. p_xyCorr) then 
-            do k=1, LIS_rc%nperts
-
-               if(trim(LIS_rc%perturb_state(k)).ne."none") then 
-                  allocate(pertdata1d_patch(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-                  
-                  do i =1, LIS_rc%nstvars(k)                  
-                     call LIS_readvar_restart(ftn,n,1,pertdata1d_patch)   
-                     
-                     do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
-                        col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
-                        row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
-                        ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
-                        progpert(n,k)%progpert_ntrmdt(i,col,row,ensem) = &
-                             pertdata1d_patch(t) 
-                     enddo
-                     
-                  enddo
-                  deallocate(pertdata1d_patch)
-                  
-                  allocate(pertdata1d_patch_int(LIS_rc%npatch(n,LIS_rc%lsm_index)))
-
-                  do i =1, NRANDSEED
-                     call LIS_readvar_restart(ftn,n,1,pertdata1d_patch_int)   
-                     
-                     do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
-                        col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
-                        row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
-                        ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
-                        progpert(n,k)%progpert_rseed(i,col,row,ensem) = &
-                             pertdata1d_patch_int(t) 
-                     enddo
-                     
-                  enddo
-                  deallocate(pertdata1d_patch_int)
-
-               endif
-            enddo
-         else
-            if(LIS_masterproc) then 
-               do k=1, LIS_rc%nperts
-                  if(trim(LIS_rc%perturb_state(k)).ne."none") then 
-                  
-                     do i =1, LIS_rc%nstvars(k)                  
-                        read(ftn) progPert(n,k)%progpert_ntrmdt(i,:,:,:)
-                     enddo
-                     do i =1, NRANDSEED
-                        read(ftn) progPert(n,k)%progpert_rseed(i,:,:,:)
-                     enddo
-                  endif
-               enddo
-            else
-! to keep the binary reading in sync when there is a mix of file reading that
-! happens only on one processor and across processors. 
-               allocate(dummy_var(&
-                    LIS_rc%gnc(n),LIS_rc%gnr(n),LIS_rc%nensem(n)))
-               do k=1, LIS_rc%nperts
-                  if(trim(LIS_rc%perturb_state(k)).ne."none") then 
-                     
-                     do i =1, LIS_rc%nstvars(k)                  
-                        read(ftn) dummy_var
-                     enddo
-                     do i =1, NRANDSEED
-                        read(ftn) dummy_var
-                     enddo
-                  endif
-               enddo
-               deallocate(dummy_var)
-            endif
-         endif   
-
-         if(.not. o_xyCorr) then       
-            do k=1, LIS_rc%ndas
-
-               if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
-                  allocate(pertdata1d_obs(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
-
-                  do i=1, nobs(n,k)
-                     call readvar_obspert_restart(ftn,n,k,pertdata1d_obs)   
-
-                     do t=1,LIS_rc%obs_ngrid(k)
-                        col = LIS_obs_domain(n,k)%col(t)
-                        row = LIS_obs_domain(n,k)%row(t)
-                        do kk=1,LIS_rc%nensem(n)
-                           obspert(n,k)%obspert_ntrmdt(i,col,row,kk) = & 
-                                pertdata1d_obs(kk+(t-1)*LIS_rc%nensem(n))
-                               
-                        enddo
-                     enddo
-                  enddo
-                  deallocate(pertdata1d_obs)
-                  
-                  allocate(pertdata1d_obs_int(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
-                  
-
-                  do i=1, NRANDSEED
-                     call readvar_obspert_restart_int(ftn,n,k,pertdata1d_obs_int)   
-
-                     do t=1,LIS_rc%obs_ngrid(k)
-                        col = LIS_obs_domain(n,k)%col(t)
-                        row = LIS_obs_domain(n,k)%row(t)
-                        do kk=1,LIS_rc%nensem(n)
-                           obspert(n,k)%obspert_rseed(i,col,row,kk) = & 
-                                pertdata1d_obs_int(kk+(t-1)*LIS_rc%nensem(n))
-                               
-                        enddo
-                     enddo
-                  enddo
-               endif
-               deallocate(pertdata1d_obs_int)
-
-            enddo
-         else
-            if(LIS_masterproc) then 
+            
+            if(.not. o_xyCorr) then       
                do k=1, LIS_rc%ndas
+                  
                   if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
+                     allocate(pertdata1d_obs(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
+                     
                      do i=1, nobs(n,k)
-                        read(ftn) obsPert(n,k)%obspert_ntrmdt(i,:,:,:)
+                        call readvar_obspert_restart(ftn,n,k,pertdata1d_obs)   
+                        
+                        do t=1,LIS_rc%obs_ngrid(k)
+                           col = LIS_obs_domain(n,k)%col(t)
+                           row = LIS_obs_domain(n,k)%row(t)
+                           do kk=1,LIS_rc%nensem(n)
+                              obspert(n,k)%obspert_ntrmdt(i,col,row,kk) = & 
+                                   pertdata1d_obs(kk+(t-1)*LIS_rc%nensem(n))
+                               
+                           enddo
+                        enddo
                      enddo
+                     deallocate(pertdata1d_obs)
+                  
+                     allocate(pertdata1d_obs_int(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
+                     
+                     
                      do i=1, NRANDSEED
-                        read(ftn) obsPert(n,k)%obspert_rseed(i,:,:,:)
-                     enddo
-                  end if
-               enddo
-            else
-               do k=1, LIS_rc%nperts
-                  allocate(dummy_var(&
-                       LIS_rc%obs_gnc(k),LIS_rc%obs_gnr(k),LIS_rc%nensem(n)))
-                  if(trim(LIS_rc%perturb_obs(k)).ne."none") then  
-                     do i =1, nobs(n,k)
-                        read(ftn) dummy_var
-                     enddo
-                     do i =1, NRANDSEED
-                        read(ftn) dummy_var
+                        call readvar_obspert_restart_int(ftn,n,k,pertdata1d_obs_int)   
+                        
+                        do t=1,LIS_rc%obs_ngrid(k)
+                           col = LIS_obs_domain(n,k)%col(t)
+                           row = LIS_obs_domain(n,k)%row(t)
+                           do kk=1,LIS_rc%nensem(n)
+                              obspert(n,k)%obspert_rseed(i,col,row,kk) = & 
+                                   pertdata1d_obs_int(kk+(t-1)*LIS_rc%nensem(n))
+                              
+                           enddo
+                        enddo
                      enddo
                   endif
-                  deallocate(dummy_var)
-
+                  deallocate(pertdata1d_obs_int)
+                  
                enddo
+            else
+               if(LIS_masterproc) then 
+                  do k=1, LIS_rc%ndas
+                     if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
+                        do i=1, nobs(n,k)
+                           read(ftn) obsPert(n,k)%obspert_ntrmdt(i,:,:,:)
+                        enddo
+                        do i=1, NRANDSEED
+                           read(ftn) obsPert(n,k)%obspert_rseed(i,:,:,:)
+                        enddo
+                     end if
+                  enddo
+               else
+                  do k=1, LIS_rc%nperts
+                     allocate(dummy_var(&
+                          LIS_rc%obs_gnc(k),LIS_rc%obs_gnr(k),LIS_rc%nensem(n)))
+                     if(trim(LIS_rc%perturb_obs(k)).ne."none") then  
+                        do i =1, nobs(n,k)
+                           read(ftn) dummy_var
+                        enddo
+                        do i =1, NRANDSEED
+                           read(ftn) dummy_var
+                        enddo
+                     endif
+                     deallocate(dummy_var)
+                     
+                  enddo
+
+               endif
+            endif
+         
+            call LIS_releaseUnitNumber(ftn)
+            write(LIS_logunit,*) '[INFO] Finished reading perturbations restart file ',&
+                 trim(LIS_rc%pertRestartFile(n))
+            
+         enddo
+      elseif(wformat.eq."distributed binary") then 
+         do n = 1, LIS_rc%nnest
+            
+            ftn = LIS_getNextUnitNumber()
+            
+            if(LIS_rc%runmode.eq."ensemble smoother") then 
+               if(LIS_rc%iterationid(n).gt.1) then 
+                  if(LIS_rc%pertrestartInterval.eq.2592000) then
+                     call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
+                          dd=da,calendar=LIS_calendar,rc=status)
+                     hr = 0 
+                     mn = 0 
+                     ss = 0 
+                     call LIS_tick(time,doy,gmt,yr,mo,da,hr,mn,ss,(-1)*LIS_rc%ts)
+                  else
+                     call ESMF_TimeGet(LIS_twStartTime,yy=yr,mm=mo,&
+                          dd=da,calendar=LIS_calendar,rc=status)
+                     hr = 0 
+                     mn = 0 
+                     ss = 0 
+                  endif
+                  call LIS_create_dapert_filename(n,filen, yr, mo, da, hr, mn, ss)
+                  LIS_rc%pertRestartFile(n) = filen
+               endif
+            endif
+
+            write(temp1,'(i4.4)') LIS_localPet
+            read(temp1,fmt='(4a1)') fproc
+            
+            open(ftn,file=trim(LIS_rc%pertRestartFile(n))//&
+                 '.'//fproc(1)//fproc(2)//fproc(3)//fproc(4), form='unformatted')
+            write(LIS_logunit,*) '[INFO] Reading perturbations restart file ',&
+                 trim(LIS_rc%pertRestartFile(n))
+            
+            if(LIS_rc%perturb_forcing .ne."none") then 
+               if(.not. f_xyCorr) then 
+                  allocate(pertdata1d(LIS_rc%ntiles(n)))
+                  
+                  k = 1
+                  do i=1,LIS_rc%nforcepert
+
+                     read(ftn) pertdata1d
+                     
+                     do t=1,LIS_rc%ntiles(n)
+                        col = LIS_domain(n)%tile(t)%col
+                        row = LIS_domain(n)%tile(t)%row
+                        ensem = LIS_domain(n)%tile(t)%ensem
+                        forcpert(n,k)%forcepert_ntrmdt(i,col,row,ensem) = pertdata1d(t)
+                     enddo
+                  enddo
+                  
+                  deallocate(pertdata1d)
+                  
+                  allocate(pertdata1d_int(LIS_rc%ntiles(n)))
+                  
+                  do i=1,NRANDSEED
+
+                     read(ftn) pertdata1d_int
+                     
+                     do t=1,LIS_rc%ntiles(n)
+                        col = LIS_domain(n)%tile(t)%col
+                        row = LIS_domain(n)%tile(t)%row
+                        ensem = LIS_domain(n)%tile(t)%ensem
+                        forcpert(n,k)%forcepert_rseed(i,col,row,ensem) = pertdata1d_int(t)
+                     enddo
+                  enddo
+                  deallocate(pertdata1d_int)
+                  
+               else
+                  print*, 'Restart read with horizontal correlations not supported '
+                  print*, 'for distributed binary writing format '
+                  call LIS_endrun()
+                                   
+               endif
+            endif
+            if(.not. p_xyCorr) then 
+               do k=1, LIS_rc%nperts
+                  
+                  if(trim(LIS_rc%perturb_state(k)).ne."none") then 
+                     allocate(pertdata1d_patch(LIS_rc%npatch(n,LIS_rc%lsm_index)))
+                     
+                     do i =1, LIS_rc%nstvars(k)
+
+                        read(ftn) pertdata1d_patch
+                        
+                        do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+                           col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
+                           row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
+                           ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
+                           progpert(n,k)%progpert_ntrmdt(i,col,row,ensem) = &
+                                pertdata1d_patch(t) 
+                        enddo
+                        
+                     enddo
+                     deallocate(pertdata1d_patch)
+                     
+                     allocate(pertdata1d_patch_int(LIS_rc%npatch(n,LIS_rc%lsm_index)))
+                     
+                     do i =1, NRANDSEED
+
+                        read(ftn) pertdata1d_patch_int
+                        
+                        do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+                           col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
+                           row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
+                           ensem = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%ensem
+                           progpert(n,k)%progpert_rseed(i,col,row,ensem) = &
+                                pertdata1d_patch_int(t) 
+                        enddo
+                        
+                     enddo
+                     deallocate(pertdata1d_patch_int)
+                     
+                  endif
+               enddo
+            else
+               print*, 'Restart read with horizontal correlations not supported '
+               print*, 'for distributed binary writing format '
+               call LIS_endrun()
 
             endif
-         endif
+            
+            if(.not. o_xyCorr) then       
+               do k=1, LIS_rc%ndas
+                  
+                  if(trim(LIS_rc%perturb_obs(k)).ne."none") then 
+                     allocate(pertdata1d_obs(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
+                     
+                     do i=1, nobs(n,k)
+                        read(ftn) pertdata1d_obs
+                        
+                        do t=1,LIS_rc%obs_ngrid(k)
+                           col = LIS_obs_domain(n,k)%col(t)
+                           row = LIS_obs_domain(n,k)%row(t)
+                           do kk=1,LIS_rc%nensem(n)
+                              obspert(n,k)%obspert_ntrmdt(i,col,row,kk) = & 
+                                   pertdata1d_obs(kk+(t-1)*LIS_rc%nensem(n))
+                               
+                           enddo
+                        enddo
+                     enddo
+                     deallocate(pertdata1d_obs)
+                  
+                     allocate(pertdata1d_obs_int(LIS_rc%obs_ngrid(k)*LIS_rc%nensem(n)))
+                     
+                     
+                     do i=1, NRANDSEED
+                        read(ftn) pertdata1d_obs_int
+                        
+                        do t=1,LIS_rc%obs_ngrid(k)
+                           col = LIS_obs_domain(n,k)%col(t)
+                           row = LIS_obs_domain(n,k)%row(t)
+                           do kk=1,LIS_rc%nensem(n)
+                              obspert(n,k)%obspert_rseed(i,col,row,kk) = & 
+                                   pertdata1d_obs_int(kk+(t-1)*LIS_rc%nensem(n))
+                              
+                           enddo
+                        enddo
+                     enddo
+                  endif
+                  deallocate(pertdata1d_obs_int)
+                  
+               enddo
+            else
+               print*, 'Restart read with horizontal correlations not supported '
+               print*, 'for distributed binary writing format '
+               call LIS_endrun()
+            endif
          
-         call LIS_releaseUnitNumber(ftn)
-         write(LIS_logunit,*) '[INFO] Finished reading perturbations restart file ',&
-              trim(LIS_rc%pertRestartFile(n))
-
-      enddo
+            call LIS_releaseUnitNumber(ftn)
+            write(LIS_logunit,*) '[INFO] Finished reading perturbations restart file ',&
+                 trim(LIS_rc%pertRestartFile(n))
+            
+         enddo
+         
+      endif
+      
     end subroutine gmaopert_readrestart
 
 !BOP

--- a/lis/dataassim/perturb/gmaopert/gmaopert_Mod.F90
+++ b/lis/dataassim/perturb/gmaopert/gmaopert_Mod.F90
@@ -1835,7 +1835,7 @@ module gmaopert_Mod
       integer, allocatable     :: pertdata1d_int(:)
       integer, allocatable     :: pertdata1d_patch_int(:)
       character(len=LIS_CONST_PATH_LEN) :: filen,filenp
-      character*100            :: temp1
+      character*4              :: temp1
       character*1              :: fproc(4)
       integer                  :: ftn
       character*20 :: wformat
@@ -2198,7 +2198,7 @@ module gmaopert_Mod
       integer                   :: yr,mo,da,hr,mn,ss, doy
       integer                   :: status
       character(len=LIS_CONST_PATH_LEN) :: filen
-      character*100             :: temp1
+      character*4               :: temp1
       real*8                    :: time
       real                      :: gmt
       character*1               :: fproc(4)

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readcrd.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readcrd.F90
@@ -420,9 +420,19 @@ subroutine NoahMP401_readcrd()
 
 !------------------------------------------------------------------------------------------
     ! set default restart format to netcdf
-    do n=1,LIS_rc%nnest
-        NOAHMP401_struc(n)%rformat = "netcdf"
-    enddo
+   ! do n=1,LIS_rc%nnest
+   !     NOAHMP401_struc(n)%rformat = "netcdf"
+   ! enddo
+    Call ESMF_ConfigFindLabel(LIS_config, &
+             "Noah-MP.4.0.1 restart file format:", rc=rc)
+        do n=1,LIS_rc%nnest
+            call ESMF_ConfigGetAttribute(LIS_config, NOAHMP401_struc(n)%rformat, rc=rc)
+            call LIS_verify(rc, &
+                 "Noah-MP.4.0.1 restart file format: not defined")
+        enddo
+
+
+
     ! restart run, read restart file
     if (trim(LIS_rc%startcode) == "restart") then 
         Call ESMF_ConfigFindLabel(LIS_config, &

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
@@ -117,7 +117,8 @@ subroutine NoahMP401_readrst()
   real, allocatable :: tmptilen(:)
   logical           :: file_exists
   character*20      :: wformat
-  character(len=LIS_CONST_PATH_LEN)     :: filen,temp1,rfile
+  character(len=LIS_CONST_PATH_LEN)     :: filen,rfile
+  character*4       :: temp1
   character*1       :: fproc(4)
   integer           :: yr,mo,da,hr,mn,ss,doy
   real*8            :: time

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
@@ -130,7 +130,7 @@ subroutine NoahMP401_readrst()
      call NoahMP401_coldstart(LIS_rc%lsm_index)     
      ! coldstart
 !     wformat = "netcdf"
-!     if(LIS_rc%startcode .eq. "coldstart") then  
+!     if(LIS_rc%startcode .eq. "coldstart") then
 
         ! restart
      if(LIS_rc%startcode .eq. "restart") then
@@ -171,7 +171,7 @@ subroutine NoahMP401_readrst()
            rfile = trim(NOAHMP401_struc(n)%rfile)//&
                 '.'//fproc(1)//fproc(2)//fproc(3)//fproc(4)
         endif
-        
+
         inquire(file=rfile, exist=file_exists)
         If (.not. file_exists) then 
            write(LIS_logunit,*) "[ERR] NoahMP401 restart file: ", &
@@ -204,11 +204,11 @@ subroutine NoahMP401_readrst()
               write(LIS_logunit,*) "[ERR] Program stopping..."
               call LIS_endrun
            endif
-        elseif(wformat.eq."distributed binary") then 
+        elseif(wformat.eq."distributed binary") then
            ftn = LIS_getNextUnitNumber()
            open(ftn, file=rfile, &
                 form="unformatted")
-           
+
         elseif(wformat .eq. "netcdf") then
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
            status = nf90_open(path=rfile, &
@@ -218,234 +218,234 @@ subroutine NoahMP401_readrst()
         endif
 
         if(wformat.eq."distributed binary") then
-!           if(LIS_rc%npatch(n, LIS_rc%lsm_index).ne.0) then 
+!           if(LIS_rc%npatch(n, LIS_rc%lsm_index).ne.0) then
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%sfcrunoff = tmptilen(t)
               endif
            enddo
-           
+
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%udrrunoff = tmptilen(t)
               endif
-           enddo           
-           
+           enddo
+
            do l=1, NOAHMP401_struc(n)%nsoil   ! TODO: check loop
               read(ftn) tmptilen
               do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-                 if(tmptilen(t).ne.LIS_rc%udef) then 
+                 if(tmptilen(t).ne.LIS_rc%udef) then
                     NOAHMP401_struc(n)%noahmp401(t)%smc(l) = tmptilen(t)
                  endif
               enddo
            enddo
            do l=1, NOAHMP401_struc(n)%nsoil   ! TODO: check loop
-              read(ftn) tmptilen         
+              read(ftn) tmptilen
               do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-                 if(tmptilen(t).ne.LIS_rc%udef) then 
+                 if(tmptilen(t).ne.LIS_rc%udef) then
                     NOAHMP401_struc(n)%noahmp401(t)%sh2o(l) = tmptilen(t)
                  endif
               enddo
            enddo
            ! soil temperature
            do l=1, NOAHMP401_struc(n)%nsoil   ! TODO: check loop
-              read(ftn) tmptilen         
+              read(ftn) tmptilen
               do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-                 if(tmptilen(t).ne.LIS_rc%udef) then 
+                 if(tmptilen(t).ne.LIS_rc%udef) then
                     NOAHMP401_struc(n)%noahmp401(t)%tslb(l) = tmptilen(t)
                  endif
               enddo
            enddo
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%sneqv = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%snowh = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%canwat = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%acsnom = tmptilen(t)
               endif
            enddo
-           
+
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%acsnow = tmptilen(t)
               endif
            enddo
-           
+
            read(ftn) tmptilen
            do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%isnow = nint(tmptilen(t))
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%tv = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%tg = tmptilen(t)
               endif
            enddo
-           
+
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%canice = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%canliq = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%eah = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%tah = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%cm = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%ch = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%fwet = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%sneqvo = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%albold = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%qsnow = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%wslake = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%zwt = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%wa = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%wt = tmptilen(t)
               endif
            enddo
-                     
+
            ! snow layer temperature
            do l=1, NOAHMP401_struc(n)%nsnow   ! TODO: check loop
               read(ftn) tmptilen
               do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-                 if(tmptilen(t).ne.LIS_rc%udef) then 
+                 if(tmptilen(t).ne.LIS_rc%udef) then
                     NOAHMP401_struc(n)%noahmp401(t)%tsno(l) = tmptilen(t)
                  endif
               enddo
            enddo
            ! snow/soil layer depth from snow surface
-           do l=1, NOAHMP401_struc(n)%nsnow + NOAHMP401_struc(n)%nsoil          
+           do l=1, NOAHMP401_struc(n)%nsnow + NOAHMP401_struc(n)%nsoil
               read(ftn) tmptilen
-              
+
               do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
                  if(tmptilen(t).ne.LIS_rc%udef.and.&
-                      tmptilen(t).ne.0) then 
+                      tmptilen(t).ne.0) then
                     NOAHMP401_struc(n)%noahmp401(t)%zss(l)= tmptilen(t)
                  endif
               enddo
            enddo
            ! snow layer ice
            do l=1, NOAHMP401_struc(n)%nsnow   ! TODO: check loop
-              read(ftn) tmptilen         
+              read(ftn) tmptilen
               do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-                 if(tmptilen(t).ne.LIS_rc%udef) then 
+                 if(tmptilen(t).ne.LIS_rc%udef) then
                     NOAHMP401_struc(n)%noahmp401(t)%snowice(l)= tmptilen(t)
                  endif
               enddo
            enddo
            ! snow layer liquid water
            do l=1, NOAHMP401_struc(n)%nsnow   ! TODO: check loop
-              read(ftn) tmptilen                       
+              read(ftn) tmptilen
               do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-                 if(tmptilen(t).ne.LIS_rc%udef) then 
+                 if(tmptilen(t).ne.LIS_rc%udef) then
                     NOAHMP401_struc(n)%noahmp401(t)%snowliq(l)= tmptilen(t)
                  endif
               enddo
@@ -453,63 +453,63 @@ subroutine NoahMP401_readrst()
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%lfmass = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%rtmass = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%stmass = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%wood = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%stblcp = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%fastcp = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%lai = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%sai = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%tauss = tmptilen(t)
               endif
            enddo
@@ -518,7 +518,7 @@ subroutine NoahMP401_readrst()
            do l=1, NOAHMP401_struc(n)%nsoil   ! TODO: check loop
               read(ftn) tmptilen
               do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-                 if(tmptilen(t).ne.LIS_rc%udef) then 
+                 if(tmptilen(t).ne.LIS_rc%udef) then
                     NOAHMP401_struc(n)%noahmp401(t)%smoiseq(l) = tmptilen(t)
                  endif
               enddo
@@ -526,50 +526,50 @@ subroutine NoahMP401_readrst()
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%smcwtd = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%deeprech = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%rech = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%grain = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1,LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%gdd = tmptilen(t)
               endif
            enddo
 
            read(ftn) tmptilen
            do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-              if(tmptilen(t).ne.LIS_rc%udef) then 
+              if(tmptilen(t).ne.LIS_rc%udef) then
                  NOAHMP401_struc(n)%noahmp401(t)%pgs = nint(tmptilen(t))
               endif
-           enddo                      
-           
+           enddo
+
 !           do l=1, 60  ! TODO: check loop
 !              read(ftn) tmptilen
 !              do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-!                 if(tmptilen(t).ne.LIS_rc%udef) then 
+!                 if(tmptilen(t).ne.LIS_rc%udef) then
 !                    NOAHMP401_struc(n)%noahmp401(t)%gecros_state(l)= tmptilen(t!)
 !                 endif
 !              enddo
@@ -579,11 +579,11 @@ subroutine NoahMP401_readrst()
            ! read: accumulated surface runoff
            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP401_struc(n)%noahmp401%sfcrunoff, &
                 varname="SFCRUNOFF", wformat=wformat)
-           
+
            ! read: accumulated sub-surface runoff
            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP401_struc(n)%noahmp401%udrrunoff, &
                 varname="UDRRUNOFF", wformat=wformat)
-           
+
            ! read: volumtric soil moisture
            do l=1, NOAHMP401_struc(n)%nsoil ! TODO: check loop
               call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SMC", &
@@ -601,7 +601,7 @@ subroutine NoahMP401_readrst()
                  NOAHMP401_struc(n)%noahmp401(t)%sh2o(l) = tmptilen(t)
               enddo
            enddo
-           
+
            ! read: soil temperature
            do l=1, NOAHMP401_struc(n)%nsoil ! TODO: check loop
               call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="TSLB", &
@@ -610,11 +610,11 @@ subroutine NoahMP401_readrst()
                  NOAHMP401_struc(n)%noahmp401(t)%tslb(l) = tmptilen(t)
               enddo
            enddo
-           
+
            ! read: snow water equivalent
            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP401_struc(n)%noahmp401%sneqv, &
                 varname="SNEQV", wformat=wformat)
-           
+
            ! read: physical snow depth
            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP401_struc(n)%noahmp401%snowh, &
                 varname="SNOWH", wformat=wformat)
@@ -713,12 +713,12 @@ subroutine NoahMP401_readrst()
               call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="ZSS", &
                    dim=l, vlevels = NOAHMP401_struc(n)%nsnow + NOAHMP401_struc(n)%nsoil, wformat=wformat)
               do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-                 if(tmptilen(t).ne.0) then                    
+                 if(tmptilen(t).ne.0) then
                     NOAHMP401_struc(n)%noahmp401(t)%zss(l) = tmptilen(t)
                  endif
               enddo
            enddo
-           
+
            ! read: snow layer ice
            do l=1, NOAHMP401_struc(n)%nsnow ! TODO: check loop
               call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SNOWICE", &
@@ -727,7 +727,7 @@ subroutine NoahMP401_readrst()
                  NOAHMP401_struc(n)%noahmp401(t)%snowice(l) = tmptilen(t)
               enddo
            enddo
-           
+
            ! read: snow layer liquid water
            do l=1, NOAHMP401_struc(n)%nsnow ! TODO: check loop
               call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="SNOWLIQ", &
@@ -736,7 +736,7 @@ subroutine NoahMP401_readrst()
                  NOAHMP401_struc(n)%noahmp401(t)%snowliq(l) = tmptilen(t)
               enddo
            enddo
-           
+
            ! read: leaf mass
            call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, NOAHMP401_struc(n)%noahmp401%lfmass, &
                 varname="LFMASS", wformat=wformat)
@@ -826,7 +826,7 @@ subroutine NoahMP401_readrst()
 #endif
         elseif(wformat.eq."distributed binary") then
            call LIS_releaseUnitNumber(ftn)
-           
+
         endif
         deallocate(tmptilen)
      endif

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
@@ -129,9 +129,6 @@ subroutine NoahMP401_readrst()
   do n=1, LIS_rc%nnest
      wformat = trim(NOAHMP401_struc(n)%rformat)
      call NoahMP401_coldstart(LIS_rc%lsm_index)     
-     ! coldstart
-!     wformat = "netcdf"
-!     if(LIS_rc%startcode .eq. "coldstart") then
 
         ! restart
      if(LIS_rc%startcode .eq. "restart") then

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
@@ -155,7 +155,6 @@ subroutine NoahMP401_readrst()
                    'SURFACEMODEL','NOAHMP401', &
                    yr,mo,da,hr,mn,ss, wformat=wformat)
               NOAHMP401_struc(n)%rfile = filen
-              rfile = filen
            endif
         endif
 
@@ -168,6 +167,8 @@ subroutine NoahMP401_readrst()
 
            rfile = trim(NOAHMP401_struc(n)%rfile)//&
                 '.'//fproc(1)//fproc(2)//fproc(3)//fproc(4)
+        else
+           rfile = NOAHMP401_struc(n)%rfile
         endif
 
         inquire(file=rfile, exist=file_exists)
@@ -211,7 +212,7 @@ subroutine NoahMP401_readrst()
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
            status = nf90_open(path=rfile, &
                 mode=NF90_NOWRITE, ncid=ftn)
-           call LIS_verify(status, "Error opening file "//rfile)
+           call LIS_verify(status, "Error opening file "//trim(rfile))
 #endif
         endif
 

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readrst.F90
@@ -808,13 +808,13 @@ subroutine NoahMP401_readrst()
                 varname="PGS", wformat=wformat)
 
            ! read: optional gecros crop
-         !  do l=1, 60 ! TODO: check loop
-         !     call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="GECROS_STATE", &
-         !          dim=l, vlevels = 60, wformat=wformat)
-         !     do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-         !        NOAHMP401_struc(n)%noahmp401(t)%gecros_state(l) = tmptilen(t)
-         !     enddo
-         !  enddo
+!           do l=1, 60 ! TODO: check loop
+!              call LIS_readvar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, varname="GECROS_STATE", &
+!                   dim=l, vlevels = 60, wformat=wformat)
+!              do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+!                 NOAHMP401_struc(n)%noahmp401(t)%gecros_state(l) = tmptilen(t)
+!              enddo
+!           enddo
         endif
         ! close restart file
         if(wformat .eq. "binary") then

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
@@ -68,7 +68,6 @@ subroutine NoahMP401_writerst(n)
     
     ! set restart file format (read from LIS configration file_
     wformat = trim(NOAHMP401_struc(n)%rformat)
-    wformat = "distributed binary"
 
     if(alarmCheck .or. (LIS_rc%endtime ==1)) then
        call LIS_create_output_directory("SURFACEMODEL")
@@ -794,10 +793,10 @@ subroutine NoahMP401_dump_restart(n, ftn, wformat)
                                  "-", vlevels=1, valid_min=-99999.0, valid_max=99999.0)
     ! write the header for state variable gecros_state
     !TODO: replace -99999 and 99999 with correct values for valid_min and valid_max
-    call LIS_writeHeader_restart(ftn, n, dimID, gecros_state_ID, "GECROS_STATE", &
-                                 "optional gecros crop", &
-                                 "-", vlevels=60, valid_min=-99999.0, valid_max=99999.0, &
-                                 var_flag = "dim4") 
+!    call LIS_writeHeader_restart(ftn, n, dimID, gecros_state_ID, "GECROS_STATE", &
+!                                 "optional gecros crop", &
+!                                 "-", vlevels=60, valid_min=-99999.0, valid_max=99999.0, &
+!                                 var_flag = "dim4") 
  
     ! close header of restart file
     call LIS_closeHeader_restart(ftn, n, LIS_rc%lsm_index, dimID, NOAHMP401_struc(n)%rstInterval)

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
@@ -528,7 +528,8 @@ subroutine NoahMP401_dump_restart(n, ftn, wformat)
                                        dim1=NOAHMP401_struc(n)%nsoil+NOAHMP401_struc(n)%nsnow, &
                                        dim2=NOAHMP401_struc(n)%nsoil,                          &
                                        dim3=NOAHMP401_struc(n)%nsnow,                          &
-                                       dim4=60,                                                &
+!                                       dim4=60,                                                & ! GECROS
+                                       dim4=1,                                                 &
                                        dimID=dimID,                                            &
                                        output_format = trim(wformat))
 
@@ -1031,13 +1032,12 @@ subroutine NoahMP401_dump_restart(n, ftn, wformat)
                               varid=pgs_ID, dim=1, wformat=wformat)
 
     ! optional gecros crop
-  !  do l=1, 60  ! TODO: check loop
-  !      tmptilen = 0
-  !      do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-  !          tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%gecros_state(l)
-  !      enddo
-  !      call LIS_writevar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, &
-  !                                varid=gecros_state_ID, dim=l, wformat=wformat)
-  !  enddo
+!    do l=1, 60  ! TODO: check loop
+!        tmptilen = 0
+!        do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+!            tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%gecros_state(l)
+!        enddo
+!        call LIS_writevar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, &
+!                                  varid=gecros_state_ID, dim=l, wformat=wformat)
+!    enddo
 end subroutine NoahMP401_dump_restart
-

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
@@ -56,7 +56,7 @@ subroutine NoahMP401_writerst(n)
 !EOP
 
     character(len=LIS_CONST_PATH_LEN) :: filen,filenp
-    character*100 :: temp1
+    character*4   :: temp1
     character*1   :: fproc(4)
     character*20  :: wformat
     logical       :: alarmCheck

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
@@ -74,12 +74,12 @@ subroutine NoahMP401_writerst(n)
        call LIS_create_restart_filename(n, filen, "SURFACEMODEL", &
             "NOAHMP401",wformat=wformat)
        if(wformat .eq. "binary") then
-          if(LIS_masterproc) then 
+          if(LIS_masterproc) then
              ftn = LIS_getNextUnitNumber()
              open(ftn,file=filen,status="unknown", form="unformatted")
           endif
        elseif(wformat .eq. "netcdf") then
-          if(LIS_masterproc) then 
+          if(LIS_masterproc) then
 #if (defined USE_NETCDF4)
              status = nf90_create(path=filen, cmode=nf90_hdf5, ncid = ftn)
              call LIS_verify(status, &
@@ -93,13 +93,13 @@ subroutine NoahMP401_writerst(n)
           endif
        elseif(wformat.eq."distributed binary") then
           ftn = LIS_getNextUnitNumber()
-          
+
           write(temp1,'(i4.4)') LIS_localPet
           read(temp1,fmt='(4a1)') fproc
-          
+
           filenp = trim(filen)//'.'//fproc(1)//fproc(2)//fproc(3)//fproc(4)
           open(ftn,file=trim(filenp),&
-               form='unformatted')                                
+               form='unformatted')
        endif
 
        if(wformat.eq."distributed binary") then
@@ -109,13 +109,13 @@ subroutine NoahMP401_writerst(n)
        endif
         
        if(wformat .eq. "binary") then
-          if (LIS_masterproc) then          
+          if (LIS_masterproc) then
              call LIS_releaseUnitNumber(ftn)
           endif
        elseif(wformat.eq."distributed binary") then
           call LIS_releaseUnitNumber(ftn)
        elseif(wformat .eq. "netcdf") then
-          if(LIS_masterproc) then 
+          if(LIS_masterproc) then
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
              status = nf90_close(ftn)
              call LIS_verify(status, &
@@ -135,8 +135,8 @@ end subroutine NoahMP401_writerst
 !
 ! !REVISION HISTORY:
 !  This subroutine is generated with the Model Implementation Toolkit developed
-!  by Shugong Wang for the NASA Land Information System Version 7. The initial 
-!  specification of the subroutine is defined by Sujay Kumar. 
+!  by Shugong Wang for the NASA Land Information System Version 7. The initial
+!  specification of the subroutine is defined by Sujay Kumar.
 !  10/25/18: Shugong Wang, Zhuo Wang, initial implementation for LIS 7 and NoahMP401
 ! !INTERFACE:
 subroutine NoahMP401_dump_restart_dist(n, ftn, wformat)
@@ -233,10 +233,10 @@ subroutine NoahMP401_dump_restart_dist(n, ftn, wformat)
 !   \item[LIS\_writevar\_restart](\ref{LIS_writevar_restart})\\
 !      writes a variable to the restart file
 ! \end{description}
-! 
-!EOP 
-               
-    integer :: l, t 
+!
+!EOP
+
+    integer :: l, t
     real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index))
 
     write(ftn) NOAHMP401_struc(n)%noahmp401%sfcrunoff
@@ -254,7 +254,7 @@ subroutine NoahMP401_dump_restart_dist(n, ftn, wformat)
        do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
           tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%sh2o(l)
        enddo
-       write(ftn) tmptilen         
+       write(ftn) tmptilen
     enddo
     ! soil temperature
     do l=1, NOAHMP401_struc(n)%nsoil   ! TODO: check loop
@@ -262,7 +262,7 @@ subroutine NoahMP401_dump_restart_dist(n, ftn, wformat)
        do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
           tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%tslb(l)
        enddo
-       write(ftn) tmptilen         
+       write(ftn) tmptilen
     enddo
     write(ftn) NOAHMP401_struc(n)%noahmp401%sneqv
     write(ftn) NOAHMP401_struc(n)%noahmp401%snowh
@@ -313,7 +313,7 @@ subroutine NoahMP401_dump_restart_dist(n, ftn, wformat)
        do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
           tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%snowice(l)
        enddo
-       write(ftn) tmptilen         
+       write(ftn) tmptilen
     enddo
     ! snow layer liquid water
     do l=1, NOAHMP401_struc(n)%nsnow   ! TODO: check loop
@@ -321,7 +321,7 @@ subroutine NoahMP401_dump_restart_dist(n, ftn, wformat)
        do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
           tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%snowliq(l)
        enddo
-       write(ftn) tmptilen         
+       write(ftn) tmptilen
     enddo
     write(ftn) NOAHMP401_struc(n)%noahmp401%lfmass
     write(ftn) NOAHMP401_struc(n)%noahmp401%rtmass
@@ -352,7 +352,7 @@ subroutine NoahMP401_dump_restart_dist(n, ftn, wformat)
        tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%pgs
     enddo
     write(ftn) tmptilen
-    
+
 !    do l=1, 60  ! TODO: check loop
 !      tmptilen = 0
 !       do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
@@ -23,7 +23,7 @@
 ! !INTERFACE:
 subroutine NoahMP401_writerst(n)
 ! !USES:
-    use LIS_coreMod, only    : LIS_rc, LIS_masterproc
+    use LIS_coreMod
     use LIS_timeMgrMod, only : LIS_isAlarmRinging
     use LIS_logMod, only     : LIS_logunit, LIS_getNextUnitNumber, &
                                LIS_releaseUnitNumber , LIS_verify
@@ -55,7 +55,9 @@ subroutine NoahMP401_writerst(n)
 ! \end{description}
 !EOP
 
-    character(len=LIS_CONST_PATH_LEN) :: filen
+    character(len=LIS_CONST_PATH_LEN) :: filen,filenp
+    character*100 :: temp1
+    character*1   :: fproc(4)
     character*20  :: wformat
     logical       :: alarmCheck
     integer       :: ftn
@@ -66,46 +68,300 @@ subroutine NoahMP401_writerst(n)
     
     ! set restart file format (read from LIS configration file_
     wformat = trim(NOAHMP401_struc(n)%rformat)
-    
+    wformat = "distributed binary"
+
     if(alarmCheck .or. (LIS_rc%endtime ==1)) then
-        If (LIS_masterproc) Then
-            call LIS_create_output_directory("SURFACEMODEL")
-            call LIS_create_restart_filename(n, filen, "SURFACEMODEL", &
-                                            "NOAHMP401",wformat=wformat)
-            if(wformat .eq. "binary") then
-                ftn = LIS_getNextUnitNumber()
-                open(ftn,file=filen,status="unknown", form="unformatted")
-            elseif(wformat .eq. "netcdf") then
+       call LIS_create_output_directory("SURFACEMODEL")
+       call LIS_create_restart_filename(n, filen, "SURFACEMODEL", &
+            "NOAHMP401",wformat=wformat)
+       if(wformat .eq. "binary") then
+          if(LIS_masterproc) then 
+             ftn = LIS_getNextUnitNumber()
+             open(ftn,file=filen,status="unknown", form="unformatted")
+          endif
+       elseif(wformat .eq. "netcdf") then
+          if(LIS_masterproc) then 
 #if (defined USE_NETCDF4)
-                status = nf90_create(path=filen, cmode=nf90_hdf5, ncid = ftn)
-                call LIS_verify(status, &
-                     "Error in nf90_open in NoahMP401_writerst")
+             status = nf90_create(path=filen, cmode=nf90_hdf5, ncid = ftn)
+             call LIS_verify(status, &
+                  "Error in nf90_open in NoahMP401_writerst")
 #endif
 #if (defined USE_NETCDF3)
-                status = nf90_create(Path = filen, cmode = nf90_clobber, ncid = ftn)
-                call LIS_verify(status, &
-                     "Error in nf90_open in NoahMP401_writerst")
+             status = nf90_create(Path = filen, cmode = nf90_clobber, ncid = ftn)
+             call LIS_verify(status, &
+                  "Error in nf90_open in NoahMP401_writerst")
 #endif
-             endif
-        endif
-    
-        call NoahMP401_dump_restart(n, ftn, wformat)
-    
-        if (LIS_masterproc) then
-            if(wformat .eq. "binary") then
-                call LIS_releaseUnitNumber(ftn)
-            elseif(wformat .eq. "netcdf") then
+          endif
+       elseif(wformat.eq."distributed binary") then
+          ftn = LIS_getNextUnitNumber()
+          
+          write(temp1,'(i4.4)') LIS_localPet
+          read(temp1,fmt='(4a1)') fproc
+          
+          filenp = trim(filen)//'.'//fproc(1)//fproc(2)//fproc(3)//fproc(4)
+          open(ftn,file=trim(filenp),&
+               form='unformatted')                                
+       endif
+
+       if(wformat.eq."distributed binary") then
+          call NoahMP401_dump_restart_dist(n, ftn, wformat)
+       else
+          call NoahMP401_dump_restart(n, ftn, wformat)
+       endif
+        
+       if(wformat .eq. "binary") then
+          if (LIS_masterproc) then          
+             call LIS_releaseUnitNumber(ftn)
+          endif
+       elseif(wformat.eq."distributed binary") then
+          call LIS_releaseUnitNumber(ftn)
+       elseif(wformat .eq. "netcdf") then
+          if(LIS_masterproc) then 
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-                status = nf90_close(ftn)
-                call LIS_verify(status, &
-                     "Error in nf90_close in NoahMP401_writerst")
+             status = nf90_close(ftn)
+             call LIS_verify(status, &
+                  "Error in nf90_close in NoahMP401_writerst")
 #endif
-            endif
-            write(LIS_logunit, *)&
-                 "[INFO] Noah-MP.4.0.1 archive restart written: ",trim(filen)
-        endif
+             write(LIS_logunit, *)&
+                  "[INFO] Noah-MP.4.0.1 archive restart written: ",trim(filen)
+          endif
+       endif
     endif
 end subroutine NoahMP401_writerst
+
+!BOP
+!
+! !ROUTINE: NoahMP401_dump_restart_dist
+! \label{NoahMP401_dump_restart_dist}
+!
+! !REVISION HISTORY:
+!  This subroutine is generated with the Model Implementation Toolkit developed
+!  by Shugong Wang for the NASA Land Information System Version 7. The initial 
+!  specification of the subroutine is defined by Sujay Kumar. 
+!  10/25/18: Shugong Wang, Zhuo Wang, initial implementation for LIS 7 and NoahMP401
+! !INTERFACE:
+subroutine NoahMP401_dump_restart_dist(n, ftn, wformat)
+
+! !USES:
+    use LIS_coreMod
+    use LIS_logMod, only  : LIS_logunit
+    use LIS_historyMod
+    use NoahMP401_lsmMod
+
+    implicit none
+
+    integer, intent(in) :: ftn
+    integer, intent(in) :: n
+    character(len=*), intent(in) :: wformat
+!
+! !DESCRIPTION:
+!  This routine gathers the necessary restart variables and performs
+!  the actual write statements to create the restart files.
+!
+!  The arguments are:
+!  \begin{description}
+!   \item[n]
+!    index of the nest
+!   \item[ftn]
+!    unit number for the restart file
+!   \item[wformat]
+!    restart file format (binary/netcdf)
+!  \end{description}
+!
+!
+!  The following is the list of variables written in the NoahMP401
+!  restart file:
+!  \begin{verbatim}
+!    nc, nr, ntiles             - grid and tile space dimensions
+!    sfcrunoff                  - NoahMP401 accumulated surface runoff [m]
+!    udrrunoff                  - NoahMP401 accumulated sub-surface runoff [m]
+!    smc                        - NoahMP401 volumtric soil moisture [m3/m3]
+!    sh2o                       - NoahMP401 volumtric liquid soil moisture [m3/m3]
+!    tslb                       - NoahMP401 soil temperature [K]
+!    sneqv                      - NoahMP401 snow water equivalent [mm]
+!    snowh                      - NoahMP401 physical snow depth [m]
+!    canwat                     - NoahMP401 total canopy water + ice [mm]
+!    acsnom                     - NoahMP401 accumulated snow melt leaving pack [-]
+!    acsnow                     - NoahMP401 accumulated snow on grid [mm]
+!    isnow                      - NoahMP401 actual no. of snow layers [-]
+!    tv                         - NoahMP401 vegetation leaf temperature [K]
+!    tg                         - NoahMP401 bulk ground surface temperature [K]
+!    canice                     - NoahMP401 canopy-intercepted ice [mm]
+!    canliq                     - NoahMP401 canopy-intercepted liquid water [mm]
+!    eah                        - NoahMP401 canopy air vapor pressure [Pa]
+!    tah                        - NoahMP401 canopy air temperature [K]
+!    cm                         - NoahMP401 bulk momentum drag coefficient [-]
+!    ch                         - NoahMP401 bulk sensible heat exchange coefficient [-]
+!    fwet                       - NoahMP401 wetted or snowed fraction of canopy [-]
+!    sneqvo                     - NoahMP401 snow mass at last time step [mm h2o]
+!    albold                     - NoahMP401 snow albedo at last time step [-]
+!    qsnow                      - NoahMP401 snowfall on the ground [mm/s]
+!    wslake                     - NoahMP401 lake water storage [mm]
+!    zwt                        - NoahMP401 water table depth [m]
+!    wa                         - NoahMP401 water in the "aquifer" [mm]
+!    wt                         - NoahMP401 water in aquifer and saturated soil [mm]
+!    tsno                       - NoahMP401 snow layer temperature [K]
+!    zss                        - NoahMP401 snow/soil layer depth from snow surface [m]
+!    snowice                    - NoahMP401 snow layer ice [mm]
+!    snowliq                    - NoahMP401 snow layer liquid water [mm]
+!    lfmass                     - NoahMP401 leaf mass [g/m2]
+!    rtmass                     - NoahMP401 mass of fine roots [g/m2]
+!    stmass                     - NoahMP401 stem mass [g/m2]
+!    wood                       - NoahMP401 mass of wood (including woody roots) [g/m2]
+!    stblcp                     - NoahMP401 stable carbon in deep soil [g/m2]
+!    fastcp                     - NoahMP401 short-lived carbon in shallow soil [g/m2]
+!    lai                        - NoahMP401 leaf area index [-]
+!    sai                        - NoahMP401 stem area index [-]
+!    tauss                      - NoahMP401 snow age factor [-]
+!    smoiseq                    - NoahMP401 equilibrium volumetric soil moisture content [m3/m3]
+!    smcwtd                     - NoahMP401 soil moisture content in the layer to the water table when deep [-]
+!    deeprech                   - NoahMP401 recharge to the water table when deep [-]
+!    rech                       - NoahMP401 recharge to the water table (diagnostic) [-]
+!    grain                      - NoahMP401 mass of grain XING [g/m2]
+!    gdd                        - NoahMP401 growing degree days XING (based on 10C) [-]
+!    pgs                        - NoahMP401 growing degree days XING [-]
+!    gecros_state               - NoahMP401 optional gecros crop [-]
+!  \end{verbatim}
+!
+! The routines invoked are:
+! \begin{description}
+!   \item[LIS\_writeGlobalHeader\_restart](\ref{LIS_writeGlobalHeader_restart})\\
+!      writes the global header information
+!   \item[LIS\_writeHeader\_restart](\ref{LIS_writeHeader_restart})\\
+!      writes the header information for a variable
+!   \item[LIS\_closeHeader\_restart](\ref{LIS_closeHeader_restart})\\
+!      close the header
+!   \item[LIS\_writevar\_restart](\ref{LIS_writevar_restart})\\
+!      writes a variable to the restart file
+! \end{description}
+! 
+!EOP 
+               
+    integer :: l, t 
+    real    :: tmptilen(LIS_rc%npatch(n, LIS_rc%lsm_index))
+
+    write(ftn) NOAHMP401_struc(n)%noahmp401%sfcrunoff
+    write(ftn) NOAHMP401_struc(n)%noahmp401%udrrunoff
+
+    do l=1, NOAHMP401_struc(n)%nsoil   ! TODO: check loop
+       tmptilen = 0
+       do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+          tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%smc(l)
+       enddo
+       write(ftn) tmptilen
+    enddo
+    do l=1, NOAHMP401_struc(n)%nsoil   ! TODO: check loop
+       tmptilen = 0
+       do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+          tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%sh2o(l)
+       enddo
+       write(ftn) tmptilen         
+    enddo
+    ! soil temperature
+    do l=1, NOAHMP401_struc(n)%nsoil   ! TODO: check loop
+       tmptilen = 0
+       do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+          tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%tslb(l)
+       enddo
+       write(ftn) tmptilen         
+    enddo
+    write(ftn) NOAHMP401_struc(n)%noahmp401%sneqv
+    write(ftn) NOAHMP401_struc(n)%noahmp401%snowh
+    write(ftn) NOAHMP401_struc(n)%noahmp401%canwat
+    write(ftn) NOAHMP401_struc(n)%noahmp401%acsnom
+    write(ftn) NOAHMP401_struc(n)%noahmp401%acsnow
+    tmptilen = 0
+    do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+       tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%isnow
+    enddo
+    write(ftn) tmptilen
+    write(ftn) NOAHMP401_struc(n)%noahmp401%tv
+    write(ftn) NOAHMP401_struc(n)%noahmp401%tg
+    write(ftn) NOAHMP401_struc(n)%noahmp401%canice
+    write(ftn) NOAHMP401_struc(n)%noahmp401%canliq
+    write(ftn) NOAHMP401_struc(n)%noahmp401%eah
+    write(ftn) NOAHMP401_struc(n)%noahmp401%tah
+    write(ftn) NOAHMP401_struc(n)%noahmp401%cm
+    write(ftn) NOAHMP401_struc(n)%noahmp401%ch
+    write(ftn) NOAHMP401_struc(n)%noahmp401%fwet
+    write(ftn) NOAHMP401_struc(n)%noahmp401%sneqvo
+    write(ftn) NOAHMP401_struc(n)%noahmp401%albold
+    write(ftn) NOAHMP401_struc(n)%noahmp401%qsnow
+    write(ftn) NOAHMP401_struc(n)%noahmp401%wslake
+    write(ftn) NOAHMP401_struc(n)%noahmp401%zwt
+    write(ftn) NOAHMP401_struc(n)%noahmp401%wa
+    write(ftn) NOAHMP401_struc(n)%noahmp401%wt
+
+    ! snow layer temperature
+    do l=1, NOAHMP401_struc(n)%nsnow   ! TODO: check loop
+       tmptilen = 0
+       do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+          tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%tsno(l)
+       enddo
+       write(ftn) tmptilen
+    enddo
+    ! snow/soil layer depth from snow surface
+    do l=1, NOAHMP401_struc(n)%nsnow+NOAHMP401_struc(n)%nsoil   ! TODO: check loop
+       tmptilen = 0
+       do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+          tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%zss(l)
+       enddo
+       write(ftn) tmptilen
+    enddo
+    ! snow layer ice
+    do l=1, NOAHMP401_struc(n)%nsnow   ! TODO: check loop
+       tmptilen = 0
+       do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+          tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%snowice(l)
+       enddo
+       write(ftn) tmptilen         
+    enddo
+    ! snow layer liquid water
+    do l=1, NOAHMP401_struc(n)%nsnow   ! TODO: check loop
+       tmptilen = 0
+       do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+          tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%snowliq(l)
+       enddo
+       write(ftn) tmptilen         
+    enddo
+    write(ftn) NOAHMP401_struc(n)%noahmp401%lfmass
+    write(ftn) NOAHMP401_struc(n)%noahmp401%rtmass
+    write(ftn) NOAHMP401_struc(n)%noahmp401%stmass
+    write(ftn) NOAHMP401_struc(n)%noahmp401%wood
+    write(ftn) NOAHMP401_struc(n)%noahmp401%stblcp
+    write(ftn) NOAHMP401_struc(n)%noahmp401%fastcp
+    write(ftn) NOAHMP401_struc(n)%noahmp401%lai
+    write(ftn) NOAHMP401_struc(n)%noahmp401%sai
+    write(ftn) NOAHMP401_struc(n)%noahmp401%tauss
+
+    ! equilibrium volumetric soil moisture content
+    do l=1, NOAHMP401_struc(n)%nsoil   ! TODO: check loop
+       tmptilen = 0
+       do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+          tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%smoiseq(l)
+       enddo
+       write(ftn) tmptilen
+    enddo
+    write(ftn) NOAHMP401_struc(n)%noahmp401%smcwtd
+    write(ftn) NOAHMP401_struc(n)%noahmp401%deeprech
+    write(ftn) NOAHMP401_struc(n)%noahmp401%rech
+    write(ftn) NOAHMP401_struc(n)%noahmp401%grain
+    write(ftn) NOAHMP401_struc(n)%noahmp401%gdd
+
+    tmptilen = 0
+    do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+       tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%pgs
+    enddo
+    write(ftn) tmptilen
+    
+!    do l=1, 60  ! TODO: check loop
+!      tmptilen = 0
+!       do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+!          tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%gecros_state(l)
+!       enddo
+!       write(ftn) tmptilen
+!    enddo
+  end subroutine NoahMP401_dump_restart_dist
 
 !BOP
 !
@@ -273,8 +529,7 @@ subroutine NoahMP401_dump_restart(n, ftn, wformat)
                                        dim1=NOAHMP401_struc(n)%nsoil+NOAHMP401_struc(n)%nsnow, &
                                        dim2=NOAHMP401_struc(n)%nsoil,                          &
                                        dim3=NOAHMP401_struc(n)%nsnow,                          &
-!                                       dim4=60,                                                & ! GECROS
-                                       dim4=1,                                                 &
+                                       dim4=60,                                                &
                                        dimID=dimID,                                            &
                                        output_format = trim(wformat))
 
@@ -539,10 +794,10 @@ subroutine NoahMP401_dump_restart(n, ftn, wformat)
                                  "-", vlevels=1, valid_min=-99999.0, valid_max=99999.0)
     ! write the header for state variable gecros_state
     !TODO: replace -99999 and 99999 with correct values for valid_min and valid_max
-!    call LIS_writeHeader_restart(ftn, n, dimID, gecros_state_ID, "GECROS_STATE", &
-!                                 "optional gecros crop", &
-!                                 "-", vlevels=60, valid_min=-99999.0, valid_max=99999.0, &
-!                                 var_flag = "dim4") 
+    call LIS_writeHeader_restart(ftn, n, dimID, gecros_state_ID, "GECROS_STATE", &
+                                 "optional gecros crop", &
+                                 "-", vlevels=60, valid_min=-99999.0, valid_max=99999.0, &
+                                 var_flag = "dim4") 
  
     ! close header of restart file
     call LIS_closeHeader_restart(ftn, n, LIS_rc%lsm_index, dimID, NOAHMP401_struc(n)%rstInterval)
@@ -777,12 +1032,13 @@ subroutine NoahMP401_dump_restart(n, ftn, wformat)
                               varid=pgs_ID, dim=1, wformat=wformat)
 
     ! optional gecros crop
-!    do l=1, 60  ! TODO: check loop
-!        tmptilen = 0
-!        do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
-!            tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%gecros_state(l)
-!        enddo
-!        call LIS_writevar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, &
-!                                  varid=gecros_state_ID, dim=l, wformat=wformat)
-!    enddo
+  !  do l=1, 60  ! TODO: check loop
+  !      tmptilen = 0
+  !      do t=1, LIS_rc%npatch(n, LIS_rc%lsm_index)
+  !          tmptilen(t) = NOAHMP401_struc(n)%noahmp401(t)%gecros_state(l)
+  !      enddo
+  !      call LIS_writevar_restart(ftn, n, LIS_rc%lsm_index, tmptilen, &
+  !                                varid=gecros_state_ID, dim=l, wformat=wformat)
+  !  enddo
 end subroutine NoahMP401_dump_restart
+


### PR DESCRIPTION
### Description

Adds the ability to write LIS_RST and LIS_DAPERT files as distributed binary. This will help with memory intensive simulations, particularly with reading/writing the LIS_DAPERT files.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
There's an example testcase available here:
/discover/nobackup/projects/eis_freshwater/mwrzesie/TestCase_distRST

This test demonstrates writing distributed binary for both LIS_RST and LIS_DAPERT files with a assimilation example over the Tuolumne watershed.


