### PR TITLE
Removed -Wpedantic debug flag for gfortran.

### DIFF
--- a/ldt/arch/Config.pl
+++ b/ldt/arch/Config.pl
@@ -134,7 +134,7 @@ if($opt_lev == -3) {
     }
     elsif($sys_arch eq "Darwin_gfortran" || $sys_arch eq "linux_gfortran") {
 	$sys_opt = "-g -Wall -Wcharacter-truncation";
-	$sys_opt .= " -Wconversion-extra -Wextra -Wpedantic -Wrealloc-lhs";
+	$sys_opt .= " -Wconversion-extra -Wextra -Wrealloc-lhs";
 	$sys_opt .= " -Wrealloc-lhs-all";
 	# Run-time options
 	$sys_opt .= " -ffpe-trap=invalid,zero,overflow";

--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -190,7 +190,7 @@ if($opt_lev == -3) {
       #print "Using '-g'\n";
       #$sys_opt = "-g";
       $sys_opt = "-g -Wall -Wcharacter-truncation";
-      $sys_opt .= " -Wconversion-extra -Wextra -Wpedantic -Wrealloc-lhs";
+      $sys_opt .= " -Wconversion-extra -Wextra -Wrealloc-lhs";
       $sys_opt .= " -Wrealloc-lhs-all";
       # Run-time options
       $sys_opt .= " -ffpe-trap=invalid,zero,overflow";

--- a/lvt/arch/Config.pl
+++ b/lvt/arch/Config.pl
@@ -116,7 +116,7 @@ if($opt_lev == -3) {
     }
     elsif($sys_arch eq "Darwin_gfortran" || $sys_arch eq "linux_gfortran") {
 	$sys_opt = "-g -Wall -Wcharacter-truncation";
-	$sys_opt .= " -Wconversion-extra -Wextra -Wpedantic -Wrealloc-lhs";
+	$sys_opt .= " -Wconversion-extra -Wextra -Wrealloc-lhs";
 	$sys_opt .= " -Wrealloc-lhs-all";
 	# Run-time options
 	$sys_opt .= " -ffpe-trap=invalid,zero,overflow";


### PR DESCRIPTION
### Description

Removed -Wpedantic debug flag in arch/Config.pl for gfortran.

There are two reasons that chain together for this change.

First, Intel MPI doesn't seem to export Fortran interfaces for MPI subroutines and functions, which causes gfortran to complain when argument types change between MPI calls.

Second, the -Wpedantic flag elevates these mismatches to syntax errors with gfortran 11.2.0.  (This may be a compiler bug, as there is a separate -pedantic-error that is supposed to do this.)

Taken together, -Wpedantic will cause gfortran 11.2.0 to halt when it encounters MPI calls in code, when using Intel MPI.  By removing the flag, the compiler will downgrade this to a warning -- this would allow a developer to still identify actual bugs with argument mismatches when using gfortran.

(It *may* be worth adding explicit interfaces for MPI routines not provided by the MPI library.  See
https://www.scivision.dev/gfortran-type-mismatch-error/.  But that's a lot of work.)
