### PR TITLE
Fix cosphi roundoff error in spatial downscaling

### DIFF
--- a/lis/core/LIS_spatialDownscalingMod.F90
+++ b/lis/core/LIS_spatialDownscalingMod.F90
@@ -336,6 +336,12 @@ contains
           ha = (tst*0.25 - 180.0)*deg2rad
 
           cosphi = sin(lat)*sin(decl)+cos(lat)*cos(decl)*cos(ha)
+          if (cosphi .ge. 1.0) then
+              cosphi = 0.9999999
+          endif
+          if (cosphi .le. -1.0) then
+              cosphi = -0.9999999
+          endif
           phi = acos(cosphi)
           szen = phi/deg2rad
           !EMK...Avoid division by zero


### PR DESCRIPTION
### Description

LIS crashes in some situations when spatial downscaling is turned on due to a roundoff error, which results in subsequent calculations going to infinity.

Resolves #1455 

An if-statement structure has been added to the lis/core/LIS_spatialDownscalingMod.F90 file in the LIS_slopeAspectCorrection subroutine. In the event that cosphi is rounded to (1.0) or (-1.0), is is reduced to (0.9999999) or (-0.9999999), respectively to prevent this error

### Testcase

Testcase for global simulation:
/discover/nobackup/projects/eis_freshwater/lahmers/RUN/GLOBAL_05km_OL_LSM_MMF_Demo


