### PR TITLE
Add MOGREPS-G forecast reader

### DIFF
--- a/lis/make/default.cfg
+++ b/lis/make/default.cfg
@@ -472,7 +472,10 @@ enabled: True
 macro: MF_GALWEM_GE_FORECAST
 path: metforcing/galwem_ge
 
-
+[MOGREPS-G forecast]
+enabled: True
+macro: MF_MOGREPS_G_FORECAST
+path: metforcing/mogreps_g
 
 #}}}
 

--- a/lis/metforcing/mogreps_g/finalize_mogrepsg.F90
+++ b/lis/metforcing/mogreps_g/finalize_mogrepsg.F90
@@ -1,0 +1,30 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !MODULE: finalize_mogrepsg
+! \label{finalize_mogrepsg}
+!
+! !REVISION HISTORY:
+! 26 Jan 2023; Yeosang Yoon, Initial Code
+!
+! !INTERFACE:
+subroutine finalize_mogrepsg
+! !USES:
+  use mogrepsg_forcingMod, only : mogrepsg_struc
+!
+! !DESCRIPTION:
+!  Routine to cleanup allocated structures for MOGREPS-G forcing.
+!
+!EOP
+  implicit none
+
+  deallocate(mogrepsg_struc)
+
+end subroutine finalize_mogrepsg

--- a/lis/metforcing/mogreps_g/get_mogrepsg.F90
+++ b/lis/metforcing/mogreps_g/get_mogrepsg.F90
@@ -1,0 +1,230 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+!
+! !ROUTINE: get_mogrepsg
+! \label{get_mogrepsg}
+!
+!
+! !REVISION HISTORY:
+! 26 Jan 2023: Yeosang Yoon, initial code
+! 13 Mar 2023: Yeosang Yoon, update codes to fit new format
+!
+! !INTERFACE:
+subroutine get_mogrepsg(n, findex)
+! !USES:
+  use LIS_coreMod
+  use LIS_timeMgrMod
+  use LIS_logMod
+  use LIS_metforcingMod
+  use mogrepsg_forcingMod
+  use LIS_constantsMod, only: LIS_CONST_PATH_LEN
+
+  implicit none
+
+! !ARGUMENTS:
+  integer, intent(in) :: n
+  integer, intent(in) :: findex
+!
+!
+! !DESCRIPTION:
+!  Opens, reads, and interpolates MOGREPS-G forecast forcing.
+!
+!  At the beginning of a simulation, the code reads the most recent
+!  past data (nearest 3-hour interval), and the nearest future data.
+!  These two datasets are used to temporally interpolate the data to
+!  the current model timestep.
+
+!EOP
+  integer           :: order, ferror, m, t
+  character(len=LIS_CONST_PATH_LEN) :: fname
+  integer           :: yr1, mo1, da1, hr1, mn1, ss1, doy1
+  integer           :: yr2, mo2, da2, hr2, mn2, ss2, doy2
+  real*8            :: time1, time2
+  real              :: gmt1, gmt2
+  real              :: ts1, ts2
+  integer           :: fc_hr
+
+  integer           :: hr_int1, hr_int2
+  integer           :: valid_hour
+  integer           :: fcsthr_intv
+  integer           :: fcst_hour
+  integer           :: openfile
+
+  ! MOGREPS-G cycles every 6 hours; ecch cycle provide up to 192 hours (8 days; 3-hour interval) forecast
+  if(LIS_rc%ts.gt.10800) then
+     write(LIS_logunit,*) '[WARN] The model timestep is > forcing data timestep ...'
+     write(LIS_logunit,*) '[WARN] LIS does not support this mode currently.'
+     call LIS_endrun()
+  endif
+
+  openfile=0
+
+  if(LIS_rc%tscount(n).eq.1 .or.LIS_rc%rstflag(n).eq.1) then  !beginning of run
+     LIS_rc%rstflag(n) = 0
+  endif
+
+  ! First timestep of run
+  if(LIS_rc%tscount(n).eq.1 .or.LIS_rc%rstflag(n).eq.1) then
+    ! Bookend-time record 1
+     yr1 = LIS_rc%yr
+     mo1=LIS_rc%mo
+     da1=LIS_rc%da
+     hr1=LIS_rc%hr
+     mn1=0
+     ss1=0
+     ts1=0
+     call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+
+     ! Bookend-time record 2
+     yr2=LIS_rc%yr    !next hour
+     mo2=LIS_rc%mo
+     da2=LIS_rc%da
+     hr2=3            
+     mn2=0
+     ss2=0
+     ts2=0
+     call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+     openfile=1
+  endif
+
+  ! 3 hourly interval  
+  fcsthr_intv = 3
+  valid_hour = fcsthr_intv * (LIS_rc%hr/fcsthr_intv)
+
+  if((valid_hour==LIS_rc%hr .and. LIS_rc%mn==0) .or. &
+      openfile == 1)  then
+
+     ! Forecast hour condition within each file:
+     mogrepsg_struc(n)%fcst_hour = mogrepsg_struc(n)%fcst_hour + fcsthr_intv
+ 
+     ! Check if local forecast hour exceeds max grib file forecast hour:
+     if(mogrepsg_struc(n)%fcst_hour > 195 ) then
+        write(LIS_logunit,*) &
+              "[INFO] MOGREPS-G Forecast hour has exceeded the grib file's final"
+        write(LIS_logunit,*) &
+              '  forecast hour (record). Run will end here for now ... '
+        call LIS_endrun
+     endif
+  
+     ! Update bookend-time record 2:
+     if(LIS_rc%tscount(n).ne.1) then
+        mogrepsg_struc(n)%fcsttime1=mogrepsg_struc(n)%fcsttime2
+        mogrepsg_struc(n)%metdata1=mogrepsg_struc(n)%metdata2
+
+        yr2=LIS_rc%yr
+        mo2=LIS_rc%mo
+        da2=LIS_rc%da
+        hr2=valid_hour
+        mn2=fcsthr_intv*60    ! Backward looking
+        ss2=0
+        ts2=0
+        call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+     endif
+
+     do m=1,mogrepsg_struc(n)%max_ens_members    
+
+        ! Read in file contents:
+        if(LIS_rc%tscount(n) == 1) then  ! Read in first two book-ends 
+           ferror=0
+           order=1
+           call get_mogrepsg_filename(mogrepsg_struc(n)%odir,mogrepsg_struc(n)%init_yr,&
+                mogrepsg_struc(n)%init_mo,mogrepsg_struc(n)%init_da,mogrepsg_struc(n)%init_hr,&
+                0,m,fname)
+
+           write(LIS_logunit,*)'[INFO] Getting MOGREPS-G forecast file1 ... ',trim(fname)
+           call read_mogrepsg(n, m, findex, order, fname, ferror)
+           if(ferror.ge.1) mogrepsg_struc(n)%fcsttime1=time1
+
+           ferror=0
+           order=2
+           call get_mogrepsg_filename(mogrepsg_struc(n)%odir,mogrepsg_struc(n)%init_yr,&
+                mogrepsg_struc(n)%init_mo,mogrepsg_struc(n)%init_da,mogrepsg_struc(n)%init_hr,&
+                mogrepsg_struc(n)%fcst_hour,m,fname)
+
+           write(LIS_logunit,*)'[INFO] Getting MOGREPS-G forecast file2 ... ',trim(fname)
+           call read_mogrepsg(n, m, findex, order, fname, ferror)
+           if(ferror.ge.1) mogrepsg_struc(n)%fcsttime2=time2
+
+           !only for T+0 due to mssing LW varaible
+           mogrepsg_struc(n)%metdata1(4,m,:) = mogrepsg_struc(n)%metdata2(4,m,:)
+        else
+           ferror=0
+           order=2
+           ! met forcings except for pcp
+           call get_mogrepsg_filename(mogrepsg_struc(n)%odir,mogrepsg_struc(n)%init_yr,&
+                mogrepsg_struc(n)%init_mo,mogrepsg_struc(n)%init_da,mogrepsg_struc(n)%init_hr,&
+                mogrepsg_struc(n)%fcst_hour,m,fname)
+
+           write(LIS_logunit,*)'[INFO] Getting MOGREPS-G forecast file2 ... ',trim(fname)
+           call read_mogrepsg(n, m, findex, order, fname, ferror)
+           if(ferror.ge.1) mogrepsg_struc(n)%fcsttime2=time2
+
+           !only for T+141 due to mssing LW varaible
+           if(mogrepsg_struc(n)%fcst_hour == 141) then
+              mogrepsg_struc(n)%metdata2(4,m,:) = mogrepsg_struc(n)%metdata1(4,m,:)
+           endif
+        endif
+     enddo
+  endif
+  openfile=0
+
+end subroutine get_mogrepsg
+
+!BOP
+!
+! !ROUTINE: get_mogrepsg_filename
+! \label{get_mogrepsg_filename}
+!
+! !INTERFACE:
+subroutine get_mogrepsg_filename(rootdir,yr,mo,da,hr,fc_hr,ens_id,filename)
+
+  use LIS_logMod, only: LIS_logunit, LIS_endrun
+  implicit none
+! !ARGUMENTS:
+  character(len=*), intent(in)  :: rootdir
+  integer,          intent(in)  :: yr,mo,da,hr
+  integer,          intent(in)  :: fc_hr
+  integer,          intent(in)  :: ens_id
+  character(len=*), intent(out) :: filename
+!
+! !DESCRIPTION:
+!  This subroutine puts together MOGREPS-G file name for
+!   operational products
+!EOP
+  character(8) :: ftime
+  character(2) :: chr
+  character(3) :: fchr
+  character(2) :: ens 
+
+  character(len=36) :: fname
+
+  write (UNIT=chr, FMT='(i2.2)') hr        ! cycle 00/06/12/18
+  write (UNIT=fchr, FMT='(i3.3)') fc_hr    ! forecast time 
+  write (UNIT=ftime, FMT='(i4, i2.2, i2.2)') yr, mo, da
+
+  fname = 'prods_op_mogreps-g_'
+
+  !00/12z cycle memebers 00,01-17
+  !06/18z cycle memebers 00,18-34
+  if ((hr == 0) .or. (hr == 12)) then
+       write (UNIT=ens, FMT='(i2.2)') ens_id-1   ! start 00, 01 - 17
+  else
+     if (ens_id == 1) then
+        write (UNIT=ens, FMT='(i2.2)') ens_id-1  ! start 00
+     else 
+        write (UNIT=ens, FMT='(i2.2)') ens_id+16 ! start 18-34
+     endif
+  endif
+
+  filename = trim(rootdir)//'/'//ftime//chr//'/'//trim(fname) &
+             //ftime//'_'//chr//'_'//ens//'_'//fchr//'.grib2'
+end subroutine get_mogrepsg_filename
+

--- a/lis/metforcing/mogreps_g/mogrepsg_forcingMod.F90
+++ b/lis/metforcing/mogreps_g/mogrepsg_forcingMod.F90
@@ -1,0 +1,327 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
+module mogrepsg_forcingMod
+!BOP
+! !MODULE: mogrepsg_forcingMod
+
+! !DESCRIPTION:
+!  This module contains variables and data structures that are used
+!  for the implementation of MOGREPS-G 8-day forecast data used as forcing
+!  within LIS.
+
+! REVISION HISTORY:
+! 26 Jan 2023; Yeosang Yoon; Initial Specification
+
+! !USES:
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
+  implicit none
+
+  PRIVATE
+!-----------------------------------------------------------------------------
+! !PUBLIC MEMBER FUNCTIONS:
+!-----------------------------------------------------------------------------
+  public :: init_mogrepsg      !defines the native resolution of the input data
+!-----------------------------------------------------------------------------
+! !PUBLIC TYPES:
+!-----------------------------------------------------------------------------
+  public :: mogrepsg_struc
+
+  type, public ::  mogrepsg_type_dec
+     real                              :: ts
+     integer                           :: nc, nr, vector_len
+     real*8                            :: fcsttime1,fcsttime2
+     character(len=LIS_CONST_PATH_LEN) :: odir     !MOGREPS-G forecast forcing Directory
+     character*20                      :: runmode
+     integer                           :: max_ens_members
+
+     integer, allocatable   :: gindex(:,:)
+
+     integer                :: mi
+     
+     integer, allocatable   :: n111(:)
+     integer, allocatable   :: n121(:)
+     integer, allocatable   :: n211(:)
+     integer, allocatable   :: n221(:)
+     real, allocatable      :: w111(:),w121(:)
+     real, allocatable      :: w211(:),w221(:)
+     
+     integer, allocatable   :: n112(:,:)
+     integer, allocatable   :: n122(:,:)
+     integer, allocatable   :: n212(:,:)
+     integer, allocatable   :: n222(:,:)
+     real, allocatable      :: w112(:,:),w122(:,:)
+     real, allocatable      :: w212(:,:),w222(:,:)
+
+     integer, allocatable   :: n113(:)
+     
+     integer                :: findtime1, findtime2
+     integer                :: fcst_hour
+     integer                :: init_yr, init_mo, init_da, init_hr
+     real, allocatable      :: metdata1(:,:,:) 
+     real, allocatable      :: metdata2(:,:,:)
+    
+     integer                :: nmodels   
+
+     ! only for v-wind due to difference resolution
+     integer                :: nrv
+     integer, allocatable   :: nv111(:)
+     integer, allocatable   :: nv121(:)
+     integer, allocatable   :: nv211(:)
+     integer, allocatable   :: nv221(:)
+     real, allocatable      :: wv111(:),wv121(:)
+     real, allocatable      :: wv211(:),wv221(:)
+
+     integer, allocatable   :: nv112(:,:)
+     integer, allocatable   :: nv122(:,:)
+     integer, allocatable   :: nv212(:,:)
+     integer, allocatable   :: nv222(:,:)
+     real, allocatable      :: wv112(:,:),wv122(:,:)
+     real, allocatable      :: wv212(:,:),wv222(:,:)
+
+     integer, allocatable   :: nv113(:)
+
+  end type mogrepsg_type_dec
+
+  type(mogrepsg_type_dec), allocatable :: mogrepsg_struc(:)
+!EOP
+contains
+
+!BOP
+!
+! !ROUTINE: init_mogrepsg
+! \label{init_mogrepsg}
+! 
+! !INTERFACE:
+  subroutine init_mogrepsg(findex)
+! !USES: 
+    use LIS_coreMod,    only : LIS_rc, LIS_domain
+    use LIS_timeMgrMod, only : LIS_update_timestep
+    use LIS_logMod,     only : LIS_logunit, LIS_endrun
+
+    implicit none
+! !USES: 
+    integer, intent(in)  :: findex
+! 
+! !DESCRIPTION: 
+!  Defines the native resolution of the input forcing for MOGREPS-G
+!  data. The grid description arrays are based on the decoding
+!  schemes used by NCEP and followed in the LIS interpolation
+!  schemes (see Section~\ref{interp}).
+!
+!EOP
+
+    integer :: n
+    real    :: gridDesci(LIS_rc%nnest,50)
+    real    :: gridDesci_v(LIS_rc%nnest,50) ! v-wind
+
+    write(LIS_logunit,*) "[INFO] Initializing the MOGREPS-G forecast inputs "
+
+    ! Forecast mode -- NOT Available at this time for this forcing reader:
+    if( LIS_rc%forecastMode.eq.1 ) then
+       write(LIS_logunit,*) '[ERR] Currently the MOGREPS-G forecast forcing reader'
+       write(LIS_logunit,*) '[ERR] is not set up to run in forecast mode.'
+       write(LIS_logunit,*) '[ERR] LIS forecast run-time ending.'
+       call LIS_endrun()
+    endif
+
+    allocate(mogrepsg_struc(LIS_rc%nnest))
+    call readcrd_mogrepsg()
+
+    do n=1, LIS_rc%nnest
+       mogrepsg_struc(n)%ts = 3600*3  !check
+       call LIS_update_timestep(LIS_rc, n, mogrepsg_struc(n)%ts)
+    enddo
+
+    do n=1, LIS_rc%nnest
+       mogrepsg_struc(:)%nc  = 1280  ! mogreps-g
+       mogrepsg_struc(:)%nr  = 960
+       mogrepsg_struc(:)%nrv = 961   ! v-wind
+    enddo
+
+    ! 8 - key met field
+    LIS_rc%met_nf(findex) = 8  
+
+    do n=1,LIS_rc%nnest
+     
+       ! Check if starting hour of LIS run matches 00/06/12/18 UTC:
+       if((LIS_rc%shr .ne.  0) .and. (LIS_rc%shr .ne. 6) .and. &
+          (LIS_rc%shr .ne.  12) .and. (LIS_rc%shr .ne. 18)) then
+          write(LIS_logunit,*) "[ERR] GALWEM forecast type begins"
+          write(LIS_logunit,*) "[ERR] at 00/12Z for a forecast window, so the "
+          write(LIS_logunit,*) "[ERR] 'Starting hour:' should be set to 0/12 in"
+          write(LIS_logunit,*) "[ERR]  your lis.config file.."
+          call LIS_endrun()
+       endif
+      
+       ! Allocate and initialize MOGREPS-G metforcing data structures:
+       LIS_rc%met_nensem(findex) = mogrepsg_struc(n)%max_ens_members
+ 
+       allocate(mogrepsg_struc(n)%metdata1(LIS_rc%met_nf(findex),&
+                mogrepsg_struc(n)%max_ens_members,LIS_rc%ngrid(n)))
+       allocate(mogrepsg_struc(n)%metdata2(LIS_rc%met_nf(findex),&
+                mogrepsg_struc(n)%max_ens_members,LIS_rc%ngrid(n)))
+
+       ! Initialize the forecast initial date-time and grib record:
+       mogrepsg_struc(n)%init_yr = LIS_rc%syr
+       mogrepsg_struc(n)%init_mo = LIS_rc%smo
+       mogrepsg_struc(n)%init_da = LIS_rc%sda
+       mogrepsg_struc(n)%init_hr = LIS_rc%shr
+
+       mogrepsg_struc(n)%fcst_hour = 0
+       mogrepsg_struc(n)%metdata1 = 0
+       mogrepsg_struc(n)%metdata2 = 0
+       gridDesci = 0
+ 
+       gridDesci(n,1)  = 0
+       gridDesci(n,2)  = mogrepsg_struc(n)%nc !gnc
+       gridDesci(n,3)  = mogrepsg_struc(n)%nr !gnr
+       gridDesci(n,4)  =  -89.906250   !lat(1,1)
+       gridDesci(n,5)  = -179.859375   !lon(1,1)
+       gridDesci(n,6)  = 128
+       gridDesci(n,7)  =  89.906250    !lat(gnc,gnr)
+       gridDesci(n,8)  = 179.859375    !lon(gnc,gnr)
+       gridDesci(n,9)  = 0.28125       !dx
+       gridDesci(n,10) = 0.18750       !dy
+       gridDesci(n,20) = 0             !for 0 to 360?
+
+       mogrepsg_struc(n)%mi = mogrepsg_struc(n)%nc*mogrepsg_struc(n)%nr
+       mogrepsg_struc(n)%fcsttime1 = 3000.0
+       mogrepsg_struc(n)%fcsttime2 = 0.0
+
+       ! v-wind
+       gridDesci_v(n,1)  = 0
+       gridDesci_v(n,2)  = mogrepsg_struc(n)%nc  !gnc
+       gridDesci_v(n,3)  = mogrepsg_struc(n)%nrv !gnr
+       gridDesci_v(n,4)  =  -90.000000   !lat(1,1)
+       gridDesci_v(n,5)  = -179.859375   !lon(1,1)
+       gridDesci_v(n,6)  = 128
+       gridDesci_v(n,7)  =  90.000000    !lat(gnc,gnr)
+       gridDesci_v(n,8)  = 179.859375    !lon(gnc,gnr)
+       gridDesci_v(n,9)  = 0.28125       !dx
+       gridDesci_v(n,10) = 0.18750       !dy
+       gridDesci(n,20) = 0             !for 0 to 360?
+    enddo
+
+    do n=1,LIS_rc%nnest
+       !Setting up weights for Interpolation
+       if(trim(LIS_rc%met_interp(findex)).eq."bilinear") then
+          allocate(mogrepsg_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+          call bilinear_interp_input(n,gridDesci(n,:),&
+               mogrepsg_struc(n)%n111,mogrepsg_struc(n)%n121,&
+               mogrepsg_struc(n)%n211,mogrepsg_struc(n)%n221,&
+               mogrepsg_struc(n)%w111,mogrepsg_struc(n)%w121,&
+               mogrepsg_struc(n)%w211,mogrepsg_struc(n)%w221)
+
+       elseif(trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then
+          allocate(mogrepsg_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+          call bilinear_interp_input(n,gridDesci(n,:),&
+               mogrepsg_struc(n)%n111,mogrepsg_struc(n)%n121,&
+               mogrepsg_struc(n)%n211,mogrepsg_struc(n)%n221,&
+               mogrepsg_struc(n)%w111,mogrepsg_struc(n)%w121,&
+               mogrepsg_struc(n)%w211,mogrepsg_struc(n)%w221)
+
+          allocate(mogrepsg_struc(n)%n112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%n122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%n212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%n222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%w112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%w122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%w212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%w222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+
+          call conserv_interp_input(n,gridDesci(n,:),&
+               mogrepsg_struc(n)%n112,mogrepsg_struc(n)%n122,&
+               mogrepsg_struc(n)%n212,mogrepsg_struc(n)%n222,&
+               mogrepsg_struc(n)%w112,mogrepsg_struc(n)%w122,&
+               mogrepsg_struc(n)%w212,mogrepsg_struc(n)%w222)
+       elseif(trim(LIS_rc%met_interp(findex)).eq."neighbor") then
+          allocate(mogrepsg_struc(n)%n113(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+          call neighbor_interp_input(n,gridDesci(n,:),&
+               mogrepsg_struc(n)%n113)
+       endif
+
+       ! v-wind
+       !Setting up weights for Interpolation
+       if(trim(LIS_rc%met_interp(findex)).eq."bilinear") then
+          allocate(mogrepsg_struc(n)%nv111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%nv121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%nv211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%nv221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%wv111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%wv121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%wv211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%wv221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+          call bilinear_interp_input(n,gridDesci_v(n,:),&
+               mogrepsg_struc(n)%nv111,mogrepsg_struc(n)%nv121,&
+               mogrepsg_struc(n)%nv211,mogrepsg_struc(n)%nv221,&
+               mogrepsg_struc(n)%wv111,mogrepsg_struc(n)%wv121,&
+               mogrepsg_struc(n)%wv211,mogrepsg_struc(n)%wv221)
+
+       elseif(trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then
+          allocate(mogrepsg_struc(n)%nv111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%nv121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%nv211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%nv221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%wv111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%wv121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%wv211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(mogrepsg_struc(n)%wv221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+          call bilinear_interp_input(n,gridDesci_v(n,:),&
+               mogrepsg_struc(n)%nv111,mogrepsg_struc(n)%nv121,&
+               mogrepsg_struc(n)%nv211,mogrepsg_struc(n)%nv221,&
+               mogrepsg_struc(n)%wv111,mogrepsg_struc(n)%wv121,&
+               mogrepsg_struc(n)%wv211,mogrepsg_struc(n)%wv221)
+
+          allocate(mogrepsg_struc(n)%nv112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%nv122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%nv212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%nv222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%wv112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%wv122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%wv212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(mogrepsg_struc(n)%wv222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+
+          call conserv_interp_input(n,gridDesci_v(n,:),&
+               mogrepsg_struc(n)%nv112,mogrepsg_struc(n)%nv122,&
+               mogrepsg_struc(n)%nv212,mogrepsg_struc(n)%nv222,&
+               mogrepsg_struc(n)%wv112,mogrepsg_struc(n)%wv122,&
+               mogrepsg_struc(n)%wv212,mogrepsg_struc(n)%wv222)
+
+       elseif(trim(LIS_rc%met_interp(findex)).eq."neighbor") then
+          allocate(mogrepsg_struc(n)%nv113(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+          call neighbor_interp_input(n,gridDesci_v(n,:),&
+               mogrepsg_struc(n)%nv113)
+       endif
+    enddo
+
+  end subroutine init_mogrepsg
+end module mogrepsg_forcingMod

--- a/lis/metforcing/mogreps_g/read_mogrepsg.F90
+++ b/lis/metforcing/mogreps_g/read_mogrepsg.F90
@@ -1,0 +1,851 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
+!BOP
+!
+! !ROUTINE: read_mogrepsg
+! \label{read_mogrepsg}
+!
+! !REVISION HISTORY:
+! 26 Jan 2023: Yeosang Yoon, initial code
+! 13 Mar 2023: Yeosang Yoon, update code to fit new format (precpitation)
+!
+! !INTERFACE:
+subroutine read_mogrepsg(n, m, findex, order, gribfile, rc)
+
+! !USES:
+  use LIS_coreMod
+  use LIS_logMod
+  use mogrepsg_forcingMod, only : mogrepsg_struc
+
+#if (defined USE_GRIBAPI)
+  use grib_api
+#endif
+
+  implicit none
+
+!ARGUMENTS:
+  integer,           intent(in)    :: n
+  integer,           intent(in)    :: m       ! number of ensembles
+  integer,           intent(in)    :: findex  ! forcing index
+  integer,           intent(in)    :: order
+  character(len=*),  intent(in)    :: gribfile
+
+!DESCRIPTION:
+!  For the given time, reads the forcing data from the
+!  MOGREPS-G file, transforms into LIS forcing
+!  parameters and interpolates to the LIS domain.
+!
+!  The arguments are:
+!  \begin{description}
+!  \item[n]
+!    index of the nest
+!  \item[findex]
+!    index of the forcing
+!  \item[order]
+!    flag indicating which data to be read (order=1, read the previous
+!    hourly instance, order=2, read the next hourly instance)
+!  \item[gribfile]
+!    name of the file to be read
+!  \item[rc]
+!    return error flag (0-fail, 1-success)
+!  \end{description}
+!
+!  The routines invoked are:
+!  \begin{description}
+!  \item[interp\_mogrepsg](\ref{interp_mogrepsg}) \newline
+!    Performs spatial interpolation of GALEM-GE forecast data to the LIS grid
+!  \end{description}
+
+!EOP
+  integer         :: ftn, igrib, ierr
+  integer         :: center
+  character*100   :: gtype
+  integer         :: file_julhr
+  integer         :: yr1, mo1, da1, hr1
+  character*255   :: message     ( 20 )
+  integer         :: iginfo      ( 40 )
+  real            :: gridres_dlat, gridres_dlon
+  integer         :: ifguess, jfguess
+  integer         :: dataDate, dataTime
+  integer         :: fc_hr
+
+  real            :: tair(LIS_rc%lnc(n),LIS_rc%lnr(n))      !Temperature interpolated to 2 metres [K] 
+  real            :: qair(LIS_rc%lnc(n),LIS_rc%lnr(n))      !Relative humidity interpolated to 2 metres[kg/kg] 
+  real            :: swdown(LIS_rc%lnc(n),LIS_rc%lnr(n))    !Downward shortwave flux at the ground [W/m^2] 
+  real            :: lwdown(LIS_rc%lnc(n),LIS_rc%lnr(n))    !Downward longwave radiation at the ground [W/m^2] 
+  real            :: uwind(LIS_rc%lnc(n),LIS_rc%lnr(n))     !Instantaneous zonal wind interpolated to 10 metres [m/s]
+  real            :: vwind(LIS_rc%lnc(n),LIS_rc%lnr(n))     !Instantaneous meridional wind interpolated to 10 metres[m/s]
+  real            :: ps(LIS_rc%lnc(n),LIS_rc%lnr(n))        !Instantaneous Surface Pressure [Pa] 
+  real            :: prectot(LIS_rc%lnc(n),LIS_rc%lnr(n))   ! Total precipitation [kg/m^2]
+
+  integer, intent(out) :: rc
+
+  ! Initialize return code to "no error".  We will change it below if
+  ! necessary.
+  rc = 0
+
+#if (defined USE_GRIBAPI)
+
+   call grib_open_file(ftn,trim(gribfile),'r',ierr)
+   if ( ierr .ne. 0 ) then
+      write(LIS_logunit,*) '[ERR] Failed to open - '//trim(gribfile)
+      call LIS_endrun()
+   end if
+
+   ! Read in the first grib record, unpack the header and extract
+   ! section 1 and section 2 information.
+   call grib_new_from_file(ftn,igrib,ierr)
+   if ( ierr .ne. 0 ) then
+      write(LIS_logunit,*) '[ERR] failed to read - '//trim(gribfile)
+      call grib_close_file(ftn)
+      call LIS_endrun()
+   endif
+
+   call grib_get(igrib,'centre',center,ierr)
+   if ( ierr .ne. 0 ) then
+      write(LIS_logunit,*) '[ERR] in grib_get: ' // &
+           'centre in read_mogrepsg'
+      call grib_release(igrib,ierr)
+      call grib_close_file(ftn)
+      call LIS_endrun()
+   endif
+
+   call grib_get(igrib,'gridType',gtype,ierr)
+   if ( ierr .ne. 0 ) then
+      write(LIS_logunit,*) '[ERR] in grid_get: ' // &
+           'gridtype in read_mogrepsg'
+      call grib_release(igrib,ierr)
+      call grib_close_file(ftn)
+      call LIS_endrun()
+   endif
+
+   if(trim(gtype).ne."regular_ll") then
+      write(LIS_logunit,*)'[ERR] MOGREPS-G file not on lat/lon grid!'
+      call grib_release(igrib,ierr)
+      call grib_close_file(ftn)
+      call LIS_endrun()
+   endif
+
+   call grib_get(igrib,'Ni',iginfo(1),ierr)
+   if ( ierr .ne. 0 ) then
+      write(LIS_logunit,*) '[ERR] in grid_get: Ni read_mogrepsg'
+      call grib_release(igrib,ierr)
+      call grib_close_file(ftn)
+      call LIS_endrun()
+   endif
+
+   call grib_get(igrib,'Nj',iginfo(2),ierr)
+   if ( ierr .ne. 0 ) then
+      write(LIS_logunit,*) '[ERR] in grid_get: Nj in read_mogrepsg'
+      call grib_release(igrib,ierr)
+      call grib_close_file(ftn)
+      call LIS_endrun()
+   endif
+
+   call grib_get(igrib,'jDirectionIncrementInDegrees',gridres_dlat,ierr)
+   if ( ierr .ne. 0 ) then
+      write(LIS_logunit,*) '[ERR] in grid_get: ' // &
+           'jDirectionIncrementInDegrees ' // &
+           'in read_mogrepsg'
+      call grib_release(igrib,ierr)
+      call grib_close_file(ftn)
+      call LIS_endrun()
+   endif
+
+   ! EMK...Added dlon
+   call grib_get(igrib, 'iDirectionIncrementInDegrees', gridres_dlon, ierr)
+   if ( ierr .ne. 0 ) then
+      write(LIS_logunit,*) '[ERR] in grid_get: ' // &
+           'iDirectionIncrementInDegrees ' // &
+           'in read_mogrepsg'
+      call grib_release(igrib, ierr)
+      call grib_close_file(ftn)
+      call LIS_endrun()
+   endif
+
+   call grib_get(igrib,'dataDate',dataDate,ierr)
+   if ( ierr .ne. 0 ) then
+      write(LIS_logunit,*) '[ERR] in grid_get: ' // &
+           'dataDate in read_mogrepsg'
+      call grib_release(igrib,ierr)
+      call grib_close_file(ftn)
+      call LIS_endrun()
+   endif
+
+   call grib_get(igrib,'dataTime',dataTime,ierr)
+   if ( ierr .ne. 0 ) then
+      write(LIS_logunit,*) '[ERR] in grid_get: ' // &
+           'dataTime in read_mogrepsg'
+      call grib_release(igrib,ierr)
+      call grib_close_file(ftn)
+      call LIS_endrun()
+   endif
+
+   ! Here we tentatively have a file we can use. Close it for now, and
+   ! prepare to pull the appropriate variables.
+   call grib_release(igrib,ierr)
+   call grib_close_file(ftn)
+
+   ifguess = iginfo(1)
+   jfguess = iginfo(2)
+
+   call fldbld_read_mogrepsg(n, findex, order, gribfile, ifguess, jfguess, &
+           tair, qair, swdown, lwdown, uwind, vwind, ps, prectot, rc)
+
+   call assign_processed_mogrepsgforc(n, m, order, 1, tair)
+   call assign_processed_mogrepsgforc(n, m, order, 2, qair)
+   call assign_processed_mogrepsgforc(n, m, order, 3, swdown)
+   call assign_processed_mogrepsgforc(n, m, order, 4, lwdown)
+   call assign_processed_mogrepsgforc(n, m, order, 5, uwind)
+   call assign_processed_mogrepsgforc(n, m, order, 6, vwind)
+   call assign_processed_mogrepsgforc(n, m, order, 7, ps)
+   call assign_processed_mogrepsgforc(n, m, order, 8, prectot)
+      
+#endif
+
+end subroutine read_mogrepsg
+
+subroutine fldbld_read_mogrepsg(n, findex, order, gribfile, ifguess, jfguess,     &
+                                tair, qair, swdown, lwdown, uwind, vwind, ps, prectot, rc)                            
+ 
+! !USES:
+  use LIS_coreMod, only : LIS_rc
+  use LIS_logMod,  only : LIS_logunit, LIS_abort, LIS_alert, LIS_verify
+
+#if (defined USE_GRIBAPI)
+  use grib_api
+#endif
+
+  implicit none
+! !ARGUMENTS:
+  integer,        intent(in)    :: n
+  integer, intent(in)           :: findex  ! Forcing index
+  integer,        intent(in)    :: order
+  character(len=*),  intent(in) :: gribfile
+  integer,        intent(in)    :: ifguess
+  integer,        intent(in)    :: jfguess
+  real,           intent(out)   :: tair(LIS_rc%lnc(n),LIS_rc%lnr(n))      !Temperature interpolated to 2 metres [K]
+  real,           intent(out)   :: qair(LIS_rc%lnc(n),LIS_rc%lnr(n))      !Relative humidity interpolated to 2 metres[kg/kg]
+  real,           intent(out)   :: swdown(LIS_rc%lnc(n),LIS_rc%lnr(n))    !Downward shortwave flux at the ground [W/m^2]
+  real,           intent(out)   :: lwdown(LIS_rc%lnc(n),LIS_rc%lnr(n))    !Downward longwave radiation at the ground [W/m^2]
+  real,           intent(out)   :: uwind(LIS_rc%lnc(n),LIS_rc%lnr(n))     !Instantaneous zonal wind interpolated to 10 metres [m/s]
+  real,           intent(out)   :: vwind(LIS_rc%lnc(n),LIS_rc%lnr(n))     !Instantaneous meridional wind interpolated to 10 metres[m/s]
+  real,           intent(out)   :: ps(LIS_rc%lnc(n),LIS_rc%lnr(n))        !Instantaneous Surface Pressure [Pa]
+  real,           intent(out)   :: prectot(LIS_rc%lnc(n),LIS_rc%lnr(n))   !Total precipitation [kg/m^2]
+
+  integer,        intent(out)   :: rc
+!
+! !DESCRIPTION:
+!
+!     To read MOGREPS-G data in GRIB-2 format.
+!
+!EOP
+  character*9                   :: cstat
+  character*255                 :: message     ( 20 )
+  character(len=7)              :: grib_msg
+  character(len=7)              :: check_mogrepsg_message
+  integer                       :: count_tair, count_qair
+  integer                       :: count_swdown, count_lwdown
+  integer                       :: count_uwind, count_vwind
+  integer                       :: count_ps, count_prectot
+  integer                       :: ierr
+  integer                       :: istat1
+  integer                       :: igrib
+  integer                       :: ftn
+  integer                       :: kk, nvars
+  integer                       :: param_disc_val, param_cat_val, &
+                                   param_num_val, surface_val, level_val
+  real, allocatable             :: dum1d   ( : )
+  real, allocatable             :: dumv1d  ( : ) ! v-wind
+
+  real, allocatable             :: fg_tair    ( : , : )
+  real, allocatable             :: fg_qair    ( : , : )
+  real, allocatable             :: fg_swdown  ( : , : )
+  real, allocatable             :: fg_lwdown  ( : , : )
+  real, allocatable             :: fg_uwind   ( : , : )
+  real, allocatable             :: fg_vwind   ( : , : )
+  real, allocatable             :: fg_ps      ( : , : )
+  real, allocatable             :: fg_prectot ( : , : )
+
+  logical                       :: found_inq
+
+  rc = 1 ! Initialize as "no error"
+
+  ! EMK...Before using ECCODES/GRIB_API, see if the GRIB file exists
+  ! using a simple inquire statement.  This avoids ECCODES/GRIB_API
+  ! writing error messages to stdout/stderr, which may lead to runtime
+  ! problems.
+  inquire(file=trim(gribfile),exist=found_inq)
+  if (.not. found_inq) then
+     write(LIS_logunit,*) '[WARN] Cannot find file '//trim(gribfile)
+     rc = 0
+     return
+  end if
+
+#if (defined USE_GRIBAPI)
+
+  ! If a problem occurs here, we can just return immediately since no
+  ! memory has been allocated yet.
+  call grib_open_file(ftn,trim(gribfile),'r',ierr)
+  if ( ierr .ne. 0 ) then
+     write(LIS_logunit,*) '[WARN] Failed to open - '//trim(gribfile)
+     rc = 0
+     return
+  end if
+
+  allocate ( fg_tair    (ifguess, jfguess) )
+  allocate ( fg_qair    (ifguess, jfguess) )
+  allocate ( fg_swdown  (ifguess, jfguess) )
+  allocate ( fg_lwdown  (ifguess, jfguess) )
+  allocate ( fg_uwind   (ifguess, jfguess) )   ! nr=960
+  allocate ( fg_vwind   (ifguess, jfguess+1) ) ! v-wind, nr=961
+  allocate ( fg_ps      (ifguess, jfguess) )
+  allocate ( fg_prectot (ifguess, jfguess) )
+
+  allocate ( dum1d   (ifguess*jfguess) )
+  allocate ( dumv1d  (ifguess*(jfguess+1)) ) ! v-wind
+
+  ! Initalization
+  fg_tair = LIS_rc%udef
+  fg_qair = LIS_rc%udef
+  fg_swdown = LIS_rc%udef
+  fg_lwdown = LIS_rc%udef
+  fg_uwind = LIS_rc%udef
+  fg_vwind = LIS_rc%udef
+  fg_ps = LIS_rc%udef
+  fg_prectot = LIS_rc%udef
+  dum1d = LIS_rc%udef
+
+  tair = LIS_rc%udef
+  qair = LIS_rc%udef
+  swdown = LIS_rc%udef
+  lwdown = LIS_rc%udef
+  uwind = LIS_rc%udef
+  vwind = LIS_rc%udef
+  ps = LIS_rc%udef
+  prectot = LIS_rc%udef
+
+  ! From this point, we must deallocate memory before returning.
+  ! Unfortunately this means using a GOTO statement if a problem is
+  ! encountered, but such is life.
+  count_tair  = 0
+  count_qair   = 0
+  count_swdown  = 0
+  count_lwdown = 0
+  count_uwind = 0
+  count_vwind = 0
+  count_ps = 0
+  count_prectot = 0
+
+  call grib_count_in_file(ftn,nvars,ierr)
+  if ( ierr .ne. 0 ) then
+     write(LIS_logunit,*) '[WARN] in grib_count_in_file in ' // &
+          'fldbld_read_mogrepsg'
+     goto 100
+  end if
+
+  ! Tentatively loop through every field in GRIB file looking for the variables
+  ! we want. The code below will exit the loop early if a problem is found *or*
+  ! once all the required variables are found and read in.
+  do kk=1,nvars
+
+     call grib_new_from_file(ftn,igrib,ierr)
+     if ( ierr .ne. 0 ) then
+        write(LIS_logunit,*) '[WARN] failed to read - '//trim(gribfile)
+        goto 100
+     end if
+
+     call grib_get(igrib,'discipline',param_disc_val,ierr)
+     if ( ierr .ne. 0 ) then
+        write(LIS_logunit,*) '[WARN] in grib_get: parameterNumber in ' // &
+             'fldbld_read_mogrepsg'
+        call grib_release(igrib,ierr)
+        goto 100
+     end if
+
+     call grib_get(igrib,'parameterCategory',param_cat_val,ierr)
+     if ( ierr .ne. 0 ) then
+        write(LIS_logunit,*) &
+             '[WARN] in grib_get: parameterCategory in ' // &
+             'fldbld_read_mogrepsg'
+        call grib_release(igrib,ierr)
+        goto 100
+     end if
+
+     call grib_get(igrib,'parameterNumber',param_num_val,ierr)
+     if ( ierr .ne. 0 ) then
+        write(LIS_logunit,*) &
+             '[WARN] in grib_get: parameterNumber in ' // &
+             'fldbld_read_mogrepsg'
+        call grib_release(igrib,ierr)
+        goto 100
+     end if
+
+     call grib_get(igrib,'typeOfFirstFixedSurface',surface_val,ierr)
+     if ( ierr .ne. 0 ) then
+        write(LIS_logunit,*) &
+             '[WARN] in grib_get: level in ' // &
+             'fldbld_read_mogrepsg'
+        call grib_release(igrib,ierr)
+        goto 100
+     end if
+
+     call grib_get(igrib,'level',level_val,ierr)
+     if ( ierr .ne. 0 ) then
+        write(LIS_logunit,*) &
+             '[WARN] in grib_get: level in ' // &
+             'fldbld_read_mogrepsg'
+        call grib_release(igrib,ierr)
+        goto 100
+     end if
+
+     ! We have enough information to determine what GRIB parameter this is.
+     grib_msg = check_mogrepsg_message(param_disc_val, &
+          param_cat_val, param_num_val, surface_val, level_val)
+
+     ! Skip this field if GRIB parameter is not required.
+     if (grib_msg == 'none') then
+        call grib_release(igrib,ierr)
+        if (ierr .ne. 0) then
+           write(LIS_logunit,*)'[WARN], in grib_release: in ' //&
+                'fldbld_read_mogrepsg'
+           goto 100
+        end if
+        cycle ! Not a message we are interested in.
+     end if
+
+     if (grib_msg == 'v10') then
+        call grib_get(igrib,'values',dumv1d,ierr)
+     else
+        call grib_get(igrib,'values',dum1d,ierr)
+     endif
+
+     if ( ierr .ne. 0 ) then
+        write(LIS_logunit,*) &
+             '[WARN] in grib_get: values for '//grib_msg// ' in ' // &
+             'fldbld_read_mogrepsg'
+        call grib_release(igrib,ierr)
+        goto 100
+     end if
+
+     select case (grib_msg)
+     case('t2')       ! 2-m temperature
+        fg_tair = reshape(dum1d, (/ifguess,jfguess/))
+        count_tair = count_tair + 1
+     case ('q2')      ! 2-m relative humidity 
+        fg_qair = reshape(dum1d, (/ifguess,jfguess/))
+        count_qair = count_qair + 1
+     case ('swdown')  ! downward shortwave
+        fg_swdown = reshape(dum1d, (/ifguess,jfguess/))
+        count_swdown = count_swdown + 1
+     case ('lwdown')  ! downward longwave radiation
+        fg_lwdown = reshape(dum1d, (/ifguess,jfguess/))
+        count_lwdown = count_lwdown + 1
+     case ('u10')     ! 10m u-wind
+        fg_uwind = reshape(dum1d, (/ifguess,jfguess/))
+        count_uwind = count_uwind + 1
+     case('v10')      ! 10m v-wind
+        fg_vwind = reshape(dumv1d, (/ifguess,jfguess+1/))
+        count_vwind = count_vwind + 1
+     case('ps')       ! surface pressure
+        fg_ps = reshape(dum1d, (/ifguess,jfguess/))
+        count_ps = count_ps + 1
+     case('prectot')  ! accumulated total precipitation
+        fg_prectot = reshape(dum1d, (/ifguess,jfguess/))
+        count_prectot = count_prectot + 1
+
+     case default ! Internal error, we shouldn't be here
+        write(LIS_logunit,*)'[WARN] Unknown grib_message ',grib_msg
+        write(LIS_logunit,*)'Aborting...'
+        flush(LIS_logunit)
+        write(cstat,'(i9)',iostat=istat1) ierr
+        message(1) = 'Program: LIS'
+        message(2) = '  Subroutine:  fldbld_read_mogrepsg.'
+        message(3) = '  Error reading first guess file:'
+        message(4) = '  ' // trim(gribfile)
+        if( istat1 .eq. 0 )then
+           message(5) = '  Status = ' // trim(cstat)
+        endif
+        call LIS_abort( message)
+     end select
+
+     ! Finished with this field
+     call grib_release(igrib,ierr)
+     if (ierr .ne. 0) then
+        write(LIS_logunit,*)'[WARN], in grib_release: in ' //&
+             'fldbld_read_mogrepsg'
+        goto 100
+     end if
+
+     ! Jump out of loop early if we have everything
+     if ( (count_tair   .eq. 1)  .and. (count_qair    .eq. 1)   .and. &
+          (count_swdown .eq. 1 ) .and. (count_lwdown  .eq. 1)   .and. &
+          (count_uwind  .eq. 1)  .and. (count_vwind   .eq. 1)   .and. &
+          (count_ps     .eq. 1)  .and. (count_prectot .eq. 1)) then
+        exit
+     end if
+  enddo ! Loop through all GRIB file fields
+
+  ! Interpolate the fields to the LIS grid
+  ! tair
+  call interp_mogrepsg(n, findex, ifguess, jfguess, .false., fg_tair, tair)
+  ! qair
+  call interp_mogrepsg(n, findex, ifguess, jfguess, .false., fg_qair, qair)
+  ! swdown
+  call interp_mogrepsg(n, findex, ifguess, jfguess, .false., fg_swdown, swdown)
+  ! lwdown
+  call interp_mogrepsg(n, findex, ifguess, jfguess, .false., fg_lwdown, lwdown)
+  ! uwind
+  call interp_mogrepsg(n, findex, ifguess, jfguess, .false., fg_uwind, uwind)
+  ! vwind
+  call interp_mogrepsg_vwind(n, findex, ifguess, jfguess+1, .false., fg_vwind, vwind)
+  ! ps
+  call interp_mogrepsg(n, findex, ifguess, jfguess, .false., fg_ps, ps)
+  ! prectot
+  call interp_mogrepsg(n, findex, ifguess, jfguess, .true., fg_prectot, prectot)
+
+  ! At this point, we have everything.  Close the file and return.
+  call grib_close_file(ftn)
+  rc = 1
+  return
+
+  ! Jump down here to clean up memory before returning after finding a
+  ! problem.
+  100 continue
+  call grib_close_file(ftn)
+
+  deallocate ( dum1d      )
+  deallocate ( dumv1d     )
+  deallocate ( fg_tair    )
+  deallocate ( fg_qair    )
+  deallocate ( fg_swdown  )
+  deallocate ( fg_lwdown  )
+  deallocate ( fg_uwind   )
+  deallocate ( fg_vwind   )
+  deallocate ( fg_ps      )
+  deallocate ( fg_prectot )
+
+  rc = 0
+#endif
+
+end subroutine fldbld_read_mogrepsg
+
+function check_mogrepsg_message(param_disc_val, &
+     param_cat_val, param_num_val, surface_val, level_val)
+! !USES:
+! none
+
+   implicit none
+! !ARGUMENTS:
+   integer, intent(in) :: param_disc_val, param_cat_val, &
+        param_num_val, surface_val, level_val
+   character(len=7)    :: check_mogrepsg_message
+!EOP
+
+   if     ( param_disc_val == 0 .and. &
+            param_cat_val  == 0 .and. &
+            param_num_val  == 0 .and. &
+            surface_val    == 103 )then
+      check_mogrepsg_message = 't2'      ! Temperature interpolated to 2 metres [K] 
+   elseif ( param_disc_val == 0 .and. &
+            param_cat_val  == 1 .and. &
+            param_num_val  == 0 .and. &
+            surface_val    == 103 ) then
+      check_mogrepsg_message = 'q2'      ! Specific humidity interpolated to 2 metres [kg/kg]
+   elseif ( param_disc_val == 255 .and. &
+            param_cat_val  == 255 .and. &
+            param_num_val  == 255 .and. &
+            surface_val    == 1 ) then
+      check_mogrepsg_message = 'swdown'  ! Downward shortwave flux at the ground [W/m^2]
+   elseif ( param_disc_val == 0 .and. &
+            param_cat_val  == 5 .and. &
+            param_num_val  == 3 .and. &
+            surface_val    == 1 ) then
+      check_mogrepsg_message = 'lwdown'  ! Downward longwave radiation at the ground [W/m^2] 
+   elseif ( param_disc_val == 0 .and. &
+            param_cat_val  == 2 .and. &
+            param_num_val  == 2 .and. &
+            surface_val    == 103 .and. &
+            level_val == 10) then
+      check_mogrepsg_message = 'u10'     ! Instantaneous zonal wind interpolated to 10 metres [m/s] 
+   elseif ( param_disc_val == 0 .and. &
+            param_cat_val  == 2 .and. &
+            param_num_val  == 3 .and. &
+            surface_val    == 103 .and. &
+            level_val == 10) then
+      check_mogrepsg_message = 'v10'     ! Instantaneous meridional wind interpolated to 10 metres[m/s]
+   elseif ( param_disc_val == 0 .and. &
+            param_cat_val  == 3 .and. &
+            param_num_val  == 1 ) then
+      check_mogrepsg_message = 'ps'      ! Instantaneous Surface Pressure [Pa]
+   elseif ( param_disc_val == 0 .and.  &
+            param_cat_val  == 1 .and.  &
+            param_num_val  == 49 .and. &
+            surface_val    == 1 ) then
+      check_mogrepsg_message = 'prectot' ! Total precipitation [kg/m2]
+   else
+      check_mogrepsg_message = 'none'
+   endif
+end function check_mogrepsg_message
+
+subroutine interp_mogrepsg(n, findex, ifguess, jfguess, pcp_flag, input, output)
+
+! !USES:
+  use LIS_coreMod,       only : LIS_rc, LIS_domain
+  use LIS_logMod,        only : LIS_logunit, LIS_endrun
+  use mogrepsg_forcingMod, only : mogrepsg_struc
+
+  implicit none
+! !ARGUMENTS:
+  integer, intent(in)  :: n
+  integer, intent(in)  :: findex
+  integer, intent(in)  :: ifguess
+  integer, intent(in)  :: jfguess
+  logical, intent(in)  :: pcp_flag
+  real,    intent(in)  :: input  ( ifguess,jfguess )
+  real,    intent(out) :: output ( LIS_rc%lnc(n),LIS_rc%lnr(n) )
+!
+! !DESCRIPTION:
+!
+! This routine interpolates the MOGREPS-G data to the LIS grid.
+
+!EOP
+
+  integer   :: mi, mo
+  integer   :: k
+  integer   :: i,j
+  integer   :: iret
+  integer   :: midway
+  character(len=50) :: method
+  real, allocatable, dimension(:,:)    :: var
+  logical*1, allocatable, dimension(:) :: lb
+  logical*1, allocatable, dimension(:) :: lo
+
+  allocate(var(ifguess,jfguess))
+  allocate(lb(ifguess*jfguess))
+  allocate(lo(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+  mi = ifguess * jfguess
+  mo = LIS_rc%lnc(n)*LIS_rc%lnr(n)
+  lb = .true.
+  lo = .true.
+  output = LIS_rc%udef
+
+  ! translate from (0,360) to (-180,180).
+  midway = ifguess/2
+  do j = 1, jfguess
+     do i = 1, ifguess
+        if ( (i+midway) < ifguess ) then
+           var(i,j) = input((i+midway),j)
+        else
+           var(i,j) = input((i-midway+1),j)
+        endif
+     enddo
+  enddo
+
+  ! Interpolate to LIS grid
+  select case( LIS_rc%met_interp(findex) )
+
+    case( "bilinear" )
+     call bilinear_interp(LIS_rc%gridDesc(n,:),lb,                         &
+          var,lo,output,mi,mo,                                             &
+          LIS_domain(n)%lat,LIS_domain(n)%lon,                             &
+          mogrepsg_struc(n)%w111,mogrepsg_struc(n)%w121,                   &
+          mogrepsg_struc(n)%w211,mogrepsg_struc(n)%w221,                   &
+          mogrepsg_struc(n)%n111,mogrepsg_struc(n)%n121,                   &
+          mogrepsg_struc(n)%n211,mogrepsg_struc(n)%n221,LIS_rc%udef,iret)
+
+    case( "budget-bilinear" )
+     if (pcp_flag) then
+        call conserv_interp(LIS_rc%gridDesc(n,:),lb,                       &
+             var,lo,output,mi,mo,                                          &
+             LIS_domain(n)%lat, LIS_domain(n)%lon,                         &
+             mogrepsg_struc(n)%w112,mogrepsg_struc(n)%w122,                &
+             mogrepsg_struc(n)%w212,mogrepsg_struc(n)%w222,                &
+             mogrepsg_struc(n)%n112,mogrepsg_struc(n)%n122,                &
+             mogrepsg_struc(n)%n212,mogrepsg_struc(n)%n222,LIS_rc%udef,iret)
+     else
+        call bilinear_interp(LIS_rc%gridDesc(n,:),lb,                      &
+             var,lo,output,mi,mo,                                          &
+             LIS_domain(n)%lat, LIS_domain(n)%lon,                         &
+             mogrepsg_struc(n)%w111,mogrepsg_struc(n)%w121,                &
+             mogrepsg_struc(n)%w211,mogrepsg_struc(n)%w221,                &
+             mogrepsg_struc(n)%n111,mogrepsg_struc(n)%n121,                &
+             mogrepsg_struc(n)%n211,mogrepsg_struc(n)%n221,LIS_rc%udef,iret)
+     endif
+
+     case( "neighbor" )
+        call neighbor_interp(LIS_rc%gridDesc(n,:),lb,                     &
+             var,lo,output,mi,mo,                                         &
+             LIS_domain(n)%lat, LIS_domain(n)%lon,                        &
+             mogrepsg_struc(n)%n113,LIS_rc%udef,iret)
+
+     case DEFAULT
+        write(LIS_logunit,*) 'ERR: Unexpected interpolation method'
+        write(LIS_logunit,*) '     in interp_mogrepsg_first_guess'
+        write(LIS_logunit,*) '     ', trim(LIS_rc%met_interp(findex))
+        call LIS_endrun()  
+  end select
+
+  deallocate(var)
+  deallocate(lb)
+  deallocate(lo)
+
+end subroutine interp_mogrepsg
+
+subroutine interp_mogrepsg_vwind(n, findex, ifguess, jfguess, pcp_flag, input, output)
+
+! !USES:
+  use LIS_coreMod,       only : LIS_rc, LIS_domain
+  use LIS_logMod,        only : LIS_logunit, LIS_endrun
+  use mogrepsg_forcingMod, only : mogrepsg_struc
+
+  implicit none
+! !ARGUMENTS:
+  integer, intent(in)  :: n
+  integer, intent(in)  :: findex
+  integer, intent(in)  :: ifguess
+  integer, intent(in)  :: jfguess
+  logical, intent(in)  :: pcp_flag
+  real,    intent(in)  :: input  ( ifguess,jfguess )
+  real,    intent(out) :: output ( LIS_rc%lnc(n),LIS_rc%lnr(n) )
+!
+! !DESCRIPTION:
+!
+! This routine interpolates the MOGREPS-G data to the LIS grid.
+
+!EOP
+
+  integer   :: mi, mo
+  integer   :: k
+  integer   :: i,j
+  integer   :: iret
+  integer   :: midway
+  character(len=50) :: method
+  real, allocatable, dimension(:,:)    :: var
+  logical*1, allocatable, dimension(:) :: lb
+  logical*1, allocatable, dimension(:) :: lo
+
+  allocate(var(ifguess,jfguess))
+  allocate(lb(ifguess*jfguess))
+  allocate(lo(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+  mi = ifguess * jfguess
+  mo = LIS_rc%lnc(n)*LIS_rc%lnr(n)
+  lb = .true.
+  lo = .true.
+  output = LIS_rc%udef
+
+  ! translate from (0,360) to (-180,180).
+  midway = ifguess/2
+  do j = 1, jfguess
+     do i = 1, ifguess
+        if ( (i+midway) < ifguess ) then
+           var(i,j) = input((i+midway),j)
+        else
+           var(i,j) = input((i-midway+1),j)
+        endif
+     enddo
+  enddo
+
+  ! Interpolate to LIS grid
+  select case( LIS_rc%met_interp(findex) )
+
+    case( "bilinear" )
+     call bilinear_interp(LIS_rc%gridDesc(n,:),lb,                           &
+          var,lo,output,mi,mo,                                               &
+          LIS_domain(n)%lat,LIS_domain(n)%lon,                               &
+          mogrepsg_struc(n)%wv111,mogrepsg_struc(n)%wv121,                   &
+          mogrepsg_struc(n)%wv211,mogrepsg_struc(n)%wv221,                   &
+          mogrepsg_struc(n)%nv111,mogrepsg_struc(n)%nv121,                   &
+          mogrepsg_struc(n)%nv211,mogrepsg_struc(n)%nv221,LIS_rc%udef,iret)
+
+    case( "budget-bilinear" )
+     if (pcp_flag) then
+        call conserv_interp(LIS_rc%gridDesc(n,:),lb,                         &
+             var,lo,output,mi,mo,                                            &
+             LIS_domain(n)%lat, LIS_domain(n)%lon,                           &
+             mogrepsg_struc(n)%wv112,mogrepsg_struc(n)%wv122,                &
+             mogrepsg_struc(n)%wv212,mogrepsg_struc(n)%wv222,                &
+             mogrepsg_struc(n)%nv112,mogrepsg_struc(n)%nv122,                &
+             mogrepsg_struc(n)%nv212,mogrepsg_struc(n)%nv222,LIS_rc%udef,iret)
+     else
+        call bilinear_interp(LIS_rc%gridDesc(n,:),lb,                        &
+             var,lo,output,mi,mo,                                            &
+             LIS_domain(n)%lat, LIS_domain(n)%lon,                           &
+             mogrepsg_struc(n)%wv111,mogrepsg_struc(n)%wv121,                &
+             mogrepsg_struc(n)%wv211,mogrepsg_struc(n)%wv221,                &
+             mogrepsg_struc(n)%nv111,mogrepsg_struc(n)%nv121,                &
+             mogrepsg_struc(n)%nv211,mogrepsg_struc(n)%nv221,LIS_rc%udef,iret)
+     endif
+
+     case( "neighbor" )
+        call neighbor_interp(LIS_rc%gridDesc(n,:),lb,                        &
+             var,lo,output,mi,mo,                                            &
+             LIS_domain(n)%lat, LIS_domain(n)%lon,                           &
+             mogrepsg_struc(n)%nv113,LIS_rc%udef,iret)
+
+     case DEFAULT
+        write(LIS_logunit,*) 'ERR: Unexpected interpolation method'
+        write(LIS_logunit,*) '     in interp_mogrepsg_first_guess'
+        write(LIS_logunit,*) '     ', trim(LIS_rc%met_interp(findex))
+        call LIS_endrun()
+  end select
+
+  deallocate(var)
+  deallocate(lb)
+  deallocate(lo)
+
+end subroutine interp_mogrepsg_vwind
+
+!BOP
+!
+! !ROUTINE: assign_processed_mogrepsgforc
+! \label{assign_processed_mogrepsgforc}
+!
+! !INTERFACE:
+subroutine assign_processed_mogrepsgforc(n,m,order,var_index,mogrepsgforc)
+! !USES:
+  use LIS_coreMod
+  use mogrepsg_forcingMod, only : mogrepsg_struc
+!
+! !DESCRIPTION:
+!  This routine assigns the interpolated MOGREPS-G forcing data
+!  to the module data structures to be used later for
+!  time interpolation
+!
+!EOP
+  implicit none
+
+  integer, intent(in) :: n
+  integer, intent(in) :: m 
+  integer, intent(in) :: order
+  integer, intent(in) :: var_index
+  real,    intent(in) :: mogrepsgforc(LIS_rc%lnc(n),LIS_rc%lnr(n))
+
+  integer :: c,r
+
+  do r=1,LIS_rc%lnr(n)
+     do c=1,LIS_rc%lnc(n)
+        if(LIS_domain(n)%gindex(c,r).ne.-1) then
+           if(order.eq.1) then
+              mogrepsg_struc(n)%metdata1(var_index,m,&
+                   LIS_domain(n)%gindex(c,r)) = &
+                   mogrepsgforc(c,r)
+           elseif(order.eq.2) then
+              mogrepsg_struc(n)%metdata2(var_index,m,&
+                   LIS_domain(n)%gindex(c,r)) = &
+                   mogrepsgforc(c,r)
+           endif
+        endif
+     enddo
+  enddo
+end subroutine assign_processed_mogrepsgforc

--- a/lis/metforcing/mogreps_g/readcrd_mogrepsg.F90
+++ b/lis/metforcing/mogreps_g/readcrd_mogrepsg.F90
@@ -1,0 +1,62 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+!
+! !ROUTINE: readcrd_mogrepsg
+! \label{readcrd_mogrepsg}
+!
+! !REVISION HISTORY:
+! 26 Jan 2023; Yeosang Yoon, Initial Code
+!
+! !INTERFACE:    
+subroutine readcrd_mogrepsg()
+! !USES:
+  use LIS_logMod
+  use LIS_coreMod
+  use mogrepsg_forcingMod, only : mogrepsg_struc
+  use ESMF
+!
+! !DESCRIPTION:
+!
+!  This routine reads the options specific to MOGREPS-G forecast forcing from 
+!  the LIS configuration file. 
+!  
+!EOP
+
+  implicit none
+
+  integer :: n,rc
+
+  call ESMF_ConfigFindLabel(LIS_config,"MOGREPS-G forecast forcing directory:",rc=rc)
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,mogrepsg_struc(n)%odir,rc=rc)
+     call LIS_verify(rc,'MOGREPS-G forecast forcing directory: not defined')
+  enddo
+
+  call ESMF_ConfigFindLabel(LIS_config,"MOGREPS-G forecast run mode:",rc=rc)
+  call LIS_verify(rc, 'MOGREPS-G forecast run mode: not defined ')
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,mogrepsg_struc(n)%runmode,rc=rc)
+  enddo
+
+  call ESMF_ConfigFindLabel(LIS_config,"MOGREPS-G forecast number of ensemble members:",rc=rc)
+  call LIS_verify(rc, 'MOGREPS-G forecast number of ensemble members: not defined')
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,mogrepsg_struc(n)%max_ens_members,rc=rc)
+  enddo
+
+  do n=1,LIS_rc%nnest
+     write(LIS_logunit,*) '[INFO] Using MOGREPS-G forecast forcing'
+     write(LIS_logunit,*) '[INFO] MOGREPS-G forecast forcing directory: ', trim(mogrepsg_struc(n)%odir)
+     write(LIS_logunit,*) '[INFO] MOGREPS-G forecast run mode: ',mogrepsg_struc(n)%runmode
+     write(LIS_logunit,*) '[INFO] MOGREPS-G forecast number of ensemble members:',&
+           mogrepsg_struc(n)%max_ens_members
+  enddo
+end subroutine readcrd_mogrepsg

--- a/lis/metforcing/mogreps_g/reset_mogrepsg.F90
+++ b/lis/metforcing/mogreps_g/reset_mogrepsg.F90
@@ -1,0 +1,38 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
+!BOP
+! !MODULE: reset_mogrepsg
+!  \label{reset_mogrepsg}
+!
+! !REVISION HISTORY:
+! 26 Jan 2023; Yeosang Yoon, Initial Code
+!
+! !INTERFACE:
+subroutine reset_mogrepsg()
+! !USES:
+  use LIS_coreMod,       only : LIS_rc
+  use mogrepsg_forcingMod, only : mogrepsg_struc
+!
+! !DESCRIPTION:
+!  Routine to reset GALWEM-GE forcing related memory allocations.
+!
+!EOP
+  implicit none
+
+  integer   :: n
+  integer   :: findex
+
+  do n=1,LIS_rc%nnest
+     mogrepsg_struc(n)%fcsttime1 = 3000.0
+     mogrepsg_struc(n)%fcsttime2 = 0.0
+  enddo
+
+end subroutine reset_mogrepsg

--- a/lis/metforcing/mogreps_g/timeinterp_mogrepsg.F90
+++ b/lis/metforcing/mogreps_g/timeinterp_mogrepsg.F90
@@ -1,0 +1,301 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.3
+!
+! Copyright (c) 2020 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
+!BOP
+! !ROUTINE: timeinterp_mogrepsg
+! \label{timeinterp_mogrepsg}
+!
+! !REVISION HISTORY:
+!
+! 26 Jan 2023: Yeosang Yoon, Initial specification
+!
+! !INTERFACE:
+subroutine timeinterp_mogrepsg(n,findex)
+! !USES:
+  use ESMF
+  use LIS_coreMod
+  use LIS_constantsMod
+  use LIS_metforcingMod
+  use LIS_FORC_AttributesMod
+  use LIS_timeMgrMod
+  use LIS_logMod
+  use mogrepsg_forcingMod
+  use LIS_forecastMod
+
+  implicit none
+! !ARGUMENTS:
+  integer, intent(in) :: n
+  integer, intent(in) :: findex
+!
+! !DESCRIPTION:
+!  Temporally interpolates the forcing data to the current model
+!  timestep. Downward shortwave radiation is interpolated using a
+!  zenith-angled based approach. Precipitation and longwave radiation
+!  are not temporally interpolated, and the previous 3 hourly value
+!  is used. All other variables are linearly interpolated between
+!  the 3 hourly blocks.
+!
+!  The routines invoked are:
+!  \begin{description}
+!   \item[LIS\_time2date](\ref{LIS_time2date}) \newline
+!    converts the time to a date format
+!   \item[LIS\_tick](\ref{LIS_tick}) \newline
+!    advances or retracts time by the specified amount
+!   \item[zterp](\ref{zterp}) \newline
+!    zenith-angle based interpolation
+!  \end{description}
+!EOP
+  integer :: zdoy
+  real    :: zw1, zw2
+  real    :: czm, cze, czb
+  real    :: wt1, wt2, swt1, swt2
+  real    :: gmt1, gmt2
+  integer :: t,index1
+  integer :: bdoy,byr,bmo,bda,bhr,bmn
+  real*8  :: btime,newtime1,newtime2
+  real    :: tempgmt1,tempgmt2,tempbts
+  integer :: tempbdoy,tempbyr,tempbmo,tempbda,tempbhr,tempbmn,tempbss
+  integer            :: status
+  type(ESMF_Field)   :: tmpField,q2Field,uField,vField,swdField,lwdField
+  type(ESMF_Field)   :: psurfField,pcpField
+  real,pointer       :: tmp(:),q2(:),uwind(:),vwind(:)
+  real,pointer       :: swd(:),lwd(:),psurf(:),pcp(:)
+  real               :: pcp_tmp
+  integer            :: mfactor, m, k, tid, fcsthr_intv
+! ________________________________________
+
+  btime=mogrepsg_struc(n)%fcsttime1
+  call LIS_time2date(btime,bdoy,gmt1,byr,bmo,bda,bhr,bmn)
+
+  tempbdoy=bdoy
+  tempgmt1=gmt1
+  tempbyr=byr
+  tempbmo=bmo
+  tempbda=bda
+  tempbhr=bhr
+  if (tempbhr.eq.24) tempbhr=0
+  tempbmn=bmn
+  tempbss=0
+  tempbts=0
+  call LIS_tick(newtime1,tempbdoy,tempgmt1,&
+       tempbyr,tempbmo,tempbda,tempbhr,tempbmn, &
+       tempbss,tempbts)
+
+  btime=mogrepsg_struc(n)%fcsttime2
+  call LIS_time2date(btime,bdoy,gmt2,byr,bmo,bda,bhr,bmn)
+
+  tempbdoy=bdoy
+  tempgmt2=gmt2
+  tempbyr=byr
+  tempbmo=bmo
+  tempbda=bda
+  tempbhr=bhr
+  if (tempbhr.eq.24) tempbhr=0
+  tempbmn=bmn
+  tempbss=0
+  tempbts=0
+  call LIS_tick(newtime2,tempbdoy,tempgmt2,&
+       tempbyr,tempbmo,tempbda,tempbhr,tempbmn,&
+       tempbss,tempbts)
+
+  !Interpolate Data in Time
+  wt1=(mogrepsg_struc(n)%fcsttime2-LIS_rc%time)/ &
+       (mogrepsg_struc(n)%fcsttime2-mogrepsg_struc(n)%fcsttime1)
+  wt2=1.0-wt1
+  swt1=(newtime2-LIS_rc%time)/(newtime2-newtime1)
+  swt2=1.0-swt1
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Tair%varname(1),tmpField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable Tair in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Qair%varname(1),q2Field,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable Qair in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_SWdown%varname(1),swdField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable SWdown in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_LWdown%varname(1),lwdField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable LWdown in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Wind_E%varname(1),uField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable Wind_E in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Wind_N%varname(1),vField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable Wind_N in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Psurf%varname(1),psurfField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable Psurf in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),LIS_FORC_Rainf%varname(1),pcpField,&
+       rc=status)
+  call LIS_verify(status, 'Error: Enable Rainf in the forcing variables list')
+
+
+  call ESMF_FieldGet(tmpField,localDE=0,farrayPtr=tmp,rc=status)
+  call LIS_verify(status)
+
+  call ESMF_FieldGet(q2Field,localDE=0,farrayPtr=q2,rc=status)
+  call LIS_verify(status)
+
+  call ESMF_FieldGet(swdField,localDE=0,farrayPtr=swd,rc=status)
+  call LIS_verify(status)
+
+  call ESMF_FieldGet(lwdField,localDE=0,farrayPtr=lwd,rc=status)
+  call LIS_verify(status)
+
+  call ESMF_FieldGet(uField,localDE=0,farrayPtr=uwind,rc=status)
+  call LIS_verify(status)
+
+  call ESMF_FieldGet(vField,localDE=0,farrayPtr=vwind,rc=status)
+  call LIS_verify(status)
+
+  call ESMF_FieldGet(psurfField,localDE=0,farrayPtr=psurf,rc=status)
+  call LIS_verify(status)
+
+  call ESMF_FieldGet(pcpField,localDE=0,farrayPtr=pcp,rc=status)
+  call LIS_verify(status)
+
+  ! Metforcing ensemble member count factor
+  mfactor = LIS_rc%nensem(n)/mogrepsg_struc(n)%max_ens_members
+
+  ! Downward shortwave radiation (average):
+  do t=1,LIS_rc%ntiles(n)/LIS_rc%nensem(n)
+     do m=1,mogrepsg_struc(n)%max_ens_members
+        do k=1,mfactor
+           tid = (t-1)*LIS_rc%nensem(n)+(m-1)*mfactor+k
+           index1 = LIS_domain(n)%tile(tid)%index
+           zdoy=LIS_rc%doy
+
+           ! Compute and apply zenith angle weights
+           call zterp(1,LIS_domain(n)%grid(index1)%lat,&
+                LIS_domain(n)%grid(index1)%lon,&
+                gmt1,gmt2,LIS_rc%gmt,zdoy,zw1,zw2,czb,cze,czm,LIS_rc)
+
+           if(mogrepsg_struc(n)%metdata1(3,m,index1).ne.LIS_rc%udef.and.&
+              mogrepsg_struc(n)%metdata2(3,m,index1).ne.LIS_rc%udef) then
+              swd(tid) = mogrepsg_struc(n)%metdata1(3,m,index1)*zw1+&
+                       mogrepsg_struc(n)%metdata2(3,m,index1)*zw2
+              !swd(tid) = zw1 * mogrepsg_struc(n)%metdata2(3,m,index1)
+
+              ! In cases of small cos(zenith) angles, use linear weighting to avoid overly large weights
+              if((swd(tid).gt.mogrepsg_struc(n)%metdata1(3,m,index1).and. &
+                 swd(tid).gt.mogrepsg_struc(n)%metdata2(3,m,index1)).and. &
+                 (czb.lt.0.1.or.cze.lt.0.1))then
+                 swd(tid) = mogrepsg_struc(n)%metdata1(3,m,index1)*swt1+ &
+                          mogrepsg_struc(n)%metdata2(3,m,index1)*swt2
+              endif
+
+              if (swd(t).gt.LIS_CONST_SOLAR) then
+                 write(unit=LIS_logunit,fmt=*)'[WARN] sw radiation too high!!'
+                 write(unit=LIS_logunit,fmt=*)'[WARN] it is',swd(t)
+                 write(unit=LIS_logunit,fmt=*)'[WARN] mogrepsgdata1=',&
+                       mogrepsg_struc(n)%metdata1(3,m,index1)
+                 write(unit=LIS_logunit,fmt=*)'[WARN] mogrepsgdata2=',&
+                       mogrepsg_struc(n)%metdata2(3,m,index1)
+                 write(unit=LIS_logunit,fmt=*)'[WARN] zw1=',zw1,'zw2=',zw2
+                 swd(t) = LIS_CONST_SOLAR
+                 write(unit=LIS_logunit,fmt=*)'[WARN] forcing set to ',swd(t)
+              endif
+           endif
+
+           if ((swd(t).ne.LIS_rc%udef).and.(swd(t).lt.0)) then
+              if (swd(t).gt.-0.00001) then
+                 swd(t) = 0.0
+              else
+                 write(LIS_logunit,*) '[ERR] timeinterp_mogrepsg -- Stopping because ', &
+                                      'forcing not udef but lt 0,'
+                 write(LIS_logunit,*)'[ERR] timeinterp_mogrepsg -- ', &
+                                      t,swd(t),mogrepsg_struc(n)%metdata2(3,m,index1), &
+                                      ' (',LIS_localPet,')'
+                 call LIS_endrun
+              endif
+           endif 
+        enddo
+     enddo
+  enddo
+
+!-----------------------------------------------------------------------
+! precip variable Block Interpolation
+!-----------------------------------------------------------------------
+  ! Total precipitation field (accumulated):
+  do t=1,LIS_rc%ntiles(n)/LIS_rc%nensem(n)
+     do m=1,mogrepsg_struc(n)%max_ens_members
+        do k=1,mfactor
+           tid = (t-1)*LIS_rc%nensem(n)+(m-1)*mfactor+k
+           index1 = LIS_domain(n)%tile(tid)%index
+
+           if(mogrepsg_struc(n)%metdata2(8,m,index1).ne.LIS_rc%udef) then
+              ! account for the accum fields
+              pcp(tid)=(mogrepsg_struc(n)%metdata2(8,m,index1)-mogrepsg_struc(n)%metdata1(8,m,index1))/(3600*3)
+              if(pcp(tid).lt.0) then
+                 pcp(tid) = 0.0
+              endif
+           endif
+        enddo
+     enddo
+  enddo
+
+!-----------------------------------------------------------------------
+! Linearly interpolate everything else
+!-----------------------------------------------------------------------
+  do t=1,LIS_rc%ntiles(n)/LIS_rc%nensem(n)
+     do m=1,mogrepsg_struc(n)%max_ens_members
+        do k=1,mfactor
+           tid = (t-1)*LIS_rc%nensem(n)+(m-1)*mfactor+k
+           index1 = LIS_domain(n)%tile(tid)%index
+           
+           ! 2-meter air temp
+           if((mogrepsg_struc(n)%metdata1(1,m,index1).ne.LIS_rc%udef).and.&
+                (mogrepsg_struc(n)%metdata2(1,m,index1).ne.LIS_rc%udef)) then
+              tmp(tid) = mogrepsg_struc(n)%metdata1(1,m,index1)*wt1 + &
+                         mogrepsg_struc(n)%metdata2(1,m,index1)*wt2
+           endif
+           ! Specific humidity
+           if((mogrepsg_struc(n)%metdata1(2,m,index1).ne.LIS_rc%udef).and.&
+                (mogrepsg_struc(n)%metdata2(2,m,index1).ne.LIS_rc%udef)) then
+              q2(tid)  = mogrepsg_struc(n)%metdata1(2,m,index1)*wt1 + &
+                         mogrepsg_struc(n)%metdata2(2,m,index1)*wt2
+           endif
+           ! Downward longwave field
+           if((mogrepsg_struc(n)%metdata1(4,m,index1).ne.LIS_rc%udef).and.&
+                (mogrepsg_struc(n)%metdata2(4,m,index1).ne.LIS_rc%udef)) then
+              lwd(tid)  = mogrepsg_struc(n)%metdata1(4,m,index1)*wt1 + &
+                          mogrepsg_struc(n)%metdata2(4,m,index1)*wt2
+           endif
+           ! U-wind component
+           if((mogrepsg_struc(n)%metdata1(5,m,index1).ne.LIS_rc%udef).and.&
+                (mogrepsg_struc(n)%metdata2(5,m,index1).ne.LIS_rc%udef)) then
+              uwind(tid) = mogrepsg_struc(n)%metdata1(5,m,index1)*wt1+&
+                           mogrepsg_struc(n)%metdata2(5,m,index1)*wt2
+           endif
+           ! V-wind component
+           if((mogrepsg_struc(n)%metdata1(6,m,index1).ne.LIS_rc%udef).and.&
+                (mogrepsg_struc(n)%metdata2(6,m,index1).ne.LIS_rc%udef)) then
+              vwind(tid) = mogrepsg_struc(n)%metdata1(6,m,index1)*wt1 + &
+                           mogrepsg_struc(n)%metdata2(6,m,index1)*wt2
+           endif
+           ! Surface pressure field
+           if((mogrepsg_struc(n)%metdata1(7,m,index1).ne.LIS_rc%udef).and.&
+                (mogrepsg_struc(n)%metdata2(7,m,index1).ne.LIS_rc%udef)) then
+              psurf(tid) = mogrepsg_struc(n)%metdata1(7,m,index1)*wt1 + &
+                           mogrepsg_struc(n)%metdata2(7,m,index1)*wt2
+           endif
+        enddo
+     enddo
+  enddo
+
+end subroutine timeinterp_mogrepsg

--- a/lis/plugins/LIS_metforcing_pluginMod.F90
+++ b/lis/plugins/LIS_metforcing_pluginMod.F90
@@ -304,6 +304,10 @@ subroutine LIS_metforcing_plugin
    use galwemge_forcingMod
 #endif
 
+#if ( defined MF_MOGREPS_G_FORECAST )
+   use mogrepsg_forcingMod
+#endif
+
 #if ( defined MF_MET_TEMPLATE )
    external get_metForcTemplate
    external timeinterp_metForcTemplate
@@ -656,7 +660,12 @@ subroutine LIS_metforcing_plugin
    external reset_galwemge
 #endif
 
-
+#if ( defined MF_MOGREPS_G_FORECAST )
+   external get_mogrepsg
+   external timeinterp_mogrepsg
+   external finalize_mogrepsg
+   external reset_mogrepsg
+#endif
    
 #if ( defined MF_MET_TEMPLATE )
 ! - Meteorological Forcing Template:
@@ -1179,6 +1188,15 @@ subroutine LIS_metforcing_plugin
                                   timeinterp_galwemge)
    call registerfinalmetforc(trim(LIS_galwemgeId)//char(0),finalize_galwemge)
    call registerresetmetforc(trim(LIS_galwemgeId)//char(0),reset_galwemge)
+#endif
+
+#if ( defined MF_MOGREPS_G_FORECAST)
+   call registerinitmetforc(trim(LIS_mogrepsgId)//char(0),init_mogrepsg)
+   call registerretrievemetforc(trim(LIS_mogrepsgId)//char(0),get_mogrepsg)
+   call registertimeinterpmetforc(trim(LIS_mogrepsgId)//char(0), &
+                                  timeinterp_mogrepsg)
+   call registerfinalmetforc(trim(LIS_mogrepsgId)//char(0),finalize_mogrepsg)
+   call registerresetmetforc(trim(LIS_mogrepsgId)//char(0),reset_mogrepsg)
 #endif
 
 end subroutine LIS_metforcing_plugin

--- a/lis/plugins/LIS_pluginIndices.F90
+++ b/lis/plugins/LIS_pluginIndices.F90
@@ -175,6 +175,7 @@ module LIS_pluginIndices
    character*50, public,  parameter :: LIS_gddpId            = "GDDP"
    character*50, public,  parameter :: LIS_galwemId          = "GALWEM forecast"
    character*50, public,  parameter :: LIS_galwemgeId        = "GALWEM-GE forecast"
+   character*50, public,  parameter :: LIS_mogrepsgId        = "MOGREPS-G forecast"
 
 !-------------------------------------------------------------------------
 ! land surface parameters


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description
Add MOGREPS-G (Met Office Global and Regional Ensemble Prediction System - global ensemble), version PS45, medium-range forecasts reader for GHI (https://github.com/NASA-LIS/LISF/issues/1476).

These codes are part of LIS 557WW 7.6 delivery. 

**Pre-processing is needed**
The initial conditions for the MR system are sourced from the GHI NRT system. However, the ensemble sizes of the NRT (12 members) and MR (18 members) differ. Therefore, preprocessing is necessary to align the ensemble sizes.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->
LDT:
/discover/nobackup/projects/usaf_lis/yyoon4/Hydro/MRF/MOGREPS-G/testcase/ldt/ldt.config.global.noahmp401.ensemble

LIS:
/discover/nobackup/projects/usaf_lis/yyoon4/Hydro/MRF/MOGREPS-G/testcase/lis/lis.config.global.noahmp401


