### PR TITLE
Fault tolerant version of GALWEM reader

### DIFF
--- a/lis/core/LIS_coreMod.F90
+++ b/lis/core/LIS_coreMod.F90
@@ -462,10 +462,14 @@ contains
 ! \label{LIS_endofrun}
 !
 ! !INTERFACE:
-  function LIS_endofrun() result(finish)
+  function LIS_endofrun(override_end_time) result(finish)
 
-! !ARGUMENTS:
+    use LIS_logMod, only: LIS_logunit
+
+    ! !ARGUMENTS:
+    logical, optional, intent(in) :: override_end_time
     logical :: finish
+    
 ! !DESCRIPTION:
 !  This function checks to see if the runtime clock has reached the
 !  specified stop time of the simulation.
@@ -483,9 +487,19 @@ contains
 !   \end{description}
 !EOP
     integer :: ierr
+    logical, save :: force_end = .false. ! EMK
 
+    ! EMK: Allows a metforcing reader to override
+    if (present(override_end_time)) then
+       force_end = override_end_time
+    end if
     if(LIS_masterproc) then
        finish = LIS_is_last_step(LIS_rc)
+       !  EMK: Allows a metforcing reader to override
+       if (force_end) then
+          finish = .true.
+          write(LIS_logunit,*)'[INFO] LIS will terminate early!'
+       end if
     endif
 #if (defined SPMD)
     call MPI_BCAST(finish, 1, MPI_LOGICAL, 0, &

--- a/lis/metforcing/galwem/galwem_forcingMod.F90
+++ b/lis/metforcing/galwem/galwem_forcingMod.F90
@@ -20,7 +20,8 @@ module galwem_forcingMod
 ! REVISION HISTORY:
 ! 11 Mar 2022; Yeosang Yoon; Initial Specification
 ! 08 Sep 2022; Yeosang Yoon, Add codes to read GALWEM 25 DEG dataset
-
+! 11 Jan 2024; Eric Kemp, added third entries for fcsttime and metdata
+!              for temporary storage.
 ! !USES:
   use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
@@ -199,6 +200,7 @@ contains
        galwem_struc(n)%mi = galwem_struc(n)%nc*galwem_struc(n)%nr
        galwem_struc(n)%fcsttime1 = 3000.0
        galwem_struc(n)%fcsttime2 = 0.0
+       galwem_struc(n)%fcsttime3 = 0.0
     enddo
 
     do n=1,LIS_rc%nnest

--- a/lis/metforcing/galwem/galwem_forcingMod.F90
+++ b/lis/metforcing/galwem/galwem_forcingMod.F90
@@ -39,7 +39,7 @@ module galwem_forcingMod
   type, public ::  galwem_type_dec
      real                              :: ts
      integer                           :: nc, nr, vector_len   
-     real*8                            :: fcsttime1,fcsttime2
+     real*8                            :: fcsttime1,fcsttime2,fcsttime3
      character(len=LIS_CONST_PATH_LEN) :: odir      !GALWEM forecast forcing Directory
      character*20                      :: runmode
      integer                           :: resol     !GALWEM forecast resolution (17km or 25deg)
@@ -68,7 +68,7 @@ module galwem_forcingMod
      integer                :: init_yr, init_mo, init_da, init_hr
      real, allocatable      :: metdata1(:,:) 
      real, allocatable      :: metdata2(:,:)
-
+     real, allocatable      :: metdata3(:,:)
      integer                :: nmodels   
 
   end type galwem_type_dec
@@ -154,6 +154,7 @@ contains
        
        allocate(galwem_struc(n)%metdata1(LIS_rc%met_nf(findex),LIS_rc%ngrid(n)))
        allocate(galwem_struc(n)%metdata2(LIS_rc%met_nf(findex),LIS_rc%ngrid(n)))
+       allocate(galwem_struc(n)%metdata3(LIS_rc%met_nf(findex),LIS_rc%ngrid(n)))
 
        ! Initialize the forecast initial date-time and grib record:
        galwem_struc(n)%init_yr = LIS_rc%syr
@@ -164,6 +165,7 @@ contains
        galwem_struc(n)%fcst_hour = 0
        galwem_struc(n)%metdata1 = 0
        galwem_struc(n)%metdata2 = 0
+       galwem_struc(n)%metdata3 = 0
        gridDesci = 0
 
        if(galwem_struc(n)%resol == 17) then   !galwem-17km 

--- a/lis/metforcing/galwem/get_galwem.F90
+++ b/lis/metforcing/galwem/get_galwem.F90
@@ -21,7 +21,7 @@
 !              00Z, to correct time intervals between GALWEM-GD files,
 !              and to stop searching for (nonexistent) GALWEM-GD file
 !              when LIS reaches it's end time.
-! 09 Jan 2024: Eric Kemp. Reworked code to be fault tolerant, to roll
+! 11 Jan 2024: Eric Kemp. Reworked code to be fault tolerant, to roll
 !              back to an earlier GALWEM run if necessary, and to better
 !              ensure LIS outputs history files before an early
 !              termination.
@@ -110,7 +110,8 @@ subroutine get_galwem(n, findex)
         mn1 = 0
         ss1 = 0
         ts1 = -43200
-        call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+        call LIS_tick(time1, doy1, gmt1, &
+             yr1, mo1, da1, hr1, mn1, ss1, ts1)
         call run_audit(n, findex, &
              yr1, mo1, da1, hr1, &
              12, filecount)
@@ -130,10 +131,6 @@ subroutine get_galwem(n, findex)
 
   ! Get the bookends at the start of the run
   if (LIS_rc%tscount(n) .eq. 1 .or. LIS_rc%rstflag(n) .eq. 1) then
-     write(LIS_logunit,*)'[INFO] time1 = ', &
-          galwem_struc(n)%fcsttime1
-     write(LIS_logunit,*)'[INFO] time2 = ', &
-          galwem_struc(n)%fcsttime2
      openfile = 1 ! Data already stored in galwem_struc(n) by run_audit
   end if
 
@@ -277,8 +274,6 @@ subroutine run_audit(n, findex, &
      call getGALWEMfilename(n, galwem_struc(n)%odir, yr1, mo1, da1, hr1, &
           fcsthr, fname)
 
-     write(LIS_logunit,*)'EMK: Searching for ', trim(fname)
-
      ferror = 0
      inquire(file=trim(fname), exist=found_inq)
      if (found_inq) then
@@ -300,13 +295,11 @@ subroutine run_audit(n, findex, &
               galwem_struc(n)%fcsttime1 = time1
               write(LIS_logunit,*) &
                    '[INFO] Read ', trim(fname)
-              write(LIS_logunit,*) '[INFO] time1 = ', time1
            else if (order == 2) then
               galwem_struc(n)%fcsttime2 = time1
               galwem_struc(n)%fcst_hour = fcsthr
               write(LIS_logunit,*) &
                    '[INFO] Read ', trim(fname)
-              write(LIS_logunit,*) '[INFO] time2 = ', time1
            else
               galwem_struc(n)%fcsttime3 = time1
            end if

--- a/lis/metforcing/galwem/get_galwem.F90
+++ b/lis/metforcing/galwem/get_galwem.F90
@@ -55,6 +55,10 @@ subroutine get_galwem(n, findex)
   integer           :: fcsthr_intv
   integer           :: fcst_hour
   integer           :: openfile
+  integer :: filecount
+  logical, save :: use_prior_galwem_run
+  integer :: cur_fcsthr, next_fcsthr
+  integer :: ierr
 
   ! GALWEM cycles every 6 hours; each cycle provide up to 168 hours (7 days) forecast for GALWEM-17km;
   ! each cycle provide up to 240 hours (10 days) forecast for GALWEM-25deg;
@@ -78,12 +82,84 @@ subroutine get_galwem(n, findex)
           '[INFO] LIS run has reached end time, will not read more GALWEM'
      return
   end if
-  
+
   openfile=0
 
   if(LIS_rc%tscount(n).eq.1 .or.LIS_rc%rstflag(n).eq.1) then  !beginning of run
      LIS_rc%rstflag(n) = 0
   endif
+
+  !EMK...Perform audit of available GALWEM-GD GRIB files for current fcst
+  !run.
+  if (LIS_rc%tscount(n) .eq. 1 .or. LIS_rc%rstflag(n) .eq. 1) then
+     use_prior_galwem_run = .false.
+     call run_audit(n, LIS_rc%syr, LIS_rc%smo, LIS_rc%sda, LIS_rc%shr, &
+          0, filecount)
+     if (filecount == 0) then !Roll back to prior GALWEM run
+        yr1 = LIS_rc%syr
+        mo1 = LIS_rc%smo
+        da1 = LIS_rc%sda
+        hr1 = LIS_rc%shr
+        mn1 = 0
+        ss1 = 0
+        ts1 = -43200
+        call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+        call run_audit(n, yr1, mo1, da1, hr1, &
+             12, filecount)
+        if (filecount == 0) then
+           write(LIS_logunit,*)"[ERR] No GALWEM files found!"
+           call LIS_endrun()
+        else
+           use_prior_galwem_run = .true.
+           galwem_struc(n)%init_yr = yr1
+           galwem_struc(n)%init_mo = mo1
+           galwem_struc(n)%init_da = da1
+           galwem_struc(n)%init_hr = hr1
+        end if
+     end if
+  end if
+  write(LIS_logunit,*) '[INFO] use_prior_galwem_run = ', &
+       use_prior_galwem_run
+
+  ! Get the bookends at the start of the run
+  if (LIS_rc%tscount(n) .eq. 1 .or. LIS_rc%rstflag(n) .eq. 1) then
+
+     ! Bookend-time record 1
+     yr1 = LIS_rc%syr
+     mo1 = LIS_rc%smo
+     da1 = LIS_rc%sda
+     hr1 = LIS_rc%shr
+     mn1 = 0
+     ss1 = 0
+     ts1 = 0
+     if (use_prior_galwem_run) ts1 = -43200
+     call LIS_tick(time1, doy1, gmt1, yr1, mo1, da1, hr1, mn1, ss1, ts1)
+
+     ! Find Bookend-time record 2
+     cur_fcsthr = 0
+     if (use_prior_galwem_run) cur_fcsthr = 12
+     call find_next_fcsthr(n, galwem_struc(n)%init_yr, &
+          galwem_struc(n)%init_mo, &
+          galwem_struc(n)%init_da, &
+          galwem_struc(n)%init_hr, &
+          cur_fcsthr, next_fcsthr, ierr)
+     if (ierr .ne. 0) then
+        write(LIS_logunit,*) '[ERR] Cannot find next GALWEM GRIB file!'
+        call LIS_endrun()
+     end if
+     yr2 = LIS_rc%syr
+     mo2 = LIS_rc%smo
+     da2 = LIS_rc%sda
+     hr2 = LIS_rc%shr
+     mn2 = 0
+     ss2 = 0
+     ts2 = next_fcsthr * 3600
+     if (use_prior_galwem_run) ts2 = ts2 - 43200
+     call LIS_tick(time2, doy2, gmt2, yr2, mo2, da2, hr2, mn2, ss2, ts2)
+
+     openfile = 1
+  end if
+  call LIS_endrun() ! EMK TEST
 
   ! First timestep of run
   if(LIS_rc%tscount(n).eq.1 .or.LIS_rc%rstflag(n).eq.1) then
@@ -276,4 +352,114 @@ subroutine getGALWEMfilename(n,rootdir,yr,mo,da,hr,fc_hr,filename)
              trim(fname) // ftime // '_CY.' // chr // '_FH.' // fchr // '_DF.GR2'
 end subroutine getGALWEMfilename
 
+! Run audit on GRIB files with specified start date and time.
+subroutine run_audit(n, yr, mo, da, hr, first_fcsthr, filecount)
 
+  ! Imports
+  use galwem_forcingMod, only: galwem_struc
+  use LIS_constantsMod, only: LIS_CONST_PATH_LEN
+  use LIS_logMod, only: LIS_logunit, LIS_endrun
+  use LIS_timeMgrMod, only: LIS_tick
+
+  ! Defaults
+  implicit none
+
+  ! Arguments
+  integer, intent(in) :: n
+  integer, intent(in) :: yr
+  integer, intent(in) :: mo
+  integer, intent(in) :: da
+  integer, intent(in) :: hr
+  integer, intent(in) :: first_fcsthr
+  integer, intent(out) :: filecount
+
+  ! Locals
+  integer, parameter :: MAX_FCSTHRS = 240
+  character(len=LIS_CONST_PATH_LEN) :: fname
+  integer :: fcsthr, delta
+  logical :: found_inq
+  integer :: i
+
+  ! Loop through list of forecast hours, and see how many files exist
+  delta = 1
+  filecount = 0
+  do i = 0, MAX_FCSTHRS
+     fcsthr = first_fcsthr + (i * delta)
+     call getGALWEMfilename(n, galwem_struc(n)%odir, yr, mo, da, hr, &
+          fcsthr, fname)
+     inquire(file=trim(fname), exist=found_inq)
+     if (found_inq) then
+        write(LIS_logunit,*)'[INFO] Found ', trim(fname)
+        filecount = filecount + 1
+     else
+        if (i == 0) then
+           write(LIS_logunit,*) &
+                '[WARN] Cannot find GALWEM GRIB file for LIS start date'
+           write(LIS_logunit,*) &
+                '[WARN] Will need to use earlier GALWEM run for forcing'
+           filecount = 0
+           exit
+        end if
+     end if
+  end do
+
+  if (filecount > 0) then
+     write(LIS_logunit,*)'[INFO] Found ', filecount, ' files'
+  end if
+  !yr1 = yr
+  !mo1 = mo
+  !da1 = da
+  !hr1 = hr
+  !mn1 = 0
+  !ss1 = 0
+  !ts1 = 0
+  !call LIS_tick(time1, doy1, gmt1, yr1, mo1, da1, hr1, mn1, ss1, ts1)
+
+end subroutine run_audit
+
+! Find next GALWEM grib file given current selected time and
+! forecast hour
+subroutine find_next_fcsthr(n, yr, mo, da, hr, cur_fcsthr, &
+     next_fcsthr, ierr)
+
+  ! Imports
+  use galwem_forcingMod, only: galwem_struc
+  use LIS_constantsMod, only: LIS_CONST_PATH_LEN
+  use LIS_logMod, only: LIS_logunit, LIS_endrun
+
+  ! Defaults
+  implicit none
+
+  ! Arguments
+  integer, intent(in) :: n
+  integer, intent(in) :: yr
+  integer, intent(in) :: mo
+  integer, intent(in) :: da
+  integer, intent(in) :: hr
+  integer, intent(in) :: cur_fcsthr
+  integer, intent(out) :: next_fcsthr
+  integer, intent(out) :: ierr
+
+  ! Locals
+  integer, parameter :: MAX_FCSTHRS = 240
+  character(len=LIS_CONST_PATH_LEN) :: fname
+  integer :: fcsthr, delta
+  logical :: found_inq
+  integer :: i
+
+  ! Loop through list of forecast hours, and see how many files exist
+  ierr = 1
+  delta = 1
+  do i = 1, MAX_FCSTHRS
+     fcsthr = cur_fcsthr + (i * delta)
+     call getGALWEMfilename(n, galwem_struc(n)%odir, yr, mo, da, hr, &
+          fcsthr, fname)
+     inquire(file=trim(fname), exist=found_inq)
+     if (found_inq) then
+        next_fcsthr = fcsthr
+        ierr = 0
+        exit
+     end if
+  end do
+
+end subroutine find_next_fcsthr

--- a/lis/metforcing/galwem/get_galwem.F90
+++ b/lis/metforcing/galwem/get_galwem.F90
@@ -57,7 +57,7 @@ subroutine get_galwem(n, findex)
   integer           :: openfile
   integer :: filecount
   logical, save :: use_prior_galwem_run
-  integer :: cur_fcsthr, next_fcsthr
+  integer :: first_fcsthr, next_fcsthr
   integer :: ierr
 
   ! GALWEM cycles every 6 hours; each cycle provide up to 168 hours (7 days) forecast for GALWEM-17km;
@@ -95,7 +95,7 @@ subroutine get_galwem(n, findex)
      use_prior_galwem_run = .false.
      call run_audit(n, LIS_rc%syr, LIS_rc%smo, LIS_rc%sda, LIS_rc%shr, &
           0, filecount)
-     if (filecount == 0) then !Roll back to prior GALWEM run
+     if (filecount < 2) then !Roll back to prior GALWEM run
         yr1 = LIS_rc%syr
         mo1 = LIS_rc%smo
         da1 = LIS_rc%sda
@@ -106,7 +106,7 @@ subroutine get_galwem(n, findex)
         call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
         call run_audit(n, yr1, mo1, da1, hr1, &
              12, filecount)
-        if (filecount == 0) then
+        if (filecount < 2) then
            write(LIS_logunit,*)"[ERR] No GALWEM files found!"
            call LIS_endrun()
         else
@@ -118,8 +118,13 @@ subroutine get_galwem(n, findex)
         end if
      end if
   end if
-  write(LIS_logunit,*) '[INFO] use_prior_galwem_run = ', &
-       use_prior_galwem_run
+  !write(LIS_logunit,*) '[INFO] use_prior_galwem_run = ', &
+  !     use_prior_galwem_run
+  if (use_prior_galwem_run) then
+     write(LIS_logunit,*) &
+          '[WARN] LIS run may terminate early since a prior ' // &
+          'GALWEM run is being used for forcing'
+  end if
 
   ! Get the bookends at the start of the run
   if (LIS_rc%tscount(n) .eq. 1 .or. LIS_rc%rstflag(n) .eq. 1) then
@@ -136,17 +141,20 @@ subroutine get_galwem(n, findex)
      call LIS_tick(time1, doy1, gmt1, yr1, mo1, da1, hr1, mn1, ss1, ts1)
 
      ! Find Bookend-time record 2
-     cur_fcsthr = 0
-     if (use_prior_galwem_run) cur_fcsthr = 12
+     first_fcsthr = 0
+     if (use_prior_galwem_run) first_fcsthr = 12
      call find_next_fcsthr(n, galwem_struc(n)%init_yr, &
           galwem_struc(n)%init_mo, &
           galwem_struc(n)%init_da, &
           galwem_struc(n)%init_hr, &
-          cur_fcsthr, next_fcsthr, ierr)
+          first_fcsthr, next_fcsthr, ierr)
      if (ierr .ne. 0) then
         write(LIS_logunit,*) '[ERR] Cannot find next GALWEM GRIB file!'
+        write(LIS_logunit,*) '[ERR] LIS run with terminate...'
+        flush(LIS_logunit)
         call LIS_endrun()
      end if
+     galwem_struc(n)%fcst_hour = next_fcsthr
      yr2 = LIS_rc%syr
      mo2 = LIS_rc%smo
      da2 = LIS_rc%sda
@@ -159,151 +167,262 @@ subroutine get_galwem(n, findex)
 
      openfile = 1
   end if
-  call LIS_endrun() ! EMK TEST
 
-  ! First timestep of run
-  if(LIS_rc%tscount(n).eq.1 .or.LIS_rc%rstflag(n).eq.1) then
-    ! Bookend-time record 1
-     yr1 = LIS_rc%syr
-     mo1=LIS_rc%smo
-     da1=LIS_rc%sda
-     hr1=LIS_rc%shr
-     mn1=0
-     ss1=0
-     ts1=0
-     call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+  ! ! First timestep of run
+  ! if(LIS_rc%tscount(n).eq.1 .or.LIS_rc%rstflag(n).eq.1) then
+  !   ! Bookend-time record 1
+  !    yr1 = LIS_rc%syr
+  !    mo1=LIS_rc%smo
+  !    da1=LIS_rc%sda
+  !    hr1=LIS_rc%shr
+  !    mn1=0
+  !    ss1=0
+  !    ts1=0
+  !    call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
 
-     ! Bookend-time record 2
-     yr2=LIS_rc%syr
-     mo2=LIS_rc%smo
-     da2=LIS_rc%sda
-     hr2=LIS_rc%shr
-     mn2=0
-     ss2=0
-     ts2=3600 ! Advance 1 hour
-     call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+  !    ! Bookend-time record 2
+  !    yr2=LIS_rc%syr
+  !    mo2=LIS_rc%smo
+  !    da2=LIS_rc%sda
+  !    hr2=LIS_rc%shr
+  !    mn2=0
+  !    ss2=0
+  !    ts2=3600 ! Advance 1 hour
+  !    call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
 
-     !movetime = 1
-     openfile=1
+  !    !movetime = 1
+  !    openfile=1
 
-     !write(LIS_logunit,*)'EMK: time1,yr1,mo1,da1,hr1,ts1 = ', &
-     !     time1,yr1,mo1,da1,hr1,ts1
-     !write(LIS_logunit,*)'EMK: time2,yr2,mo2,da2,hr2,ts2 = ', &
-     !     time2,yr2,mo2,da2,hr2,ts2
+  !    !write(LIS_logunit,*)'EMK: time1,yr1,mo1,da1,hr1,ts1 = ', &
+  !    !     time1,yr1,mo1,da1,hr1,ts1
+  !    !write(LIS_logunit,*)'EMK: time2,yr2,mo2,da2,hr2,ts2 = ', &
+  !    !     time2,yr2,mo2,da2,hr2,ts2
 
-  endif
+  ! endif
 
-  ! Determine valid times when forecasts are available to be read in:
-  ! EMK...Revised based on sample forecast runs for 20230523.
-  if(galwem_struc(n)%fcst_hour < 42) then
-     fcsthr_intv = 1
-     valid_hour = fcsthr_intv * (LIS_rc%hr/fcsthr_intv)
-  elseif(galwem_struc(n)%fcst_hour >= 42 .and. &
-       galwem_struc(n)%fcst_hour < 168) then
-     fcsthr_intv = 3
-     valid_hour = fcsthr_intv * (LIS_rc%hr/fcsthr_intv)
-  else
-     fcsthr_intv = 6
-     valid_hour = fcsthr_intv * (LIS_rc%hr/fcsthr_intv)
-  endif
+  ! ! Determine valid times when forecasts are available to be read in:
+  ! ! EMK...Revised based on sample forecast runs for 20230523.
+  ! if(galwem_struc(n)%fcst_hour < 42) then
+  !    fcsthr_intv = 1
+  !    valid_hour = fcsthr_intv * (LIS_rc%hr/fcsthr_intv)
+  ! elseif(galwem_struc(n)%fcst_hour >= 42 .and. &
+  !      galwem_struc(n)%fcst_hour < 168) then
+  !    fcsthr_intv = 3
+  !    valid_hour = fcsthr_intv * (LIS_rc%hr/fcsthr_intv)
+  ! else
+  !    fcsthr_intv = 6
+  !    valid_hour = fcsthr_intv * (LIS_rc%hr/fcsthr_intv)
+  ! endif
 
-  if((valid_hour==LIS_rc%hr .and. LIS_rc%mn==0) .or. &
-      openfile == 1)  then
+  ! If this is the beginning of the LIS run, read the two bookends
+  if (openfile == 1) then
 
-     ! Forecast hour condition within each file:
-     if(galwem_struc(n)%fcst_hour < 42) then
-        galwem_struc(n)%fcst_hour = galwem_struc(n)%fcst_hour + fcsthr_intv
-     elseif(galwem_struc(n)%fcst_hour >= 42) then
-        galwem_struc(n)%fcst_hour = galwem_struc(n)%fcst_hour + fcsthr_intv
-     endif
+     ferror = 0
+     order = 1
+     call getGALWEMfilename(n, galwem_struc(n)%odir, &
+          galwem_struc(n)%init_yr, &
+          galwem_struc(n)%init_mo, &
+          galwem_struc(n)%init_da, &
+          galwem_struc(n)%init_hr, &
+          first_fcsthr, fname)
 
-     ! Check if local forecast hour exceeds max grib file forecast hour (GALWEM-17km):
-     if(galwem_struc(n)%resol == 17) then
-        if(galwem_struc(n)%fcst_hour > 168 ) then
-           write(LIS_logunit,*) &
-                 "[INFO] GALWEM Forecast hour has exceeded the grib file's final"
-           write(LIS_logunit,*) &
-                 "  forecast hour (record). Run will end here for now ... "
-           call LIS_endrun
-        endif
-     endif
-     ! Check if local forecast hour exceeds max grib file forecast hour (GALWEM-25deg):
-     if(galwem_struc(n)%resol == 25) then
-        if(galwem_struc(n)%fcst_hour > 240 ) then
-           write(LIS_logunit,*) &
-                 "[INFO] GALWEM Forecast hour has exceeded the grib file's final"
-           write(LIS_logunit,*) &
-                 "  forecast hour (record). Run will end here for now ... "
-           call LIS_endrun
-        endif
-     endif
-   
-     ! Update bookend-time record 2:
-     if(LIS_rc%tscount(n).ne.1) then
-        galwem_struc(n)%fcsttime1=galwem_struc(n)%fcsttime2
-        galwem_struc(n)%metdata1=galwem_struc(n)%metdata2
+     write(LIS_logunit,*) '[INFO] Getting GALWEM forecast file1 ... ', &
+          trim(fname)
+     call read_galwem(n, findex, order, fname, ferror)
+     if (ferror .ge. 1) galwem_struc(n)%fcsttime1 = time1
 
-        yr2=LIS_rc%syr
-        mo2=LIS_rc%smo
-        da2=LIS_rc%sda
-        hr2=LIS_rc%shr
-        mn2=0
-        ss2=0
-        ts2=3600 * galwem_struc(n)%fcst_hour
-        call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
-      endif
+     ferror = 0
+     order = 2
+     call getGALWEMfilename(n, galwem_struc(n)%odir, &
+          galwem_struc(n)%init_yr, &
+          galwem_struc(n)%init_mo, &
+          galwem_struc(n)%init_da, &
+          galwem_struc(n)%init_hr, &
+          galwem_struc(n)%fcst_hour, fname)
 
-      ! Read in file contents:
-      if(LIS_rc%tscount(n) == 1) then  ! Read in first two book-ends 
+     write(LIS_logunit,*)'[INFO] Getting GALWEM forecast file2 ... ', &
+          trim(fname)
+     call read_galwem(n, findex, order, fname, ferror)
+     if (ferror .ge. 1) galwem_struc(n)%fcsttime2 = time2
 
-         !write(LIS_logunit,*)'EMK: galwem_struc(n)%init_yr = ', &
-         !     galwem_struc(n)%init_yr
-         !write(LIS_logunit,*)'EMK: galwem_struc(n)%init_mo = ', &
-         !     galwem_struc(n)%init_mo
-         !write(LIS_logunit,*)'EMK: galwem_struc(n)%init_da = ', &
-         !     galwem_struc(n)%init_da
-         !write(LIS_logunit,*)'EMK: galwem_struc(n)%init_hr = ', &
-         !     galwem_struc(n)%init_hr
-         !write(LIS_logunit,*)'EMK: galwem_struc(n)%fcst_hour = ', &
-         ! galwem_struc(n)%fcst_hour
+  else if (LIS_rc%mn==0 .and. &
+       LIS_rc%tscount(n) .ne. 1) then
 
-         ferror=0
-         order=1   
-         call getGALWEMfilename(n,galwem_struc(n)%odir,galwem_struc(n)%init_yr,&
-              galwem_struc(n)%init_mo,galwem_struc(n)%init_da,galwem_struc(n)%init_hr,&
-              0,fname)
+     ! See if we need to update the bookends
+     yr1 = LIS_rc%yr
+     mo1 = LIS_rc%mo
+     da1 = LIS_rc%da
+     hr1 = LIS_rc%hr
+     mn1 = 0
+     ss1 = 0
+     ts1 = 0
+     call LIS_tick(time1, doy1, gmt1, yr1, mo1, da1, hr1, mn1, ss1, ts1)
 
-         write(LIS_logunit,*)'[INFO] Getting GALWEM forecast file1 ... ',trim(fname)
-         call read_galwem(n, findex, order, fname, ferror)
-         if(ferror.ge.1) galwem_struc(n)%fcsttime1=time1
-                 
-         ferror=0
-         order=2
-         call getGALWEMfilename(n,galwem_struc(n)%odir,galwem_struc(n)%init_yr,&
-              galwem_struc(n)%init_mo,galwem_struc(n)%init_da,galwem_struc(n)%init_hr,&
-              galwem_struc(n)%fcst_hour,fname)
+     yr2 = galwem_struc(n)%init_yr
+     mo2 = galwem_struc(n)%init_mo
+     da2 = galwem_struc(n)%init_da
+     hr2 = galwem_struc(n)%init_hr
+     mn2 = 0
+     ss2 = 0
+     ts2 = 3600 * galwem_struc(n)%fcst_hour
+     call LIS_tick(time2, doy2, gmt2, yr2, mo2, da2, hr2, mn2, ss2, ts2)
 
-         write(LIS_logunit,*)'[INFO] Getting GALWEM forecast file2 ... ',trim(fname)
-         call read_galwem(n, findex, order, fname, ferror)
-         if(ferror.ge.1) galwem_struc(n)%fcsttime2=time2
-      else
-         ferror=0
-         order=2
-         call getGALWEMfilename(n,galwem_struc(n)%odir,galwem_struc(n)%init_yr,&
-              galwem_struc(n)%init_mo,galwem_struc(n)%init_da,galwem_struc(n)%init_hr,&
-              galwem_struc(n)%fcst_hour,fname)
+     !write(LIS_logunit,*)'EMK: time1: ', time1
+     !write(LIS_logunit,*)'EMK: time2: ', time2
 
-         write(LIS_logunit,*)'[INFO] Getting GALWEM forecast file2 ... ',trim(fname)
-         call read_galwem(n, findex, order, fname, ferror)
-         if(ferror.ge.1) galwem_struc(n)%fcsttime2=time2
-      endif
-  endif
-  openfile=0
+     if (time2 .le. time1) then
+
+        ! Update the bookends
+        call find_next_fcsthr(n, galwem_struc(n)%init_yr, &
+             galwem_struc(n)%init_mo, &
+             galwem_struc(n)%init_da, &
+             galwem_struc(n)%init_hr, &
+             galwem_struc(n)%fcst_hour, next_fcsthr, ierr)
+        if (ierr .ne. 0) then
+           write(LIS_logunit,*) '[ERR] Cannot find next GALWEM GRIB file!'
+           write(LIS_logunit,*) '[ERR] LIS will terminate early'
+           flush(LIS_logunit)
+           call LIS_endrun()
+        end if
+        yr2 = galwem_struc(n)%init_yr
+        mo2 = galwem_struc(n)%init_mo
+        da2 = galwem_struc(n)%init_da
+        hr2 = galwem_struc(n)%init_hr
+        mn2 = 0
+        ss2 = 0
+        ts2 = 3600 * next_fcsthr
+        call LIS_tick(time2, doy2, gmt2, yr2, mo2, da2, hr2, mn2, ss2, &
+             ts2)
+
+        ! Update the bookends
+        galwem_struc(n)%fcsttime1 = galwem_struc(n)%fcsttime2
+        galwem_struc(n)%metdata1 = galwem_struc(n)%metdata2
+
+        galwem_struc(n)%fcst_hour = next_fcsthr
+
+        ferror = 0
+        order = 2
+        call getGALWEMfilename(n, galwem_struc(n)%odir, &
+             galwem_struc(n)%init_yr, &
+             galwem_struc(n)%init_mo, &
+             galwem_struc(n)%init_da, &
+             galwem_struc(n)%init_hr, &
+             galwem_struc(n)%fcst_hour, fname)
+
+        write(LIS_logunit,*)'[INFO] Getting GALWEM forecast file2 ... ', &
+             trim(fname)
+        call read_galwem(n, findex, order, fname, ferror)
+        if (ferror .ge. 1) galwem_struc(n)%fcsttime2 = time2
+
+     end if
+  end if
+  openfile = 0
 
   !write(LIS_logunit,*)"EMK: galwem_struc(n)%fcsttime1 = ", &
   !     galwem_struc(n)%fcsttime1
   !write(LIS_logunit,*)"EMK: galwem_struc(n)%fcsttime2 = ", &
   !     galwem_struc(n)%fcsttime2
+
+  !call LIS_endrun() ! EMK TEST
+
+
+  ! if((valid_hour==LIS_rc%hr .and. LIS_rc%mn==0) .or. &
+  !     openfile == 1)  then
+
+  !    ! Forecast hour condition within each file:
+  !    if(galwem_struc(n)%fcst_hour < 42) then
+  !       galwem_struc(n)%fcst_hour = galwem_struc(n)%fcst_hour + fcsthr_intv
+  !    elseif(galwem_struc(n)%fcst_hour >= 42) then
+  !       galwem_struc(n)%fcst_hour = galwem_struc(n)%fcst_hour + fcsthr_intv
+  !    endif
+
+  !    ! Check if local forecast hour exceeds max grib file forecast hour (GALWEM-17km):
+  !    if(galwem_struc(n)%resol == 17) then
+  !       if(galwem_struc(n)%fcst_hour > 168 ) then
+  !          write(LIS_logunit,*) &
+  !                "[INFO] GALWEM Forecast hour has exceeded the grib file's final"
+  !          write(LIS_logunit,*) &
+  !                "  forecast hour (record). Run will end here for now ... "
+  !          call LIS_endrun
+  !       endif
+  !    endif
+  !    ! Check if local forecast hour exceeds max grib file forecast hour (GALWEM-25deg):
+  !    if(galwem_struc(n)%resol == 25) then
+  !       if(galwem_struc(n)%fcst_hour > 240 ) then
+  !          write(LIS_logunit,*) &
+  !                "[INFO] GALWEM Forecast hour has exceeded the grib file's final"
+  !          write(LIS_logunit,*) &
+  !                "  forecast hour (record). Run will end here for now ... "
+  !          call LIS_endrun
+  !       endif
+  !    endif
+   
+  !    ! Update bookend-time record 2:
+  !    if(LIS_rc%tscount(n).ne.1) then
+  !       galwem_struc(n)%fcsttime1=galwem_struc(n)%fcsttime2
+  !       galwem_struc(n)%metdata1=galwem_struc(n)%metdata2
+
+  !       yr2=LIS_rc%syr
+  !       mo2=LIS_rc%smo
+  !       da2=LIS_rc%sda
+  !       hr2=LIS_rc%shr
+  !       mn2=0
+  !       ss2=0
+  !       ts2=3600 * galwem_struc(n)%fcst_hour
+  !       call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+  !     endif
+
+  !     ! Read in file contents:
+  !     if(LIS_rc%tscount(n) == 1) then  ! Read in first two book-ends 
+
+  !        !write(LIS_logunit,*)'EMK: galwem_struc(n)%init_yr = ', &
+  !        !     galwem_struc(n)%init_yr
+  !        !write(LIS_logunit,*)'EMK: galwem_struc(n)%init_mo = ', &
+  !        !     galwem_struc(n)%init_mo
+  !        !write(LIS_logunit,*)'EMK: galwem_struc(n)%init_da = ', &
+  !        !     galwem_struc(n)%init_da
+  !        !write(LIS_logunit,*)'EMK: galwem_struc(n)%init_hr = ', &
+  !        !     galwem_struc(n)%init_hr
+  !        !write(LIS_logunit,*)'EMK: galwem_struc(n)%fcst_hour = ', &
+  !        ! galwem_struc(n)%fcst_hour
+
+  !        ferror=0
+  !        order=1   
+  !        call getGALWEMfilename(n,galwem_struc(n)%odir,galwem_struc(n)%init_yr,&
+  !             galwem_struc(n)%init_mo,galwem_struc(n)%init_da,galwem_struc(n)%init_hr,&
+  !             0,fname)
+
+  !        write(LIS_logunit,*)'[INFO] Getting GALWEM forecast file1 ... ',trim(fname)
+  !        call read_galwem(n, findex, order, fname, ferror)
+  !        if(ferror.ge.1) galwem_struc(n)%fcsttime1=time1
+                 
+  !        ferror=0
+  !        order=2
+  !        call getGALWEMfilename(n,galwem_struc(n)%odir,galwem_struc(n)%init_yr,&
+  !             galwem_struc(n)%init_mo,galwem_struc(n)%init_da,galwem_struc(n)%init_hr,&
+  !             galwem_struc(n)%fcst_hour,fname)
+
+  !        write(LIS_logunit,*)'[INFO] Getting GALWEM forecast file2 ... ',trim(fname)
+  !        call read_galwem(n, findex, order, fname, ferror)
+  !        if(ferror.ge.1) galwem_struc(n)%fcsttime2=time2
+  !     else
+  !        ferror=0
+  !        order=2
+  !        call getGALWEMfilename(n,galwem_struc(n)%odir,galwem_struc(n)%init_yr,&
+  !             galwem_struc(n)%init_mo,galwem_struc(n)%init_da,galwem_struc(n)%init_hr,&
+  !             galwem_struc(n)%fcst_hour,fname)
+
+  !        write(LIS_logunit,*)'[INFO] Getting GALWEM forecast file2 ... ',trim(fname)
+  !        call read_galwem(n, findex, order, fname, ferror)
+  !        if(ferror.ge.1) galwem_struc(n)%fcsttime2=time2
+  !     endif
+  ! endif
+  ! openfile=0
+
+  ! !write(LIS_logunit,*)"EMK: galwem_struc(n)%fcsttime1 = ", &
+  ! !     galwem_struc(n)%fcsttime1
+  ! !write(LIS_logunit,*)"EMK: galwem_struc(n)%fcsttime2 = ", &
+  ! !     galwem_struc(n)%fcsttime2
 
 end subroutine get_galwem
 
@@ -389,7 +508,7 @@ subroutine run_audit(n, yr, mo, da, hr, first_fcsthr, filecount)
           fcsthr, fname)
      inquire(file=trim(fname), exist=found_inq)
      if (found_inq) then
-        write(LIS_logunit,*)'[INFO] Found ', trim(fname)
+        !write(LIS_logunit,*)'[INFO] Found ', trim(fname)
         filecount = filecount + 1
      else
         if (i == 0) then

--- a/lis/metforcing/galwem/read_galwem.F90
+++ b/lis/metforcing/galwem/read_galwem.F90
@@ -15,6 +15,7 @@
 !
 ! !REVISION HISTORY:
 ! 15 Mar 2022: Yeosang Yoon, initial code
+! 11 Jan 2024; Eric Kemp, revisions for fault tolerance.
 !
 ! !INTERFACE:
 subroutine read_galwem(n, findex, order, gribfile, rc)
@@ -98,6 +99,7 @@ subroutine read_galwem(n, findex, order, gribfile, rc)
       write(LIS_logunit,*) '[ERR] failed to read - '//trim(gribfile)
       call grib_close_file(ftn)
       rc = 1
+      return
    endif
 
    call grib_get(igrib,'centre',center,ierr)
@@ -199,6 +201,7 @@ subroutine read_galwem(n, findex, order, gribfile, rc)
 
    call fldbld_read_galwem(n, findex, order, gribfile, ifguess, jfguess, &
            tair, qair, swdown, lwdown, uwind, vwind, ps, prectot, rc)
+   if (rc .ne. 0) return
 
    call assign_processed_galwemforc(n,order,1,tair)
    call assign_processed_galwemforc(n,order,2,qair)

--- a/lis/metforcing/galwem/read_galwem.F90
+++ b/lis/metforcing/galwem/read_galwem.F90
@@ -59,8 +59,8 @@ subroutine read_galwem(n, findex, order, gribfile, rc)
   real            :: vwind(LIS_rc%lnc(n),LIS_rc%lnr(n))     !Instantaneous meridional wind interpolated to 10 metres[m/s]
   real            :: ps(LIS_rc%lnc(n),LIS_rc%lnr(n))        !Instantaneous Surface Pressure [Pa] 
   real            :: prectot(LIS_rc%lnc(n),LIS_rc%lnr(n))   !Total precipitation [kg/m^2/s] 
-
   integer, intent(out) :: rc
+  logical :: found_inq
 
    ! Initialize return code to "no error".  We will change it below if
    ! necessary.
@@ -70,6 +70,17 @@ subroutine read_galwem(n, findex, order, gribfile, rc)
    ! the first file only, as all data will be of the same type.
    ! (GALWEM) because the search script ensures that it is.
    !
+
+   ! EMK...Before using ECCODES/GRIB_API, see if the GRIB file exists
+   ! using a simple inquire statement.  This avoids ECCODES/GRIB_API
+   ! writing error messages to stdout/stderr, which may lead to runtime
+   ! problems.
+   inquire(file=trim(gribfile),exist=found_inq)
+   if (.not. found_inq) then
+      write(LIS_logunit,*)'[ERR] Cannot find file '//trim(gribfile)
+      call LIS_endrun()
+   end if
+
 #if (defined USE_GRIBAPI)
 
    call grib_open_file(ftn,trim(gribfile),'r',ierr)


### PR DESCRIPTION

### Description

Significant reorg of LIS GALWEM reader code to add fault tolerance.

This includes rolling back to the previous (started 12-hr prior) GALWEM run if the current GALWEM run does not have at least 2 bookends to temporally interpolate atmospheric forcing for LIS. Also, LIS will gracefully terminate early if not enough GALWEM files are found to complete the requested LIS run (e.g., 228 hours instead of 240 hours).

This is a DRAFT pending requirements review.