### PR TITLE
Fixed preprocessing commands for HDF4 routines.

### DIFF
--- a/ldt/SMAP_E_OPL/TOOLSUBS.F90
+++ b/ldt/SMAP_E_OPL/TOOLSUBS.F90
@@ -68,7 +68,7 @@ MODULE TOOLSUBS
          !sd_id = sfstart(trim(filename),DFACC)
          !ssid = sfselect(sd_id, 0)
 
-#if (defined USE_HDF5)
+#if (defined USE_HDF4)
          status = sfrdata(ssid,start, stride,edges, data)
 #endif
         !PRINT *, "Filename", filename
@@ -99,7 +99,7 @@ MODULE TOOLSUBS
          !DFACC=1 !Read Only Access
          !sd_id = sfstart(trim(filename),DFACC)
          !ssid = sfselect(sd_id, 0)
-#if (defined USE_HDF5)
+#if (defined USE_HDF4)
          status = sfrdata(ssid,start, stride,edges, data)
 #endif
          NDVI_MAT=-9999


### PR DESCRIPTION


### Description

Fixed preprocessing statements around HDF4 function calls.

NOTE:  The modified Fortran routines are not actually used, so it would be better to purge them altogether (along with other unused routines).  However, that would require repeating SMAP_E_OPL testing, and that should probably wait until after LISF 7.6 tag creation and delivery to customer.



