### PR TITLE
Fixed preprocessing statements for HDF4 function calls.

### DIFF
--- a/ldt/SMAP_E_OPL/TOOLSUBS.F90
+++ b/ldt/SMAP_E_OPL/TOOLSUBS.F90
@@ -68,7 +68,7 @@ MODULE TOOLSUBS
          !sd_id = sfstart(trim(filename),DFACC)
          !ssid = sfselect(sd_id, 0)
 
-#if (defined USE_HDF5)
+#if (defined USE_HDF4)
          status = sfrdata(ssid,start, stride,edges, data)
 #endif
         !PRINT *, "Filename", filename
@@ -99,7 +99,7 @@ MODULE TOOLSUBS
          !DFACC=1 !Read Only Access
          !sd_id = sfstart(trim(filename),DFACC)
          !ssid = sfselect(sd_id, 0)
-#if (defined USE_HDF5)
+#if (defined USE_HDF4)
          status = sfrdata(ssid,start, stride,edges, data)
 #endif
          NDVI_MAT=-9999


### PR DESCRIPTION


### Description

Fixed preprocessor statements around HDF4 function calls.  This fixes linking errors if LDT is configured w/o HDF4 support.

Thanks to David Mocko for reporting these errors.

NOTE:  The modified Fortran routines are not actually used, and in the long term it would probably be best to just delete them (and any other unused routines).  However, such deletions would need to be tested against the SMAP_E_OPL use cases, and at this time it seems best to wait until after LISF 7.6 is delivered to the customer.

