### PR TITLE
Compile on discover SCU 17

### DIFF
--- a/ldt/make/makedep.py
+++ b/ldt/make/makedep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 # NASA Goddard Space Flight Center

--- a/lis/make/makedep.py
+++ b/lis/make/makedep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 # NASA Goddard Space Flight Center

--- a/lis/make/plugins.py
+++ b/lis/make/plugins.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 # NASA Goddard Space Flight Center

--- a/lvt/make/makedep.py
+++ b/lvt/make/makedep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 # NASA Goddard Space Flight Center


### PR DESCRIPTION
### Description

To compile and run LISF on the new SCU 17, you must use the new _lisf_7.5_intel_2023.2.1_ modulefile found in the **master** branch.

Copy _env/discover/sles15/lisf_7.5_intel_2023.2.1_ into your _~/privatemodules_ directory and then run

```
module load lisf_7.5_intel_2023.2.1
```

See PR #1482.


