### PR TITLE
Fix to S2S NMME-CFSv2 Jan/Feb-2011 Case

### DIFF
--- a/lis/utils/usaf/s2s/s2s_app/download_nmme_hindcasts.sh
+++ b/lis/utils/usaf/s2s/s2s_app/download_nmme_hindcasts.sh
@@ -8,6 +8,7 @@
 #  AUTHOR:  Shrad Shukla, UCSB, MAY-2016
 #  Edited:  Abheera Hazra, NASA, MAR-2019
 #  Edited:  Ryan Zamora, NASA, MAR-2022
+#  Edited:  KR Arsenault, NASA, FEB-2024; Added Jan-, Feb-2011 CFSv2 downloads
 #
 #  SOURCE WEBSITE:  https://iridl.ldeo.columbia.edu/SOURCES/.Models/.NMME/
 #
@@ -44,11 +45,26 @@ do
     if [ $model == 'NCEP-CFSv2' ]; then
         SYRA=1982
         EYRA=2010
+
         SYRB=2011
         EYRB=2021
 
+        # Years: Jan-1982 to Dec-2010:
         strA="http://iridl.ldeo.columbia.edu/SOURCES/.Models/.NMME/."$model"/.HINDCAST/.MONTHLY/."$var"/S/%280000%201%20"$month"%20"$SYRA"-"$EYRA"%29VALUES/data.nc -o "$OUTDIR"/"$var"."$model".mon_"$month"_"$SYRA"_"$EYRA".nc"
+
+        # Years: Mar-2011 to present:
         strB="http://iridl.ldeo.columbia.edu/SOURCES/.Models/.NMME/."$model"/.FORECAST/.EARLY_MONTH_SAMPLES/.MONTHLY/."$var"/S/%280000%201%20"$month"%20"$SYRB"-"$EYRB"%29VALUES/data.nc -o "$OUTDIR"/"$var"."$model".mon_"$month"_"$SYRB"_"$EYRB".nc"
+
+        # ABOVE DATASETS - MISSING:  Jan- and Feb-2011:
+        #  ... So must download separately here:
+        if [ $month == 'Jan' -o $month == 'Feb' ]; then
+          SYRC=2011
+          EYRC=2011
+
+          strC="http://iridl.ldeo.columbia.edu/SOURCES/.Models/.NMME/."$model"/.HINDCAST/.PENTAD_SAMPLES/.MONTHLY/."$var"/S/%280000%201%20"$month"%20"$SYRC"-"$EYRC"%29VALUES/data.nc -o "$OUTDIR"/"$var"."$model".mon_"$month"_"$SYRC"_"$EYRC".nc"
+          echo $strC
+          curl -v $strC
+        fi
 
         echo $strA
         curl -v $strA

--- a/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/nmme_reorg_h.py
+++ b/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/nmme_reorg_h.py
@@ -15,6 +15,7 @@
 #This module reorganizes
 #NMME preciptation forecasts
 #Date: May 06, 2021
+# Update: KR Arsenault; Feb-2024; CFSv2 Jan/Feb update
 """
 
 from datetime import datetime
@@ -129,10 +130,23 @@ if NMME_MODEL == 'CFSv2':
     INFILE = INFILE_TEMP.format(NMME_DOWNLOAD_DIR, MODEL, MODEL, MON[MM], SYR1, EYR1)
     XPREC[0:29,:,:,:,:] = read_nc_files(INFILE, 'prec')[:, 0:LEAD_MON, 0:ENS_NUM, :, :]
 
-    SYR2 = 2011
-    EYR2 = 2021
-    INFILE = INFILE_TEMP.format(NMME_DOWNLOAD_DIR, MODEL, MODEL, MON[MM], SYR2, EYR2)
-    XPREC[29:40,:,:,:,:] = read_nc_files(INFILE, 'prec')[:, 0:LEAD_MON, 0:ENS_NUM, :, :]
+    if MON[MM] == 'Jan' or MON[MM] == 'Feb':
+        SYR2 = 2011
+        EYR2 = 2011
+        INFILE = INFILE_TEMP.format(NMME_DOWNLOAD_DIR, MODEL, MODEL, MON[MM], SYR2, EYR2)
+        XPREC[29,:,:,:,:] = read_nc_files(INFILE, 'prec')[:, 0:LEAD_MON, 0:ENS_NUM, :, :]
+
+        SYR3 = 2011
+        EYR3 = 2021
+        INFILE = INFILE_TEMP.format(NMME_DOWNLOAD_DIR, MODEL, MODEL, MON[MM], SYR3, EYR3)
+        XPREC[30:40,:,:,:,:] = read_nc_files(INFILE, 'prec')[:, 0:LEAD_MON, 0:ENS_NUM, :, :]
+
+    else:
+        SYR2 = 2011
+        EYR2 = 2021
+        INFILE = INFILE_TEMP.format(NMME_DOWNLOAD_DIR, MODEL, MODEL, MON[MM], SYR2, EYR2)
+        XPREC[29:40,:,:,:,:] = read_nc_files(INFILE, 'prec')[:, 0:LEAD_MON, 0:ENS_NUM, :, :]
+
 elif NMME_MODEL == 'GEOSv2':
     MODEL = 'NASA-GEOSS2S'
     if MM == 0:


### PR DESCRIPTION
 Updates made to the NMME hindcast data download and preprocessing
   scripts, include:
 - download_nmme_hindcasts.sh:  Added NMME-CFSv2 data download for the the missing Jan-, Feb-2011 hindcast months.
 - nmme_reorg_h.py:  Added conditional block for the unique CFSv2 Jan-, Feb-2011 hindcast lead months to be processed.

The new updates have been tested thoroughly for different initial forecast months, in addition to Jan and Feb-2011.

This addresses GitHub Issue #1489. 
To be included for future S2S releases.