### PR TITLE
Removed unnecessary unit conversion in LIS SMAP_E_OPL reader

### DIFF
--- a/lis/dataassim/obs/SMAP_E_OPLsm/read_SMAPEOPLsm.F90
+++ b/lis/dataassim/obs/SMAP_E_OPLsm/read_SMAPEOPLsm.F90
@@ -649,7 +649,7 @@ subroutine read_SMAPEOPLsm_data(n, k,fname, smobs_inp, time)
      do c = 1, nlon
         if (tmp(c,r,1) >= 0 .and. &
              tmp(c,r,1) <= 1) then
-           sm_in(c + (r-1)*nc) = tmp(c,r,1)*100
+           sm_in(c + (r-1)*nc) = tmp(c,r,1)
            sm_data_b(c + (r-1)*nc) = .true.
         end if
      end do


### PR DESCRIPTION


### Description

Removed unnecessary unit conversion in LIS SMAP_E_OPL reader.
