### PR TITLE
[LDT] Fix bug slope value along the coastal area

### DIFF
--- a/ldt/params/topo/read_MERIT1K_slope.F90
+++ b/ldt/params/topo/read_MERIT1K_slope.F90
@@ -18,6 +18,7 @@
 !  01 Aug  2012: KR Arsenault; Expanded for elevation tiling
 !  30 May  2017: KR Arsenault; Expanded for Antarctica
 !  03 Mar  2020: Yeosang Yoon; Modify codes for MERIT DEM
+!  04 Apr  2024: Yeosang Yoon; Fix bug slope value along the coastal area
 !
 ! !INTERFACE:
 subroutine read_MERIT1K_slope( n, num_bins, fgrd, slopeave )
@@ -279,6 +280,11 @@ subroutine read_MERIT1K_slope( n, num_bins, fgrd, slopeave )
    do r = 1, subpnr
       do c = 1, subpnc
          subset_elev(c,r) = yrev_elev(lon_line(c,r),lat_line(c,r))
+       
+         ! for coastal areas
+         if (subset_elev(c,r) .eq. LDT_rc%udef) then
+            subset_elev(c,r) = 0.
+         endif
       enddo
    enddo
    deallocate( yrev_elev )


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Fixed bug (#1515):  Slope values generated using LDT with the MERIT 1-km DEM show unrealistically high values along the coastal area.

**Caution**  
If you did not use the following option in 'lis.config,' this issue may not affect your results.
Topographic correction method (met forcing):  "slope-aspect"


<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->
/discover/nobackup/projects/usaf_lis/yyoon4/Hydro/NRT_hymap/procLSM/ldt.config.test
