### PR TITLE
Updated LIS to read ASCAT Metop-B and C from SMOPS V4

### DIFF
--- a/lis/dataassim/obs/SMOPS_ASCATsm/SMOPS_ASCATsm_Mod.F90
+++ b/lis/dataassim/obs/SMOPS_ASCATsm/SMOPS_ASCATsm_Mod.F90
@@ -1,9 +1,9 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 ! NASA Goddard Space Flight Center
 ! Land Information System Framework (LISF)
-! Version 7.4
+! Version 7.5
 !
-! Copyright (c) 2022 United States Government as represented by the
+! Copyright (c) 2024 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
@@ -37,6 +37,7 @@
 !  8 May 2013    Sujay Kumar; initial specification
 !  28 Sep 2017: Mahdi Navari; Updated to read ASCAT from SMOPS V3
 !  1  Apr 2019  Yonghwan Kwon: Upated for reading monthy CDF for the current month
+!  08 May 2024: Mahdi Navari; Updated to read ASCAT Metop-B and C from SMOPS V4
 ! 
 module SMOPS_ASCATsm_Mod
 ! !USES: 
@@ -83,7 +84,7 @@ module SMOPS_ASCATsm_Mod
 
      integer                :: nbins
      integer                :: ntimes
-     real*8                 :: version2_time, version3_time
+     real*8                 :: version2_time, version3_time, version4_time
      character(len=17)      :: version
      character(len=10)      :: conv
 
@@ -601,6 +602,11 @@ contains
           yr1 = 2017; mo1 = 8; da1 = 24; hr1 = 12; mn1 = 0; ss1 = 0
           call LIS_date2time(SMOPS_ASCATsm_struc(n)%version3_time,updoy,upgmt,&
              yr1,mo1,da1,hr1,mn1,ss1)
+
+          yr1 = 2024; mo1 = 4; da1 = 25; hr1 = 0; mn1 = 0; ss1 = 0
+          call LIS_date2time(SMOPS_ASCATsm_struc(n)%version4_time,updoy,upgmt,&
+             yr1,mo1,da1,hr1,mn1,ss1)
+
        endif
 
        gridDesci = 0 

--- a/lis/dataassim/obs/SMOPS_ASCATsm/SMOPS_GRIB2_Tables_NESDIS.txt
+++ b/lis/dataassim/obs/SMOPS_ASCATsm/SMOPS_GRIB2_Tables_NESDIS.txt
@@ -102,3 +102,38 @@ SMOPS V3.0 GRIB Table:
 { 2, 0, 7, 1, 3, 248, "SMAPSMQA", "NASA SMAP Liquid Volumetric Soil Moisture QA", "-"},
 { 2, 0, 7, 1, 3, 249, "RESSM1QA", "Reserved Liquid Volumetric Soil Moisture 1 QA", "-"},
 
+SMPOS V4.0 belnded product table: 
+NPR-SMOPS-CMAP-6hrly_v4r0_blend_syyyymmddhh00000_eyyyymmddxxxxxxx_cyyyymmddxxxxxxx.grib2
+210 = blended soil moisture (Blended_SM)
+214 = ASCAT_B soil moisture (ASCAT_B_SM)
+250 = ASCAT_C soil moisture (ASCAT_C_SM)
+215 = AMSR2 soil moisture (AMSR2_SM)
+216 = GMI SM (GMI_SM)
+217 = NRT SMAP SM (NSMAP_SM)
+218 = SMAP SM (SMAP_SM)
+219 = Blended SM SD (Blended_SM_SD)
+220 = Hour for blended soil moisture (Blended_hour)
+221 = Minute for blended soil moisture (Blended_minute)
+228 = Hour for ASCAT_B soil moisture (ASCAT_B_hour)
+229 = Minute for ASCAT_B soil moisture (ASCAT_B_minute)
+251 = Hour for ASCAT_C soil moisture (ASCAT_C_hour)
+252 = Minute for ASCAT_C soil moisture (ASCAT_C_minute)
+230 = Hour for AMSR2 soil moisture (AMSR2_hour)
+231 = Minute for AMSR2 soil moisture (AMSR2_minute)
+232 = Hour for GMI SM (GMI_hour)
+233 = Minute for GMI SM (GMI_minute)
+234 = Hour for NSMAP SM (NSMAP_hour)
+235 = Minute for NSMAP SM (NSMAP_minute)
+236 = Hour for SMAP SM (SMAP_hour)
+237 = Minute for SMAP SM (SMAP_minute)
+238 = Hour for spare 1 (Blended_SM_SD_hour)
+239 = Minute for spare 1 (Blended_SM_SD_minute)
+240 = QA for blended soil moisture (Blended_QA)
+244 = QA for ASCAT_B soil moisture (ASCAT_B_QA)
+253 = QA for ASCAT_C soil moisture (ASCAT_C_QA)
+245 = QA for AMSR2 soil moisture (AMSR2_QA)
+246 = QA for GMI SM (GMI_QA)
+247 = QA for NSMAP (NSMAP_QA)
+248 = QA for SMAP SM (SMAP_QA)
+249 = QA for spare 1 (Blended_SM_SD_QA)
+


### PR DESCRIPTION
### Update LIS DA obs reader to read ASCAT Metop-B and C from SMOPS V4

NOAA-NESDIS is planning to retire the legacy SMOPS product, a change that will directly impact the LIS DA system. Currently, the LIS DA system assimilates SMOPS data using the following naming convention: "**NPR_SMOPS_CMAP_Dyyyymmddhh.gr2**". However, the new files will adopt a different naming convention, illustrated as follows: **NPR-SMOPS-CMAP-6hrly_v4r0_blend_syyyymmddhh00000_eyyyymmddxxxxxxx_cyyyymmddxxxxxxx.grib2**.

### Steps: 
To accommodate these changes, we need to update the LIS code to enhance the capability of the DA system to:
1-  read the new file names. Additionally,
2- update the GRIB ID based on the latest version of the GRIB ID table 
3- add modules to read and assimilate ASCAT-Metop-C.

Resolves #1535

### Testcase
Will provided later by Ehsan Jalilvand.

