### PR TITLE
Bug fixes for LIS 7.5 NAFPA to handle unrecognized gage networks

### DIFF
--- a/lis/metforcing/usaf/AGRMET_getpcpobs.F90
+++ b/lis/metforcing/usaf/AGRMET_getpcpobs.F90
@@ -33,6 +33,8 @@
 !   11 May 11  Store obs from 3,9,15,& 21Z for India and Sri Lanka in a 
 !              new array and pass to processobs............Chris Franks/16WS/WXE/SEMS
 !   29 Aug 23  Call LIS_alert if a preobs file is missing..............Eric Kemp/NASA
+!   23 May 24  Updated calls to AGRMET_storeobs and
+!              AGRMET_storeobs_offhour.......................Eric Kemp/NASA
 !
 ! !INTERFACE:
 subroutine AGRMET_getpcpobs(n, j6hr, month, prcpwe, &
@@ -361,7 +363,7 @@ subroutine AGRMET_getpcpobs(n, j6hr, month, prcpwe, &
                        call AGRMET_storeobs(nsize, nsize3, agrmet_struc(n)%max_pcpobs, &
                             obs, obs3, ilat, ilon, &
                             mscprc, sixprc, twfprc, network, plat_id, cdms_flag, bsn, &
-                            duration, j3hr, stncnt)
+                            duration, j3hr, stncnt, alert_number, filename)
                     
                     else
                        
@@ -371,7 +373,7 @@ subroutine AGRMET_getpcpobs(n, j6hr, month, prcpwe, &
                        call AGRMET_storeobs_offhour(nsize, agrmet_struc(n)%max_pcpobs, &
                             obs3, ilat, ilon, &
                             mscprc, sixprc, twfprc, network, plat_id, cdms_flag, bsn, &
-                            duration, nsize3)
+                            duration, nsize3, alert_number, filename)
                     
                     end if
                  

--- a/lis/metforcing/usaf/AGRMET_storeobs.F90
+++ b/lis/metforcing/usaf/AGRMET_storeobs.F90
@@ -20,11 +20,20 @@
 !                block stn number.............Chris Franks/16WS/WXE/SEMS
 !    11 may 11   improve processing of obs from India and Sri Lanka
 !                .............................Chris Franks/16WS/WXE/SEMS
+!    23 May 24   Check network of each report to ensure it is recognized;
+!                reject if unknown; keep track of unknown networks
+!                encountered during the run; and write alert file as a
+!                new unknown network is encountered..........Eric Kemp/NASA
 !
 ! !INTERFACE: 
 subroutine AGRMET_storeobs(nsize, nsize3, isize, obs, obs3, ilat, ilon,  &
      mscprc, sixprc, twfprc, network, plat_id, cdms_flag, bsn, &
-     duration, julhr, stncnt)
+     duration, julhr, stncnt, alert_number, filename)
+
+  ! Imports
+  use LIS_coreMod, only: LIS_masterproc        ! EMK 20240523
+  use LIS_logMod, only: LIS_logunit, LIS_alert ! EMK 20240523
+  use USAF_bratsethMod, only: USAF_is_gauge    ! EMK 20240523
 
   implicit none
   
@@ -43,7 +52,8 @@ subroutine AGRMET_storeobs(nsize, nsize3, isize, obs, obs3, ilat, ilon,  &
   integer,    intent(in)         :: julhr
   integer,    intent(inout)      :: stncnt
   integer,    intent(in)         :: twfprc(isize)   
-
+  integer, intent(inout) :: alert_number ! EMK 20240523
+  character(*), intent(in) :: filename ! EMK 20240523
 !
 ! !DESCRIPTION: 
 !    performs some preprocessing on the raw observations and stores
@@ -165,6 +175,32 @@ subroutine AGRMET_storeobs(nsize, nsize3, isize, obs, obs3, ilat, ilon,  &
   type(rain_obs), intent(inout)  :: obs(isize)
   type(rain_obs), intent(in)     :: obs3(isize)
 
+  ! EMK 20240523
+  character(255) :: message(20)
+  integer, parameter :: MAX_NEW_NETWORKS = 20
+  character(10), save :: new_networks(MAX_NEW_NETWORKS) = &
+       (/"NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      "/)
+  integer :: i
+
 !     ------------------------------------------------------------------
 !     If observations were retrieved from CDMS use 6-digit BSN limits 
 !     for the specially processed regions
@@ -214,7 +250,36 @@ subroutine AGRMET_storeobs(nsize, nsize3, isize, obs, obs3, ilat, ilon,  &
      else
         cycle RECORD
      end if
-     
+
+     ! EMK 20240523...Skip report if network is not recognized. Issue an
+     ! alert. Keep track of unknown networks to avoid redundant alerts.
+     if (.not. USAF_is_gauge(network(irecord))) then
+        do i = 1, MAX_NEW_NETWORKS
+           if (trim(new_networks(i)) == trim(network(irecord))) then
+              cycle RECORD
+           else if (trim(new_networks(i)) == "NULL") then
+              new_networks(i) = network(irecord)
+              write(LIS_logunit,*)'[WARN] Found unrecognized network ', &
+                   trim(network(irecord))
+              write(LIS_logunit,*)'[WARN] Will skip report in preobs file'
+              message(:) = ''
+              message(1) = '[WARN] Program:  LIS'
+              message(2) = '  Routine: AGRMET_storeobs'
+              message(3) = '  Found unrecognized network in '// &
+                   trim(filename)
+              message(4) = '  Network '//trim(network(irecord))
+              message(5) = '  Contact NASA developers to add this network'
+              if (LIS_masterproc) then
+                 call LIS_alert('LIS.AGRMET_storeobs', &
+                      alert_number, message)
+                 alert_number = alert_number + 1
+              end if
+              cycle RECORD
+           end if
+        end do
+        if (i > MAX_NEW_NETWORKS) cycle RECORD
+     end if
+
 !     ------------------------------------------------------------------
 !     If bsn is not zero either the observations came from CDMS or they
 !     came from JMOBS and this is a WMO observation.  Set the flag to 

--- a/lis/metforcing/usaf/AGRMET_storeobs.F90
+++ b/lis/metforcing/usaf/AGRMET_storeobs.F90
@@ -255,9 +255,9 @@ subroutine AGRMET_storeobs(nsize, nsize3, isize, obs, obs3, ilat, ilon,  &
      ! alert. Keep track of unknown networks to avoid redundant alerts.
      if (.not. USAF_is_gauge(network(irecord))) then
         do i = 1, MAX_NEW_NETWORKS
-           if (trim(new_networks(i)) == trim(network(irecord))) then
+           if (new_networks(i) == network(irecord)) then
               cycle RECORD
-           else if (trim(new_networks(i)) == "NULL") then
+           else if (new_networks(i) == "NULL") then
               new_networks(i) = network(irecord)
               write(LIS_logunit,*)'[WARN] Found unrecognized network ', &
                    trim(network(irecord))

--- a/lis/metforcing/usaf/AGRMET_storeobs_offhour.F90
+++ b/lis/metforcing/usaf/AGRMET_storeobs_offhour.F90
@@ -217,9 +217,9 @@ subroutine AGRMET_storeobs_offhour(nsize, isize, obs, ilat, ilon,  &
      ! alert. Keep track of unknown networks to avoid redundant alerts.
      if (.not. USAF_is_gauge(network(irecord))) then
         do i = 1, MAX_NEW_NETWORKS
-           if (trim(new_networks(i)) == trim(network(irecord))) then
+           if (new_networks(i) == network(irecord)) then
               cycle RECORD
-           else if (trim(new_networks(i)) == "NULL") then
+           else if (new_networks(i) == "NULL") then
               new_networks(i) = network(irecord)
               write(LIS_logunit,*)'[WARN] Found unrecognized network ', &
                    trim(network(irecord))

--- a/lis/metforcing/usaf/AGRMET_storeobs_offhour.F90
+++ b/lis/metforcing/usaf/AGRMET_storeobs_offhour.F90
@@ -14,14 +14,23 @@
 ! 
 ! !REVISION HISTORY: 
 !    11 may 11   Adapted from AGRMET_storeobs...Chris Franks/16WS/WXE/SEMS
+!    23 May 24   Check network of each report to ensure it is recognized;
+!                reject if unknown; keep track of unknown networks
+!                encountered during the run; and write alert file as a
+!                new unknown network is encountered..........Eric Kemp/NASA
 !
 ! !INTERFACE: 
 subroutine AGRMET_storeobs_offhour(nsize, isize, obs, ilat, ilon,  &
      mscprc, sixprc, twfprc, network, plat_id, cdms_flag, bsn, &
-     duration, stncnt)
+     duration, stncnt, alert_number, filename)
+
+  ! Imports
+  use LIS_coreMod, only: LIS_masterproc        ! EMK 20240523
+  use LIS_logMod, only: LIS_logunit, LIS_alert ! EMK 20240523
+  use USAF_bratsethMod, only: USAF_is_gauge    ! EMK 20240523
 
   implicit none
-  
+
   integer,    intent(in)         :: isize
   character*10, intent(in)       :: network(isize)
   character*10, intent(in)       :: plat_id(isize)
@@ -34,8 +43,9 @@ subroutine AGRMET_storeobs_offhour(nsize, isize, obs, ilat, ilon,  &
   integer,    intent(in)         :: nsize
   integer,    intent(in)         :: sixprc(isize)
   integer,    intent(inout)      :: stncnt
-  integer,    intent(in)         :: twfprc(isize)   
-
+  integer,    intent(in)         :: twfprc(isize)
+  integer, intent(inout) :: alert_number ! EMK 20240523
+  character(*), intent(in) :: filename ! EMK 20240523
 !
 ! !DESCRIPTION: 
 !    performs some preprocessing on raw 3-hourly observations for 
@@ -130,6 +140,32 @@ subroutine AGRMET_storeobs_offhour(nsize, isize, obs, ilat, ilon,  &
   
   type(rain_obs), intent(inout)  :: obs(isize)
 
+  ! EMK 20240523
+  character(255) :: message(20)
+  integer, parameter :: MAX_NEW_NETWORKS = 20
+  character(10), save :: new_networks(MAX_NEW_NETWORKS) = &
+       (/"NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      ", &
+       "NULL      "/)
+  integer :: i
+
 !     ------------------------------------------------------------------
 !     If observations were retrieved from CDMS use 6-digit BSN limits 
 !     for the specially processed regions
@@ -176,7 +212,36 @@ subroutine AGRMET_storeobs_offhour(nsize, isize, obs, ilat, ilon,  &
      else
         cycle RECORD
      end if
-     
+
+     ! EMK 20240523...Skip report if network is not recognized. Issue an
+     ! alert. Keep track of unknown networks to avoid redundant alerts.
+     if (.not. USAF_is_gauge(network(irecord))) then
+        do i = 1, MAX_NEW_NETWORKS
+           if (trim(new_networks(i)) == trim(network(irecord))) then
+              cycle RECORD
+           else if (trim(new_networks(i)) == "NULL") then
+              new_networks(i) = network(irecord)
+              write(LIS_logunit,*)'[WARN] Found unrecognized network ', &
+                   trim(network(irecord))
+              write(LIS_logunit,*)'[WARN] Will skip report in preobs file'
+              message(:) = ''
+              message(1) = '[WARN] Program:  LIS'
+              message(2) = '  Routine: AGRMET_storeobs_offhour'
+              message(3) = '  Found unrecognized network in '// &
+                   trim(filename)
+              message(4) = '  Network '//trim(network(irecord))
+              message(5) = '  Contact NASA developers to add this network'
+              if (LIS_masterproc) then
+                 call LIS_alert('LIS.AGRMET_storeobs_offhour', &
+                      alert_number, message)
+                 alert_number = alert_number + 1
+              end if
+              cycle RECORD
+           end if
+        end do
+        if (i > MAX_NEW_NETWORKS) cycle RECORD
+     end if
+
 !     ------------------------------------------------------------------
 !       check for valid wmo block station number (bsn) and valid
 !       precipitation totals.  if they exist, process this ob.

--- a/lis/metforcing/usaf/USAF_bratsethMod.F90
+++ b/lis/metforcing/usaf/USAF_bratsethMod.F90
@@ -20,6 +20,8 @@
 !              ........................................Eric Kemp/SSAI/NASA
 ! 03 Jun 2020  Removed Box-Cox transform in precipitation analysis
 !              ........................................Eric Kemp/SSAI/NASA
+! 23 May 2024  Export USAF_is_gauge function, and add HADS and
+!              NWSLI gage networks.....................Eric Kemp/SSAI/NASA
 !
 ! DESCRIPTION:
 !
@@ -133,6 +135,8 @@ module USAF_bratsethMod
    public :: USAF_snowDepthQC
    public :: USAF_backQC
    public :: USAF_superstatQC
+   ! EMK 20240523
+   public :: USAF_is_gauge
 
    ! A simple linked list type that can be used in a hash table.  Intended
    ! to store indices of arrays in the USAF_obsData type for efficient look-up.
@@ -1617,7 +1621,7 @@ contains
       call calc_invDataDensities(precipAll,sigmaBSqr,nest, &
            agrmet_struc(nest)%bratseth_precip_max_dist, &
            agrmet_struc(nest)%bratseth_precip_back_err_scale_length, &
-           is_gauge, &
+           USAF_is_gauge, &
            invDataDensities)
 
       ! Run Bratseth analysis at observation points, and collect the sum of
@@ -1628,7 +1632,7 @@ contains
       call calc_obsAnalysis(precipAll,sigmaBSqr,nobs,invDataDensities,nest,&
            agrmet_struc(nest)%bratseth_precip_max_dist, &
            agrmet_struc(nest)%bratseth_precip_back_err_scale_length, &
-           convergeThresh, is_gauge, sumObsEstimates, &
+           convergeThresh, USAF_is_gauge, sumObsEstimates, &
            npasses, precipOBA)
 
       ! Calculate analysis at grid points.
@@ -3306,7 +3310,7 @@ contains
                   if (.not. is_imerg(this%net(j))) cycle
                end if
             else ! Gauges
-               if (.not. is_gauge(this%net(j))) cycle
+               if (.not. USAF_is_gauge(this%net(j))) cycle
             end if
 
             ! Now see which LIS grid box this is in.  First, handle latitude.
@@ -4067,7 +4071,7 @@ contains
 
    !---------------------------------------------------------------------------
    ! Checks if observation network is recognized as a gauge.
-   logical function is_gauge(net)
+   logical function USAF_is_gauge(net)
       implicit none
       character(len=10), intent(in) :: net
       logical :: answer
@@ -4075,14 +4079,16 @@ contains
       if (trim(net) .eq. "AMIL") answer = .true.
       if (trim(net) .eq. "CANA") answer = .true.
       if (trim(net) .eq. "FAA") answer = .true.
+      if (trim(net) .eq. "HADS") answer = .true.  ! EMK 20240523
       if (trim(net) .eq. "ICAO") answer = .true.
+      if (trim(net) .eq. "NWSLI") answer = .true. ! EMK 20240523
       if (trim(net) .eq. "WMO") answer = .true.
       if (trim(net) .eq. "MOBL") answer = .true.
       if (trim(net) .eq. "SUPERGAGE") answer = .true.
       ! Handle reformatted CDMS data that are missing the network type.
       if (trim(net) .eq. "CDMS") answer = .true.
-      is_gauge = answer
-   end function is_gauge
+      USAF_is_gauge = answer
+   end function USAF_is_gauge
 
    !---------------------------------------------------------------------------
    ! Dummy function for establishing a surface station is uncorrelated.

--- a/lis/metforcing/usaf/USAF_bratsethMod.F90
+++ b/lis/metforcing/usaf/USAF_bratsethMod.F90
@@ -4076,17 +4076,17 @@ contains
       character(len=10), intent(in) :: net
       logical :: answer
       answer = .false.
-      if (trim(net) .eq. "AMIL") answer = .true.
-      if (trim(net) .eq. "CANA") answer = .true.
-      if (trim(net) .eq. "FAA") answer = .true.
-      if (trim(net) .eq. "HADS") answer = .true.  ! EMK 20240523
-      if (trim(net) .eq. "ICAO") answer = .true.
-      if (trim(net) .eq. "NWSLI") answer = .true. ! EMK 20240523
-      if (trim(net) .eq. "WMO") answer = .true.
-      if (trim(net) .eq. "MOBL") answer = .true.
-      if (trim(net) .eq. "SUPERGAGE") answer = .true.
+      if (net .eq. "AMIL") answer = .true.
+      if (net .eq. "CANA") answer = .true.
+      if (net .eq. "FAA") answer = .true.
+      if (net .eq. "HADS") answer = .true.  ! EMK 20240523
+      if (net .eq. "ICAO") answer = .true.
+      if (net .eq. "NWSLI") answer = .true. ! EMK 20240523
+      if (net .eq. "WMO") answer = .true.
+      if (net .eq. "MOBL") answer = .true.
+      if (net .eq. "SUPERGAGE") answer = .true.
       ! Handle reformatted CDMS data that are missing the network type.
-      if (trim(net) .eq. "CDMS") answer = .true.
+      if (net .eq. "CDMS") answer = .true.
       USAF_is_gauge = answer
    end function USAF_is_gauge
 


### PR DESCRIPTION


### Description

Revised code to gracefully handle unrecognized gage networks in preobs files. Such reports are tossed, and an alert
file is written to notify user.  Internal bookkeeping is performed to only produce a single alert file per unique unrecognized
network.  Also added HADS and NWSLI networks to list of recognized gage networks.

NOTE:  DIfferent patch will be needed for LIS 7.6 because the gage processing code in LIS 7.6 was rewritten.  



