### PR TITLE
Feature/ Resolved Issues and Added Tests to SMOPS Ver4 Reader

### DIFF
--- a/lis/dataassim/obs/SMOPS_ASCATsm/SMOPS_ASCATsm_Mod.F90
+++ b/lis/dataassim/obs/SMOPS_ASCATsm/SMOPS_ASCATsm_Mod.F90
@@ -1,9 +1,9 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 ! NASA Goddard Space Flight Center
 ! Land Information System Framework (LISF)
-! Version 7.4
+! Version 7.5
 !
-! Copyright (c) 2022 United States Government as represented by the
+! Copyright (c) 2024 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
@@ -37,6 +37,7 @@
 !  8 May 2013    Sujay Kumar; initial specification
 !  28 Sep 2017: Mahdi Navari; Updated to read ASCAT from SMOPS V3
 !  1  Apr 2019  Yonghwan Kwon: Upated for reading monthy CDF for the current month
+!  08 May 2024: Mahdi Navari; Updated to read ASCAT Metop-B and C from SMOPS V4
 ! 
 module SMOPS_ASCATsm_Mod
 ! !USES: 
@@ -83,7 +84,7 @@ module SMOPS_ASCATsm_Mod
 
      integer                :: nbins
      integer                :: ntimes
-     real*8                 :: version2_time, version3_time
+     real*8                 :: version2_time, version3_time, version4_time
      character(len=17)      :: version
      character(len=10)      :: conv
 
@@ -601,6 +602,11 @@ contains
           yr1 = 2017; mo1 = 8; da1 = 24; hr1 = 12; mn1 = 0; ss1 = 0
           call LIS_date2time(SMOPS_ASCATsm_struc(n)%version3_time,updoy,upgmt,&
              yr1,mo1,da1,hr1,mn1,ss1)
+
+          yr1 = 2024; mo1 = 4; da1 = 25; hr1 = 0; mn1 = 0; ss1 = 0
+          call LIS_date2time(SMOPS_ASCATsm_struc(n)%version4_time,updoy,upgmt,&
+             yr1,mo1,da1,hr1,mn1,ss1)
+
        endif
 
        gridDesci = 0 

--- a/lis/dataassim/obs/SMOPS_ASCATsm/SMOPS_GRIB2_Tables_NESDIS.txt
+++ b/lis/dataassim/obs/SMOPS_ASCATsm/SMOPS_GRIB2_Tables_NESDIS.txt
@@ -102,3 +102,38 @@ SMOPS V3.0 GRIB Table:
 { 2, 0, 7, 1, 3, 248, "SMAPSMQA", "NASA SMAP Liquid Volumetric Soil Moisture QA", "-"},
 { 2, 0, 7, 1, 3, 249, "RESSM1QA", "Reserved Liquid Volumetric Soil Moisture 1 QA", "-"},
 
+SMPOS V4.0 belnded product table: 
+NPR-SMOPS-CMAP-6hrly_v4r0_blend_syyyymmddhh00000_eyyyymmddxxxxxxx_cyyyymmddxxxxxxx.grib2
+210 = blended soil moisture (Blended_SM)
+214 = ASCAT_B soil moisture (ASCAT_B_SM)
+250 = ASCAT_C soil moisture (ASCAT_C_SM)
+215 = AMSR2 soil moisture (AMSR2_SM)
+216 = GMI SM (GMI_SM)
+217 = NRT SMAP SM (NSMAP_SM)
+218 = SMAP SM (SMAP_SM)
+219 = Blended SM SD (Blended_SM_SD)
+220 = Hour for blended soil moisture (Blended_hour)
+221 = Minute for blended soil moisture (Blended_minute)
+228 = Hour for ASCAT_B soil moisture (ASCAT_B_hour)
+229 = Minute for ASCAT_B soil moisture (ASCAT_B_minute)
+251 = Hour for ASCAT_C soil moisture (ASCAT_C_hour)
+252 = Minute for ASCAT_C soil moisture (ASCAT_C_minute)
+230 = Hour for AMSR2 soil moisture (AMSR2_hour)
+231 = Minute for AMSR2 soil moisture (AMSR2_minute)
+232 = Hour for GMI SM (GMI_hour)
+233 = Minute for GMI SM (GMI_minute)
+234 = Hour for NSMAP SM (NSMAP_hour)
+235 = Minute for NSMAP SM (NSMAP_minute)
+236 = Hour for SMAP SM (SMAP_hour)
+237 = Minute for SMAP SM (SMAP_minute)
+238 = Hour for spare 1 (Blended_SM_SD_hour)
+239 = Minute for spare 1 (Blended_SM_SD_minute)
+240 = QA for blended soil moisture (Blended_QA)
+244 = QA for ASCAT_B soil moisture (ASCAT_B_QA)
+253 = QA for ASCAT_C soil moisture (ASCAT_C_QA)
+245 = QA for AMSR2 soil moisture (AMSR2_QA)
+246 = QA for GMI SM (GMI_QA)
+247 = QA for NSMAP (NSMAP_QA)
+248 = QA for SMAP SM (SMAP_QA)
+249 = QA for spare 1 (Blended_SM_SD_QA)
+

--- a/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
+++ b/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
@@ -509,6 +509,7 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
   integer :: imsg
   character(len=512) :: message(20)
   integer, save :: alert_number = 0
+  logical :: a_exist,b_exist,c_exist
 
 #if(defined USE_GRIBAPI)
   ! When we are reading the 6-hourly datasets, we read the file HR+6
@@ -545,6 +546,7 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
      param_ASCAT_A_hr = 223; param_ASCAT_A_mn = 224
      param_ASCAT_B = 214; param_ASCAT_B_qa = 235
      param_ASCAT_B_hr = 225; param_ASCAT_B_mn = 226
+     a_exist = .true.; b_exist = .true.; c_exist = .false.
      write(LIS_logunit,*) '[MSG] Reading SMOPS ASCAT dataset '//&
         'as SMOPS version 1.3/2.0'
 
@@ -555,6 +557,7 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
      param_ASCAT_A_hr = 226; param_ASCAT_A_mn = 227
      param_ASCAT_B = 214; param_ASCAT_B_qa = 244
      param_ASCAT_B_hr = 228; param_ASCAT_B_mn = 229
+     a_exist = .true.; b_exist = .true.; c_exist = .false.
      write(LIS_logunit,*) '[MSG] Reading SMOPS ASCAT dataset '//&
         'as SMOPS version 3.0'
   else 
@@ -563,6 +566,7 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
      param_ASCAT_B_hr = 228; param_ASCAT_B_mn = 229
      param_ASCAT_C = 250; param_ASCAT_C_qa = 253
      param_ASCAT_C_hr = 251; param_ASCAT_C_mn = 252
+     a_exist = .false.; b_exist = .true.; c_exist = .true.
      write(LIS_logunit,*) '[MSG] Reading SMOPS ASCAT dataset '//&
         'as SMOPS version 4.0'
   endif
@@ -593,222 +597,224 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
      end if
 
      var_found = .false.
-     if (param_num .eq. param_ASCAT_A) then
-        var_found = .true.
-     endif
-     if (var_found) then
-        call grib_get(igrib, 'values', sm_ASCAT_A, iret)
-        if (iret .ne. 0) then
-           write(LIS_logunit,*)'[WARN] Problem reading values for ASCAT_A'
-           call grib_release(igrib, iret)
-           imsg = -1
-           exit
-        end if
-        do r = 1, SMOPS_ASCATsm_struc(n)%nr
-           do c = 1, SMOPS_ASCATsm_struc(n)%nc
-              sm_ASCAT_A_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = &
-                   sm_ASCAT_A(c+((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
-                   SMOPS_ASCATsm_struc(n)%nc)
-           enddo
-        enddo
-     endif
+     if (a_exist) then 
+             if(param_num .eq. param_ASCAT_A) then
+                var_found = .true.
+             endif
+             if (var_found) then
+                call grib_get(igrib, 'values', sm_ASCAT_A, iret)
+                if (iret .ne. 0) then
+                   write(LIS_logunit,*)'[WARN] Problem reading values for ASCAT_A'
+                   call grib_release(igrib, iret)
+                   imsg = -1
+                   exit
+                end if
+                do r = 1, SMOPS_ASCATsm_struc(n)%nr
+                   do c = 1, SMOPS_ASCATsm_struc(n)%nc
+                      sm_ASCAT_A_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = &
+                           sm_ASCAT_A(c+((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
+                           SMOPS_ASCATsm_struc(n)%nc)
+                   enddo
+                enddo
+             endif
 
-     var_found = .false.
-     if (param_num .eq. param_ASCAT_A_qa) then
-        var_found = .true.
-     endif
-     if (var_found) then
-        call grib_get(igrib, 'values', sm_ASCAT_A_qa, iret)
-        if (iret .ne. 0) then
-           write(LIS_logunit,*)'[WARN] Problem reading QA values for ASCAT_A'
-           call grib_release(igrib, iret)
-           imsg = -1
-           exit
-        end if
-        do r = 1, SMOPS_ASCATsm_struc(n)%nr
-           do c = 1, SMOPS_ASCATsm_struc(n)%nc
-              sm_ASCAT_A_qa_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = &
-                   INT(sm_ASCAT_A_qa(c+((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
-                   SMOPS_ASCATsm_struc(n)%nc))
-           enddo
-        enddo
-     endif
+             var_found = .false.
+             if (param_num .eq. param_ASCAT_A_qa) then
+                var_found = .true.
+             endif
+             if (var_found) then
+                call grib_get(igrib, 'values', sm_ASCAT_A_qa, iret)
+                if (iret .ne. 0) then
+                   write(LIS_logunit,*)'[WARN] Problem reading QA values for ASCAT_A'
+                   call grib_release(igrib, iret)
+                   imsg = -1
+                   exit
+                end if
+                do r = 1, SMOPS_ASCATsm_struc(n)%nr
+                   do c = 1, SMOPS_ASCATsm_struc(n)%nc
+                      sm_ASCAT_A_qa_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = &
+                           INT(sm_ASCAT_A_qa(c+((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
+                           SMOPS_ASCATsm_struc(n)%nc))
+                   enddo
+                enddo
+             endif
 
-     var_found = .false.
-     if (param_num .eq. param_ASCAT_A_hr) then
-        var_found = .true.
-     endif
-     if (var_found) then
-        call grib_get(igrib, 'values', sm_ASCAT_A_hr, iret)
-        if (iret .ne. 0) then
-           write(LIS_logunit,*)'[WARN] Problem reading hr values for ASCAT_A'
-           call grib_release(igrib, iret)
-           imsg = -1
-           exit
-        end if
-     endif
+             var_found = .false.
+             if (param_num .eq. param_ASCAT_A_hr) then
+                var_found = .true.
+             endif
+             if (var_found) then
+                call grib_get(igrib, 'values', sm_ASCAT_A_hr, iret)
+                if (iret .ne. 0) then
+                   write(LIS_logunit,*)'[WARN] Problem reading hr values for ASCAT_A'
+                   call grib_release(igrib, iret)
+                   imsg = -1
+                   exit
+                end if
+             endif
 
-     var_found = .false.
-     if (param_num .eq. param_ASCAT_A_mn) then
-        var_found = .true.
+             var_found = .false.
+             if (param_num .eq. param_ASCAT_A_mn) then
+                var_found = .true.
+             endif
+             if (var_found) then
+                call grib_get(igrib, 'values', sm_ASCAT_A_mn, iret)
+                if (iret .ne. 0) then
+                   write(LIS_logunit,*)'[WARN] Problem reading mn values for ASCAT_A'
+                   call grib_release(igrib, iret)
+                   imsg = -1
+                   exit
+                end if
+             endif
      endif
-     if (var_found) then
-        call grib_get(igrib, 'values', sm_ASCAT_A_mn, iret)
-        if (iret .ne. 0) then
-           write(LIS_logunit,*)'[WARN] Problem reading mn values for ASCAT_A'
-           call grib_release(igrib, iret)
-           imsg = -1
-           exit
-        end if
-     endif
+     if (b_exist) then   
+             var_found = .false.
+             if (param_num .eq. param_ASCAT_B) then
+                var_found = .true.
+             endif
+             if (var_found) then
+                call grib_get(igrib, 'values', sm_ASCAT_B, iret)
+                if (iret .ne. 0) then
+                   write(LIS_logunit,*)'[WARN] Problem reading values for ASCAT_B'
+                   call grib_release(igrib, iret)
+                   imsg = -1
+                   exit
+                end if
+                do r = 1, SMOPS_ASCATsm_struc(n)%nr
+                   do c = 1, SMOPS_ASCATsm_struc(n)%nc
+                      sm_ASCAT_B_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = &
+                           sm_ASCAT_B(c+((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
+                           SMOPS_ASCATsm_struc(n)%nc)
+                   enddo
+                enddo
+             endif
 
-     var_found = .false.
-     if (param_num .eq. param_ASCAT_B) then
-        var_found = .true.
-     endif
-     if (var_found) then
-        call grib_get(igrib, 'values', sm_ASCAT_B, iret)
-        if (iret .ne. 0) then
-           write(LIS_logunit,*)'[WARN] Problem reading values for ASCAT_B'
-           call grib_release(igrib, iret)
-           imsg = -1
-           exit
-        end if
-        do r = 1, SMOPS_ASCATsm_struc(n)%nr
-           do c = 1, SMOPS_ASCATsm_struc(n)%nc
-              sm_ASCAT_B_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = &
-                   sm_ASCAT_B(c+((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
-                   SMOPS_ASCATsm_struc(n)%nc)
-           enddo
-        enddo
-     endif
+             var_found = .false.
+             if (param_num .eq. param_ASCAT_B_qa) then
+                var_found = .true.
+             endif
+             if (var_found) then
+                call grib_get(igrib, 'values', sm_ASCAT_B_qa, iret)
+                if (iret .ne. 0) then
+                   write(LIS_logunit,*)'[WARN] Problem reading QA values for ASCAT_B'
+                   call grib_release(igrib, iret)
+                   imsg = -1
+                   exit
+                end if
+                do r = 1, SMOPS_ASCATsm_struc(n)%nr
+                   do c = 1, SMOPS_ASCATsm_struc(n)%nc
+                      sm_ASCAT_B_qa_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = &
+                           INT(sm_ASCAT_B_qa(c+((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
+                           SMOPS_ASCATsm_struc(n)%nc))
+                   enddo
+                enddo
+             endif
 
-     var_found = .false.
-     if (param_num .eq. param_ASCAT_B_qa) then
-        var_found = .true.
-     endif
-     if (var_found) then
-        call grib_get(igrib, 'values', sm_ASCAT_B_qa, iret)
-        if (iret .ne. 0) then
-           write(LIS_logunit,*)'[WARN] Problem reading QA values for ASCAT_B'
-           call grib_release(igrib, iret)
-           imsg = -1
-           exit
-        end if
-        do r = 1, SMOPS_ASCATsm_struc(n)%nr
-           do c = 1, SMOPS_ASCATsm_struc(n)%nc
-              sm_ASCAT_B_qa_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = &
-                   INT(sm_ASCAT_B_qa(c+((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
-                   SMOPS_ASCATsm_struc(n)%nc))
-           enddo
-        enddo
-     endif
+             var_found = .false.
+             if (param_num .eq. param_ASCAT_B_hr) then
+                var_found = .true.
+             endif
+             if(var_found) then
+                call grib_get(igrib, 'values', sm_ASCAT_B_hr, iret)
+                if (iret .ne. 0) then
+                   write(LIS_logunit,*)'[WARN] Problem reading hr values for ASCAT_B'
+                   call grib_release(igrib, iret)
+                   imsg = -1
+                   exit
+                end if
+             endif
 
-     var_found = .false.
-     if (param_num .eq. param_ASCAT_B_hr) then
-        var_found = .true.
+             var_found = .false.
+             if (param_num .eq. param_ASCAT_B_mn) then
+                var_found = .true.
+             endif
+             if (var_found) then
+                call grib_get(igrib, 'values', sm_ASCAT_B_mn, iret)
+                if (iret .ne. 0) then
+                   write(LIS_logunit,*)'[WARN] Problem reading mn values for ASCAT_B'
+                   call grib_release(igrib, iret)
+                   imsg = -1
+                   exit
+                end if
+             endif
      endif
-     if(var_found) then
-        call grib_get(igrib, 'values', sm_ASCAT_B_hr, iret)
-        if (iret .ne. 0) then
-           write(LIS_logunit,*)'[WARN] Problem reading hr values for ASCAT_B'
-           call grib_release(igrib, iret)
-           imsg = -1
-           exit
-        end if
-     endif
+     if (c_exist) then
+             var_found = .false.
+             if (param_num .eq. param_ASCAT_C) then
+                var_found = .true.
+             endif
+             if (var_found) then
+                call grib_get(igrib, 'values', sm_ASCAT_C, iret)
+                if (iret .ne. 0) then
+                   write(LIS_logunit,*)'[WARN] Problem reading values for ASCAT_C'
+                   call grib_release(igrib, iret)
+                   imsg = -1
+                   exit
+                end if
+                do r = 1, SMOPS_ASCATsm_struc(n)%nr
+                   do c = 1, SMOPS_ASCATsm_struc(n)%nc
+                      sm_ASCAT_C_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = &
+                           sm_ASCAT_C(c+((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
+                           SMOPS_ASCATsm_struc(n)%nc)
+                   enddo
+                enddo
+             endif
 
-     var_found = .false.
-     if (param_num .eq. param_ASCAT_B_mn) then
-        var_found = .true.
-     endif
-     if (var_found) then
-        call grib_get(igrib, 'values', sm_ASCAT_B_mn, iret)
-        if (iret .ne. 0) then
-           write(LIS_logunit,*)'[WARN] Problem reading mn values for ASCAT_B'
-           call grib_release(igrib, iret)
-           imsg = -1
-           exit
-        end if
-     endif
+             var_found = .false.
+             if (param_num .eq. param_ASCAT_C_qa) then
+                var_found = .true.
+             endif
+             if (var_found) then
+                call grib_get(igrib, 'values', sm_ASCAT_C_qa, iret)
+                if (iret .ne. 0) then
+                   write(LIS_logunit,*)'[WARN] Problem reading QA values for ASCAT_C'
+                   call grib_release(igrib, iret)
+                   imsg = -1
+                   exit
+                end if
+                do r = 1, SMOPS_ASCATsm_struc(n)%nr
+                   do c = 1, SMOPS_ASCATsm_struc(n)%nc
+                      sm_ASCAT_C_qa_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = &
+                           INT(sm_ASCAT_C_qa(c+((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
+                           SMOPS_ASCATsm_struc(n)%nc))
+                   enddo
+                enddo
+             endif
 
+             var_found = .false.
+             if (param_num .eq. param_ASCAT_C_hr) then
+                var_found = .true.
+             endif
+             if (var_found) then
+                call grib_get(igrib, 'values', sm_ASCAT_C_hr, iret)
+                if (iret .ne. 0) then
+                   write(LIS_logunit,*)'[WARN] Problem reading hr values for ASCAT_C'
+                   call grib_release(igrib, iret)
+                   imsg = -1
+                   exit
+                end if
+             endif
+
+             var_found = .false.
+             if (param_num .eq. param_ASCAT_C_mn) then
+                var_found = .true.
+             endif
+             if (var_found) then
+                call grib_get(igrib, 'values', sm_ASCAT_C_mn, iret)
+                if (iret .ne. 0) then
+                   write(LIS_logunit,*)'[WARN] Problem reading mn values for ASCAT_C'
+                   call grib_release(igrib, iret)
+                   imsg = -1
+                   exit
+                end if
+             endif
+     endif
      call grib_release(igrib, iret)
      if (iret .ne. 0) then
         write(LIS_logunit,*)'[WARN] Problem releasing from ', trim(fname)
         imsg = -1
         exit
      end if
-
-     var_found = .false.
-     if (param_num .eq. param_ASCAT_C) then
-        var_found = .true.
-     endif
-     if (var_found) then
-        call grib_get(igrib, 'values', sm_ASCAT_C, iret)
-        if (iret .ne. 0) then
-           write(LIS_logunit,*)'[WARN] Problem reading values for ASCAT_C'
-           call grib_release(igrib, iret)
-           imsg = -1
-           exit
-        end if
-        do r = 1, SMOPS_ASCATsm_struc(n)%nr
-           do c = 1, SMOPS_ASCATsm_struc(n)%nc
-              sm_ASCAT_C_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = &
-                   sm_ASCAT_C(c+((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
-                   SMOPS_ASCATsm_struc(n)%nc)
-           enddo
-        enddo
-     endif
-
-     var_found = .false.
-     if (param_num .eq. param_ASCAT_C_qa) then
-        var_found = .true.
-     endif
-     if (var_found) then
-        call grib_get(igrib, 'values', sm_ASCAT_C_qa, iret)
-        if (iret .ne. 0) then
-           write(LIS_logunit,*)'[WARN] Problem reading QA values for ASCAT_C'
-           call grib_release(igrib, iret)
-           imsg = -1
-           exit
-        end if
-        do r = 1, SMOPS_ASCATsm_struc(n)%nr
-           do c = 1, SMOPS_ASCATsm_struc(n)%nc
-              sm_ASCAT_C_qa_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = &
-                   INT(sm_ASCAT_C_qa(c+((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
-                   SMOPS_ASCATsm_struc(n)%nc))
-           enddo
-        enddo
-     endif
-
-     var_found = .false.
-     if (param_num .eq. param_ASCAT_C_hr) then
-        var_found = .true.
-     endif
-     if (var_found) then
-        call grib_get(igrib, 'values', sm_ASCAT_C_hr, iret)
-        if (iret .ne. 0) then
-           write(LIS_logunit,*)'[WARN] Problem reading hr values for ASCAT_C'
-           call grib_release(igrib, iret)
-           imsg = -1
-           exit
-        end if
-     endif
-
-     var_found = .false.
-     if (param_num .eq. param_ASCAT_C_mn) then
-        var_found = .true.
-     endif
-     if (var_found) then
-        call grib_get(igrib, 'values', sm_ASCAT_C_mn, iret)
-        if (iret .ne. 0) then
-           write(LIS_logunit,*)'[WARN] Problem reading mn values for ASCAT_C'
-           call grib_release(igrib, iret)
-           imsg = -1
-           exit
-        end if
-     endif
-
   enddo
 
   call grib_close_file(ftn)
@@ -854,108 +860,111 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
   sm_time_ASCAT_C = LIS_rc%udef
   sm_data         = LIS_rc%udef
   sm_data_b       = .false.
+  
+  if (a_exist) then
+          do r=1, SMOPS_ASCATsm_struc(n)%nr
+             do c=1, SMOPS_ASCATsm_struc(n)%nc
+                qavalue = sm_ASCAT_A_qa_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc)
+                if ( qavalue .ne. 9999 ) then
+                   !estimated error
+                   err = get_byte1(qavalue)
+                   !quality flag - not used currently
+                   ql = get_byte2(qavalue)
 
-  do r=1, SMOPS_ASCATsm_struc(n)%nr
-     do c=1, SMOPS_ASCATsm_struc(n)%nc
-        qavalue = sm_ASCAT_A_qa_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc)
-        if ( qavalue .ne. 9999 ) then
-           !estimated error
-           err = get_byte1(qavalue)
-           !quality flag - not used currently
-           ql = get_byte2(qavalue)
+                   if(err.lt.err_threshold) then
+                      hr_val = nint(sm_ASCAT_A_hr(c+&
+                           ((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
+                           SMOPS_ASCATsm_struc(n)%nc))
+                      mn_val =  nint(sm_ASCAT_A_mn(c+&
+                           ((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
+                           SMOPS_ASCATsm_struc(n)%nc))
+                      call LIS_get_timeoffset_sec(LIS_rc%yr, LIS_rc%mo, LIS_rc%da, &
+                           hr_val, mn_val, 0, julss)
+                      sm_time_ASCAT_A(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = julss
+                      sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .true.
+                   else
+                      sm_ASCAT_A_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
+                      sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .false.
+                   endif
+                else
+                   sm_ASCAT_A_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
+                   sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .false.
+                endif
+                if(sm_ASCAT_A_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc).lt.0.001) then
+                   sm_ASCAT_A_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
+                   sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .false.
+                endif
+             enddo
+          enddo
+  endif
+  if (b_exist) then
+          do r=1, SMOPS_ASCATsm_struc(n)%nr
+             do c=1, SMOPS_ASCATsm_struc(n)%nc
+                qavalue = sm_ASCAT_B_qa_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc)
+                if ( qavalue .ne. 9999 ) then
+                   !estimated error
+                   err = get_byte1(qavalue)
+                   !quality flag - not used currently
+                   ql = get_byte2(qavalue)
 
-           if(err.lt.err_threshold) then
-              hr_val = nint(sm_ASCAT_A_hr(c+&
-                   ((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
-                   SMOPS_ASCATsm_struc(n)%nc))
-              mn_val =  nint(sm_ASCAT_A_mn(c+&
-                   ((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
-                   SMOPS_ASCATsm_struc(n)%nc))
-              call LIS_get_timeoffset_sec(LIS_rc%yr, LIS_rc%mo, LIS_rc%da, &
-                   hr_val, mn_val, 0, julss)
-              sm_time_ASCAT_A(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = julss
-              sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .true.
-           else
-              sm_ASCAT_A_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
-              sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .false.
-           endif
-        else
-           sm_ASCAT_A_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
-           sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .false.
-        endif
-        if(sm_ASCAT_A_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc).lt.0.001) then
-           sm_ASCAT_A_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
-           sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .false.
-        endif
-     enddo
-  enddo
+                   if(err.lt.err_threshold) then
+                      hr_val = nint(sm_ASCAT_B_hr(c+&
+                           ((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
+                           SMOPS_ASCATsm_struc(n)%nc))
+                      mn_val =  nint(sm_ASCAT_B_mn(c+&
+                           ((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
+                           SMOPS_ASCATsm_struc(n)%nc))
+                      call LIS_get_timeoffset_sec(LIS_rc%yr, LIS_rc%mo, LIS_rc%da, &
+                           hr_val, mn_val, 0, julss)
+                      sm_time_ASCAT_B(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = julss
+                   else
+                      sm_ASCAT_B_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
+                   endif
+                else
+                   sm_ASCAT_B_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
+                endif
+                if(sm_ASCAT_B_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc).lt.0.001) then
+                   sm_ASCAT_B_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
+                endif
+             enddo
+          enddo
+  endif
+  if (c_exist) then
+          do r=1, SMOPS_ASCATsm_struc(n)%nr
+             do c=1, SMOPS_ASCATsm_struc(n)%nc
+                qavalue = sm_ASCAT_C_qa_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc)
+                if ( qavalue .ne. 9999 ) then
+                   !estimated error
+                   err = get_byte1(qavalue)
+                   !quality flag - not used currently
+                   ql = get_byte2(qavalue)
 
-  do r=1, SMOPS_ASCATsm_struc(n)%nr
-     do c=1, SMOPS_ASCATsm_struc(n)%nc
-        qavalue = sm_ASCAT_B_qa_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc)
-        if ( qavalue .ne. 9999 ) then
-           !estimated error
-           err = get_byte1(qavalue)
-           !quality flag - not used currently
-           ql = get_byte2(qavalue)
-
-           if(err.lt.err_threshold) then
-              hr_val = nint(sm_ASCAT_B_hr(c+&
-                   ((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
-                   SMOPS_ASCATsm_struc(n)%nc))
-              mn_val =  nint(sm_ASCAT_B_mn(c+&
-                   ((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
-                   SMOPS_ASCATsm_struc(n)%nc))
-              call LIS_get_timeoffset_sec(LIS_rc%yr, LIS_rc%mo, LIS_rc%da, &
-                   hr_val, mn_val, 0, julss)
-              sm_time_ASCAT_B(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = julss
-           else
-              sm_ASCAT_B_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
-           endif
-        else
-           sm_ASCAT_B_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
-        endif
-        if(sm_ASCAT_B_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc).lt.0.001) then
-           sm_ASCAT_B_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
-        endif
-     enddo
-  enddo
-
-  do r=1, SMOPS_ASCATsm_struc(n)%nr
-     do c=1, SMOPS_ASCATsm_struc(n)%nc
-        qavalue = sm_ASCAT_C_qa_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc)
-        if ( qavalue .ne. 9999 ) then
-           !estimated error
-           err = get_byte1(qavalue)
-           !quality flag - not used currently
-           ql = get_byte2(qavalue)
-
-           if(err.lt.err_threshold) then
-              hr_val = nint(sm_ASCAT_C_hr(c+&
-                   ((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
-                   SMOPS_ASCATsm_struc(n)%nc))
-              mn_val =  nint(sm_ASCAT_C_mn(c+&
-                   ((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
-                   SMOPS_ASCATsm_struc(n)%nc))
-              call LIS_get_timeoffset_sec(LIS_rc%yr, LIS_rc%mo, LIS_rc%da, &
-                   hr_val, mn_val, 0, julss)
-              sm_time_ASCAT_C(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = julss
-              sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .true.
-           else
-              sm_ASCAT_C_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
-              sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .false.
-           endif
-        else
-           sm_ASCAT_C_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
-           sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .false.
-        endif
-        if(sm_ASCAT_C_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc).lt.0.001) then
-           sm_ASCAT_C_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
-           sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .false.
-        endif
-     enddo
-  enddo
-
+                   if(err.lt.err_threshold) then
+                      hr_val = nint(sm_ASCAT_C_hr(c+&
+                           ((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
+                           SMOPS_ASCATsm_struc(n)%nc))
+                      mn_val =  nint(sm_ASCAT_C_mn(c+&
+                           ((SMOPS_ASCATsm_struc(n)%nr-r+1)-1)*&
+                           SMOPS_ASCATsm_struc(n)%nc))
+                      call LIS_get_timeoffset_sec(LIS_rc%yr, LIS_rc%mo, LIS_rc%da, &
+                           hr_val, mn_val, 0, julss)
+                      sm_time_ASCAT_C(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = julss
+                      sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .true.
+                   else
+                      sm_ASCAT_C_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
+                      sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .false.
+                   endif
+                else
+                   sm_ASCAT_C_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
+                   sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .false.
+                endif
+                if(sm_ASCAT_C_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc).lt.0.001) then
+                   sm_ASCAT_C_t(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = LIS_rc%udef
+                   sm_data_b(c+(r-1)*SMOPS_ASCATsm_struc(n)%nc) = .false.
+                endif
+             enddo
+          enddo
+  endif
 
   if ( file_time <  SMOPS_ASCATsm_struc(n)%version4_time ) then
      sm_data = sm_ASCAT_A_t
@@ -1103,7 +1112,7 @@ subroutine create_SMOPS_ASCATsm_filename(ndir, useRT, yr, mo,da, hr, conv, filen
         rc = rc)
 
      call ESMF_TimeSet(Ver4_blended_time, &
-        yy = 2224, &
+        yy = 2024, &
         mm = 4,   &
         dd = 25,    &
         h  = 0,    &
@@ -1146,7 +1155,7 @@ subroutine create_SMOPS_ASCATsm_filename(ndir, useRT, yr, mo,da, hr, conv, filen
         filename = trim(ndir)//'/'//trim(fyr)//'/NPR_SMOPS_CMAP_D' &
                    //trim(fyr)//trim(fmo)//trim(fda)//trim(fhr)//'.gr2'     
      else
-        if ( file_time >= naming3_time) then
+        if ( file_time >= naming3_time .and. file_time < Ver4_blended_time) then
            filename = trim(ndir)//'/'//'/NPR_SMOPS_CMAP_D' &
               //trim(fyr)//trim(fmo)//trim(fda)//trim(fhr)//'.gr2'     
         elseif (file_time >= Ver4_blended_time) then 

--- a/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
+++ b/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
@@ -541,7 +541,8 @@ subroutine read_SMOPS_ASCAT_data(n, k, fname, smobs_ip, smtime_ip)
      call LIS_date2time(file_time,updoy,upgmt,yr1,mo1,da1,hr1,mn1,ss1)
      if ( file_time >= SMOPS_ASCATsm_struc(n)%version3_time .and. &
            file_time <  SMOPS_ASCATsm_struc(n)%version4_time ) then
-         file_time = file_time+offset
+           hr1 = LIS_rc%hr+offset
+           call LIS_date2time(file_time,updoy,upgmt,yr1,mo1,da1,hr1,mn1,ss1)
      endif
   endif
 


### PR DESCRIPTION
### Changes in this Pull Request

- **In `create_SMOPS_ASCATsm_filename` subroutine**:
  - Updated the `Ver4_blended_time` year to 2024 from 2224.
  - Updated the `if` statement to select the file version based on the date.

- **In `read_SMOPS_ASCAT_data` subroutine**:
  - Moved the immature GRIB message release to after checking for SMOPS Metop-C data.
  - Added logical variables `a_exist`, `b_exist`, and `c_exist` to check the existence of Metop-A, B, or C based on the file version.
  - Added conditions to read SMOPS Metop-A and B data for version 3 and before, and SMOPS Metop-B and C for version 4.
  - Added conditions to read SMOPS Metop-A and B QA data for version 3 and before, and SMOPS Metop-B and C QA data for version 4.
  - Added an if statement to conditionally apply the 6-hour time offset based on the file version (add offset for version 3 and do not add it for version 4)

- **Global testcase:**

DA run: /discover/nobackup/ejalilva/SHARE/SMOPS_testcase/LIS_run

