### PR TITLE
Patch to gracefully handle unrecognized gage networks

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5463,6 +5463,12 @@ Acceptable values are:
 |"`cloud optical depth`" | use cloud optical depth
 |====
 
+`AGRMET number of gauge networks to use:` specifies nonnegative number
+of gauge networks to use, to be identified in separate config entry.
+
+`AGRMET gauge networks to use::` specifies list of names of gauge
+networks to be used. (One line of names per domain.)
+
 .Example _lis.config_ entry
 ....
 AGRMET forcing directory:               ./FORCING/
@@ -5535,6 +5541,10 @@ AGRMET CMORPH dy:
 AGRMET use GFS precip:     1
 AGRMET use GALWEM precip:  0
 AGRMET radiation derived from: 'cloud types'
+AGRMET number of gauge networks to use: 6
+AGRMET gauge networks to use::
+AMIL CANA FAA ICAO WMO HADS NWSLI
+::
 ....
 
 

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5541,7 +5541,7 @@ AGRMET CMORPH dy:
 AGRMET use GFS precip:     1
 AGRMET use GALWEM precip:  0
 AGRMET radiation derived from: 'cloud types'
-AGRMET number of gauge networks to use: 6
+AGRMET number of gauge networks to use: 7
 AGRMET gauge networks to use::
 AMIL CANA FAA ICAO WMO HADS NWSLI
 ::

--- a/lis/metforcing/usaf/AGRMET_forcingMod.F90
+++ b/lis/metforcing/usaf/AGRMET_forcingMod.F90
@@ -730,6 +730,10 @@ integer, allocatable   :: n112_sh4(:)
      real, allocatable :: gfs_nrt_bias_ratio(:,:)
      real, allocatable :: galwem_nrt_bias_ratio(:,:)
      integer :: pcp_back_bias_ratio_month
+
+     ! EMK Add list of gage networks to use
+     integer :: num_gage_networks
+     character(32), allocatable :: gage_networks(:)
   end type agrmet_type_dec
 
   type(agrmet_type_dec), allocatable :: agrmet_struc(:)

--- a/lis/metforcing/usaf/AGRMET_getpcpobs.F90
+++ b/lis/metforcing/usaf/AGRMET_getpcpobs.F90
@@ -360,7 +360,7 @@ subroutine AGRMET_getpcpobs(n, j6hr, month, prcpwe, &
                        write(LIS_logunit,*)'- CALLING STOREOBS TO PROCESS RAIN GAUGE DATA', j3hr
                        write(LIS_logunit,*)' '
                        
-                       call AGRMET_storeobs(nsize, nsize3, agrmet_struc(n)%max_pcpobs, &
+                       call AGRMET_storeobs(n, nsize, nsize3, agrmet_struc(n)%max_pcpobs, &
                             obs, obs3, ilat, ilon, &
                             mscprc, sixprc, twfprc, network, plat_id, cdms_flag, bsn, &
                             duration, j3hr, stncnt, alert_number, filename)
@@ -370,7 +370,7 @@ subroutine AGRMET_getpcpobs(n, j6hr, month, prcpwe, &
                        write(LIS_logunit,*)'- CALLING STOREOBS_OFFHOUR TO PROCESS 3HOUR RAIN GAUGE DATA', j3hr
                        write(LIS_logunit,*)' '
                        
-                       call AGRMET_storeobs_offhour(nsize, agrmet_struc(n)%max_pcpobs, &
+                       call AGRMET_storeobs_offhour(n, nsize, agrmet_struc(n)%max_pcpobs, &
                             obs3, ilat, ilon, &
                             mscprc, sixprc, twfprc, network, plat_id, cdms_flag, bsn, &
                             duration, nsize3, alert_number, filename)

--- a/lis/metforcing/usaf/AGRMET_storeobs.F90
+++ b/lis/metforcing/usaf/AGRMET_storeobs.F90
@@ -26,7 +26,7 @@
 !                new unknown network is encountered..........Eric Kemp/NASA
 !
 ! !INTERFACE: 
-subroutine AGRMET_storeobs(nsize, nsize3, isize, obs, obs3, ilat, ilon,  &
+subroutine AGRMET_storeobs(n, nsize, nsize3, isize, obs, obs3, ilat, ilon,  &
      mscprc, sixprc, twfprc, network, plat_id, cdms_flag, bsn, &
      duration, julhr, stncnt, alert_number, filename)
 
@@ -37,6 +37,7 @@ subroutine AGRMET_storeobs(nsize, nsize3, isize, obs, obs3, ilat, ilon,  &
 
   implicit none
   
+  integer,    intent(in)         :: n
   integer,    intent(in)         :: isize
   character*10, intent(in)       :: network(isize)
   character*10, intent(in)       :: plat_id(isize)
@@ -253,7 +254,7 @@ subroutine AGRMET_storeobs(nsize, nsize3, isize, obs, obs3, ilat, ilon,  &
 
      ! EMK 20240523...Skip report if network is not recognized. Issue an
      ! alert. Keep track of unknown networks to avoid redundant alerts.
-     if (.not. USAF_is_gauge(network(irecord))) then
+     if (.not. USAF_is_gauge(network(irecord),n)) then
         do i = 1, MAX_NEW_NETWORKS
            if (new_networks(i) == network(irecord)) then
               cycle RECORD

--- a/lis/metforcing/usaf/AGRMET_storeobs_offhour.F90
+++ b/lis/metforcing/usaf/AGRMET_storeobs_offhour.F90
@@ -20,7 +20,7 @@
 !                new unknown network is encountered..........Eric Kemp/NASA
 !
 ! !INTERFACE: 
-subroutine AGRMET_storeobs_offhour(nsize, isize, obs, ilat, ilon,  &
+subroutine AGRMET_storeobs_offhour(n, nsize, isize, obs, ilat, ilon,  &
      mscprc, sixprc, twfprc, network, plat_id, cdms_flag, bsn, &
      duration, stncnt, alert_number, filename)
 
@@ -31,6 +31,7 @@ subroutine AGRMET_storeobs_offhour(nsize, isize, obs, ilat, ilon,  &
 
   implicit none
 
+  integer,    intent(in)         :: n
   integer,    intent(in)         :: isize
   character*10, intent(in)       :: network(isize)
   character*10, intent(in)       :: plat_id(isize)
@@ -215,7 +216,7 @@ subroutine AGRMET_storeobs_offhour(nsize, isize, obs, ilat, ilon,  &
 
      ! EMK 20240523...Skip report if network is not recognized. Issue an
      ! alert. Keep track of unknown networks to avoid redundant alerts.
-     if (.not. USAF_is_gauge(network(irecord))) then
+     if (.not. USAF_is_gauge(network(irecord),n)) then
         do i = 1, MAX_NEW_NETWORKS
            if (new_networks(i) == network(irecord)) then
               cycle RECORD

--- a/lis/metforcing/usaf/USAF_PreobsReaderMod.F90
+++ b/lis/metforcing/usaf/USAF_PreobsReaderMod.F90
@@ -352,9 +352,9 @@ contains
           ! redundant alerts.
           if (.not. USAF_is_gauge(network_tmp, n)) then
              do j = 1, MAX_NEW_NETWORKS
-                if (trim(new_networks(j)) == trim(network_tmp)) then
+                if (new_networks(j) == network_tmp) then
                    exit ! Out of immediate do loop
-                else if (trim(new_networks(j)) == "NULL") then
+                else if (new_networks(j) == "NULL") then
                    new_networks(j) = network_tmp
                    write(LIS_logunit,*) &
                         '[WARN] Found unrecognized network ', &

--- a/lis/metforcing/usaf/USAF_PreobsReaderMod.F90
+++ b/lis/metforcing/usaf/USAF_PreobsReaderMod.F90
@@ -32,7 +32,7 @@ contains
 
   ! Read preobs files, perform simple preprocessing, and store
   ! in database.
-  subroutine USAF_read_preobs(preobsdir, presavdir, &
+  subroutine USAF_read_preobs(n, preobsdir, presavdir, &
        use_timestamp, &
        year, month, day, hour, use_expanded_station_ids, &
        alert_number)
@@ -50,6 +50,7 @@ contains
     implicit none
 
     ! Arguments
+    integer, intent(in) :: n
     character(*), intent(in) :: preobsdir
     character(*), intent(in) :: presavdir
     integer, intent(in) :: use_timestamp
@@ -349,7 +350,7 @@ contains
           ! EMK 20240524...Skip report if network is not recognized.
           ! Issue an alert. Keep track of unknown networks to avoid
           ! redundant alerts.
-          if (.not. USAF_is_gauge(network_tmp)) then
+          if (.not. USAF_is_gauge(network_tmp, n)) then
              do j = 1, MAX_NEW_NETWORKS
                 if (trim(new_networks(j)) == trim(network_tmp)) then
                    exit ! Out of immediate do loop
@@ -367,7 +368,7 @@ contains
                         trim(filename)
                    message(4) = '  Network '//trim(network_tmp)
                    message(5) = &
-                        '  Contact NASA developers to add this network'
+                        '  Modify lis.config to add this network'
                    if (LIS_masterproc) then
                       alert_number = alert_number + 1
                       call LIS_alert('LIS.USAF_read_preobs', &

--- a/lis/metforcing/usaf/USAF_bratsethMod.F90
+++ b/lis/metforcing/usaf/USAF_bratsethMod.F90
@@ -26,6 +26,8 @@
 ! 21 Mar 2024  Changed internal BackQC and SuperstatQC logic to only
 !              skip for IMERG.  This allows use with T, RH, and wind
 !              speed analyses..........................Eric Kemp/SSAI/NASA
+! 24 May 2024  Export USAF_is_gauge function, and add HADS and
+!              NWSLI gage networks.....................Eric Kemp/SSAI/NASA
 !
 ! DESCRIPTION:
 !
@@ -139,6 +141,8 @@ module USAF_bratsethMod
    public :: USAF_snowDepthQC
    public :: USAF_backQC
    public :: USAF_superstatQC
+   ! EMK 20240524
+   public :: USAF_is_gauge
 
    ! A simple linked list type that can be used in a hash table.  Intended
    ! to store indices of arrays in the USAF_obsData type for efficient look-up.
@@ -1673,7 +1677,7 @@ contains
       call calc_invDataDensities(precipAll,sigmaBSqr,nest, &
            agrmet_struc(nest)%bratseth_precip_max_dist, &
            agrmet_struc(nest)%bratseth_precip_back_err_scale_length, &
-           is_gauge, &
+           USAF_is_gauge, &
            invDataDensities)
 
       ! Run Bratseth analysis at observation points, and collect the sum of
@@ -1684,7 +1688,7 @@ contains
       call calc_obsAnalysis(precipAll,sigmaBSqr,nobs,invDataDensities,nest,&
            agrmet_struc(nest)%bratseth_precip_max_dist, &
            agrmet_struc(nest)%bratseth_precip_back_err_scale_length, &
-           convergeThresh, is_gauge, sumObsEstimates, &
+           convergeThresh, USAF_is_gauge, sumObsEstimates, &
            npasses, precipOBA)
 
       ! Calculate analysis at grid points.
@@ -4280,7 +4284,7 @@ contains
 
    !---------------------------------------------------------------------------
    ! Checks if observation network is recognized as a gauge.
-   logical function is_gauge(net)
+   logical function USAF_is_gauge(net)
       implicit none
       character(len=32), intent(in) :: net
       logical :: answer
@@ -4288,14 +4292,16 @@ contains
       if (trim(net) .eq. "AMIL") answer = .true.
       if (trim(net) .eq. "CANA") answer = .true.
       if (trim(net) .eq. "FAA") answer = .true.
+      if (trim(net) .eq. "HADS") answer = .true.
       if (trim(net) .eq. "ICAO") answer = .true.
+      if (trim(net) .eq. "NWSLI") answer = .true.
       if (trim(net) .eq. "WMO") answer = .true.
       if (trim(net) .eq. "MOBL") answer = .true.
       if (trim(net) .eq. "SUPERGAGE") answer = .true.
       ! Handle reformatted CDMS data that are missing the network type.
       if (trim(net) .eq. "CDMS") answer = .true.
-      is_gauge = answer
-   end function is_gauge
+      USAF_is_gauge = answer
+   end function USAF_is_gauge
 
    !---------------------------------------------------------------------------
    ! Dummy function for establishing a surface station is uncorrelated.

--- a/lis/metforcing/usaf/USAF_bratsethMod.F90
+++ b/lis/metforcing/usaf/USAF_bratsethMod.F90
@@ -4310,7 +4310,7 @@ contains
 
      ! General case:  Check list from LIS config file
      do j = 1, agrmet_struc(n)%num_gage_networks
-        if (trim(net) == trim(agrmet_struc(n)%gage_networks(j))) then
+        if (net == agrmet_struc(n)%gage_networks(j)) then
            answer = .true.
            exit
         end if

--- a/lis/metforcing/usaf/USAF_bratsethMod.F90
+++ b/lis/metforcing/usaf/USAF_bratsethMod.F90
@@ -1987,7 +1987,7 @@ contains
                      num = num + this%sigmaOSqr(job)
                   else if (trim(this%net(iob)) .eq. trim(this%net(job))) then
                      ! Satellite observations have correlated errors.
-                     if (.not. isUncorrObType(this%net(job))) then
+                     if (.not. isUncorrObType(this%net(job),nest)) then
                         if (.not. this%oErrScaleLength(job) > 0 .and. &
                              .not. this%oErrScaleLength(job) < 0) then
                            write(LIS_logunit,*) &
@@ -2302,7 +2302,7 @@ contains
                      else if (trim(this%net(iob)) .eq. &
                               trim(this%net(job))) then
                         ! Satellite data have horizontal error correlations
-                        if (.not. isUncorrObType(this%net(job))) then
+                        if (.not. isUncorrObType(this%net(job),nest)) then
                            weight = weight + &
                                 obsErrCov(this%sigmaOSqr(job), &
                                 this%oErrScaleLength(job), &
@@ -4284,23 +4284,37 @@ contains
 
    !---------------------------------------------------------------------------
    ! Checks if observation network is recognized as a gauge.
-   logical function USAF_is_gauge(net)
-      implicit none
-      character(len=32), intent(in) :: net
-      logical :: answer
-      answer = .false.
-      if (trim(net) .eq. "AMIL") answer = .true.
-      if (trim(net) .eq. "CANA") answer = .true.
-      if (trim(net) .eq. "FAA") answer = .true.
-      if (trim(net) .eq. "HADS") answer = .true.
-      if (trim(net) .eq. "ICAO") answer = .true.
-      if (trim(net) .eq. "NWSLI") answer = .true.
-      if (trim(net) .eq. "WMO") answer = .true.
-      if (trim(net) .eq. "MOBL") answer = .true.
-      if (trim(net) .eq. "SUPERGAGE") answer = .true.
-      ! Handle reformatted CDMS data that are missing the network type.
-      if (trim(net) .eq. "CDMS") answer = .true.
-      USAF_is_gauge = answer
+   logical function USAF_is_gauge(net, n) result(answer)
+
+     ! Imports
+     use AGRMET_forcingMod, only: agrmet_struc
+
+     ! Defaults
+     implicit none
+
+     ! Arguments
+     character(len=32), intent(in) :: net
+     integer, intent(in) :: n
+
+     ! Locals
+     integer :: j
+
+     answer = .false. ! First guess
+
+     ! Two special cases
+     if (trim(net) .eq. "SUPERGAGE" .or. &
+          trim(net) .eq. "CDMS") then
+        answer = .true.
+        return
+     end if
+
+     ! General case:  Check list from LIS config file
+     do j = 1, agrmet_struc(n)%num_gage_networks
+        if (trim(net) == trim(agrmet_struc(n)%gage_networks(j))) then
+           answer = .true.
+           exit
+        end if
+     end do
    end function USAF_is_gauge
 
    !---------------------------------------------------------------------------
@@ -4309,9 +4323,10 @@ contains
    ! Bratseth routines that need to know which reports in a collection
    ! have correlated errors.  When analyzing screen-level variables with
    ! surface stations, all observations should have uncorrelated errors.
-   logical function is_stn(net)
+   logical function is_stn(net, n)
       implicit none
       character(len=32), intent(in) :: net
+      integer, intent(in) :: n
       logical :: answer
       answer = .true.
       is_stn = answer

--- a/lis/metforcing/usaf/USAF_getpcpobs.F90
+++ b/lis/metforcing/usaf/USAF_getpcpobs.F90
@@ -82,7 +82,7 @@ subroutine USAF_getpcpobs(n, j6hr, month, use_twelve, pcp_src, &
 
      ! Read appropriate preobs file(s), intercompare with older presav2
      ! files, and create new presav2 file for current date/time.
-     call USAF_read_preobs(preobsdir, &
+     call USAF_read_preobs(n, preobsdir, &
           trim(agrmet_struc(n)%analysisdir), &
           agrmet_struc(n)%use_timestamp, yr, mo, da, hr, &
           use_expanded_station_ids, alert_number)

--- a/lis/metforcing/usaf/readcrd_agrmet.F90
+++ b/lis/metforcing/usaf/readcrd_agrmet.F90
@@ -1231,16 +1231,16 @@ subroutine readcrd_agrmet()
   call ESMF_ConfigFindLabel(LIS_config, &
        'AGRMET gauge networks to use::', rc=rc)
   call LIS_verify(rc, &
-       "[ERR] AGRMET gauge networks to use: not specified in config file")
+       "[ERR] AGRMET gauge networks to use:: not specified in config file")
   do n=1, LIS_rc%nnest
      call ESMF_ConfigNextLine(LIS_config, rc=rc)
      call LIS_verify(rc, &
-          '[ERR] AGRMET gauge networks to use: problem reading next line')
+          '[ERR] AGRMET gauge networks to use:: problem reading next line')
      do j = 1, agrmet_struc(n)%num_gage_networks
         call ESMF_ConfigGetAttribute(LIS_config, &
              agrmet_struc(n)%gage_networks(j), rc=rc)
         call LIS_verify(rc, &
-             '[ERR] AGRMET gauge networks to use: problem reading entry')
+             '[ERR] AGRMET gauge networks to use:: problem reading entry')
      end do
      write(LIS_logunit,*) &
           '[INFO] Will use following gauge networks for domain ', n


### PR DESCRIPTION

### Description

Number and IDs of gage networks to use in Bratseth analysis are now specified in lis.config file.

Also, if LIS encounters a gage report from an unrecognized network, the ob is rejected and an alert file is created
to notify the user of the network.

NOTE:  In the future, it may be better to keep the observation in memory and write to the OBA file for autotuning purposes while still excluding from the Bratseth scheme.

