### PR TITLE
New Top-40 cm soil moisture metric product

### DIFF
--- a/lis/utils/usaf/s2s/s2s_app/s2s_config_global_fcast
+++ b/lis/utils/usaf/s2s/s2s_app/s2s_config_global_fcast
@@ -85,4 +85,4 @@ POST:
   var_tair_max_list: [Tair_f_max]
   var_tair_min_list: [Tair_f_min]
   const_list: [lat, lon, ensemble, soil_layer, soil_layer_thickness, atime, Landmask_inst, LANDMASK, Landcover_inst, Soiltype_inst, Elevation_inst, Greenness_inst]
-  metric_vars: [RZSM, SFCSM, TWS, Precip, AirT, ET, Streamflow]
+  metric_vars: [RZSM, TOP40SM, SFCSM, TWS, Precip, AirT, ET, Streamflow]

--- a/lis/utils/usaf/s2s/s2s_modules/s2smetric/convert_s2s_anom_cf.py
+++ b/lis/utils/usaf/s2s/s2s_modules/s2smetric/convert_s2s_anom_cf.py
@@ -47,6 +47,7 @@ from netCDF4 import Dataset #pylint: disable=no-name-in-module
 # Units for variable anomalies.  Standardized anomalies will be dimensionless.
 _UNITS_ANOM = {
     "RZSM" : "m3 m-3",
+    "TOP40SM" : "m3 m-3",
     "SFCSM" : "m3 m-3",
     "TWS" : "mm",
     "Precip" : "kg m-2",
@@ -56,6 +57,7 @@ _UNITS_ANOM = {
 }
 _LONG_NAMES_SANOM = {
     "RZSM" : "Root zone soil moisture standardized anomaly",
+    "TOP40SM" : "Top 0-40 cm soil moisture standardized anomaly",
     "SFCSM" : "Surface soil moisture standardized anomaly",
     "TWS" : "Terrestrial water storage standardized anomaly",
     "Precip" : "Total precipitation amount standardized anomaly",
@@ -65,6 +67,7 @@ _LONG_NAMES_SANOM = {
 }
 _LONG_NAMES_ANOM = {
     "RZSM" : "Root zone soil moisture anomaly",
+    "TOP40SM" : "Top 0-40 cm soil moisture anomaly",
     "SFCSM" : "Surface soil moisture anomaly",
     "TWS" : "Terrestrial water storage anomaly",
     "Precip" : "Total precipitation amount anomaly",

--- a/lis/utils/usaf/s2s/s2s_modules/s2smetric/metrics_library/metricslib.py
+++ b/lis/utils/usaf/s2s/s2s_modules/s2smetric/metrics_library/metricslib.py
@@ -60,6 +60,15 @@ def sel_var(sel_cim_data, var_name, model):
             print(f"[ERR] Unknown model {model}")
             sys.exit(1)
 
+    elif var_name == "TOP40SM":
+        if model in ('NOAHMP', 'NoahMP'):
+            term1 = sel_cim_data.SoilMoist_tavg.isel(soil_layer=0) * 0.1
+            term2 = sel_cim_data.SoilMoist_tavg.isel(soil_layer=1) * 0.3
+            var_sel_clim_data = term1 + term2
+        else:
+            print(f"[ERR] Unknown model {model}")
+            sys.exit(1)
+
     elif var_name == 'Total-SM':
         if model == 'CLSM':
             # for clsm the total soil moisture is in the third layer


### PR DESCRIPTION
 Added new top-40cm layer soil moisture s2s metric product
  to the s2smetric postprocessing step of the S2S E2ES.

 - Updates made to two python scripts and addition in the Python config file: s2s_config_global_fcast

 - Top two soil layers are integrated, similar to the root-zone soil moisture layer (which is done for the top 1-meter).

 - Calculates the anomaly and standardized anomaly metrics and written to *TIF files and added to the *NC files.

This is for the next LIS support 7.5.x patch.