### PR TITLE
Change build scripts to explicitly use Python 3

### DIFF
--- a/ldt/make/makedep.py
+++ b/ldt/make/makedep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 # NASA Goddard Space Flight Center

--- a/lis/make/makedep.py
+++ b/lis/make/makedep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 # NASA Goddard Space Flight Center

--- a/lis/make/plugins.py
+++ b/lis/make/plugins.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 # NASA Goddard Space Flight Center

--- a/lvt/make/makedep.py
+++ b/lvt/make/makedep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 # NASA Goddard Space Flight Center


### PR DESCRIPTION
### Description

Change build scripts to explicitly use Python 3.  Cray/SLES 15.5 no longer provides `/usr/bin/env python`.  You must explicitly use `python3`.
