### PR TITLE
Fixed reset of alert_number.

### DIFF
--- a/lis/metforcing/usaf/USAF_fldbld_radflux_galwem.F90
+++ b/lis/metforcing/usaf/USAF_fldbld_radflux_galwem.F90
@@ -464,7 +464,6 @@ subroutine USAF_fldbld_radflux_galwem(n,julhr,fg_swdata,fg_lwdata,rc)
 ! ------------------------------------------------------------------
 ! read in first guess data for this julian hour.
 ! ------------------------------------------------------------------
-     alert_number = 0
      call USAF_fldbld_read_radflux_galwem(avnfile, ifguess, jfguess,&
           fg_swdown1, fg_lwdown1, rc)
 


### PR DESCRIPTION

### Description

This change prevents alert numbers from being reused when reporting missing GALWEM radiation files. Thus, it provides the user with a more accurate record of which GALWEM files are missing (alert files are not overwritten).
