### PR TITLE
Fix create release docs action

### DIFF
--- a/.github/workflows/build-release-docs.yaml
+++ b/.github/workflows/build-release-docs.yaml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Install Asciidoctor-PDF
         run: |
+          gem install public_suffix -v 5.1.1
           gem install asciidoctor-pdf
           asciidoctor-pdf --version
 


### PR DESCRIPTION
### Description

Explicitly install public_suffix gem at version 5.1.1

This is needed to install the asciidoctor-pdf gem.
