### PR TITLE
Change start date of SMOPS ASCAT v4 data to match our archive.

### DIFF
--- a/lis/dataassim/obs/SMOPS_ASCATsm/SMOPS_ASCATsm_Mod.F90
+++ b/lis/dataassim/obs/SMOPS_ASCATsm/SMOPS_ASCATsm_Mod.F90
@@ -603,7 +603,7 @@ contains
           call LIS_date2time(SMOPS_ASCATsm_struc(n)%version3_time,updoy,upgmt,&
              yr1,mo1,da1,hr1,mn1,ss1)
 
-          yr1 = 2024; mo1 = 4; da1 = 25; hr1 = 0; mn1 = 0; ss1 = 0
+          yr1 = 2024; mo1 = 7; da1 = 4; hr1 = 18; mn1 = 0; ss1 = 0
           call LIS_date2time(SMOPS_ASCATsm_struc(n)%version4_time,updoy,upgmt,&
              yr1,mo1,da1,hr1,mn1,ss1)
 

--- a/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
+++ b/lis/dataassim/obs/SMOPS_ASCATsm/read_SMOPS_ASCATsm.F90
@@ -1125,9 +1125,9 @@ subroutine create_SMOPS_ASCATsm_filename(ndir, useRT, yr, mo,da, hr, conv, filen
 
      call ESMF_TimeSet(Ver4_blended_time, &
         yy = 2024, &
-        mm = 4,   &
-        dd = 25,    &
-        h  = 0,    &
+        mm = 7,    &
+        dd = 4,    &
+        h  = 18,   &
         m  = 0,    &
         s  = 0,    &
         calendar = LIS_calendar, &


### PR DESCRIPTION
This pull request changes the start data of the v4 (version 4) of the SMOPS ASCAT data.

The new start date is 18Z 4 July 2024, which matches the start date of the v4 data in our archive.

Resolves: #1581


