### PR TITLE
Added inverse exponential correlation function option.

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5632,6 +5632,44 @@ Acceptable values are:
 `AGRMET forcing domain resolution (dx):` specifies east-west grid resolution in degrees longitude
 `AGRMET forcing domain resolution (dy):` specifies north-south grid resolution in degrees latitude
 
+`AGRMET use IMERG data:` specifies whether to use 30-min IMERG data
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|0                       ! Do not assimilate IMERG
+!1                       | Assimilate IMERG
+|====
+
+`AGRMET IMERG temperature threshold:` temperature threshold (K) below which to reject IMERG retrievals
+`AGRMET IMERG data directory:` top directory to find IMERG files
+`AGRMET IMERG product:` identifies which IMERG run to assimilate
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|3B-HHR-E                | 30-min Early Run
+!3B-HHR-L                | 30-min Late Run
+|3B-HHR                  | 30-min Final Run
+|====
+
+`AGRMET IMERG version:` text string identifying IMERG version to assimilate.  Used to construct file names.  V06x and V07x are supported.
+Acceptable values include:
+
+|====
+|Value                   | Description
+
+|V06B                    | Version 06B
+|V06C                    | Version 06C
+|V06D                    | Version 06D
+|V07B                    | Version 07B
+
+|====
+
+`AGRMET IMERG Probability Liquid Precip Threshold:` threshold to reject IMERG if liquid precip likelihood is too low
+
 .Example _lis.config_ entry
 ....
 AGRMET forcing directory:               ./FORCING/
@@ -5769,6 +5807,13 @@ AGRMET forcing domain upper right lat:       89.9531250
 AGRMET forcing domain upper right lon:      179.9296875
 AGRMET forcing domain resolution (dx):        0.1406250
 AGRMET forcing domain resolution (dy):        0.0937500
+
+AGRMET use IMERG data:                      1
+AGRMET IMERG temperature threshold:        278
+AGRMET IMERG data directory:               ./input/IMERG/Early_V07B
+AGRMET IMERG product:                      3B-HHR-E        # Early Run
+AGRMET IMERG version:                      V07B # Jun 2024
+AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 ....
 

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5670,6 +5670,45 @@ Acceptable values include:
 
 `AGRMET IMERG Probability Liquid Precip Threshold:` threshold to reject IMERG if liquid precip likelihood is too low
 
+`AGRMET output OBA data:` option for writing OBA (observation, background, analysis) files from Bratseth.
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|0                       | Do not write OBA files
+|1                       | Write OBA files
+|2                       | Write OBA files w/o actually running Bratseth scheme
+|====
+
+`AGRMET skip backQC:` option to disable backQC step
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|0                       | Do not skip backQC step
+|1                       | Skip backQC step
+|====
+
+`AGRMET skip superstatQC:` option to disable superstatQC step
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|0                       | Do not skip superstatQC step
+|1                       | Skip superstatQC step
+|====
+
+`AGRMET 3hr maximum precip ceiling:` set threshold (mm) above which to reject precipitation
+
+`AGRMET mask file:` path to legacy AGRMET landmask file
+
+`AGRMET terrain file:` path to legacy AGRMET terrain file
+
+|====
+
 .Example _lis.config_ entry
 ....
 AGRMET forcing directory:               ./FORCING/
@@ -5815,6 +5854,14 @@ AGRMET IMERG product:                      3B-HHR-E        # Early Run
 AGRMET IMERG version:                      V07B # Jun 2024
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
+AGRMET output OBA data: 0
+AGRMET skip backQC: 0
+AGRMET skip superstatQC: 0
+
+AGRMET 3hr maximum precip ceiling: 200.0
+
+AGRMET mask file:                ./input/legacy/all_16/point_switches
+AGRMET terrain file:              ./input/legacy/pst_16/terrain
 ....
 
 

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5616,6 +5616,21 @@ Acceptable values are:
 `AGRMET GFS SPD10M background error variance:` specifies GFS 10m wind speed error variance
 `AGRMET GFS SPD10M station observation error variance:` specifies station observation 10 wind speed error variance
 
+`AGRMET forcing map projection:` specifies map projection type.
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|latlon                  | use latitude/longitude projection
+|====
+
+`AGRMET forcing domain lower left lat:` specifies southwest latitude corner
+`AGRMET forcing domain lower left lon:` specifies southwest longitude corner
+`AGRMET forcing domain upper right lat:` specifies northeast latitude corner
+`AGRMET forcing domain upper right lon:` specifies northeast longitude corner
+`AGRMET forcing domain resolution (dx):` specifies east-west grid resolution in degrees longitude
+`AGRMET forcing domain resolution (dy):` specifies north-south grid resolution in degrees latitude
 
 .Example _lis.config_ entry
 ....
@@ -5746,6 +5761,14 @@ AGRMET GFS RH2M station observation error variance:                 66.8
 AGRMET GFS SPD10M background error scale length (m):             86000.
 AGRMET GFS SPD10M background error variance:                         0.57
 AGRMET GFS SPD10M station observation error variance:                2.48
+
+AGRMET forcing map projection:             latlon
+AGRMET forcing domain lower left lat:       -89.9531250
+AGRMET forcing domain lower left lon:      -179.9296875
+AGRMET forcing domain upper right lat:       89.9531250
+AGRMET forcing domain upper right lon:      179.9296875
+AGRMET forcing domain resolution (dx):        0.1406250
+AGRMET forcing domain resolution (dy):        0.0937500
 
 ....
 

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5574,6 +5574,48 @@ Acceptable values are:
 |2                       | use WIGOS supported files
 |====
 
+`AGRMET GALWEM Precip background error scale length (m):` specifies scale length for GALWEM precipitation error correlation
+`AGRMET GALWEM Precip background error variance:` specifies GALWEM precipitation error variance
+`AGRMET GALWEM Precip Gauge observation error variance:` specifies rain gauge observation precipitation error variance
+`AGRMET GALWEM Precip GEOPRECIP observation error scale length (m):` specifies scale length for GEOPRECIP precipitation error correlation
+`AGRMET GALWEM Precip GEOPRECIP observation error variance:` specifies GEOPRECIP observation precipitation error variance
+`AGRMET GALWEM Precip SSMI observation error scale length (m):` specifies scale length for SSMI precipitation error correlation
+`AGRMET GALWEM Precip SSMI observation error variance:` specifies SSMI observation precipitation error variance
+`AGRMET GALWEM Precip CMORPH observation error scale length (m):` specifies scale length for CMORPH precipitation error correlation
+`AGRMET GALWEM Precip CMORPH observation error variance:` specifies CMORPH observation precipitation error variance
+`AGRMET GALWEM Precip IMERG observation error scale length (m):` specifies scale length for IMERG precipitation error correlation
+`AGRMET GALWEM Precip IMERG observation error variance:` specifies IMERG observation precipitation error variance
+`AGRMET GALWEM T2M background error scale length (m):` specifies scale length for GALWEM 2m temperature error correlation
+`AGRMET GALWEM T2M background error variance:` specifies GALWEM 2m temperature error variance
+`AGRMET GALWEM T2M station observation error variance:` specifies station observation 2m temperature error variance
+`AGRMET GALWEM RH2M background error scale length (m):` specifies scale length for GALWEM 2m relative humidity error correlation
+`AGRMET GALWEM RH2M background error variance:` specifies GALWEM 2m relative humidity error variance
+`AGRMET GALWEM RH2M station observation error variance:` specifies station observation 2m relative humidity error variance
+`AGRMET GALWEM SPD10M background error scale length (m):` specifies scale length for GALWEM 10m wind speed error correlation
+`AGRMET GALWEM SPD10M background error variance:` specifies GALWEM 10m wind speed error variance
+`AGRMET GALWEM SPD10M station observation error variance:` specifies station observation 10 wind speed error variance
+
+`AGRMET GFS Precip background error scale length (m):` specifies scale length for GFS precipitation error correlation
+`AGRMET GFS Precip background error variance:` specifies GFS precipitation error variance
+`AGRMET GFS Precip Gauge observation error variance:` specifies rain gauge observation precipitation error variance
+`AGRMET GFS Precip GEOPRECIP observation error scale length (m):` specifies scale length for GEOPRECIP precipitation error correlation
+`AGRMET GFS Precip GEOPRECIP observation error variance:` specifies GEOPRECIP observation precipitation error variance
+`AGRMET GFS Precip SSMI observation error scale length (m):` specifies scale length for SSMI precipitation error correlation
+`AGRMET GFS Precip SSMI observation error variance:` specifies SSMI observation precipitation error variance
+`AGRMET GFS Precip CMORPH observation error scale length (m):` specifies scale length for CMORPH precipitation error correlation
+`AGRMET GFS Precip CMORPH observation error variance:` specifies CMORPH observation precipitation error variance
+`AGRMET GFS Precip IMERG observation error scale length (m):` specifies scale length for IMERG precipitation error correlation
+`AGRMET GFS Precip IMERG observation error variance:` specifies IMERG observation precipitation error variance
+`AGRMET GFS T2M background error scale length (m):` specifies scale length for GFS 2m temperature error correlation
+`AGRMET GFS T2M background error variance:` specifies GFS 2m temperature error variance
+`AGRMET GFS T2M station observation error variance:` specifies station observation 2m temperature error variance
+`AGRMET GFS RH2M background error scale length (m):` specifies scale length for GFS 2m relative humidity error correlation
+`AGRMET GFS RH2M background error variance:` specifies GFS 2m relative humidity error variance
+`AGRMET GFS RH2M station observation error variance:` specifies station observation 2m relative humidity error variance
+`AGRMET GFS SPD10M background error scale length (m):` specifies scale length for GFS 10m wind speed error correlation
+`AGRMET GFS SPD10M background error variance:` specifies GFS 10m wind speed error variance
+`AGRMET GFS SPD10M station observation error variance:` specifies station observation 10 wind speed error variance
+
 
 .Example _lis.config_ entry
 ....
@@ -5662,6 +5704,48 @@ AGRMET GFS RH2M correlation function type: 1
 AGRMET GFS SPD10M correlation function type: 1
 AGRMET precip obs file format: 1
 AGRMET sfc obs file format: 1
+
+AGRMET GALWEM Precip background error scale length (m):         102000.
+AGRMET GALWEM Precip background error variance:                      0.83
+AGRMET GALWEM Precip Gauge observation error variance:               0.86
+AGRMET GALWEM Precip GEOPRECIP observation error scale length (m): 132000.
+AGRMET GALWEM Precip GEOPRECIP observation error variance:           1.24
+AGRMET GALWEM Precip SSMI observation error scale length (m):   133000.
+AGRMET GALWEM Precip SSMI observation error variance:                2.58
+AGRMET GALWEM Precip CMORPH observation error scale length (m):  89000.
+AGRMET GALWEM Precip CMORPH observation error variance:              1.15
+AGRMET GALWEM Precip IMERG observation error scale length (m):  101000.
+AGRMET GALWEM Precip IMERG observation error variance:               1.93
+AGRMET GALWEM T2M background error scale length (m):            110000.
+AGRMET GALWEM T2M background error variance:                         1.48
+AGRMET GALWEM T2M station observation error variance:                2.30
+AGRMET GALWEM RH2M background error scale length (m):           119000.
+AGRMET GALWEM RH2M background error variance:                       30.7
+AGRMET GALWEM RH2M station observation error variance:              65.8
+AGRMET GALWEM SPD10M background error scale length (m):          53000.
+AGRMET GALWEM SPD10M background error variance:                      0.62
+AGRMET GALWEM SPD10M station observation error variance:             2.37
+
+AGRMET GFS Precip background error scale length (m):             93000.
+AGRMET GFS Precip background error variance:                         0.47
+AGRMET GFS Precip Gauge observation error variance:                  0.70
+AGRMET GFS Precip GEOPRECIP observation error scale length (m): 131000.
+AGRMET GFS Precip GEOPRECIP observation error variance:              1.06
+AGRMET GFS Precip SSMI observation error scale length (m):      131000.
+AGRMET GFS Precip SSMI observation error variance:                   2.10
+AGRMET GFS Precip CMORPH observation error scale length (m):     91000.
+AGRMET GFS Precip CMORPH observation error variance:                 0.92
+AGRMET GFS Precip IMERG observation error scale length (m):     100000.
+AGRMET GFS Precip IMERG observation error variance:                  1.62
+AGRMET GFS T2M background error scale length (m):               125000.
+AGRMET GFS T2M background error variance:                            1.36
+AGRMET GFS T2M station observation error variance:                   2.38
+AGRMET GFS RH2M background error scale length (m):              197000.
+AGRMET GFS RH2M background error variance:                          51.3
+AGRMET GFS RH2M station observation error variance:                 66.8
+AGRMET GFS SPD10M background error scale length (m):             86000.
+AGRMET GFS SPD10M background error variance:                         0.57
+AGRMET GFS SPD10M station observation error variance:                2.48
 
 ....
 

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5638,8 +5638,8 @@ Acceptable values are:
 |====
 |Value                   | Description
 
-|0                       ! Do not assimilate IMERG
-!1                       | Assimilate IMERG
+|0                       | Do not assimilate IMERG
+|1                       | Assimilate IMERG
 |====
 
 `AGRMET IMERG temperature threshold:` temperature threshold (K) below which to reject IMERG retrievals
@@ -5651,7 +5651,7 @@ Acceptable values are:
 |Value                   | Description
 
 |3B-HHR-E                | 30-min Early Run
-!3B-HHR-L                | 30-min Late Run
+|3B-HHR-L                | 30-min Late Run
 |3B-HHR                  | 30-min Final Run
 |====
 
@@ -5706,8 +5706,6 @@ Acceptable values are:
 `AGRMET mask file:` path to legacy AGRMET landmask file
 
 `AGRMET terrain file:` path to legacy AGRMET terrain file
-
-|====
 
 .Example _lis.config_ entry
 ....

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5473,6 +5473,108 @@ of gauge networks to use, to be identified in separate config entry.
 `AGRMET gauge networks to use::` specifies list of names of gauge
 networks to be used. (One line of names per domain.)
 
+`AGRMET GALWEM Precip correlation function type:` specifies function for modeling precipitation error correlations.
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|1                       | use Gaussian function
+|2                       | use inverse exponential function
+|====
+
+`AGRMET GALWEM T2M correlation function type:` specifies function for modeling 2m temperature error correlations.
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|1                       | use Gaussian function
+|2                       | use inverse exponential function
+|====
+
+`AGRMET GALWEM RH2M correlation function type:` specifies function for modeling 2m relative humidity error correlations.
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|1                       | use Gaussian function
+|2                       | use inverse exponential function
+|====
+
+`AGRMET GALWEM SPD10M correlation function type:` specifies function for modeling 10m wind speed error correlations.
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|1                       | use Gaussian function
+|2                       | use inverse exponential function
+|====
+
+
+`AGRMET GFS Precip correlation function type:` specifies function for modeling precipitation error correlations.
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|1                       | use Gaussian function
+|2                       | use inverse exponential function
+|====
+
+`AGRMET GFS T2M correlation function type:` specifies function for modeling 2m temperature error correlations.
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|1                       | use Gaussian function
+|2                       | use inverse exponential function
+|====
+
+`AGRMET GFS RH2M correlation function type:` specifies function for modeling 2m relative humidity error correlations.
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|1                       | use Gaussian function
+|2                       | use inverse exponential function
+|====
+
+`AGRMET GFS SPD10M correlation function type:` specifies function for modeling 10m wind speed error correlations.
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|1                       | use Gaussian function
+|2                       | use inverse exponential function
+|====
+
+`AGRMET precip obs file format:` specifies preobs file format
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|1                       | use legacy files
+|2                       | use WIGOS supported files
+|====
+
+`AGRMET sfc obs file format:` specifies sfcobs file format
+Acceptable values are:
+
+|====
+|Value                   | Description
+
+|1                       | use legacy files
+|2                       | use WIGOS supported files
+|====
+
+
 .Example _lis.config_ entry
 ....
 AGRMET forcing directory:               ./FORCING/
@@ -5550,6 +5652,17 @@ AGRMET number of gauge networks to use: 7
 AGRMET gauge networks to use::
 AMIL CANA FAA ICAO WMO HADS NWSLI
 ::
+AGRMET GALWEM Precip correlation function type: 1
+AGRMET GALWEM T2M correlation function type: 1
+AGRMET GALWEM RH2M correlation function type: 1
+AGRMET GALWEM SPD10M correlation function type: 1
+AGRMET GFS Precip correlation function type: 1
+AGRMET GFS T2M correlation function type: 1
+AGRMET GFS RH2M correlation function type: 1
+AGRMET GFS SPD10M correlation function type: 1
+AGRMET precip obs file format: 1
+AGRMET sfc obs file format: 1
+
 ....
 
 

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5172,7 +5172,7 @@ x direction which is useful for when precip and native grid differ.
 |1024   | 16th mesh polar stereo
 |(4096) | (64th mesh polar stereo reserved for future use)
 |(3600) | (1/10 degree latlon reserved for future use {emdash} note
-          this isn`'t grid centered)
+          this is not grid centered)
 |====
 
 `AGRMET GEOPRECIP jmax:` specifies the GEOPRECIP grid dimension
@@ -5185,7 +5185,7 @@ y direction which is useful for when precip and native grid differ.
 |1024   | 16th mesh polar stereo
 |(4096) | (64th mesh polar stereo reserved fro future use)
 |(1801) | (1/10 degree latlon reserved for future use {emdash} note
-          this isn`'t grid centered)
+          this is not grid centered)
 |====
 
 `AGRMET SSMI imax:` specifies the SSMI/S grid dimension x direction
@@ -5280,7 +5280,7 @@ Acceptable values are:
 |0     | do not use
 |1     | use the estimate, do not use the rank {emdash}
          assumes that rank of GEOPRECIP is 1;
-         i.e., uses it when it`'s available
+         i.e., uses it when it is available
 |2     | use the estimate and use the rank
 |====
 
@@ -5703,7 +5703,7 @@ AGRMET CMORPH dx:
 AGRMET CMORPH dy:
 AGRMET use GFS precip:     1
 AGRMET use GALWEM precip:  0
-AGRMET radiation derived from: 'GALWEM_RAD'
+AGRMET radiation derived from: GALWEM_RAD
 AGRMET GALWEM radiation data directory: GALWEM_Rad
 AGRMET number of gauge networks to use: 7
 AGRMET gauge networks to use::

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5554,7 +5554,7 @@ Acceptable values are:
 |2                       | use inverse exponential function
 |====
 
-`AGRMET precip obs file format:` specifies preobs file format
+`AGRMET precip obs file format:` specifies preobs file format.
 Acceptable values are:
 
 |====
@@ -5564,7 +5564,7 @@ Acceptable values are:
 |2                       | use WIGOS supported files
 |====
 
-`AGRMET sfc obs file format:` specifies sfcobs file format
+`AGRMET sfc obs file format:` specifies sfcobs file format.
 Acceptable values are:
 
 |====
@@ -5574,47 +5574,85 @@ Acceptable values are:
 |2                       | use WIGOS supported files
 |====
 
-`AGRMET GALWEM Precip background error scale length (m):` specifies scale length for GALWEM precipitation error correlation
-`AGRMET GALWEM Precip background error variance:` specifies GALWEM precipitation error variance
-`AGRMET GALWEM Precip Gauge observation error variance:` specifies rain gauge observation precipitation error variance
-`AGRMET GALWEM Precip GEOPRECIP observation error scale length (m):` specifies scale length for GEOPRECIP precipitation error correlation
-`AGRMET GALWEM Precip GEOPRECIP observation error variance:` specifies GEOPRECIP observation precipitation error variance
-`AGRMET GALWEM Precip SSMI observation error scale length (m):` specifies scale length for SSMI precipitation error correlation
-`AGRMET GALWEM Precip SSMI observation error variance:` specifies SSMI observation precipitation error variance
-`AGRMET GALWEM Precip CMORPH observation error scale length (m):` specifies scale length for CMORPH precipitation error correlation
-`AGRMET GALWEM Precip CMORPH observation error variance:` specifies CMORPH observation precipitation error variance
-`AGRMET GALWEM Precip IMERG observation error scale length (m):` specifies scale length for IMERG precipitation error correlation
-`AGRMET GALWEM Precip IMERG observation error variance:` specifies IMERG observation precipitation error variance
-`AGRMET GALWEM T2M background error scale length (m):` specifies scale length for GALWEM 2m temperature error correlation
-`AGRMET GALWEM T2M background error variance:` specifies GALWEM 2m temperature error variance
-`AGRMET GALWEM T2M station observation error variance:` specifies station observation 2m temperature error variance
-`AGRMET GALWEM RH2M background error scale length (m):` specifies scale length for GALWEM 2m relative humidity error correlation
-`AGRMET GALWEM RH2M background error variance:` specifies GALWEM 2m relative humidity error variance
-`AGRMET GALWEM RH2M station observation error variance:` specifies station observation 2m relative humidity error variance
-`AGRMET GALWEM SPD10M background error scale length (m):` specifies scale length for GALWEM 10m wind speed error correlation
-`AGRMET GALWEM SPD10M background error variance:` specifies GALWEM 10m wind speed error variance
-`AGRMET GALWEM SPD10M station observation error variance:` specifies station observation 10 wind speed error variance
+`AGRMET GALWEM Precip background error scale length (m):` specifies scale length for GALWEM precipitation error correlation.
 
-`AGRMET GFS Precip background error scale length (m):` specifies scale length for GFS precipitation error correlation
-`AGRMET GFS Precip background error variance:` specifies GFS precipitation error variance
-`AGRMET GFS Precip Gauge observation error variance:` specifies rain gauge observation precipitation error variance
-`AGRMET GFS Precip GEOPRECIP observation error scale length (m):` specifies scale length for GEOPRECIP precipitation error correlation
-`AGRMET GFS Precip GEOPRECIP observation error variance:` specifies GEOPRECIP observation precipitation error variance
-`AGRMET GFS Precip SSMI observation error scale length (m):` specifies scale length for SSMI precipitation error correlation
-`AGRMET GFS Precip SSMI observation error variance:` specifies SSMI observation precipitation error variance
-`AGRMET GFS Precip CMORPH observation error scale length (m):` specifies scale length for CMORPH precipitation error correlation
-`AGRMET GFS Precip CMORPH observation error variance:` specifies CMORPH observation precipitation error variance
-`AGRMET GFS Precip IMERG observation error scale length (m):` specifies scale length for IMERG precipitation error correlation
-`AGRMET GFS Precip IMERG observation error variance:` specifies IMERG observation precipitation error variance
-`AGRMET GFS T2M background error scale length (m):` specifies scale length for GFS 2m temperature error correlation
-`AGRMET GFS T2M background error variance:` specifies GFS 2m temperature error variance
-`AGRMET GFS T2M station observation error variance:` specifies station observation 2m temperature error variance
-`AGRMET GFS RH2M background error scale length (m):` specifies scale length for GFS 2m relative humidity error correlation
-`AGRMET GFS RH2M background error variance:` specifies GFS 2m relative humidity error variance
-`AGRMET GFS RH2M station observation error variance:` specifies station observation 2m relative humidity error variance
-`AGRMET GFS SPD10M background error scale length (m):` specifies scale length for GFS 10m wind speed error correlation
-`AGRMET GFS SPD10M background error variance:` specifies GFS 10m wind speed error variance
-`AGRMET GFS SPD10M station observation error variance:` specifies station observation 10 wind speed error variance
+`AGRMET GALWEM Precip background error variance:` specifies GALWEM precipitation error variance.
+
+`AGRMET GALWEM Precip Gauge observation error variance:` specifies rain gauge observation precipitation error variance.
+
+`AGRMET GALWEM Precip GEOPRECIP observation error scale length (m):` specifies scale length for GEOPRECIP precipitation error correlation.
+
+`AGRMET GALWEM Precip GEOPRECIP observation error variance:` specifies GEOPRECIP observation precipitation error variance.
+
+`AGRMET GALWEM Precip SSMI observation error scale length (m):` specifies scale length for SSMI precipitation error correlation.
+
+`AGRMET GALWEM Precip SSMI observation error variance:` specifies SSMI observation precipitation error variance.
+
+`AGRMET GALWEM Precip CMORPH observation error scale length (m):` specifies scale length for CMORPH precipitation error correlation.
+
+`AGRMET GALWEM Precip CMORPH observation error variance:` specifies CMORPH observation precipitation error variance.
+
+`AGRMET GALWEM Precip IMERG observation error scale length (m):` specifies scale length for IMERG precipitation error correlation.
+
+`AGRMET GALWEM Precip IMERG observation error variance:` specifies IMERG observation precipitation error variance.
+
+`AGRMET GALWEM T2M background error scale length (m):` specifies scale length for GALWEM 2m temperature error correlation.
+
+`AGRMET GALWEM T2M background error variance:` specifies GALWEM 2m temperature error variance.
+
+`AGRMET GALWEM T2M station observation error variance:` specifies station observation 2m temperature error variance.
+
+`AGRMET GALWEM RH2M background error scale length (m):` specifies scale length for GALWEM 2m relative humidity error correlation.
+
+`AGRMET GALWEM RH2M background error variance:` specifies GALWEM 2m relative humidity error variance.
+
+`AGRMET GALWEM RH2M station observation error variance:` specifies station observation 2m relative humidity error variance.
+
+`AGRMET GALWEM SPD10M background error scale length (m):` specifies scale length for GALWEM 10m wind speed error correlation.
+
+`AGRMET GALWEM SPD10M background error variance:` specifies GALWEM 10m wind speed error variance.
+
+`AGRMET GALWEM SPD10M station observation error variance:` specifies station observation 10 wind speed error variance.
+
+`AGRMET GFS Precip background error scale length (m):` specifies scale length for GFS precipitation error correlation.
+
+`AGRMET GFS Precip background error variance:` specifies GFS precipitation error variance.
+
+`AGRMET GFS Precip Gauge observation error variance:` specifies rain gauge observation precipitation error variance.
+
+`AGRMET GFS Precip GEOPRECIP observation error scale length (m):` specifies scale length for GEOPRECIP precipitation error correlation.
+
+`AGRMET GFS Precip GEOPRECIP observation error variance:` specifies GEOPRECIP observation precipitation error variance.
+
+`AGRMET GFS Precip SSMI observation error scale length (m):` specifies scale length for SSMI precipitation error correlation.
+
+`AGRMET GFS Precip SSMI observation error variance:` specifies SSMI observation precipitation error variance.
+
+`AGRMET GFS Precip CMORPH observation error scale length (m):` specifies scale length for CMORPH precipitation error correlation.
+
+`AGRMET GFS Precip CMORPH observation error variance:` specifies CMORPH observation precipitation error variance.
+
+`AGRMET GFS Precip IMERG observation error scale length (m):` specifies scale length for IMERG precipitation error correlation.
+
+`AGRMET GFS Precip IMERG observation error variance:` specifies IMERG observation precipitation error variance.
+
+`AGRMET GFS T2M background error scale length (m):` specifies scale length for GFS 2m temperature error correlation.
+
+`AGRMET GFS T2M background error variance:` specifies GFS 2m temperature error variance.
+
+`AGRMET GFS T2M station observation error variance:` specifies station observation 2m temperature error variance.
+
+`AGRMET GFS RH2M background error scale length (m):` specifies scale length for GFS 2m relative humidity error correlation.
+
+`AGRMET GFS RH2M background error variance:` specifies GFS 2m relative humidity error variance.
+
+`AGRMET GFS RH2M station observation error variance:` specifies station observation 2m relative humidity error variance.
+
+`AGRMET GFS SPD10M background error scale length (m):` specifies scale length for GFS 10m wind speed error correlation.
+
+`AGRMET GFS SPD10M background error variance:` specifies GFS 10m wind speed error variance.
+
+`AGRMET GFS SPD10M station observation error variance:` specifies station observation 10 wind speed error variance.
 
 `AGRMET forcing map projection:` specifies map projection type.
 Acceptable values are:
@@ -5625,12 +5663,17 @@ Acceptable values are:
 |latlon                  | use latitude/longitude projection
 |====
 
-`AGRMET forcing domain lower left lat:` specifies southwest latitude corner
-`AGRMET forcing domain lower left lon:` specifies southwest longitude corner
-`AGRMET forcing domain upper right lat:` specifies northeast latitude corner
-`AGRMET forcing domain upper right lon:` specifies northeast longitude corner
-`AGRMET forcing domain resolution (dx):` specifies east-west grid resolution in degrees longitude
-`AGRMET forcing domain resolution (dy):` specifies north-south grid resolution in degrees latitude
+`AGRMET forcing domain lower left lat:` specifies southwest latitude corner.
+
+`AGRMET forcing domain lower left lon:` specifies southwest longitude corner.
+
+`AGRMET forcing domain upper right lat:` specifies northeast latitude corner.
+
+`AGRMET forcing domain upper right lon:` specifies northeast longitude corner.
+
+`AGRMET forcing domain resolution (dx):` specifies east-west grid resolution in degrees longitude.
+
+`AGRMET forcing domain resolution (dy):` specifies north-south grid resolution in degrees latitude.
 
 `AGRMET use IMERG data:` specifies whether to use 30-min IMERG data
 Acceptable values are:
@@ -5642,9 +5685,11 @@ Acceptable values are:
 |1                       | Assimilate IMERG
 |====
 
-`AGRMET IMERG temperature threshold:` temperature threshold (K) below which to reject IMERG retrievals
-`AGRMET IMERG data directory:` top directory to find IMERG files
-`AGRMET IMERG product:` identifies which IMERG run to assimilate
+`AGRMET IMERG temperature threshold:` temperature threshold (K) below which to reject IMERG retrievals.
+
+`AGRMET IMERG data directory:` top directory to find IMERG files.
+
+`AGRMET IMERG product:` identifies which IMERG run to assimilate.
 Acceptable values are:
 
 |====
@@ -5665,10 +5710,9 @@ Acceptable values include:
 |V06C                    | Version 06C
 |V06D                    | Version 06D
 |V07B                    | Version 07B
-
 |====
 
-`AGRMET IMERG Probability Liquid Precip Threshold:` threshold to reject IMERG if liquid precip likelihood is too low
+`AGRMET IMERG Probability Liquid Precip Threshold:` threshold to reject IMERG if liquid precip likelihood is too low.
 
 `AGRMET output OBA data:` option for writing OBA (observation, background, analysis) files from Bratseth.
 Acceptable values are:
@@ -5681,7 +5725,7 @@ Acceptable values are:
 |2                       | Write OBA files w/o actually running Bratseth scheme
 |====
 
-`AGRMET skip backQC:` option to disable backQC step
+`AGRMET skip backQC:` option to disable backQC step.
 Acceptable values are:
 
 |====
@@ -5691,7 +5735,7 @@ Acceptable values are:
 |1                       | Skip backQC step
 |====
 
-`AGRMET skip superstatQC:` option to disable superstatQC step
+`AGRMET skip superstatQC:` option to disable superstatQC step.
 Acceptable values are:
 
 |====
@@ -5701,11 +5745,11 @@ Acceptable values are:
 |1                       | Skip superstatQC step
 |====
 
-`AGRMET 3hr maximum precip ceiling:` set threshold (mm) above which to reject precipitation
+`AGRMET 3hr maximum precip ceiling:` set threshold (mm) above which to reject precipitation.
 
-`AGRMET mask file:` path to legacy AGRMET landmask file
+`AGRMET mask file:` path to legacy AGRMET landmask file.
 
-`AGRMET terrain file:` path to legacy AGRMET terrain file
+`AGRMET terrain file:` path to legacy AGRMET terrain file.
 
 .Example _lis.config_ entry
 ....

--- a/lis/metforcing/usaf/AGRMET_forcingMod.F90
+++ b/lis/metforcing/usaf/AGRMET_forcingMod.F90
@@ -637,21 +637,25 @@ integer, allocatable   :: n112_sh4(:)
      real :: galwem_precip_cmorph_sigma_o_sqr
      real :: galwem_precip_imerg_err_scale_length
      real :: galwem_precip_imerg_sigma_o_sqr
+     integer :: galwem_precip_corr_func_type
      real :: galwem_precip_max_dist
 
      real :: galwem_t2m_back_err_scale_length
      real :: galwem_t2m_back_sigma_b_sqr
      real :: galwem_t2m_stn_sigma_o_sqr
+     integer :: galwem_t2m_corr_func_type
      real :: galwem_t2m_max_dist
 
      real :: galwem_rh2m_back_err_scale_length
      real :: galwem_rh2m_back_sigma_b_sqr
      real :: galwem_rh2m_stn_sigma_o_sqr
+     integer :: galwem_rh2m_corr_func_type
      real :: galwem_rh2m_max_dist
 
      real :: galwem_spd10m_back_err_scale_length
      real :: galwem_spd10m_back_sigma_b_sqr
      real :: galwem_spd10m_stn_sigma_o_sqr
+     integer :: galwem_spd10m_corr_func_type
      real :: galwem_spd10m_max_dist
 
      ! EMK NEW...For Bratseth scheme using GFS background
@@ -666,21 +670,25 @@ integer, allocatable   :: n112_sh4(:)
      real :: gfs_precip_cmorph_sigma_o_sqr
      real :: gfs_precip_imerg_err_scale_length
      real :: gfs_precip_imerg_sigma_o_sqr
+     integer :: gfs_precip_corr_func_type
      real :: gfs_precip_max_dist
 
      real :: gfs_t2m_back_err_scale_length
      real :: gfs_t2m_back_sigma_b_sqr
      real :: gfs_t2m_stn_sigma_o_sqr
+     integer :: gfs_t2m_corr_func_type
      real :: gfs_t2m_max_dist
 
      real :: gfs_rh2m_back_err_scale_length
      real :: gfs_rh2m_back_sigma_b_sqr
      real :: gfs_rh2m_stn_sigma_o_sqr
+     integer :: gfs_rh2m_corr_func_type
      real :: gfs_rh2m_max_dist
 
      real :: gfs_spd10m_back_err_scale_length
      real :: gfs_spd10m_back_sigma_b_sqr
      real :: gfs_spd10m_stn_sigma_o_sqr
+     integer :: gfs_spd10m_corr_func_type
      real :: gfs_spd10m_max_dist
 
      ! EMK NEW...For Bratseth scheme.  Set dynamically based on available
@@ -696,24 +704,28 @@ integer, allocatable   :: n112_sh4(:)
      real :: bratseth_precip_cmorph_sigma_o_sqr
      real :: bratseth_precip_imerg_err_scale_length
      real :: bratseth_precip_imerg_sigma_o_sqr
+     integer :: bratseth_precip_corr_func_type
      real :: bratseth_precip_max_dist
 
      real :: bratseth_t2m_back_err_scale_length
      real :: bratseth_t2m_back_sigma_b_sqr
      real :: bratseth_t2m_stn_sigma_o_sqr
+     integer :: bratseth_t2m_corr_func_type
      real :: bratseth_t2m_max_dist
 
      real :: bratseth_rh2m_back_err_scale_length
      real :: bratseth_rh2m_back_sigma_b_sqr
      real :: bratseth_rh2m_stn_sigma_o_sqr
+     integer :: bratseth_rh2m_corr_func_type
      real :: bratseth_rh2m_max_dist
 
      real :: bratseth_spd10m_back_err_scale_length
      real :: bratseth_spd10m_back_sigma_b_sqr
      real :: bratseth_spd10m_stn_sigma_o_sqr
+     integer :: bratseth_spd10m_corr_func_type
      real :: bratseth_spd10m_max_dist
 
-     integer :: galwem_res ! EMK for GALWEM 10-km     
+     integer :: galwem_res ! EMK for GALWEM 10-km
      integer :: gfs_filename_version ! EMK for new GFS filename convention
 
      ! EMK Add OBA option

--- a/lis/metforcing/usaf/AGRMET_forcingMod.F90
+++ b/lis/metforcing/usaf/AGRMET_forcingMod.F90
@@ -627,32 +627,40 @@ integer, allocatable   :: n112_sh4(:)
 
      ! EMK NEW...For Bratseth scheme using GALWEM background
      real :: galwem_precip_back_err_scale_length
+     real :: galwem_precip_back_err_inv_scale_length
      real :: galwem_precip_back_sigma_b_sqr
      real :: galwem_precip_gauge_sigma_o_sqr
      real :: galwem_precip_geoprecip_err_scale_length
+     real :: galwem_precip_geoprecip_err_inv_scale_length
      real :: galwem_precip_geoprecip_sigma_o_sqr
      real :: galwem_precip_ssmi_err_scale_length
+     real :: galwem_precip_ssmi_err_inv_scale_length
      real :: galwem_precip_ssmi_sigma_o_sqr
      real :: galwem_precip_cmorph_err_scale_length
+     real :: galwem_precip_cmorph_err_inv_scale_length
      real :: galwem_precip_cmorph_sigma_o_sqr
      real :: galwem_precip_imerg_err_scale_length
+     real :: galwem_precip_imerg_err_inv_scale_length
      real :: galwem_precip_imerg_sigma_o_sqr
      integer :: galwem_precip_corr_func_type
      real :: galwem_precip_max_dist
 
      real :: galwem_t2m_back_err_scale_length
+     real :: galwem_t2m_back_err_inv_scale_length
      real :: galwem_t2m_back_sigma_b_sqr
      real :: galwem_t2m_stn_sigma_o_sqr
      integer :: galwem_t2m_corr_func_type
      real :: galwem_t2m_max_dist
 
      real :: galwem_rh2m_back_err_scale_length
+     real :: galwem_rh2m_back_err_inv_scale_length
      real :: galwem_rh2m_back_sigma_b_sqr
      real :: galwem_rh2m_stn_sigma_o_sqr
      integer :: galwem_rh2m_corr_func_type
      real :: galwem_rh2m_max_dist
 
      real :: galwem_spd10m_back_err_scale_length
+     real :: galwem_spd10m_back_err_inv_scale_length
      real :: galwem_spd10m_back_sigma_b_sqr
      real :: galwem_spd10m_stn_sigma_o_sqr
      integer :: galwem_spd10m_corr_func_type
@@ -660,32 +668,40 @@ integer, allocatable   :: n112_sh4(:)
 
      ! EMK NEW...For Bratseth scheme using GFS background
      real :: gfs_precip_back_err_scale_length
+     real :: gfs_precip_back_err_inv_scale_length
      real :: gfs_precip_back_sigma_b_sqr
      real :: gfs_precip_gauge_sigma_o_sqr
      real :: gfs_precip_geoprecip_err_scale_length
+     real :: gfs_precip_geoprecip_err_inv_scale_length
      real :: gfs_precip_geoprecip_sigma_o_sqr
      real :: gfs_precip_ssmi_err_scale_length
+     real :: gfs_precip_ssmi_err_inv_scale_length
      real :: gfs_precip_ssmi_sigma_o_sqr
      real :: gfs_precip_cmorph_err_scale_length
+     real :: gfs_precip_cmorph_err_inv_scale_length
      real :: gfs_precip_cmorph_sigma_o_sqr
      real :: gfs_precip_imerg_err_scale_length
+     real :: gfs_precip_imerg_err_inv_scale_length
      real :: gfs_precip_imerg_sigma_o_sqr
      integer :: gfs_precip_corr_func_type
      real :: gfs_precip_max_dist
 
      real :: gfs_t2m_back_err_scale_length
+     real :: gfs_t2m_back_err_inv_scale_length
      real :: gfs_t2m_back_sigma_b_sqr
      real :: gfs_t2m_stn_sigma_o_sqr
      integer :: gfs_t2m_corr_func_type
      real :: gfs_t2m_max_dist
 
      real :: gfs_rh2m_back_err_scale_length
+     real :: gfs_rh2m_back_err_inv_scale_length
      real :: gfs_rh2m_back_sigma_b_sqr
      real :: gfs_rh2m_stn_sigma_o_sqr
      integer :: gfs_rh2m_corr_func_type
      real :: gfs_rh2m_max_dist
 
      real :: gfs_spd10m_back_err_scale_length
+     real :: gfs_spd10m_back_err_inv_scale_length
      real :: gfs_spd10m_back_sigma_b_sqr
      real :: gfs_spd10m_stn_sigma_o_sqr
      integer :: gfs_spd10m_corr_func_type
@@ -694,32 +710,40 @@ integer, allocatable   :: n112_sh4(:)
      ! EMK NEW...For Bratseth scheme.  Set dynamically based on available
      ! background field
      real :: bratseth_precip_back_err_scale_length
+     real :: bratseth_precip_back_err_inv_scale_length
      real :: bratseth_precip_back_sigma_b_sqr
      real :: bratseth_precip_gauge_sigma_o_sqr
      real :: bratseth_precip_geoprecip_err_scale_length
+     real :: bratseth_precip_geoprecip_err_inv_scale_length
      real :: bratseth_precip_geoprecip_sigma_o_sqr
      real :: bratseth_precip_ssmi_err_scale_length
+     real :: bratseth_precip_ssmi_err_inv_scale_length
      real :: bratseth_precip_ssmi_sigma_o_sqr
      real :: bratseth_precip_cmorph_err_scale_length
+     real :: bratseth_precip_cmorph_err_inv_scale_length
      real :: bratseth_precip_cmorph_sigma_o_sqr
      real :: bratseth_precip_imerg_err_scale_length
+     real :: bratseth_precip_imerg_err_inv_scale_length
      real :: bratseth_precip_imerg_sigma_o_sqr
      integer :: bratseth_precip_corr_func_type
      real :: bratseth_precip_max_dist
 
      real :: bratseth_t2m_back_err_scale_length
+     real :: bratseth_t2m_back_err_inv_scale_length
      real :: bratseth_t2m_back_sigma_b_sqr
      real :: bratseth_t2m_stn_sigma_o_sqr
      integer :: bratseth_t2m_corr_func_type
      real :: bratseth_t2m_max_dist
 
      real :: bratseth_rh2m_back_err_scale_length
+     real :: bratseth_rh2m_back_err_inv_scale_length
      real :: bratseth_rh2m_back_sigma_b_sqr
      real :: bratseth_rh2m_stn_sigma_o_sqr
      integer :: bratseth_rh2m_corr_func_type
      real :: bratseth_rh2m_max_dist
 
      real :: bratseth_spd10m_back_err_scale_length
+     real :: bratseth_spd10m_back_err_inv_scale_length
      real :: bratseth_spd10m_back_sigma_b_sqr
      real :: bratseth_spd10m_stn_sigma_o_sqr
      integer :: bratseth_spd10m_corr_func_type

--- a/lis/metforcing/usaf/AGRMET_getsfc.F90
+++ b/lis/metforcing/usaf/AGRMET_getsfc.F90
@@ -613,7 +613,7 @@ subroutine AGRMET_getsfc( n, julhr, t2mObs, rh2mObs, spd10mObs, &
                              call USAF_assignObsData(t2mObs,net32, &
                                   platform32,rtmp,rlat,rlon, &
                                   agrmet_struc(n)%bratseth_t2m_stn_sigma_o_sqr,&
-                                  0.)
+                                  0., 0.)
 
                           end if
                           if (rrelh .gt. 0) then
@@ -630,7 +630,7 @@ subroutine AGRMET_getsfc( n, julhr, t2mObs, rh2mObs, spd10mObs, &
                              call USAF_assignObsData(rh2mObs,net32, &
                                   platform32,rrelh,rlat,rlon, &
                                   agrmet_struc(n)%bratseth_t2m_stn_sigma_o_sqr, &
-                                  0.)
+                                  0., 0.)
                           end if
                           if (rspd .gt. 0) then
                              net32 = blank32
@@ -646,7 +646,7 @@ subroutine AGRMET_getsfc( n, julhr, t2mObs, rh2mObs, spd10mObs, &
                              call USAF_assignObsData(spd10mObs,net32, &
                                   platform32,rspd,rlat,rlon, &
                                   agrmet_struc(n)%bratseth_spd10m_stn_sigma_o_sqr, &
-                                  0.)
+                                  0., 0.)
                           end if
 
                           obscnt         = obscnt + 1

--- a/lis/metforcing/usaf/AGRMET_processobs.F90
+++ b/lis/metforcing/usaf/AGRMET_processobs.F90
@@ -1151,7 +1151,7 @@ subroutine AGRMET_processobs(n, obs, isize, stncnt, hemi, julhr, &
                     float(obs_cur(i)%amt6) * 0.1, &
                     obs_cur(i)%lat, obs_cur(i)%lon,&
                     agrmet_struc(n)%bratseth_precip_gauge_sigma_o_sqr, &
-                    0.)
+                    0., 0.)
 
 !-----------------------------------------------------------------------
 !           calculate distance between the current observation and 
@@ -1220,7 +1220,7 @@ subroutine AGRMET_processobs(n, obs, isize, stncnt, hemi, julhr, &
                  float(obs_cur(i)%amt12) * 0.1, &
                  obs_cur(i)%lat, obs_cur(i)%lon, &
                  agrmet_struc(n)%bratseth_precip_gauge_sigma_o_sqr, &
-                 0.)
+                 0., 0.)
             
             newd = sumsqr(ri, float(nint(ri)), rj, float(nint(rj)))  &
                  * 100.0
@@ -1288,7 +1288,7 @@ subroutine AGRMET_processobs(n, obs, isize, stncnt, hemi, julhr, &
                    0.0, &
                    obs_cur(i)%lat, obs_cur(i)%lon, &
                    agrmet_struc(n)%bratseth_precip_gauge_sigma_o_sqr, &
-                   0.)
+                   0., 0.)
 
               newd = sumsqr(ri, float(nint(ri)), rj, float(nint(rj)))  &
                    * 100.0
@@ -1341,7 +1341,7 @@ subroutine AGRMET_processobs(n, obs, isize, stncnt, hemi, julhr, &
                       float(obs_cur(i)%amtmsc) * 0.1, &
                       obs_cur(i)%lat, obs_cur(i)%lon, &
                       agrmet_struc(n)%bratseth_precip_gauge_sigma_o_sqr, &
-                      0.)
+                      0., 0.)
 
                 newd = sumsqr(ri, float(nint(ri)), rj, float(nint(rj)))  &
                      * 100.0
@@ -1399,7 +1399,7 @@ subroutine AGRMET_processobs(n, obs, isize, stncnt, hemi, julhr, &
                         float(obs_6(i)%amtmsc) * 0.1, &
                         obs_6(i)%lat, obs_6(i)%lon, &
                         agrmet_struc(n)%bratseth_precip_gauge_sigma_o_sqr, &
-                        0.)
+                        0., 0.)
                    
                    newd = sumsqr(ri, float(nint(ri)), &
                         rj, float(nint(rj))) * 100.0

--- a/lis/metforcing/usaf/AGRMET_sfcalc.F90
+++ b/lis/metforcing/usaf/AGRMET_sfcalc.F90
@@ -678,12 +678,13 @@ subroutine AGRMET_sfcalc(n)
        call AGRMET_julhr_date10(julhr, yyyymmddhh)
        write(LIS_logunit,*) &
             '[INFO] RUNNING BRATSETH TEMPERATURE ANALYSIS FOR ',yyyymmddhh
-       call USAF_analyzeScreen(t2mObs,n,&
-            agrmet_struc(n)%sfctmp_glb(step_dum,:,:),&
+       call USAF_analyzeScreen(t2mObs, n, &
+            agrmet_struc(n)%sfctmp_glb(step_dum,:,:), &
             agrmet_struc(n)%bratseth_t2m_back_sigma_b_sqr, &
             agrmet_struc(n)%bratseth_t2m_max_dist, &
             agrmet_struc(n)%bratseth_t2m_back_err_scale_length, &
-            agrmet_struc(n)%sfctmp(step_dum,:,:),t2mOBA)
+            agrmet_struc(n)%bratseth_t2m_corr_func_type, &
+            agrmet_struc(n)%sfctmp(step_dum,:,:), t2mOBA)
 
        ! Output OBA data
        if (agrmet_struc(n)%oba_switch .eq. 1 .or. &
@@ -704,12 +705,13 @@ subroutine AGRMET_sfcalc(n)
        call USAF_multObsData(rh2mObs,100.)
        agrmet_struc(n)%sfcrlh_glb(step_dum,:,:) = &
             agrmet_struc(n)%sfcrlh_glb(step_dum,:,:)*100.
-       call USAF_analyzeScreen(rh2mObs,n,&
-            agrmet_struc(n)%sfcrlh_glb(step_dum,:,:),&
+       call USAF_analyzeScreen(rh2mObs, n, &
+            agrmet_struc(n)%sfcrlh_glb(step_dum,:,:), &
             agrmet_struc(n)%bratseth_rh2m_back_sigma_b_sqr, &
             agrmet_struc(n)%bratseth_rh2m_max_dist, &
             agrmet_struc(n)%bratseth_rh2m_back_err_scale_length, &
-            agrmet_struc(n)%sfcrlh(step_dum,:,:),rh2mOBA)
+            agrmet_struc(n)%bratseth_rh2m_corr_func_type, &
+            agrmet_struc(n)%sfcrlh(step_dum,:,:), rh2mOBA)
        ! Make sure RH is between 0 and 1 (convert from percent).
        do r = 1, LIS_rc%lnr(n)
           do c = 1, LIS_rc%lnc(n)
@@ -726,18 +728,19 @@ subroutine AGRMET_sfcalc(n)
              call makeFilename(rh2mPathOBA,yyyymmddhh,1,obaFilename)
              call writeToFile(rh2mOBA,obaFilename)
           end if
-          call destroyOBA(rh2mOBA)       
+          call destroyOBA(rh2mOBA)
        end if
 
        call AGRMET_julhr_date10(julhr, yyyymmddhh)
        write(LIS_logunit,*) &
             '[INFO] RUNNING BRATSETH WIND SPEED ANALYSIS FOR ',yyyymmddhh
-       call USAF_analyzeScreen(spd10mObs,n,&
-            agrmet_struc(n)%sfcspd_glb(step_dum,:,:),&
+       call USAF_analyzeScreen(spd10mObs, n, &
+            agrmet_struc(n)%sfcspd_glb(step_dum,:,:), &
             agrmet_struc(n)%bratseth_spd10m_back_sigma_b_sqr, &
             agrmet_struc(n)%bratseth_spd10m_max_dist, &
             agrmet_struc(n)%bratseth_spd10m_back_err_scale_length, &
-            agrmet_struc(n)%sfcspd(step_dum,:,:),spd10mOBA)
+            agrmet_struc(n)%bratseth_spd10m_corr_func_type, &
+            agrmet_struc(n)%sfcspd(step_dum,:,:), spd10mOBA)
 
        ! Output OBA data
        if (agrmet_struc(n)%oba_switch .eq. 1 .or. &

--- a/lis/metforcing/usaf/AGRMET_sfcalc.F90
+++ b/lis/metforcing/usaf/AGRMET_sfcalc.F90
@@ -682,7 +682,7 @@ subroutine AGRMET_sfcalc(n)
             agrmet_struc(n)%sfctmp_glb(step_dum,:,:), &
             agrmet_struc(n)%bratseth_t2m_back_sigma_b_sqr, &
             agrmet_struc(n)%bratseth_t2m_max_dist, &
-            agrmet_struc(n)%bratseth_t2m_back_err_scale_length, &
+            agrmet_struc(n)%bratseth_t2m_back_err_inv_scale_length, &
             agrmet_struc(n)%bratseth_t2m_corr_func_type, &
             agrmet_struc(n)%sfctmp(step_dum,:,:), t2mOBA)
 
@@ -709,7 +709,7 @@ subroutine AGRMET_sfcalc(n)
             agrmet_struc(n)%sfcrlh_glb(step_dum,:,:), &
             agrmet_struc(n)%bratseth_rh2m_back_sigma_b_sqr, &
             agrmet_struc(n)%bratseth_rh2m_max_dist, &
-            agrmet_struc(n)%bratseth_rh2m_back_err_scale_length, &
+            agrmet_struc(n)%bratseth_rh2m_back_err_inv_scale_length, &
             agrmet_struc(n)%bratseth_rh2m_corr_func_type, &
             agrmet_struc(n)%sfcrlh(step_dum,:,:), rh2mOBA)
        ! Make sure RH is between 0 and 1 (convert from percent).
@@ -738,7 +738,7 @@ subroutine AGRMET_sfcalc(n)
             agrmet_struc(n)%sfcspd_glb(step_dum,:,:), &
             agrmet_struc(n)%bratseth_spd10m_back_sigma_b_sqr, &
             agrmet_struc(n)%bratseth_spd10m_max_dist, &
-            agrmet_struc(n)%bratseth_spd10m_back_err_scale_length, &
+            agrmet_struc(n)%bratseth_spd10m_back_err_inv_scale_length, &
             agrmet_struc(n)%bratseth_spd10m_corr_func_type, &
             agrmet_struc(n)%sfcspd(step_dum,:,:), spd10mOBA)
 

--- a/lis/metforcing/usaf/USAF_GagesMod.F90
+++ b/lis/metforcing/usaf/USAF_GagesMod.F90
@@ -2619,7 +2619,7 @@ contains
                real(this%amts06(i)) * 0.1, &
                real(this%lats(i)) * 0.01, &
                real(this%lons(i)) * 0.01, &
-               gage_sigma_o_sqr, 0.)
+               gage_sigma_o_sqr, 0., 0.)
           num_obs_copied = num_obs_copied + 1
        end do
        write(LIS_logunit,*)'[INFO] Copied ', num_obs_copied, &
@@ -2633,7 +2633,7 @@ contains
                real(this%amts12(i)) * 0.1, &
                real(this%lats(i)) * 0.01, &
                real(this%lons(i)) * 0.01, &
-               gage_sigma_o_sqr, 0.)
+               gage_sigma_o_sqr, 0., 0.)
           num_obs_copied = num_obs_copied + 1
        end do
        write(LIS_logunit,*)'[INFO] Copied ', num_obs_copied, &

--- a/lis/metforcing/usaf/USAF_ImergHHMod.F90
+++ b/lis/metforcing/usaf/USAF_ImergHHMod.F90
@@ -99,7 +99,7 @@ contains
 
    ! Copy to obsData
    subroutine copyToObsDataImergHHPrecip(this, sigmaOSqr, &
-        oErrScaleLength, net, platform, obsData_struc)
+        oErrScaleLength, oErrInvScaleLength, net, platform, obsData_struc)
 
       ! Modules
       use USAF_bratsethMod, only: USAF_obsData, USAF_assignObsData
@@ -111,6 +111,7 @@ contains
       type(ImergHHPrecip), intent(in) :: this
       real, intent(in) :: sigmaOSqr
       real, intent(in) :: oErrScaleLength
+      real, intent(in) :: oErrInvScaleLength
       character*32, intent(in) :: net
       character*32, intent(in) :: platform
       type(USAF_ObsData), intent(inout) :: obsData_struc
@@ -129,7 +130,8 @@ contains
             lat = (this%swlat) + (i-1)*(this%dlat)
             lon = (this%swlon) + (j-1)*(this%dlon)
             call USAF_assignObsData(obsData_struc, net, platform,&
-                 ob, lat, lon, sigmaOSqr, oErrScaleLength)
+                 ob, lat, lon, sigmaOSqr, oErrScaleLength, &
+                 oErrInvScaleLength)
 
          end do ! i
       end do ! j
@@ -1360,7 +1362,9 @@ contains
 
    ! Driver routine to fetch 3hr IMERG data for given start date.
    subroutine fetch3hrImergHH(j3hr, datadir, product, version, &
-        plp_thresh, nest, sigmaOSqr, oErrScaleLength, net, platform, &
+        plp_thresh, nest, sigmaOSqr, oErrScaleLength, &
+        oErrInvScaleLength, &
+        net, platform, &
         precipObsData)
 
       ! Modules
@@ -1381,6 +1385,7 @@ contains
       integer,intent(in) :: nest
       real, intent(in) :: sigmaOSqr
       real, intent(in) :: oErrScaleLength
+      real, intent(in) :: oErrInvScaleLength
       character(len=*),intent(in) :: net
       character(len=*),intent(in) :: platform
       type(USAF_ObsData), intent(out) :: precipObsData
@@ -1478,7 +1483,7 @@ contains
 
       ! Copy the good values into the ObsData object
       call copyToObsDataImergHHPrecip(imerg, sigmaOSqr, &
-           oErrScaleLength, &
+           oErrScaleLength, oErrInvScaleLength, &
            net, platform, precipObsData)
 
       ! Clean up

--- a/lis/metforcing/usaf/readagrmetpcpforcing.F90
+++ b/lis/metforcing/usaf/readagrmetpcpforcing.F90
@@ -279,7 +279,7 @@ subroutine readagrmetpcpforcing(n,findex, order)
    character(len=20) :: imerg_version
    integer*2 :: imerg_plp_thresh
    real :: imerg_sigmaOSqr
-   real :: imerg_oErrScaleLength
+   real :: imerg_oErrScaleLength, imerg_oErrInvScaleLength
    character(len=32) :: imerg_net, imerg_platform
    real :: sigmaBSqr
    character(len=32) :: new_name
@@ -747,8 +747,10 @@ subroutine readagrmetpcpforcing(n,findex, order)
                  agrmet_struc(n)%bratseth_precip_imerg_sigma_o_sqr
             imerg_oErrScaleLength = &
                  agrmet_struc(n)%bratseth_precip_imerg_err_scale_length
+            imerg_oErrInvScaleLength = &
+                 agrmet_struc(n)%bratseth_precip_imerg_err_inv_scale_length
             imerg_net = "IMERG"
-            imerg_platform = "IMERG"            
+            imerg_platform = "IMERG"
             do ii = 1,2
                write(LIS_logunit,*) &
                     '[INFO] Fetching 6 hours of IMERG data, set ',ii
@@ -756,7 +758,8 @@ subroutine readagrmetpcpforcing(n,findex, order)
                call fetch3hrImergHH(julbeg+julbeg_adj, &
                     imerg_datadir,imerg_product, &
                     imerg_version,imerg_plp_thresh,n,imerg_sigmaOSqr,&
-                    imerg_oErrScaleLength,imerg_net,imerg_platform,&
+                    imerg_oErrScaleLength, imerg_oErrInvScaleLength, &
+                    imerg_net,imerg_platform,&
                     precip_3hrly_imerg_tmp(ii))
 
                ! Reject observations over water
@@ -1305,6 +1308,8 @@ subroutine readagrmetpcpforcing(n,findex, order)
                  agrmet_struc(n)%bratseth_precip_imerg_sigma_o_sqr
             imerg_oErrScaleLength = &
                  agrmet_struc(n)%bratseth_precip_imerg_err_scale_length
+            imerg_oErrInvScaleLength = &
+                 agrmet_struc(n)%bratseth_precip_imerg_err_inv_scale_length
             imerg_net = "IMERG"
             imerg_platform = "IMERG"                  
             do ii = 1,4
@@ -1314,7 +1319,8 @@ subroutine readagrmetpcpforcing(n,findex, order)
                call fetch3hrImergHH(julbeg+julbeg_adj, &
                     imerg_datadir,imerg_product, &
                     imerg_version,imerg_plp_thresh,n,imerg_sigmaOSqr,&
-                    imerg_oErrScaleLength,imerg_net,imerg_platform, &
+                    imerg_oErrScaleLength, imerg_oErrInvScaleLength, &
+                    imerg_net,imerg_platform, &
                     precip_3hrly_imerg_tmp(ii))
 
                ! Reject obs over water

--- a/lis/metforcing/usaf/readagrmetpcpforcing.F90
+++ b/lis/metforcing/usaf/readagrmetpcpforcing.F90
@@ -866,6 +866,7 @@ subroutine readagrmetpcpforcing(n,findex, order)
 
             call USAF_analyzePrecip(precip_3hrly_all, n, &
                  back4(:,:,k),hourindex, &
+                 agrmet_struc(n)%bratseth_precip_corr_func_type, &
                  agrmet_struc(n)%mrgp(:,:,k), precipOBA)
             
             !-----------------------------------------------------------
@@ -1426,6 +1427,7 @@ subroutine readagrmetpcpforcing(n,findex, order)
 
             call USAF_analyzePrecip(precip_3hrly_all, n, &
                  back4(:,:,k),hourindex, &
+                 agrmet_struc(n)%bratseth_precip_corr_func_type, &
                  agrmet_struc(n)%mrgp(:,:,k), precipOBA)
             
             !-----------------------------------------------------------

--- a/lis/metforcing/usaf/readcrd_agrmet.F90
+++ b/lis/metforcing/usaf/readcrd_agrmet.F90
@@ -643,6 +643,18 @@ subroutine readcrd_agrmet()
 
   ! EMK NEW...Error statistics for Bratseth precip analysis using GALWEM
   ! background.
+  ! EMK 29 Aug 2024...Specify correlation function type.
+  call ESMF_ConfigFindLabel(LIS_config,&
+       "AGRMET GALWEM Precip correlation function type:",rc=rc)
+  call LIS_verify(rc, &
+       '[ERR] AGRMET GALWEM Precip correlation function type: option not specified in the config file')
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,&
+          agrmet_struc(n)%galwem_precip_corr_func_type,rc=rc)
+     call LIS_verify(rc, &
+          '[ERR] AGRMET GALWEM Precip correlation function type: value not specified in the config file')
+  enddo ! n
+  
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GALWEM Precip background error scale length (m):",rc=rc)
   call LIS_verify(rc, &
@@ -758,7 +770,8 @@ subroutine readcrd_agrmet()
 
   ! EMK...Need to calculate maximum distance to compare or spread precip
   ! differences.  When using Gaussian function, this is 2 * largest scale 
-  ! length (for correlation of ~0.02)
+  ! length (for correlation of ~0.02). When using inverse exponential,
+  ! this is 4 * the largest scale length (for correlation of ~0.02).
   do n=1,LIS_rc%nnest
      tmp_max_dist = max( &
           agrmet_struc(n)%galwem_precip_back_err_scale_length, &
@@ -766,11 +779,34 @@ subroutine readcrd_agrmet()
           agrmet_struc(n)%galwem_precip_ssmi_err_scale_length, &
           agrmet_struc(n)%galwem_precip_cmorph_err_scale_length, &
           agrmet_struc(n)%galwem_precip_imerg_err_scale_length)
-     agrmet_struc(n)%galwem_precip_max_dist = 2*tmp_max_dist
+     if (agrmet_struc(n)%galwem_precip_corr_func_type == 1) then
+        agrmet_struc(n)%galwem_precip_max_dist = 2*tmp_max_dist
+     else if (agrmet_struc(n)%galwem_precip_corr_func_type == 2) then
+        agrmet_struc(n)%galwem_precip_max_dist = 4*tmp_max_dist
+     else
+        write(LIS_logunit,*) '[ERR] Invalid correlation option!'
+        write(LIS_logunit,*) &
+             '[ERR] Expected 1 (Gaussian) or 2 (Inverse Exponential)'
+        write(LIS_logunit,*) '[ERR] Received ', &
+             agrmet_struc(n)%galwem_precip_corr_func_type
+        call LIS_endrun()
+     end if
   end do ! n
 
   ! EMK NEW...Error statistics for Bratseth 2-m temperature analysis using 
   ! GALWEM background.
+  ! EMK 29 Aug 2024...Added correlation function type
+  call ESMF_ConfigFindLabel(LIS_config,&
+       "AGRMET GALWEM T2M correlation function type:",rc=rc)
+  call LIS_verify(rc, &
+       '[ERR] AGRMET GALWEM T2M correlation function type: option not specified in the config file')
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,&
+          agrmet_struc(n)%galwem_t2m_corr_func_type,rc=rc)
+     call LIS_verify(rc, &
+          '[ERR] AGRMET GALWEM T2M correlation function type: value not specified in the config file')
+  enddo ! n
+
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GALWEM T2M background error scale length (m):",rc=rc)
   call LIS_verify(rc, &
@@ -781,9 +817,23 @@ subroutine readcrd_agrmet()
      call LIS_verify(rc, &
           '[ERR] AGRMET GALWEM T2M background error scale length (m): value not specified in the config file') 
      ! Maximum distance for spreading data for Gaussian function correlation
-     ! is 2 * scale length (for ~0.02 correlation).
-     agrmet_struc(n)%galwem_t2m_max_dist = &
-          2*agrmet_struc(n)%galwem_t2m_back_err_scale_length
+     ! is 2 * scale length (for ~0.02 correlation).  For inverse exponential
+     !, max distance is 4 * scale length (for ~0.02 correlation).
+     if (agrmet_struc(n)%galwem_t2m_corr_func_type == 1) then
+        agrmet_struc(n)%galwem_t2m_max_dist = &
+             2 * agrmet_struc(n)%galwem_t2m_back_err_scale_length
+     else if (agrmet_struc(n)%galwem_t2m_corr_func_type == 2) then
+        agrmet_struc(n)%galwem_t2m_max_dist = &
+             4 * agrmet_struc(n)%galwem_t2m_back_err_scale_length
+     else
+        write(LIS_logunit,*) '[ERR] Invalid correlation option!'
+        write(LIS_logunit,*) &
+             '[ERR] Expected 1 (Gaussian) or 2 (Inverse Exponential)'
+        write(LIS_logunit,*) '[ERR] Received ', &
+             agrmet_struc(n)%galwem_t2m_corr_func_type
+        call LIS_endrun()
+     end if
+
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GALWEM T2M background error variance:",rc=rc)
@@ -808,6 +858,18 @@ subroutine readcrd_agrmet()
 
   ! EMK NEW...Error statistics for Bratseth 2-m relative humidity analysis 
   ! using GALWEM background.
+  ! EMK 29 Aug 2024...Set correlation function type.
+  call ESMF_ConfigFindLabel(LIS_config,&
+       "AGRMET GALWEM RH2M correlation function type:",rc=rc)
+  call LIS_verify(rc, &
+       '[ERR] AGRMET GALWEM RH2M correlation function type: option not specified in the config file')
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,&
+          agrmet_struc(n)%galwem_rh2m_corr_func_type,rc=rc)
+     call LIS_verify(rc, &
+          '[ERR] AGRMET GALWEM RH2M correlation function type: value not specified in the config file')
+  enddo ! n
+
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GALWEM RH2M background error scale length (m):",rc=rc)
   call LIS_verify(rc, &
@@ -818,9 +880,24 @@ subroutine readcrd_agrmet()
      call LIS_verify(rc, &
           '[ERR] AGRMET GALWEM RH2M background error scale length (m): value not specified in the config file') 
      ! Maximum distance for spreading data for Gaussian function correlation
-     ! is 2 * scale length (for ~0.02 correlation).
-     agrmet_struc(n)%galwem_rh2m_max_dist = &
-          2*agrmet_struc(n)%galwem_rh2m_back_err_scale_length
+     ! is 2 * scale length (for ~0.02 correlation).  For inverse
+     ! exponential correlation, max distance is 4 * scale length (for
+     ! ~0.02 correlation).
+     if (agrmet_struc(n)%galwem_rh2m_corr_func_type == 1) then
+        agrmet_struc(n)%galwem_rh2m_max_dist = &
+             2 * agrmet_struc(n)%galwem_rh2m_back_err_scale_length
+     else if (agrmet_struc(n)%galwem_rh2m_corr_func_type == 2) then
+        agrmet_struc(n)%galwem_rh2m_max_dist = &
+             4 * agrmet_struc(n)%galwem_rh2m_back_err_scale_length
+     else
+        write(LIS_logunit,*) '[ERR] Invalid correlation option!'
+        write(LIS_logunit,*) &
+             '[ERR] Expected 1 (Gaussian) or 2 (Inverse Exponential)'
+        write(LIS_logunit,*) '[ERR] Received ', &
+             agrmet_struc(n)%galwem_rh2m_corr_func_type
+        call LIS_endrun()
+     end if
+
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GALWEM RH2M background error variance:",rc=rc)
@@ -845,6 +922,18 @@ subroutine readcrd_agrmet()
 
   ! EMK NEW...Error statistics for Bratseth 10-m wind speed analysis 
   ! using GALWEM background.
+  ! EMK 29 Aug 2024...Set correlation function type.
+  call ESMF_ConfigFindLabel(LIS_config,&
+       "AGRMET GALWEM SPD10M correlation function type:",rc=rc)
+  call LIS_verify(rc, &
+       '[ERR] AGRMET GALWEM SPD10M correlation function type: option not specified in the config file')
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,&
+          agrmet_struc(n)%galwem_spd10m_corr_func_type,rc=rc)
+     call LIS_verify(rc, &
+          '[ERR] AGRMET GALWEM SPD10M correlation function type: value not specified in the config file')
+  enddo ! n
+
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GALWEM SPD10M background error scale length (m):",rc=rc)
   call LIS_verify(rc, &
@@ -855,9 +944,23 @@ subroutine readcrd_agrmet()
      call LIS_verify(rc, &
           '[ERR] AGRMET GALWEM SPD10M background error scale length (m): value not specified in the config file') 
      ! Maximum distance for spreading data for Gaussian function correlation
-     ! is 2 * scale length (for ~0.02 correlation).
-     agrmet_struc(n)%galwem_spd10m_max_dist = &
-          2*agrmet_struc(n)%galwem_spd10m_back_err_scale_length
+     ! is 2 * scale length (for ~0.02 correlation).  For Inverse Exponential
+     ! function, max distance is 4 * scale length (for ~0.02 correlation)
+     if (agrmet_struc(n)%galwem_spd10m_corr_func_type == 1) then
+        agrmet_struc(n)%galwem_spd10m_max_dist = &
+             2 * agrmet_struc(n)%galwem_spd10m_back_err_scale_length
+     else if (agrmet_struc(n)%galwem_spd10m_corr_func_type == 2) then
+        agrmet_struc(n)%galwem_spd10m_max_dist = &
+             4 * agrmet_struc(n)%galwem_spd10m_back_err_scale_length
+     else
+        write(LIS_logunit,*) '[ERR] Invalid correlation option!'
+        write(LIS_logunit,*) &
+             '[ERR] Expected 1 (Gaussian) or 2 (Inverse Exponential)'
+        write(LIS_logunit,*) '[ERR] Received ', &
+             agrmet_struc(n)%galwem_spd10m_corr_func_type
+        call LIS_endrun()
+     end if
+
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GALWEM SPD10M background error variance:",rc=rc)
@@ -883,6 +986,19 @@ subroutine readcrd_agrmet()
   ! EMK NEW...Error statistics for Bratseth precip analysis using GFS
   ! background. Note that GFS is used as emergency backup if GALWEM is
   ! not available.
+
+  ! EMK 29 Aug 2024...Set correlation function type.
+  call ESMF_ConfigFindLabel(LIS_config,&
+       "AGRMET GFS Precip correlation function type:",rc=rc)
+  call LIS_verify(rc, &
+       '[ERR] AGRMET GFS Precip correlation function type: option not specified in the config file')
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,&
+          agrmet_struc(n)%gfs_precip_corr_func_type,rc=rc)
+     call LIS_verify(rc, &
+          '[ERR] AGRMET GFS Precip correlation function type: value not specified in the config file')
+  enddo ! n
+
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GFS Precip background error scale length (m):",rc=rc)
   call LIS_verify(rc, &
@@ -998,7 +1114,8 @@ subroutine readcrd_agrmet()
 
   ! EMK...Need to calculate maximum distance to compare or spread precip
   ! differences.  When using Gaussian function, this is 2 * largest scale 
-  ! length (for correlation of ~0.02)
+  ! length (for correlation of ~0.02). For Inverse Exponential function,
+  ! max distance is 4 * largest scale length (correlation ~ 0.02)
   do n=1,LIS_rc%nnest
      tmp_max_dist = max( &
           agrmet_struc(n)%gfs_precip_back_err_scale_length, &
@@ -1006,12 +1123,35 @@ subroutine readcrd_agrmet()
           agrmet_struc(n)%gfs_precip_ssmi_err_scale_length, &
           agrmet_struc(n)%gfs_precip_cmorph_err_scale_length, &
           agrmet_struc(n)%gfs_precip_imerg_err_scale_length)
-     agrmet_struc(n)%gfs_precip_max_dist = 2*tmp_max_dist
+     if (agrmet_struc(n)%gfs_precip_corr_func_type == 1) then
+        agrmet_struc(n)%gfs_precip_max_dist = 2*tmp_max_dist
+     else if (agrmet_struc(n)%gfs_precip_corr_func_type == 2) then
+        agrmet_struc(n)%gfs_precip_max_dist = 4*tmp_max_dist
+     else
+        write(LIS_logunit,*) '[ERR] Invalid correlation option!'
+        write(LIS_logunit,*) &
+             '[ERR] Expected 1 (Gaussian) or 2 (Inverse Exponential)'
+        write(LIS_logunit,*) '[ERR] Received ', &
+             agrmet_struc(n)%gfs_precip_corr_func_type
+        call LIS_endrun()
+     end if
   end do ! n
 
   ! EMK NEW...Error statistics for Bratseth 2-m temperature analysis using 
   ! GFS background. Note that GFS is used as emergency backup if GALWEM is
   ! not available.
+  ! EMK 29 Aug 2024...Set correlation function type.
+  call ESMF_ConfigFindLabel(LIS_config,&
+       "AGRMET GFS T2M correlation function type:",rc=rc)
+  call LIS_verify(rc, &
+       '[ERR] AGRMET GFS T2M correlation function type: option not specified in the config file')
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,&
+          agrmet_struc(n)%gfs_t2m_corr_func_type,rc=rc)
+     call LIS_verify(rc, &
+          '[ERR] AGRMET GFS T2M correlation function type: value not specified in the config file')
+  enddo ! n
+
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GFS T2M background error scale length (m):",rc=rc)
   call LIS_verify(rc, &
@@ -1022,9 +1162,23 @@ subroutine readcrd_agrmet()
      call LIS_verify(rc, &
           '[ERR] AGRMET GFS T2M background error scale length (m): value not specified in the config file') 
      ! Maximum distance for spreading data for Gaussian function correlation
-     ! is 2 * scale length (for ~0.02 correlation).
-     agrmet_struc(n)%gfs_t2m_max_dist = &
-          2*agrmet_struc(n)%gfs_t2m_back_err_scale_length
+     ! is 2 * scale length (for ~0.02 correlation). For Inverse Exponential
+     ! function, max distance is 4 * scale length (for ~0.02 correlation)
+     if (agrmet_struc(n)%gfs_t2m_corr_func_type == 1) then
+        agrmet_struc(n)%gfs_t2m_max_dist = &
+             2 * agrmet_struc(n)%gfs_t2m_back_err_scale_length
+     else if (agrmet_struc(n)%gfs_t2m_corr_func_type == 2) then
+        agrmet_struc(n)%gfs_t2m_max_dist = &
+             4 * agrmet_struc(n)%gfs_t2m_back_err_scale_length
+     else
+        write(LIS_logunit,*) '[ERR] Invalid correlation option!'
+        write(LIS_logunit,*) &
+             '[ERR] Expected 1 (Gaussian) or 2 (Inverse Exponential)'
+        write(LIS_logunit,*) '[ERR] Received ', &
+             agrmet_struc(n)%gfs_t2m_corr_func_type
+        call LIS_endrun()
+     end if
+
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GFS T2M background error variance:",rc=rc)
@@ -1050,6 +1204,19 @@ subroutine readcrd_agrmet()
   ! EMK NEW...Error statistics for Bratseth 2-m relative humidity analysis 
   ! using GFS background.  Note that GFS is used as emergency backup if
   ! GALWEM is not available.
+
+  ! EMK 29 Aug 2024...Set correlation function type.
+  call ESMF_ConfigFindLabel(LIS_config,&
+       "AGRMET GFS RH2M correlation function type:",rc=rc)
+  call LIS_verify(rc, &
+       '[ERR] AGRMET GFS RH2M correlation function type: option not specified in the config file')
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,&
+          agrmet_struc(n)%gfs_rh2m_corr_func_type,rc=rc)
+     call LIS_verify(rc, &
+          '[ERR] AGRMET GFS RH2M correlation function type: value not specified in the config file')
+  enddo ! n
+
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GFS RH2M background error scale length (m):",rc=rc)
   call LIS_verify(rc, &
@@ -1060,9 +1227,23 @@ subroutine readcrd_agrmet()
      call LIS_verify(rc, &
           '[ERR] AGRMET GFS RH2M background error scale length (m): value not specified in the config file') 
      ! Maximum distance for spreading data for Gaussian function correlation
-     ! is 2 * scale length (for ~0.02 correlation).
-     agrmet_struc(n)%gfs_rh2m_max_dist = &
-          2*agrmet_struc(n)%gfs_rh2m_back_err_scale_length
+     ! is 2 * scale length (for ~0.02 correlation). For Inverse Exponential
+     ! function, max distance is 4 * scale length (for ~0.02 correlation)
+     if (agrmet_struc(n)%gfs_rh2m_corr_func_type == 1) then
+        agrmet_struc(n)%gfs_rh2m_max_dist = &
+             2 * agrmet_struc(n)%gfs_rh2m_back_err_scale_length
+     else if (agrmet_struc(n)%gfs_rh2m_corr_func_type == 2) then
+        agrmet_struc(n)%gfs_rh2m_max_dist = &
+             4 * agrmet_struc(n)%gfs_rh2m_back_err_scale_length
+     else
+        write(LIS_logunit,*) '[ERR] Invalid correlation option!'
+        write(LIS_logunit,*) &
+             '[ERR] Expected 1 (Gaussian) or 2 (Inverse Exponential)'
+        write(LIS_logunit,*) '[ERR] Received ', &
+             agrmet_struc(n)%gfs_rh2m_corr_func_type
+        call LIS_endrun()
+     end if
+
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GFS RH2M background error variance:",rc=rc)
@@ -1088,6 +1269,19 @@ subroutine readcrd_agrmet()
   ! EMK NEW...Error statistics for Bratseth 10-m wind speed analysis 
   ! using GFS background.  Note that GFS is used as emergency backup if
   ! GALWEM is not available
+
+  ! EMK 29 Aug 2024...Set correlation function type.
+  call ESMF_ConfigFindLabel(LIS_config,&
+       "AGRMET GFS SPD10M correlation function type:",rc=rc)
+  call LIS_verify(rc, &
+       '[ERR] AGRMET GFS SPD10M correlation function type: option not specified in the config file')
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,&
+          agrmet_struc(n)%gfs_spd10m_corr_func_type,rc=rc)
+     call LIS_verify(rc, &
+          '[ERR] AGRMET GFS SPD10M correlation function type: value not specified in the config file')
+  enddo ! n
+
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GFS SPD10M background error scale length (m):",rc=rc)
   call LIS_verify(rc, &
@@ -1098,9 +1292,23 @@ subroutine readcrd_agrmet()
      call LIS_verify(rc, &
           '[ERR] AGRMET GFS SPD10M background error scale length (m): value not specified in the config file') 
      ! Maximum distance for spreading data for Gaussian function correlation
-     ! is 2 * scale length (for ~0.02 correlation).
-     agrmet_struc(n)%gfs_spd10m_max_dist = &
-          2*agrmet_struc(n)%gfs_spd10m_back_err_scale_length
+     ! is 2 * scale length (for ~0.02 correlation).  For Inverse Exponential
+     ! function, max distance is 4 * scale length (for ~0.02 correlation)
+     if (agrmet_struc(n)%gfs_spd10m_corr_func_type == 1) then
+        agrmet_struc(n)%gfs_spd10m_max_dist = &
+             2 * agrmet_struc(n)%gfs_spd10m_back_err_scale_length
+     else if (agrmet_struc(n)%gfs_spd10m_corr_func_type == 2) then
+        agrmet_struc(n)%gfs_spd10m_max_dist = &
+             4 * agrmet_struc(n)%gfs_spd10m_back_err_scale_length
+     else
+        write(LIS_logunit,*) '[ERR] Invalid correlation option!'
+        write(LIS_logunit,*) &
+             '[ERR] Expected 1 (Gaussian) or 2 (Inverse Exponential)'
+        write(LIS_logunit,*) '[ERR] Received ', &
+             agrmet_struc(n)%gfs_spd10m_corr_func_type
+        call LIS_endrun()
+     end if
+
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GFS SPD10M background error variance:",rc=rc)

--- a/lis/metforcing/usaf/readcrd_agrmet.F90
+++ b/lis/metforcing/usaf/readcrd_agrmet.F90
@@ -664,6 +664,8 @@ subroutine readcrd_agrmet()
           agrmet_struc(n)%galwem_precip_back_err_scale_length,rc=rc)
      call LIS_verify(rc, &
           '[ERR] AGRMET GALWEM Precip background error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%galwem_precip_back_err_inv_scale_length = &
+          1. / agrmet_struc(n)%galwem_precip_back_err_scale_length
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GALWEM Precip background error variance:",rc=rc)
@@ -693,7 +695,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%galwem_precip_geoprecip_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-          '[ERR] AGRMET GALWEM Precip GEOPRECIP observation error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GALWEM Precip GEOPRECIP observation error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%galwem_precip_geoprecip_err_inv_scale_length = &
+          1. / agrmet_struc(n)%galwem_precip_geoprecip_err_scale_length
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GALWEM Precip GEOPRECIP observation error variance:",rc=rc)
@@ -713,7 +717,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%galwem_precip_ssmi_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-       '[ERR] AGRMET GALWEM Precip SSMI observation error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GALWEM Precip SSMI observation error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%galwem_precip_ssmi_err_inv_scale_length = &
+          1. / agrmet_struc(n)%galwem_precip_ssmi_err_scale_length
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GALWEM Precip SSMI observation error variance:",rc=rc)
@@ -733,7 +739,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%galwem_precip_cmorph_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-       '[ERR] AGRMET GALWEM Precip CMORPH observation error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GALWEM Precip CMORPH observation error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%galwem_precip_cmorph_err_inv_scale_length = &
+          1. / agrmet_struc(n)%galwem_precip_cmorph_err_scale_length
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GALWEM Precip CMORPH observation error variance:",rc=rc)
@@ -755,7 +763,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%galwem_precip_imerg_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-       '[ERR] AGRMET GALWEM Precip IMERG observation error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GALWEM Precip IMERG observation error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%galwem_precip_imerg_err_inv_scale_length = &
+          1. / agrmet_struc(n)%galwem_precip_imerg_err_scale_length
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GALWEM Precip IMERG observation error variance:",rc=rc)
@@ -815,7 +825,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%galwem_t2m_back_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-          '[ERR] AGRMET GALWEM T2M background error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GALWEM T2M background error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%galwem_t2m_back_err_inv_scale_length = &
+          1. / agrmet_struc(n)%galwem_t2m_back_err_scale_length
      ! Maximum distance for spreading data for Gaussian function correlation
      ! is 2 * scale length (for ~0.02 correlation).  For inverse exponential
      !, max distance is 4 * scale length (for ~0.02 correlation).
@@ -878,7 +890,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%galwem_rh2m_back_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-          '[ERR] AGRMET GALWEM RH2M background error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GALWEM RH2M background error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%galwem_rh2m_back_err_inv_scale_length = &
+          1. / agrmet_struc(n)%galwem_rh2m_back_err_scale_length
      ! Maximum distance for spreading data for Gaussian function correlation
      ! is 2 * scale length (for ~0.02 correlation).  For inverse
      ! exponential correlation, max distance is 4 * scale length (for
@@ -942,7 +956,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%galwem_spd10m_back_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-          '[ERR] AGRMET GALWEM SPD10M background error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GALWEM SPD10M background error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%galwem_spd10m_back_err_inv_scale_length = &
+          1. / agrmet_struc(n)%galwem_spd10m_back_err_scale_length
      ! Maximum distance for spreading data for Gaussian function correlation
      ! is 2 * scale length (for ~0.02 correlation).  For Inverse Exponential
      ! function, max distance is 4 * scale length (for ~0.02 correlation)
@@ -1007,7 +1023,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%gfs_precip_back_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-       '[ERR] AGRMET GFS Precip background error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GFS Precip background error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%gfs_precip_back_err_inv_scale_length = &
+          1. / agrmet_struc(n)%gfs_precip_back_err_scale_length
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GFS Precip background error variance:",rc=rc)
@@ -1037,7 +1055,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%gfs_precip_geoprecip_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-          '[ERR] AGRMET GFS Precip GEOPRECIP observation error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GFS Precip GEOPRECIP observation error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%gfs_precip_geoprecip_err_inv_scale_length = &
+          1. / agrmet_struc(n)%gfs_precip_geoprecip_err_scale_length
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GFS Precip GEOPRECIP observation error variance:",rc=rc)
@@ -1057,7 +1077,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%gfs_precip_ssmi_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-          '[ERR] AGRMET GFS Precip SSMI observation error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GFS Precip SSMI observation error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%gfs_precip_ssmi_err_inv_scale_length = &
+          1. / agrmet_struc(n)%gfs_precip_ssmi_err_scale_length
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GFS Precip SSMI observation error variance:",rc=rc)
@@ -1077,7 +1099,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%gfs_precip_cmorph_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-          '[ERR] AGRMET GFS Precip CMORPH observation error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GFS Precip CMORPH observation error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%gfs_precip_cmorph_err_inv_scale_length = &
+          1. / agrmet_struc(n)%gfs_precip_cmorph_err_scale_length
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GFS Precip CMORPH observation error variance:",rc=rc)
@@ -1099,7 +1123,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%gfs_precip_imerg_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-       '[ERR] AGRMET GFS Precip IMERG observation error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GFS Precip IMERG observation error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%gfs_precip_imerg_err_inv_scale_length = &
+          1. / agrmet_struc(n)%gfs_precip_imerg_err_scale_length
   enddo ! n
   call ESMF_ConfigFindLabel(LIS_config,&
        "AGRMET GFS Precip IMERG observation error variance:",rc=rc)
@@ -1160,7 +1186,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%gfs_t2m_back_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-          '[ERR] AGRMET GFS T2M background error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GFS T2M background error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%gfs_t2m_back_err_inv_scale_length = &
+          1. / agrmet_struc(n)%gfs_t2m_back_err_scale_length
      ! Maximum distance for spreading data for Gaussian function correlation
      ! is 2 * scale length (for ~0.02 correlation). For Inverse Exponential
      ! function, max distance is 4 * scale length (for ~0.02 correlation)
@@ -1225,7 +1253,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%gfs_rh2m_back_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-          '[ERR] AGRMET GFS RH2M background error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GFS RH2M background error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%gfs_rh2m_back_err_inv_scale_length = &
+          1. / agrmet_struc(n)%gfs_rh2m_back_err_scale_length
      ! Maximum distance for spreading data for Gaussian function correlation
      ! is 2 * scale length (for ~0.02 correlation). For Inverse Exponential
      ! function, max distance is 4 * scale length (for ~0.02 correlation)
@@ -1290,7 +1320,9 @@ subroutine readcrd_agrmet()
      call ESMF_ConfigGetAttribute(LIS_config,&
           agrmet_struc(n)%gfs_spd10m_back_err_scale_length,rc=rc)
      call LIS_verify(rc, &
-          '[ERR] AGRMET GFS SPD10M background error scale length (m): value not specified in the config file') 
+          '[ERR] AGRMET GFS SPD10M background error scale length (m): value not specified in the config file')
+     agrmet_struc(n)%gfs_spd10m_back_err_inv_scale_length = &
+          1. / agrmet_struc(n)%gfs_spd10m_back_err_scale_length
      ! Maximum distance for spreading data for Gaussian function correlation
      ! is 2 * scale length (for ~0.02 correlation).  For Inverse Exponential
      ! function, max distance is 4 * scale length (for ~0.02 correlation)


### PR DESCRIPTION
This has closer fits to data on Air Force global domain.  However, it should not be immediately used in Ops since the spin-up data we will provide used the Gaussian function.

In addition, the inverse exponential function has a longer tail, increasing the radius of influence around a particular location. This leads to more calculations and a slower analysis.  I will see if I can speed this up by replacing divisions with multiplications by an inverse variable.



