### PR TITLE
Improved end-of-file handling in LIS Bratseth scheme

### DIFF
--- a/lis/metforcing/usaf/AGRMET_forcingMod.F90
+++ b/lis/metforcing/usaf/AGRMET_forcingMod.F90
@@ -485,6 +485,7 @@ integer, allocatable   :: n112_sh4(:)
      real, allocatable      :: mrgp(:,:,:)
      logical                :: pcp_start
      logical                :: pcp_ready
+     logical                :: first_pcp_segment ! EMK 6 Sep 2024
      character(len=6)       :: agr_bgrd_src_c
      real, allocatable      :: agr_hgt_c  ( : , : , : )
      real, allocatable      :: agr_rh_c   ( : , : , : )
@@ -2150,7 +2151,8 @@ real :: xi14,xj14,xmesh4,orient4,alat14,alon14
 
           allocate(agrmet_struc(n)%mrgp(LIS_rc%lnc(n), LIS_rc%lnr(n),4))
           agrmet_struc(n)%pcp_start = .true. 
-          agrmet_struc(n)%pcp_ready = .false. 
+          agrmet_struc(n)%pcp_ready = .false.
+          agrmet_struc(n)%first_pcp_segment = .true. ! EMK 6 Sep 2024
           agrmet_struc(n)%lastSfcalcHour = 0
           agrmet_struc(n)%lastPcpHour = 0
           agrmet_struc(n)%lastRadHour = 0

--- a/lis/metforcing/usaf/AGRMET_getsfc.F90
+++ b/lis/metforcing/usaf/AGRMET_getsfc.F90
@@ -463,25 +463,23 @@ subroutine AGRMET_getsfc( n, julhr, t2mObs, rh2mObs, spd10mObs, &
 
            ! Handle unexpected end of file
 700        continue
-           if (i < nsize) then
-             write(LIS_logunit,*)'[WARN] Unexpected end of file reached!'
-             write(LIS_logunit,*) &
-                  '[WARN] Expected ', nsize, ' reports, found ', i
-             write(LIS_logunit,*)'[WARN] No further reads from ' &
-                  // trim(sfcobsfile)
+           write(LIS_logunit,*)'[WARN] Unexpected end of file reached!'
+           write(LIS_logunit,*) &
+                '[WARN] Expected ', nsize, ' reports, found ', i
+           write(LIS_logunit,*)'[WARN] No further reads from ' &
+                // trim(sfcobsfile)
 
-             message = ''
-             message(1) = '[WARN] Program:  LIS'
-             message(2) = '  Routine: AGRMET_getsfc'
-             message(3) = '  Unexpected end of file reached for ' &
-                  // trim(sfcobsfile)
-             if (LIS_masterproc) then
-                alert_number = alert_number + 1
-                call LIS_alert('LIS.AGRMET_getsfc', &
-                     alert_number, message)
-             end if
-             exit ! Stop reading lines
-          end if
+           message = ''
+           message(1) = '[WARN] Program:  LIS'
+           message(2) = '  Routine: AGRMET_getsfc'
+           message(3) = '  Unexpected end of file reached for ' &
+                // trim(sfcobsfile)
+           if (LIS_masterproc) then
+              alert_number = alert_number + 1
+              call LIS_alert('LIS.AGRMET_getsfc', &
+                   alert_number, message)
+           end if
+           exit ! Stop reading lines
 
         enddo
 

--- a/lis/metforcing/usaf/AGRMET_getsfc.F90
+++ b/lis/metforcing/usaf/AGRMET_getsfc.F90
@@ -41,7 +41,8 @@
 !                ..............................Eric Kemp/NASA/SSAI
 !     16 Dec 21  Replaced julhr with YYYYMMDDHH in log...Eric Kemp/NASA/SSAI
 !     07 Nov 23  Added new sfcobs format.......Eric Kemp/NASA/SSAI
-! 
+!     06 Sep 24  Gracefully handle unexpected end-of-file
+!                ..............................Eric Kemp/NASA/SSAI 
 ! !INTERFACE: 
 subroutine AGRMET_getsfc( n, julhr, t2mObs, rh2mObs, spd10mObs, &
      ri, rj, obstmp, obsrlh, obsspd, obscnt, &
@@ -400,7 +401,7 @@ subroutine AGRMET_getsfc( n, julhr, t2mObs, rh2mObs, spd10mObs, &
               !read(iunit, *, iostat=ierr3) platform(i), dtg(i), &
               !     itmp(i), idpt(i), irelh(i), ilat(i), ilon(i), &
               !     ispd(i), rptyp(i), netyp(i)
-              read(iunit, *, iostat=ierr3) platform9, dtg(i), &
+              read(iunit, *, iostat=ierr3, end=700) platform9, dtg(i), &
                    itmp(i), idpt(i), irelh(i), ilat(i), ilon(i), &
                    ispd(i), rptyp8, netyp8
               if (ierr3 == 0) then
@@ -409,7 +410,8 @@ subroutine AGRMET_getsfc( n, julhr, t2mObs, rh2mObs, spd10mObs, &
                  netyp(i) = netyp8
               end if
            else
-              read(iunit, 1000, iostat=ierr3) platform(i), dtg(i), &
+              read(iunit, 1000, iostat=ierr3, end=700) &
+                   platform(i), dtg(i), &
                    itmp(i), idpt(i), irelh(i), ilat(i), ilon(i), &
                    ispd(i), rptyp(i), netyp(i)
 1000          format(a32, 1x, a14, 1x, i9, 1x, i9, 1x, i9, 1x, &
@@ -457,9 +459,33 @@ subroutine AGRMET_getsfc( n, julhr, t2mObs, rh2mObs, spd10mObs, &
               skip(i) = .true.
            end if
 
+           cycle
+
+           ! Handle unexpected end of file
+700        continue
+           if (i < nsize) then
+             write(LIS_logunit,*)'[WARN] Unexpected end of file reached!'
+             write(LIS_logunit,*) &
+                  '[WARN] Expected ', nsize, ' reports, found ', i
+             write(LIS_logunit,*)'[WARN] No further reads from ' &
+                  // trim(sfcobsfile)
+
+             message = ''
+             message(1) = '[WARN] Program:  LIS'
+             message(2) = '  Routine: AGRMET_getsfc'
+             message(3) = '  Unexpected end of file reached for ' &
+                  // trim(sfcobsfile)
+             if (LIS_masterproc) then
+                alert_number = alert_number + 1
+                call LIS_alert('LIS.AGRMET_getsfc', &
+                     alert_number, message)
+             end if
+             exit ! Stop reading lines
+          end if
+
         enddo
-        close(iunit)
-        call LIS_releaseUnitNumber(iunit)
+
+        call LIS_releaseUnitNumber(iunit) ! Closes file
 
         !if(ierr2.eq.0.and.ierr3.eq.0) then
         ! EMK Patch...Allow observation storage even if problem occurred

--- a/lis/metforcing/usaf/USAF_PreobsReaderMod.F90
+++ b/lis/metforcing/usaf/USAF_PreobsReaderMod.F90
@@ -326,7 +326,6 @@ contains
              if (wmocode_id_tmp == "  ") wmocode_id_tmp = "??"
              if (fipscode_id_tmp == "  ") fipscode_id_tmp = "??"
           else
-             write(LIS_logunit,*)'EMK: i, nsize = ', i, nsize
              read(iunit, 6000, iostat=ierr, end=700) &
                   twfprc_tmp, duration_tmp, &
                   sixprc_tmp, &

--- a/lis/metforcing/usaf/USAF_PreobsReaderMod.F90
+++ b/lis/metforcing/usaf/USAF_PreobsReaderMod.F90
@@ -326,6 +326,7 @@ contains
              if (wmocode_id_tmp == "  ") wmocode_id_tmp = "??"
              if (fipscode_id_tmp == "  ") fipscode_id_tmp = "??"
           else
+             write(LIS_logunit,*)'EMK: i, nsize = ', i, nsize
              read(iunit, 6000, iostat=ierr, end=700) &
                   twfprc_tmp, duration_tmp, &
                   sixprc_tmp, &
@@ -617,25 +618,23 @@ contains
 
           ! Handle unexpected end of file
 700       continue
-          if (i < nsize) then
-             write(LIS_logunit,*)'[WARN] Unexpected end of file reached!'
-             write(LIS_logunit,*) &
-                  '[WARN] Expected ', nsize, ' reports, found ', i
-             write(LIS_logunit,*)'[WARN] No further reads from ' &
-                  // trim(filename)
+          write(LIS_logunit,*)'[WARN] Unexpected end of file reached!'
+          write(LIS_logunit,*) &
+               '[WARN] Expected ', nsize, ' reports, found ', i
+          write(LIS_logunit,*)'[WARN] No further reads from ' &
+               // trim(filename)
 
-             message = ''
-             message(1) = '[WARN] Program:  LIS'
-             message(2) = '  Routine: USAF_read_preobs'
-             message(3) = '  Unexpected end of file reached for ' &
-                  // trim(filename)
-             if (LIS_masterproc) then
-                alert_number = alert_number + 1
-                call LIS_alert('LIS.USAF_read_preobs', &
-                     alert_number, message)
-             end if
-             exit ! Stop reading lines
+          message = ''
+          message(1) = '[WARN] Program:  LIS'
+          message(2) = '  Routine: USAF_read_preobs'
+          message(3) = '  Unexpected end of file reached for ' &
+               // trim(filename)
+          if (LIS_masterproc) then
+             alert_number = alert_number + 1
+             call LIS_alert('LIS.USAF_read_preobs', &
+                  alert_number, message)
           end if
+          exit ! Stop reading lines
 
        end do
 

--- a/lis/metforcing/usaf/readagrmetpcpforcing.F90
+++ b/lis/metforcing/usaf/readagrmetpcpforcing.F90
@@ -39,6 +39,8 @@
 ! 04Jan2018: Eric Kemp, disable 6-hr cycle unless 12-hr is not run.
 ! 05Sep2018: Eric Kemp, code clean-up and addition of IMERG.
 ! 07Jan2020: Eric Kemp, added creation of precip_OBA directory.
+! 11Sep2024: Eric Kemp, disabled redundant precip analysis at 0015Z and
+!              1215Z immediately after LIS start time of 0000Z or 1200Z.
 !
 ! !INTERFACE:    
 subroutine readagrmetpcpforcing(n,findex, order)
@@ -321,10 +323,25 @@ subroutine readagrmetpcpforcing(n,findex, order)
    ! which are the time to read in precp data for the upcoming 3 hrs, and it 
    ! is not a fresh start (pcp_ready = false for fresh start). 
 
-   if ( mod(curr_time, 180.0) .ne. LIS_rc%ts/60.0 .and. &
-        agrmet_struc(n)%pcp_ready ) return 
+   write(LIS_logunit,*) 'EMK: curr_time = ', curr_time
+   write(LIS_logunit,*) 'EMK: curr_time test = ', &
+        mod(curr_time, 180.0) .ne. LIS_rc%ts/60.0
+   write(LIS_logunit,*) 'EMK: pcp_ready = ', &
+        agrmet_struc(n)%pcp_ready
 
-   
+
+   ! EMK 10 Sep 2024...Avoid repeating precip analysis 15 minutes into
+   ! the fresh start (precip fields will already be populated).  At
+   ! the fresh start time, first_pcp_segment will be true. Once we
+   ! reach 30 or 45 minutes past the hour, we can safely set it false.
+   if ( mod(curr_time, 180.0) .ne. LIS_rc%ts/60.0 .and. &
+        mod(curr_time, 180.0) .ne. 0) then
+      agrmet_struc(n)%first_pcp_segment = .false.
+   end if
+
+   if ( mod(curr_time, 180.0) .ne. LIS_rc%ts/60.0 .and. &
+        agrmet_struc(n)%pcp_ready ) return
+
    TRACE_ENTER("agrmet_readpcpforc")
 
    p6 = LIS_rc%udef
@@ -355,14 +372,17 @@ subroutine readagrmetpcpforcing(n,findex, order)
    !  precip is not ready. Need to do pcp analysis 
    if (curr_time .EQ. LIS_rc%ts/60 .or. curr_time .EQ. 12*60.0+LIS_rc%ts/60 ) then
 
-      ! EMK 9 Sep 2024...Avoid repeating precip analysis 15 minutes into
-      ! the fresh start (precip fields will already be populated)
-      if (agrmet_struc(n)%first_pcp_segment) then
-         agrmet_struc(n)%first_pcp_segment = .false.
-      else
-         agrmet_struc(n)%pcp_ready = .false. 
+      ! EMK 10 Sep 2024...Avoid repeating precip analysis 15 minutes into
+      ! the fresh start (precip fields will already be populated).
+      if (.not. agrmet_struc(n)%first_pcp_segment) then
+         agrmet_struc(n)%pcp_ready = .false.
       end if
    end if
+
+   write(LIS_logunit,*)'EMK: first_pcp_segment = ', &
+        agrmet_struc(n)%first_pcp_segment
+   write(LIS_logunit,*)'EMK: pcp_ready = ', &
+        agrmet_struc(n)%pcp_ready
 
    call AGRMET_julhr_date10(julbeg, date10_03)
    write(LIS_logunit,*)'[INFO] Entering pcp proc. pcp_ready=', &
@@ -1481,6 +1501,12 @@ subroutine readagrmetpcpforcing(n,findex, order)
 
    !******** now pcp is ready for model run *******************************
 
+   write(LIS_logunit,*) 'EMK: curr_time = ', curr_time
+   write(LIS_logunit,*) 'EMK: mod(curr_time, 180.0) = ', &
+        mod(curr_time, 180.0)
+   write(LIS_logunit,*) 'EMK LIS_rc%ts/60.0 = ', &
+        LIS_rc%ts/60.0
+   
    if ( mod(curr_time, 180.0).eq.LIS_rc%ts/60.0 ) then 
       agrmet_struc(n)%pcp_start = .false.  !once booted up, no need
      
@@ -1506,6 +1532,8 @@ subroutine readagrmetpcpforcing(n,findex, order)
       else
          k = 4
       endif
+
+      write(LIS_logunit,*)'EMK: k = ', k
 
       !simply index into the rigth data. 
       varfield = agrmet_struc(n)%mrgp(:,:,k)

--- a/lis/metforcing/usaf/readagrmetpcpforcing.F90
+++ b/lis/metforcing/usaf/readagrmetpcpforcing.F90
@@ -351,17 +351,6 @@ subroutine readagrmetpcpforcing(n,findex, order)
    call LIS_get_julhr(LIS_rc%eyr,LIS_rc%emo,LIS_rc%eda,&
         LIS_rc%ehr, LIS_rc%emn,LIS_rc%ess,julend_lis)
 
-   ! EMK TEST
-   write(LIS_logunit,*) 'EMK: curr_time = ', curr_time
-   write(LIS_logunit,*) 'EMK: LIS_rc%ts = ', LIS_rc%ts
-   write(LIS_logunit,*) 'EMK: LIS_rc%ts/60 = ', LIS_rc%ts/60
-   write(LIS_logunit,*) 'EMK: 12*60.0+LIS_rc%ts/60 = ', &
-        12*60.0+LIS_rc%ts/60
-   write(LIS_logunit,*) 'EMK: First test = ', &
-        curr_time .EQ. LIS_rc%ts/60
-   write(LIS_logunit,*) 'EMK: Second test = ', &
-        curr_time .EQ. 12*60.0+LIS_rc%ts/60
-   
    ! when start from fresh (in LIS_init) or first step into a new segment,
    !  precip is not ready. Need to do pcp analysis 
    if (curr_time .EQ. LIS_rc%ts/60 .or. curr_time .EQ. 12*60.0+LIS_rc%ts/60 ) then
@@ -1492,9 +1481,6 @@ subroutine readagrmetpcpforcing(n,findex, order)
 
    !******** now pcp is ready for model run *******************************
 
-   write(LIS_logunit,*)'EMK: k test = ', &
-        mod(curr_time, 180.0).eq.LIS_rc%ts/60.0
-   
    if ( mod(curr_time, 180.0).eq.LIS_rc%ts/60.0 ) then 
       agrmet_struc(n)%pcp_start = .false.  !once booted up, no need
      
@@ -1520,8 +1506,6 @@ subroutine readagrmetpcpforcing(n,findex, order)
       else
          k = 4
       endif
-
-      write(LIS_logunit,*)'EMK: k = ', k
 
       !simply index into the rigth data. 
       varfield = agrmet_struc(n)%mrgp(:,:,k)

--- a/lis/metforcing/usaf/readagrmetpcpforcing.F90
+++ b/lis/metforcing/usaf/readagrmetpcpforcing.F90
@@ -323,12 +323,6 @@ subroutine readagrmetpcpforcing(n,findex, order)
    ! which are the time to read in precp data for the upcoming 3 hrs, and it 
    ! is not a fresh start (pcp_ready = false for fresh start). 
 
-   write(LIS_logunit,*) 'EMK: curr_time = ', curr_time
-   write(LIS_logunit,*) 'EMK: curr_time test = ', &
-        mod(curr_time, 180.0) .ne. LIS_rc%ts/60.0
-   write(LIS_logunit,*) 'EMK: pcp_ready = ', &
-        agrmet_struc(n)%pcp_ready
-
 
    ! EMK 10 Sep 2024...Avoid repeating precip analysis 15 minutes into
    ! the fresh start (precip fields will already be populated).  At
@@ -378,11 +372,6 @@ subroutine readagrmetpcpforcing(n,findex, order)
          agrmet_struc(n)%pcp_ready = .false.
       end if
    end if
-
-   write(LIS_logunit,*)'EMK: first_pcp_segment = ', &
-        agrmet_struc(n)%first_pcp_segment
-   write(LIS_logunit,*)'EMK: pcp_ready = ', &
-        agrmet_struc(n)%pcp_ready
 
    call AGRMET_julhr_date10(julbeg, date10_03)
    write(LIS_logunit,*)'[INFO] Entering pcp proc. pcp_ready=', &
@@ -1501,12 +1490,7 @@ subroutine readagrmetpcpforcing(n,findex, order)
 
    !******** now pcp is ready for model run *******************************
 
-   write(LIS_logunit,*) 'EMK: curr_time = ', curr_time
-   write(LIS_logunit,*) 'EMK: mod(curr_time, 180.0) = ', &
-        mod(curr_time, 180.0)
-   write(LIS_logunit,*) 'EMK LIS_rc%ts/60.0 = ', &
-        LIS_rc%ts/60.0
-   
+
    if ( mod(curr_time, 180.0).eq.LIS_rc%ts/60.0 ) then 
       agrmet_struc(n)%pcp_start = .false.  !once booted up, no need
      
@@ -1532,8 +1516,6 @@ subroutine readagrmetpcpforcing(n,findex, order)
       else
          k = 4
       endif
-
-      write(LIS_logunit,*)'EMK: k = ', k
 
       !simply index into the rigth data. 
       varfield = agrmet_struc(n)%mrgp(:,:,k)


### PR DESCRIPTION


### Description

Added graceful handing of unexpected End-Of-File in sfcobs and preobs files used by LIS Bratseth scheme.  When encountered, LIS will stop trying to read the file in question, put a warning in the lislog file, and write an alert file.

Also modified code to skip unnecessary repeat of LIS precip analysis 15 minutes after start of LIS run.  Not only does this save time, it avoids redundant warnings and alerts for EOF cases.
