### PR TITLE
Fixing Speckling Issues in MR

### DIFF
--- a/ldt/configs/ldt.config.adoc
+++ b/ldt/configs/ldt.config.adoc
@@ -3303,6 +3303,7 @@ for ensemble restart generation. Options are:
 
 |none | Do not apply random sampling strategy
 |random sampling | Use random sampling strategy
+|557ww | Only use the non-perturbed member
 |===
 
 .Example _ldt.config_ entry

--- a/ldt/configs/ldt.config.adoc
+++ b/ldt/configs/ldt.config.adoc
@@ -3303,7 +3303,7 @@ for ensemble restart generation. Options are:
 
 |none | Do not apply random sampling strategy
 |random sampling | Use random sampling strategy
-|557ww | Only use the non-perturbed member
+|unperturbed sampling | Only use the non-perturbed member
 |===
 
 .Example _ldt.config_ entry

--- a/ldt/core/LDT_ensRstMod.F90
+++ b/ldt/core/LDT_ensRstMod.F90
@@ -346,13 +346,13 @@ module LDT_ensRstMod
                   endif
                enddo
             enddo
-         ! To avoid speckling issues, only use ensemble member 12
-         elseif(LDT_rc%ensrstsampling.eq."557ww") then
+         ! To avoid speckling issues, only use last ensemble member
+         elseif(LDT_rc%ensrstsampling.eq."unperturbed sampling") then
             allocate(var_map(dims(1)*LDT_rc%nens_out/LDT_rc%nens_in))
             do i=1,dims(1)/LDT_rc%nens_in
                do m=1,LDT_rc%nens_out
-                  t2 = (i-1)*LDT_rc%nens_out+m
-                  t1 = (i-1)*LDT_rc%nens_in+12
+                  t2 = (i-1)*LDT_rc%nens_out + m
+                  t1 = (i-1)*LDT_rc%nens_in  + LDT_rc%nens_in
                   var_map(t2) = t1
                enddo
             enddo
@@ -389,7 +389,7 @@ module LDT_ensRstMod
                      enddo
                   enddo
                elseif(LDT_rc%ensrstsampling.eq."random sampling" .or. &
-                      LDT_rc%ensrstsampling.eq."557ww") then
+                      LDT_rc%ensrstsampling.eq."unperturbed sampling") then
                   do i=1,dims(1)/LDT_rc%nens_in
                      do m=1,LDT_rc%nens_out
                         t2 = (i-1)*LDT_rc%nens_out+m
@@ -419,7 +419,7 @@ module LDT_ensRstMod
          deallocate(dimID2)
          deallocate(dims)
          if(LDT_rc%ensrstsampling.eq."random sampling" .or. &
-                      LDT_rc%ensrstsampling.eq."557ww") then
+              LDT_rc%ensrstsampling.eq."unperturbed sampling") then
             deallocate(var_map)
          endif
          call LDT_verify(nf90_close(ftn))
@@ -949,8 +949,8 @@ module LDT_ensRstMod
                var_map(t2) = t1
             enddo
          enddo
-      ! To avoid speckling issues, only use ensemble member 12
-      elseif(LDT_rc%ensrstsampling.eq."557ww") then
+      ! To avoid speckling issues, only use last ensemble member
+      elseif(LDT_rc%ensrstsampling.eq."unperturbed sampling") then
          allocate(var_map(dims(1)*LDT_rc%nens_out/LDT_rc%nens_in))
          var_map = -1
          do i=1,dims(1)/LDT_rc%nens_in
@@ -962,7 +962,7 @@ module LDT_ensRstMod
                cycl_check = .true.
 
                do while(cycl_check)
-                  t1 = (i-1)*LDT_rc%nens_in+12
+                  t1 = (i-1)*LDT_rc%nens_in + LDT_rc%nens_in
 
                   dupl_check =.false.
                   do p=st,en
@@ -1016,7 +1016,7 @@ module LDT_ensRstMod
                   var_new(t,:) = var_new(t,:)/LDT_rc%nens_in
                enddo
             elseif(LDT_rc%ensrstsampling.eq."random sampling" .or. &
-                   LDT_rc%ensrstsampling.eq."557ww") then
+                   LDT_rc%ensrstsampling.eq."unperturbed sampling") then
                do i=1,dims(1)/LDT_rc%nens_in
                   do m=1,LDT_rc%nens_out
                      t2 = (i-1)*LDT_rc%nens_out+m
@@ -1050,7 +1050,7 @@ module LDT_ensRstMod
       deallocate(dims)
 
       if(LDT_rc%ensrstsampling.eq."random sampling" .or. &
-         LDT_rc%ensrstsampling.eq."557ww") then
+         LDT_rc%ensrstsampling.eq."unperturbed sampling") then
          deallocate(var_map)
       endif
 


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Implemented an additional sampling strategy for ensemble restart generation to address speckling issues in MR. 
- Temporary Solution: Utilize only the non-perturbed member from the RST file to mitigate the issue.

Resolves https://github.com/NASA-LIS/LISF/issues/1606

'ldt.config'
Ensemble restart generation sampling strategy:    "**557ww**" # option: none, random sampling, 557ww
![Picture1](https://github.com/user-attachments/assets/c0d1582e-644e-4eaa-a512-fd67bf32b352)


### Testcase
LDT
/discover/nobackup/yyoon4/lis7/Testcase/speckling/ldt/ldt.config.global.noah39.ensemble
LIS
/discover/nobackup/yyoon4/lis7/Testcase/speckling/lis/lis.config.global.noah39.hymap.galwem



