### PR TITLE
Revised alert and abort message files for USAFSI

### DIFF
--- a/ldt/USAFSI/USAFSI_amsr2Mod.F90
+++ b/ldt/USAFSI/USAFSI_amsr2Mod.F90
@@ -1400,7 +1400,7 @@ contains
 
       ! EMK
       character*12                   :: program_name          ! NAME OF CALLING PROGRAM
-      character*12                   :: routine_name          ! NAME OF THIS ROUTINE
+      character*20                   :: routine_name          ! NAME OF THIS ROUTINE
 
       ! define data values
       data routine_name  / 'search_files' /

--- a/ldt/USAFSI/USAFSI_analysisMod.F90
+++ b/ldt/USAFSI/USAFSI_analysisMod.F90
@@ -23,6 +23,7 @@
 !                        run_seaice_analysis_navy to reflect use of
 !                        ESPC-D or GOFS data.  Also fixed uninitialized
 !                        variable.
+! 15 Oct 2024  Eric Kemp Updated error_message logic.
 !
 ! DESCRIPTION:
 ! Source code for Air Force snow depth analysis.
@@ -331,7 +332,8 @@ contains
       character*255               :: file_path        ! FULLY-QUALIFIED FILE NAME
       character*7                 :: iofunc           ! ACTION TO BE PERFORMED
       character*90                :: message (msglns) ! ERROR MESSAGE
-      character*12                :: routine_name     ! NAME OF THIS SUBROUTINE
+      character*20                :: routine_name     ! NAME OF THIS SUBROUTINE
+      character*10                :: yyyymmddhh
       integer                     :: fracnt           ! NUMBER OF FRACTIONAL POINTS
       integer                     :: i                ! SNODEP I-COORDINATE
       integer                     :: icount           ! LOOP COUNTER
@@ -351,6 +353,8 @@ contains
       allocate (infrac_0p05deg (igridf, jgridf))
       allocate(pntcnt( ldt_rc%lnc(1), ldt_rc%lnr(1)))
       allocate(snocum( ldt_rc%lnc(1), ldt_rc%lnr(1)))
+
+      yyyymmddhh = date10
 
       ! INITIALIZE VARIABLES.
       fracnt  = 0
@@ -440,7 +444,8 @@ contains
          usafsi_settings%usefrac = .false.
          message(1) = '[WARN]  FRACTIONAL SNOW FILE NOT FOUND'
          message(2) = '[WARN]  PATH = ' // trim(file_path)
-         call error_message (program_name, routine_name, message)
+         call error_message (program_name, routine_name, yyyymmddhh, &
+              message)
          write (LDT_logunit, 6400) routine_name, file_path
 
       end if
@@ -793,7 +798,8 @@ contains
       character*5,   allocatable  :: oldnet      (:)       ! ARRAY OF NETWORKS FOR OLDSTA
       character*32,   allocatable  :: oldsta      (:)       ! ARRAY OF PROCESSED STATIONS WITH SNOW DEPTHS
 
-      character*12                :: routine_name          ! NAME OF THIS SUBROUTINE
+      character*20                :: routine_name          ! NAME OF THIS SUBROUTINE
+      character*10 :: yyyymmddhh
       integer                     :: ctrgrd                ! TEMP HOLDER FOR GROUND OBS INFO
       integer                     :: ctrtmp                ! TEMP HOLDER FOR TOO WARM TEMPERATURE OBS
       integer                     :: ctrtrs                ! TEMP HOLDER FOR TEMP THRES OBS
@@ -833,6 +839,8 @@ contains
       allocate (oldnet (usafsi_settings%maxsobs))
       allocate (oldsta (usafsi_settings%maxsobs))
 
+      yyyymmddhh = date10
+      
       ! INITIALIZE VARIABLES.
       depth        = missing
       istat        = 0
@@ -1115,7 +1123,8 @@ contains
                        '[WARN] NO SURFACE OBSERVATIONS READ FOR ' // &
                        date10
                end if
-               call error_message (program_name, routine_name, message)
+               call error_message (program_name, routine_name, &
+                    yyyymmddhh, message)
 
             end if
 
@@ -1132,7 +1141,8 @@ contains
                     // date10
             end if
             message(2) = '[WARN] Looked for ' // trim(obsfile)
-            call error_message (program_name, routine_name, message)
+            call error_message (program_name, routine_name, &
+                 yyyymmddhh, message)
 
          end if file_check
 
@@ -1255,7 +1265,8 @@ contains
       character*7                 :: iofunc                ! ACTION TO BE PERFORMED
       character*90                :: message     (msglns)  ! ERROR MESSAGE
 
-      character*12                :: routine_name          ! NAME OF THIS ROUTINE
+      character*20                :: routine_name          ! NAME OF THIS ROUTINE
+      character*10 :: yyyymmddhh
       integer                     :: icount                ! LOOP COUNTER
       integer                     :: julhr                 ! AFWA JULIAN HOUR
       logical                     :: isfile                ! FLAG FOR INPUT FILE FOUND
@@ -1268,6 +1279,8 @@ contains
       data routine_name / 'GETSFC      ' /
 
       allocate(sfctmp_lis_0p25deg(igrid, jgrid_lis))
+
+      yyyymmddhh = date10
 
       ! GET LATEST LIS SHELTER TEMPERATURES.
       dtglis       = date10
@@ -1309,7 +1322,8 @@ contains
       ! IF NOT FOUND FOR PAST 24 HOURS, SEND ERROR MESSAGE.
       if (.not. sfctmp_found) then
          message(1) = '[WARN] LIS DATA NOT FOUND FOR PAST 24 HOURS'
-         call error_message (program_name, routine_name, message)
+         call error_message (program_name, routine_name, yyyymmddhh, &
+              message)
          write (ldt_logunit, 6400) routine_name
       end if
 
@@ -1458,7 +1472,8 @@ contains
       character*6                 :: interval              ! TIME INTERVAL FOR FILENAME
       character*90                :: message     (msglns)  ! ERROR MESSAGE
       character*4                 :: msgval                ! PLACEHOLDER FOR ERROR MESSAGE VALUES
-      character*12                :: routine_name          ! NAME OF THIS SUBROUTINE
+      character*20                :: routine_name          ! NAME OF THIS SUBROUTINE
+      character*10 :: yyyymmddhh
       integer                     :: edri16                ! EDR 16TH MESH I-COORDINATE
       integer                     :: edrj16                ! EDR 16TH MESH J-COORDINATE
       integer                     :: edrlat                ! EDR LATITUDE (100THS OF DEGREES)
@@ -1500,6 +1515,8 @@ contains
       data interval     / '.06hr.' /
       data lunsrc       /  43,  44 /
       data routine_name / 'GETSMI      '/
+
+      yyyymmddhh = date10
 
       ! ALLOCATE ARRAYS.
       allocate (icecount_0p25deg (igrid , jgrid))
@@ -1658,7 +1675,7 @@ contains
                end if
             end do
          end do
-         
+
          ! Interpolate the 0.25deg data to the LDT grid
          nr = LDT_rc%lnr(1)
          nc = LDT_rc%lnc(1)
@@ -1702,7 +1719,8 @@ contains
 
       if (msgline > 1) then
 
-         call error_message (program_name, routine_name, message)
+         call error_message (program_name, routine_name, yyyymmddhh, &
+              message)
 
       end if
 
@@ -2292,7 +2310,8 @@ contains
       character*7                 :: iofunc           ! ACTION TO BE PERFORMED
       !character*90                :: message (msglns) ! ERROR MESSAGE
       character*255                :: message (msglns) ! ERROR MESSAGE
-      character*12                :: routine_name     ! NAME OF THIS SUBROUTINE
+      character*20                :: routine_name     ! NAME OF THIS SUBROUTINE
+      character*10 :: yyyymmddhh
       integer                     :: runcycle         ! CYCLE TIME
       integer                     :: hrdiff           ! DIFFERENCE BETWEEN HOURS
       integer                     :: julsno           ! JULIAN HOUR OF SNODEP CYCLE
@@ -2311,6 +2330,8 @@ contains
       integer :: grstat
 
       data routine_name           / 'GETSST      '/
+
+      yyyymmddhh = date10
 
       ! FIND THE DATE/TIME GROUP OF THE PREVIOUS CYCLE.
       ! GET SEA SURFACE TEMPERATURE DATA.
@@ -2387,14 +2408,16 @@ contains
                else
                   message(1) = '[ERR] ERROR READING FILE'
                   message(2) = '[ERR] PATH = ' // file_grib
-                  call error_message(program_name, routine_name, message)
+                  call error_message(program_name, routine_name, &
+                       yyyymmddhh, message)
                   write(ldt_logunit, 6400) routine_name, iofunc, file_grib, &
                        grstat
                end if
             else
                message(1) = '[ERR] ERROR OPENING FILE'
                message(2) = '[ERR] PATH = ' // file_grib
-               call error_message(program_name, routine_name, message)
+               call error_message(program_name, routine_name, &
+                    yyyymmddhh, message)
                write(ldt_logunit, 6400) routine_name, iofunc, file_grib, grstat
             end if
          end if
@@ -2414,7 +2437,8 @@ contains
                message(1) = '  SST DATA IS MORE THAN 24 HOURS OLD'
                message(2) = '  USAFSI CYCLE = ' // date10
                message(3) = '  SEA SFC TEMP = ' // date10_sst
-               call error_message (program_name, routine_name, message)
+               call error_message (program_name, routine_name, &
+                    yyyymmddhh, message)
 
             end if
 
@@ -2423,7 +2447,8 @@ contains
       else
 
          message(1) = '[WARN] SEA SURFACE TEMPERATURE DATA NOT FOUND'
-         call error_message (program_name, routine_name, message)
+         call error_message (program_name, routine_name, &
+              yyyymmddhh, message)
          write (ldt_logunit, 6600) routine_name
 
       end if
@@ -2557,7 +2582,8 @@ contains
       character(255)              :: snoage_path      ! FULLY-QUALIFIED SNOAGE FILE NAME
       character(7)                :: iofunc           ! ACTION TO BE PERFORMED
       character(90)               :: message (msglns) ! ERROR MESSAGE
-      character(12)               :: routine_name     ! NAME OF THIS SUBROUTINE
+      character(20)               :: routine_name     ! NAME OF THIS SUBROUTINE
+      character(10)               :: yyyymmddhh
       integer                     :: i                ! SNODEP I-COORDINATE
       integer                     :: icount           ! LOOP COUNTER
       integer                     :: julhr            ! AFWA JULIAN HOUR
@@ -2583,11 +2609,13 @@ contains
       write(LDT_logunit,*)&
            '[ERR] Recompile with LIBGEOTIFF support and try again!'
       call LDT_endrun()
-      
+
 #else
       external :: ztif_frac_slice ! EMK 20220113
 
       data routine_name  / 'GETVIIRS    ' /
+
+      yyyymmddhh = date10
 
       ! ALLOCATE DATA ARRAYS.
       nc = LDT_rc%lnc(1)
@@ -2611,7 +2639,7 @@ contains
            idim = igrid_viirs, &
            jdim = jgrid_viirs, &
            proj=viirs_0p005deg_proj)
-      
+
       ! INITIALIZE VARIABLES.
       icount = 0
       iofunc   = 'READING'
@@ -2694,7 +2722,7 @@ contains
 
                   ! No error for this slice, so process
                   do i_viirs = 1, igrid_viirs
-               
+
                      ! Find lat/lon of VIIRS pixel, and then determine which
                      ! LDT grid box this falls in.
                      ri_viirs = real(i_viirs)
@@ -2720,13 +2748,13 @@ contains
                         j = 1
                      else if (j > nr) then
                         j = nr
-                     end if                     
+                     end if
                      pixels(i,j) = pixels(i,j) + 1
 
                      ! Skip if the pixel age is too old.
                      if (agebuf_slice(i_viirs) > &
                           usafsi_settings%maxpixage) cycle
-               
+
                      ! Increment the appropriate snow/bare counter
                      if (mapbuf_slice(i_viirs) .eq. 0) then
                         bare(i,j) = bare(i,j) + 1
@@ -2754,7 +2782,7 @@ contains
 
       end do file_search
 
-      if (map_exists .and. age_exists .and. ierr .eq. 0) then         
+      if (map_exists .and. age_exists .and. ierr .eq. 0) then
 
          ! From the geolocated data, create the final VIIRS snow cover map
          do j = 1, nr
@@ -2780,7 +2808,8 @@ contains
             usafsi_settings%useviirs = .false.
             message(1) = '[WARN] VIIRS SNOW MAP FILE NOT FOUND'
             !message(2) = '[WARN] PATH = ' // trim(snomap_path)
-            call error_message (program_name, routine_name, message)
+            call error_message (program_name, routine_name, &
+                 yyyymmddhh, message)
             write (ldt_logunit, 6400) routine_name, snomap_path
          end if
 
@@ -2788,7 +2817,8 @@ contains
             usafsi_settings%useviirs = .false.
             message(1) = '[WARN] VIIRS SNOW AGE FILE NOT FOUND'
             !message(2) = '[WARN] PATH = ' // trim(snoage_path)
-            call error_message (program_name, routine_name, message)
+            call error_message (program_name, routine_name, &
+                 yyyymmddhh, message)
             write (ldt_logunit, 6400) routine_name, snoage_path
          end if
 

--- a/ldt/USAFSI/USAFSI_analysisMod.F90
+++ b/ldt/USAFSI/USAFSI_analysisMod.F90
@@ -553,7 +553,7 @@ contains
       character*4                 :: file_ext         ! LAST PORTION OF FILE NAME
       character*255               :: file_path        ! FULLY-QUALIFIED FILE NAME
       character*90                :: message (msglns) ! ERROR MESSAGE
-      character*12                :: routine_name     ! NAME OF THIS SUBROUTINE
+      character*20                :: routine_name     ! NAME OF THIS SUBROUTINE
       real, allocatable :: climo_0p25deg(:,:)
       integer*1, allocatable :: snow_poss_0p25deg(:,:)
       type(proj_info) :: snodep_0p25deg_proj
@@ -1830,7 +1830,7 @@ contains
       character*10               :: date10_prev      ! PREVIOUS CYCLE DATE-TIME GROUP
       character*255              :: file_path        ! INPUT FILE PATH AND NAME
       character*90               :: message (msglns) ! ERROR MESSAGE
-      character*12               :: routine_name     ! NAME OF THIS SUBROUTINE
+      character*20               :: routine_name     ! NAME OF THIS SUBROUTINE
       character*255              :: prevdir          ! PATH TO PREVIOUS CYCLE'S DATA
       integer                    :: runcycle         ! CYCLE HOUR
       integer                    :: julhr            ! AFWA JULIAN HOUR
@@ -2129,7 +2129,7 @@ contains
 4200  continue
       message(1) = '[ERR] ERROR CONVERTING DATA FROM CHARACTER TO INTEGER'
       message(2) = '[ERR] DATE10 = ' // date10
-      call abort_message (program_name, program_name, message)
+      call abort_message (program_name, routine_name, message)
       call LDT_endrun()
 
       ! FORMAT STATEMENTS.
@@ -2163,7 +2163,7 @@ contains
       integer :: limit, tries
       integer :: runcycle
       integer :: julhr
-      character*12 :: routine_name
+      character*20 :: routine_name
       character*10 :: date10_prev
       character*90 :: message(msglns)
 
@@ -2232,7 +2232,7 @@ contains
 4200  continue
       message(1) = '[ERR] ERROR CONVERTING DATA FROM CHARACTER TO INTEGER'
       message(2) = '[ERR] DATE10 = ' // date10
-      call abort_message (program_name, program_name, message)
+      call abort_message (program_name, routine_name, message)
       call LDT_endrun()
 
       ! Other format statements

--- a/ldt/USAFSI/USAFSI_espcdMod.F90
+++ b/ldt/USAFSI/USAFSI_espcdMod.F90
@@ -66,7 +66,8 @@ contains
     integer :: yyyy_local, mm_local, dd_local, hh_local
     integer :: fh_local
     character*255 :: message (msglns)
-    character*12 :: routine_name
+    character*20 :: routine_name
+    character*10 :: yyyymmddhh
     integer, parameter :: nlat_arc = 2501
     integer, parameter :: nlat_ant = 1549
     integer :: ncid, aice_varid
@@ -85,6 +86,7 @@ contains
     ! Build the file name.  Note that all ESPC-D CICE runs start at 12Z.
     ! NOTE:  CICE output is 12-hrly.
     call LDT_get_julhr(yyyy, mm, dd, hh, 0, 0, julhr)
+    write(yyyymmddhh,'(i4.4,i2.2,i2.2,i2.2)') yyyy, mm, dd, hh
     if (hh == 12) then
        fh_local = 0
     else if (hh == 18) then
@@ -135,7 +137,8 @@ contains
        if (.not. file_exists) then
           message(1) = '[WARN] CANNOT FIND FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           cycle
        end if
 
@@ -146,7 +149,8 @@ contains
        if (ierr .ne. nf90_noerr) then
           message(1) = '[WARN] CANNOT OPEN FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           cycle
        end if
 
@@ -155,7 +159,8 @@ contains
        if (ierr .ne. nf90_noerr) then
           message(1) = '[WARN] CANNOT FIND aice IN FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           ierr = nf90_close(ncid)
           cycle
        end if
@@ -165,7 +170,8 @@ contains
        if (ierr .ne. nf90_noerr) then
           message(1) = '[WARN] CANNOT GET DIMENSIONS FOR aice IN FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           ierr = nf90_close(ncid)
           cycle
        end if
@@ -174,7 +180,8 @@ contains
        if (ierr .ne. nf90_noerr) then
           message(1) = '[WARN] CANNOT GET DIMENSIONS FOR aice IN FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           deallocate(dimids)
           ierr = nf90_close(ncid)
           cycle
@@ -186,7 +193,8 @@ contains
           if (ierr .ne. nf90_noerr) then
              message(1) = '[WARN] CANNOT GET DIMENSIONS FOR aice IN FILE'
              message(2) = '[WARN] PATH = ' // trim(filename)
-             call error_message(program_name, routine_name, message)
+             call error_message(program_name, routine_name, yyyymmddhh, &
+                  message)
              deallocate(dimids)
              deallocate(lens)
              ierr = nf90_close(ncid)
@@ -205,7 +213,8 @@ contains
                lens(1) .ne. nlon) then
              message(1) = '[WARN] BAD DIMENSIONS FOR aice IN FILE'
              message(2) = '[WARN] PATH = ' // trim(filename)
-             call error_message(program_name, routine_name, message)
+             call error_message(program_name, routine_name, yyyymmddhh, &
+                  message)
              deallocate(lens)
              ierr = nf90_close(ncid)
              cycle
@@ -218,7 +227,8 @@ contains
                lens(1) .ne. nlon) then
              message(1) = '[WARN] BAD DIMENSIONS FOR aice IN FILE'
              message(2) = '[WARN] PATH = ' // trim(filename)
-             call error_message(program_name, routine_name, message)
+             call error_message(program_name, routine_name, yyyymmddhh, &
+                  message)
              deallocate(lens)
              ierr = nf90_close(ncid)
              cycle
@@ -236,7 +246,8 @@ contains
        if (ierr .ne. nf90_noerr) then
           message(1) = '[WARN] CANNOT READ aice IN FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           deallocate(aice)
           ierr = nf90_close(ncid)
           cycle
@@ -344,7 +355,8 @@ contains
     integer :: yyyy_local, mm_local, dd_local, hh_local, fh_local
     logical :: file_exists
     character*255 :: message (msglns)
-    character*12 :: routine_name
+    character*20 :: routine_name
+    character*10 :: yyyymmddhh
     integer :: ncid, water_temp_varid
     integer :: ndims
     integer, allocatable :: dimids(:), lens(:)
@@ -362,6 +374,7 @@ contains
     ! Build the file name.  Note that all ESPC-D SST runs start at 12Z.
     call LDT_get_julhr(yyyy, mm, dd, hh, 0, 0, &
          julhr)
+    write(yyyymmddhh,'(i4.4,i2.2,i2.2,i2.2)') yyyy, mm, dd, hh
     if (hh == 12) then
        fh_local = 0
     else if (hh == 18) then
@@ -407,7 +420,8 @@ contains
        if (.not. file_exists) then
           message(1) = '[WARN] CANNOT FIND FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           cycle
        end if
 
@@ -418,7 +432,8 @@ contains
        if (ierr .ne. nf90_noerr) then
           message(1) = '[WARN] CANNOT OPEN FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           cycle
        end if
 
@@ -428,7 +443,8 @@ contains
        if (ierr .ne. nf90_noerr) then
           message(1) = '[WARN] CANNOT FIND water_temp IN FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           ierr = nf90_close(ncid)
           cycle
        end if
@@ -439,7 +455,8 @@ contains
           message(1) = &
                '[WARN] CANNOT GET DIMENSIONS FOR water_temp IN FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           ierr = nf90_close(ncid)
           cycle
        end if
@@ -447,7 +464,8 @@ contains
           message(1) = &
                '[WARN] BAD DIMENSIONS FOR water_temp IN FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           ierr = nf90_close(ncid)
           cycle
        end if
@@ -457,7 +475,8 @@ contains
           message(1) = &
                '[WARN] CANNOT GET DIMENSIONS FOR water_temp IN FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           deallocate(dimids)
           ierr = nf90_close(ncid)
           cycle
@@ -471,7 +490,8 @@ contains
              message(1) = &
                   '[WARN] CANNOT GET DIMENSIONS FOR water_temp IN FILE'
              message(2) = '[WARN] PATH = ' // trim(filename)
-             call error_message(program_name, routine_name, message)
+             call error_message(program_name, routine_name, yyyymmddhh, &
+                  message)
              deallocate(dimids)
              deallocate(lens)
              ierr = nf90_close(ncid)
@@ -489,7 +509,8 @@ contains
           message(1) = &
                '[WARN] CANNOT GET DIMENSIONS FOR water_temp IN FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           deallocate(lens)
           ierr = nf90_close(ncid)
           cycle
@@ -505,7 +526,8 @@ contains
           message(1) = &
                '[WARN] CANNOT READ water_temp IN FILE'
           message(2) = '[WARN] PATH = ' // trim(filename)
-          call error_message(program_name, routine_name, message)
+          call error_message(program_name, routine_name, yyyymmddhh, &
+               message)
           deallocate(water_temp)
           ierr = nf90_close(ncid)
           cycle

--- a/ldt/USAFSI/USAFSI_run.F90
+++ b/ldt/USAFSI/USAFSI_run.F90
@@ -136,7 +136,7 @@ subroutine USAFSI_run(n)
   logical                    ::  sfctmp_found         ! FLAG FOR SFC TEMP FILE FOUND
   real,       allocatable    ::  sfctmp (:, :)        ! GALWEM OR LIS SHELTER TEMPERATURE DATA
   real,       allocatable    ::  stadep     (:)       ! OBSERVATION SNOW DEPTH (METERS)
-  character*12 :: routine_name
+  character*20 :: routine_name
   type(LDT_bratseth_t) :: bratseth
   character*10 :: network10
   character*32 :: platform32
@@ -558,7 +558,7 @@ subroutine USAFSI_run(n)
 
   message(1) = ' [ERR] ERROR CONVERTING DATA FROM CHARACTER TO INTEGER'
   message(2) = ' [ERR] DATE10 = ' // date10
-  call abort_message (program_name, program_name, message)
+  call abort_message (program_name, routine_name, message)
   call LDT_endrun()
 
   ! FORMAT STATEMENTS.

--- a/ldt/USAFSI/USAFSI_ssmisMod.F90
+++ b/ldt/USAFSI/USAFSI_ssmisMod.F90
@@ -1029,7 +1029,7 @@ contains
 
       ! EMK
       character*12                   :: program_name          ! NAME OF CALLING PROGRAM
-      character*12                   :: routine_name          ! NAME OF THIS ROUTINE
+      character*20                   :: routine_name          ! NAME OF THIS ROUTINE
 
       ! define data values
       data satid            / '16', '17', '18' /

--- a/ldt/USAFSI/USAFSI_utilMod.F90
+++ b/ldt/USAFSI/USAFSI_utilMod.F90
@@ -9,18 +9,19 @@
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
 !
 ! MODULE: USAFSI_utilMod
-! 
+!
 ! REVISION HISTORY:
 ! 08 Feb 2019  Eric Kemp  First ported to LDT.
 ! 09 May 2019  Eric Kemp  Renamed LDTSI.
 ! 13 Dec 2019  Eric Kemp  Renamed USAFSI.
+! 14 Oct 2024  Eric Kemp  Updates to error_message.
 !
 ! DESCRIPTION:
 ! Source code for util library for Air Force snow depth analysis.
 !-------------------------------------------------------------------------
 
 #include "LDT_misc.h"
-   
+
 module USAFSI_utilMod
 
    !Defaults
@@ -64,7 +65,6 @@ contains
       !**  =======
       !**  11 MAY 11 INITIAL VERSION (FROM ERROR_MESSAGE)...MR LEWISTON/16WS/WXE
       !**  22 Mar 19 Ported to LDT...Eric Kemp, NASA GSFC/SSAI
-      !**
       !*************************************************************************
       !*************************************************************************
       ! Imports
@@ -84,7 +84,7 @@ contains
       ! Local variables
       character*7                 :: access_type      ! FILE ACCESS TYPE
       character*100               :: errmsg  (msglns) ! ERROR MESSAGE TO OUTPUT
-      character*40                :: message_file     ! MESSAGE FILE NAME
+      character*255               :: message_file     ! MESSAGE FILE NAME
       integer                     :: i                ! DO LOOP COUNTER
       integer                     :: istat            ! I/O STATUS
       integer                     :: nlines           ! NUMBER OF LINES IN MESSAGE
@@ -127,7 +127,7 @@ contains
       close (99)
       !call abort
       call LDT_endrun()
-      
+
       ! ERROR-HANDLING SECTION.
 5000  write (ldt_logunit, 8000) routine_name, access_type, istat
       !call abort
@@ -342,7 +342,8 @@ contains
 
    end subroutine date10_julhr
 
-   subroutine error_message (program_name, routine_name, message)
+   subroutine error_message (program_name, routine_name, yyyymmddhh, &
+        message)
 
       !*************************************************************************
       !*************************************************************************
@@ -371,6 +372,8 @@ contains
       !**  22 Mar 19  Ported to LDT...Eric Kemp, NASA GSFC/SSAI
       !**  09 May 19  Renamed LDTSI...Eric Kemp, NASA GSFC/SSAI
       !**  13 Dec 19  Renamed USAFSI...Eric Kemp, NASA GSFC/SSAI
+      !**  15 Oct 24 Extended character lengths, and added valid date/time
+      !**    of USAFSI analysis.
       !**
       !*************************************************************************
       !*************************************************************************
@@ -385,14 +388,16 @@ contains
 
       ! Arguments
       character*12, intent(in)    :: program_name     ! NAME OF CALLING ROUTINE
-      character*12, intent(in)    :: routine_name     ! NAME OF CALLING ROUTINE
+      character*20, intent(in)    :: routine_name     ! NAME OF CALLING ROUTINE
+      character*10, intent(in) :: yyyymmddhh
+
       character(len=*), intent(in) :: message (msglns) ! ERROR MESSAGE FROM CALLER
       ! Local variables
       character*7                 :: access_type      ! FILE ACCESS TYPE
       character*2                 :: calert_number    ! ALERT NUMBER FOR FILE NAME
       !character*100               :: errmsg  (msglns) ! ERROR MESSAGE TO OUTPUT
       character*255               :: errmsg  (msglns) ! ERROR MESSAGE TO OUTPUT
-      character*40                :: message_file     ! MESSAGE FILE NAME
+      character*255               :: message_file     ! MESSAGE FILE NAME
       integer                     :: alert_number     ! ALERT NUMBER
       integer                     :: i                ! DO LOOP COUNTER
       integer                     :: istat            ! I/O STATUS
@@ -426,7 +431,7 @@ contains
       do while (isfile)
          write (calert_number, '(i2.2)', iostat = istat) alert_number
          message_file = 'alert.' // trim(routine_name) // '.' //         &
-              calert_number
+              yyyymmddhh // '.' // calert_number
          inquire (file=message_file, exist=isfile)
          alert_number = alert_number + 1
       end do
@@ -529,7 +534,7 @@ contains
       message = ' '
 
       call tmjul4( hh, dd, mm, yyyy, julhr )
-     
+
       ! Check for valid hour, day, month, and year
       if( (  hh .lt.    0 .or.   hh .gt.   23) .or.                     &
            (  dd .lt.    1 .or.   dd .gt.   31) .or.                    &

--- a/ldt/USAFSI/USAFSI_utilMod.F90
+++ b/ldt/USAFSI/USAFSI_utilMod.F90
@@ -78,7 +78,7 @@ contains
 
       ! Arguments
       character*12, intent(in)    :: program_name     ! NAME OF CALLING ROUTINE
-      character*12, intent(in)    :: routine_name     ! NAME OF CALLING ROUTINE
+      character*20, intent(in)    :: routine_name     ! NAME OF CALLING ROUTINE
       character*90, intent(in)    :: message (msglns) ! ERROR MESSAGE FROM CALLER
 
       ! Local variables
@@ -140,7 +140,7 @@ contains
 6600  format (1X, 75('*'))
 8000  format (/, 1X, 75('*'),                                          &
            /, 1X, '[ERR]  ABNORMAL ABORT FROM ABORT_MESSAGE ROUTINE',  &
-           /, 1X, '[ERR]  CALLED BY ', A12,                            &
+           /, 1X, '[ERR]  CALLED BY ', A20,                            &
            /, 1X, '[ERR]  ERROR WHILE ', A7, ' MESSAGE FILE',          &
            /, 1X, '[ERR]  ISTAT = ', I6,                               &
            /, 1X, 75('*'))
@@ -213,7 +213,7 @@ contains
       character*10,  intent(in)   :: date10           ! 10-DIGIT DATE-TIME GROUP
       integer,       intent(out)  :: julhr            ! TOTAL JULIAN HOURS
       character*12,  intent(in)   :: program_name     ! NAME OF CALLING PROGRAM
-      character*12,  intent(in)   :: routine_name     ! NAME OF CALLING ROUTINE
+      character*20,  intent(in)   :: routine_name     ! NAME OF CALLING ROUTINE
 
       ! Local variables
       character*90                :: message     (20) ! ERROR MESSAGE ! EMK
@@ -419,6 +419,7 @@ contains
       errmsg(1) = '[WARN] PROGRAM: ' // trim (program_name)
       errmsg(2) = '[WARN] ROUTINE: ' // trim (routine_name)
       do i = 3, nlines
+         if (i > msglns) exit
          errmsg(i) = trim(message(i-2))
       enddo
 
@@ -434,6 +435,25 @@ contains
               yyyymmddhh // '.' // calert_number
          inquire (file=message_file, exist=isfile)
          alert_number = alert_number + 1
+         if (alert_number > 99) then
+            write(LDT_logunit,*) &
+                 '[ERR] Too many alert files in work directory for ', &
+                 'alert.' // trim(routine_name) // '.' // yyyymmddhh
+            write(LDT_logunit,*) &
+                 '[ERR] Please purge alert files and try again'
+            write(LDT_logunit,*) 'LDT will now abort'
+
+            errmsg(1) = '[ERR] PROGRAM: ' // trim (program_name)
+            errmsg(2) = '[ERR] ROUTINE: ' // trim (routine_name)
+            errmsg(3) = &
+                 '[ERR] TOO MANY ALERT FILES, SO REPORTING IN ABORT MESSAGE'
+            do i = 4, nlines
+               if (i > msglns) exit
+               errmsg(i) = trim(message(i-3))
+            enddo
+            call abort_message(program_name, routine_name, errmsg)
+
+         end if
       end do
 
       ! OPEN MESSAGE FILE.
@@ -519,7 +539,7 @@ contains
       integer,        intent(in)  :: julhr            ! AFWA JULIAN HOUR
       character*10,  intent(out)  :: date10           ! 10-DIGIT DATE-TIME GROUP
       character*12,  intent(in)   :: program_name     ! NAME OF CALLING PROGRAM
-      character*12,  intent(in)   :: routine_call     ! NAME OF CALLING ROUTINE
+      character*20,  intent(in)   :: routine_call     ! NAME OF CALLING ROUTINE
 
       ! Local variables
       character*90                :: message     (20) ! ERROR MESSAGE ! EMK
@@ -648,7 +668,7 @@ contains
       character*1,   intent(in)    :: iofunc                     ! I/O FUNCTION ('r', 'w')
       character*255, intent(in)    :: file_name                  ! FILE PATH AND NAME
       character*12,  intent(in)    :: program_name               ! NAME OF CALLING PROGRAM
-      character*12,  intent(in)    :: routine_name               ! NAME OF CALLING ROUTINE
+      character*20,  intent(in)    :: routine_name               ! NAME OF CALLING ROUTINE
       integer,       intent(in)    :: igrid                      ! SIZE OF GRID IN I-DIRECTION
       integer,       intent(in)    :: jgrid                      ! SIZE OF GRID IN I-DIRECTION
 
@@ -757,7 +777,7 @@ contains
       character*1,   intent(in)    :: iofunc                     ! I/O FUNCTION ('r', 'w')
       character*255, intent(in)    :: file_name                  ! FILE PATH AND NAME
       character*12,  intent(in)    :: program_name               ! NAME OF CALLING PROGRAM
-      character*12,  intent(in)    :: routine_name               ! NAME OF CALLING ROUTINE
+      character*20,  intent(in)    :: routine_name               ! NAME OF CALLING ROUTINE
       integer,       intent(in)    :: igrid                      ! SIZE OF GRID IN I-DIRECTION
       integer,       intent(in)    :: jgrid                      ! SIZE OF GRID IN I-DIRECTION
 
@@ -866,7 +886,7 @@ contains
       character*1,   intent(in)    :: iofunc                     ! I/O FUNCTION ('r', 'w')
       character(len=*), intent(in) :: file_name                  ! FILE PATH AND NAME
       character*12,  intent(in)    :: program_name               ! NAME OF CALLING PROGRAM
-      character*12,  intent(in)    :: routine_name               ! NAME OF CALLING ROUTINE
+      character*20,  intent(in)    :: routine_name               ! NAME OF CALLING ROUTINE
       integer,       intent(in)    :: igrid                      ! SIZE OF GRID IN I-DIRECTION
       integer,       intent(in)    :: jgrid                      ! SIZE OF GRID IN I-DIRECTION
 

--- a/ldt/USAFSI/USAFSI_utilMod.F90
+++ b/ldt/USAFSI/USAFSI_utilMod.F90
@@ -79,11 +79,11 @@ contains
       ! Arguments
       character*12, intent(in)    :: program_name     ! NAME OF CALLING ROUTINE
       character*20, intent(in)    :: routine_name     ! NAME OF CALLING ROUTINE
-      character*90, intent(in)    :: message (msglns) ! ERROR MESSAGE FROM CALLER
+      character(len=*), intent(in) :: message (msglns) ! ERROR MESSAGE FROM CALLER
 
       ! Local variables
       character*7                 :: access_type      ! FILE ACCESS TYPE
-      character*100               :: errmsg  (msglns) ! ERROR MESSAGE TO OUTPUT
+      character*255               :: errmsg  (msglns) ! ERROR MESSAGE TO OUTPUT
       character*255               :: message_file     ! MESSAGE FILE NAME
       integer                     :: i                ! DO LOOP COUNTER
       integer                     :: istat            ! I/O STATUS

--- a/ldt/USAFSI/USAFSI_xcalgmiMod.F90
+++ b/ldt/USAFSI/USAFSI_xcalgmiMod.F90
@@ -1290,7 +1290,7 @@ contains
 
       ! EMK
       character*12                   :: program_name          ! NAME OF CALLING PROGRAM
-      character*12                   :: routine_name          ! NAME OF THIS ROUTINE
+      character*20                   :: routine_name          ! NAME OF THIS ROUTINE
 
       ! define data values
       data routine_name  / 'search_files' /


### PR DESCRIPTION

### Description

Addressed runtime problems uncovered in Ops, especially if too many alert files exist in the work directory.

(1) Character lengths increased to support whole subroutine names, and to allow total alert file name to be up to 255 characters (avoid truncation).
(2) Added valid date/time (YYYYMMDDHH) of the USAFSI analysis to the alert file name.
(3) Modified abort_message to accept larger character length for routine name.
(4) Modified several subroutines to remain combatable with abort_message argument list.
(5) Modified several calls to abort_message to pass along routine name as second argument.
(6) Modified error_message to abort if alert number exceed 99 (to avoid infinite loop)
(7) Modified abort_message message argument to be flexible, and increased the internal errmsg character length to 255 (consistent with error_message)


