### PR TITLE
Fixed uninitialized variable in Noah-MP401 irrigation module

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/irrigation/noahmp401_getirrigationstates.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/irrigation/noahmp401_getirrigationstates.F90
@@ -212,7 +212,7 @@ subroutine noahmp401_getirrigationstates(n,irrigState)
 
         t=(i-1)*LIS_rc%nensem(n)+m
 
-     timestep = NOAHMP401_struc(n)%dt
+     timestep = NOAHMP401_struc(n)%ts
      soiltyp = noahmp401_struc(n)%noahmp401(t)%soiltype
     
  


### PR DESCRIPTION
This small edit resolves #1621
