### PR TITLE
Fix the bug in writing model output in 2D ensemble grid space #1627

### DIFF
--- a/lis/core/LIS_historyMod.F90
+++ b/lis/core/LIS_historyMod.F90
@@ -66,6 +66,8 @@ module LIS_historyMod
 !                   used in GRIB1 & GRIB2 format
 !  18 Oct 2018: David Mocko: Check lis.config entry for option to turn off
 !                   writing ASCII stats files with netCDF output format
+!  25 Oct 2024: Mahdi Navari: updated the code to fix the bug in writing
+!                    model output in 2D ensemble grid space (see https://github.com/NASA-LIS/LISF/issues/1627 )
 !
 ! !USES: 
   use LIS_coreMod
@@ -3440,16 +3442,16 @@ contains
                 ! lat/lon field output will write in 1D 
                 if(LIS_rc%nlatlon_dimensions == '1D') then
                    if(nmodel_status.eq.1) then
-                      call LIS_verify(nf90_def_var(ftn,trim(short_name),&
+                      call LIS_verify(nf90_def_var(ftn,trim(dataEntry%short_name),&
                            nf90_float,&
                            dimids = dimID(2), varID=dataEntry%varId_def),&
-                           'nf90_def_var for '//trim(short_name)//&
+                           'nf90_def_var for '//trim(dataEntry%short_name)//&
                            'failed in defineNETCDFheadervar')                     
                    elseif(nmodel_status.eq.2) then
-                      call LIS_verify(nf90_def_var(ftn,trim(short_name),&
+                      call LIS_verify(nf90_def_var(ftn,trim(dataEntry%short_name),&
                            nf90_float,&
                            dimids = dimID(1), varID=dataEntry%varId_def),&
-                           'nf90_def_var for '//trim(short_name)//&
+                           'nf90_def_var for '//trim(dataEntry%short_name)//&
                            'failed in defineNETCDFheadervar')                     
                    else                
                       call LIS_verify(nf90_def_var(ftn,trim(dataEntry%short_name)//'_tavg',&
@@ -3460,10 +3462,10 @@ contains
                    endif
                 ! latlon field output will write in 2D
                 else
-                     call LIS_verify(nf90_def_var(ftn,trim(short_name),&
+                     call LIS_verify(nf90_def_var(ftn,trim(dataEntry%short_name),&
                          nf90_float,&
                          dimids = dimID(1:2), varID=dataEntry%varID_def),&
-                         'nf90_def_var for '//trim(short_name)//&
+                         'nf90_def_var for '//trim(dataEntry%short_name)//&
                          'failed in defineNETCDFheadervar')
                 endif 
 


### PR DESCRIPTION
### Description

This bug is related to writing model output in 2D ensemble grid space when the map projection is not lat/lon (equidistant cylindrical) and the vertical level (vlevel) is set to 1. In this part of the code, the variable short_name is used instead of dataEntry%short_name. Since the value of short_name is not properly defined, it pulls a value from memory, which does not match dataEntry%short_name, causing the model to crash.

Resolves #1627 

### Testcase

