### PR TITLE
Add dynamic lapse rate usage and output to MERRA-2 metforcing

### DIFF
--- a/lis/configs/MODEL_OUTPUT_LIST.TBL.adoc
+++ b/lis/configs/MODEL_OUTPUT_LIST.TBL.adoc
@@ -252,6 +252,9 @@ Density_f:    0  kg/m3   -    1 0 0 1 256 1       # Atmospheric density
 VaporPress_f: 0  -       -    1 0 0 1 256 1       # Vapor pressure
 VaporPressDeficit_f: 0  -  -  1 0 0 1 256 1       # Vapor pressure deficit
 
+#Lapserate
+Lapserate:    1  K/km    UP   1 0 0 1 255 10      # Lapse rate
+
 #Additional FEWSNET Forcings
 PET_f:         0 kg/m2s  -    0 0 0 1 228 1000    # Average PET rate 
 RefET_f:       0 kg/m2s  -    0 0 0 1 256 1000    # Average RefET rate 

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5720,12 +5720,32 @@ Acceptable values are:
 |1     | Use the bias corrected total precipitation.
 |====
 
+`MERRA2 apply dynamic lapse rates:` specifies whether to read
+in and apply the pre-computed MERRA-2 lapse rates.  This is an
+optional config entry; if not present, the default is 0.  Note
+that one of the two lapse-rate options for the topographic
+correction method for met forcing must be chosen for this
+config entry to be used.
+Acceptable values are:
+
+|====
+|Value | Description
+
+|0     | Do not apply MERRA-2 dynamic lapse rates (use static lapse rate).
+|1     | Apply MERRA-2 dynamic lapse rates
+|====
+
+`MERRA2 dynamic lapse rate data directory:` specifies the
+directory of the pre-computed MERRA-2 lapse rate dataset.
+
 .Example _lis.config_ entry
 ....
-MERRA2 forcing directory:              ./MERRA2/
+MERRA2 forcing directory:                  ./MERRA2
 MERRA2 use lowest model level forcing:     1
 MERRA2 use 2m wind fields:                 0 
 MERRA2 use corrected total precipitation:  1
+MERRA2 apply dynamic lapse rates:          0
+MERRA2 dynamic lapse rate data directory:  ./MERRA2_lapse_rates
 ....
 
 [[sssec_forcings_GEOS-IT,GEOS-IT]]

--- a/lis/core/LIS_constantsMod.F90
+++ b/lis/core/LIS_constantsMod.F90
@@ -74,6 +74,7 @@ module LIS_constantsMod
 
    real, parameter :: LIS_MS2KMDAY = 86.4 ! m/s to km/day
    real, parameter :: LIS_CONST_ANGULAR_VELOCITY = 0.2618 ! Angular velocity of earth's rotation (radian/hr)
+   real, parameter :: LIS_CONST_LAPSE_RATE = -0.0065 ! Static lapse rate [K/m]; from NLDAS (Cosgrove et al., 2003)
 
 !EOC
  end module LIS_constantsMod

--- a/lis/core/LIS_histDataMod.F90
+++ b/lis/core/LIS_histDataMod.F90
@@ -40,7 +40,8 @@ module LIS_histDataMod
 !                 106 and 114 in place for 112 (some variables left alone) 
 !  01 Jun 2017    Augusto Getirana: Add/update HyMAP2 outputs [SWS, differetial and 
 !                      potential evaporation and deep water infiltration (DWI)]
-!  
+!  13 Sep 2024    Sujay Kumar, Initial code for using dynamic lapse rate
+!  31 Oct 2024    David Mocko, Final code for using dynamic lapse rate
 !  
 !EOP
   use ESMF
@@ -175,6 +176,9 @@ module LIS_histDataMod
   public :: LIS_MOC_ALBEDOFORC  
   public :: LIS_MOC_PARDRFORC  
   public :: LIS_MOC_PARDFFORC  
+
+  public :: LIS_MOC_LAPSERATE
+
 !<for vic>
   public :: LIS_MOC_SNOWFLAGFORC
   public :: LIS_MOC_DENSITYFORC
@@ -647,6 +651,8 @@ module LIS_histDataMod
    integer :: LIS_MOC_PSURFFORC  = -9999
    integer :: LIS_MOC_SWDOWNFORC = -9999
    integer :: LIS_MOC_LWDOWNFORC = -9999
+
+   integer :: LIS_MOC_LAPSERATE  = -9999
 
    ! CLSM FORCING VARIABLES
    integer :: LIS_MOC_PARDRFORC  = -9999
@@ -2881,6 +2887,18 @@ contains
        call register_dataEntry(LIS_MOC_LSM_COUNT,LIS_MOC_PARDFFORC,&
             LIS_histData(n)%head_lsm_list,&
             n,1,ntiles,(/"W/m2"/),1,(/"DN"/),2,1,1,&
+            model_patch=.true.)
+    endif
+
+    call ESMF_ConfigFindLabel(modelSpecConfig,"Lapserate:",rc=rc)
+    call get_moc_attributes(modelSpecConfig, LIS_histData(n)%head_lsm_list, &
+         "Lapserate",&
+         "lapse_rate",&
+         "lapse rate",rc)
+    if ( rc == 1 ) then
+       call register_dataEntry(LIS_MOC_LSM_COUNT,LIS_MOC_LAPSERATE,&
+            LIS_histData(n)%head_lsm_list,&
+            n,1,ntiles,(/"K/km"/),1,(/"UP"/),2,1,1,&
             model_patch=.true.)
     endif
 

--- a/lis/core/LIS_metforcingMod.F90
+++ b/lis/core/LIS_metforcingMod.F90
@@ -133,6 +133,7 @@ contains
   subroutine metforcing_init_offline
 ! !USES:
     use LIS_metforcing_pluginMod, only : LIS_metforcing_plugin
+    use LIS_constantsMod, only : LIS_CONST_LAPSE_RATE
 !
 ! !DESCRIPTION:
 !
@@ -176,7 +177,7 @@ contains
                 allocate(LIS_forc(n,m)%lapserate(LIS_rc%ngrid(n)))
 
                 !initialized to the uniform value
-                LIS_forc(n,m)%lapserate = -0.0065
+                LIS_forc(n,m)%lapserate = LIS_CONST_LAPSE_RATE
              endif
           enddo
        enddo

--- a/lis/core/LIS_spatialDownscalingMod.F90
+++ b/lis/core/LIS_spatialDownscalingMod.F90
@@ -119,7 +119,6 @@ contains
     real, pointer      :: tmp(:),q2(:),lwd(:),psurf(:)
     
     rdry = 287.
-!    lapse = -0.0065
     
     call ESMF_StateGet(LIS_FORC_Base_State,&
          trim(LIS_FORC_Tair%varname(1)),tmpField,&

--- a/lis/core/LIS_spatialDownscalingMod.F90
+++ b/lis/core/LIS_spatialDownscalingMod.F90
@@ -69,15 +69,18 @@ contains
 !  15 Mar 2001: Jon Gottschalck; if-then to handle negative vapor
 !		pressures in long wave correction
 !  14 Nov 2003: Sujay Kumar; Adopted in LIS
+!  13 Sep 2024: Sujay Kumar, Initial code for using dynamic lapse rate
+!  31 Oct 2024: David Mocko, Final code for using dynamic lapse rate
 !
 ! !INTERFACE:
-  subroutine LIS_lapseRateCorrection(nest, modelelev, LIS_FORC_Base_State)
+  subroutine LIS_lapseRateCorrection(nest, modelelev, lapserate, LIS_FORC_Base_State)
 ! !USES:
     
     implicit none
 ! !ARGUMENTS: 
     integer, intent(in) :: nest
     real                :: modelelev(LIS_rc%ngrid(nest))
+    real                :: lapserate(LIS_rc%ngrid(nest))
     type(ESMF_State)    :: LIS_FORC_Base_State
 
 ! !DESCRIPTION:
@@ -116,7 +119,7 @@ contains
     real, pointer      :: tmp(:),q2(:),lwd(:),psurf(:)
     
     rdry = 287.
-    lapse = -0.0065
+!    lapse = -0.0065
     
     call ESMF_StateGet(LIS_FORC_Base_State,&
          trim(LIS_FORC_Tair%varname(1)),tmpField,&
@@ -155,12 +158,14 @@ contains
     
 
     do t=1,LIS_rc%ntiles(nest)
-       if(tmp(t).gt.0) then 
+       if(tmp(t).gt.0) then
           force_tmp = tmp(t)
           force_hum = q2(t)
           force_lwd = lwd(t)
           force_prs = psurf(t)
           index = LIS_domain(nest)%tile(t)%index
+          lapse = lapserate(index)
+
           elevdiff = LIS_domain(nest)%tile(t)%elev-&
                modelelev(index)
           tcforce=force_tmp+(lapse*elevdiff)

--- a/lis/core/LIS_tbotAdjustMod.F90
+++ b/lis/core/LIS_tbotAdjustMod.F90
@@ -591,7 +591,7 @@ contains
                tmp_topo = &
                     LIS_topo(n)%elevation(LIS_domain(n)%tile(i)%col, &
                                           LIS_domain(n)%tile(i)%row)
-               tmp_t = tmp_t - 0.0065 * tmp_topo
+               tmp_t = tmp_t + (LIS_CONST_LAPSE_RATE * tmp_topo)
                
                placetbot1(LIS_domain(n)%tile(i)%col, &
                           LIS_domain(n)%tile(i)%row) = tmp_t

--- a/lis/metforcing/merra2/get_merra2.F90
+++ b/lis/metforcing/merra2/get_merra2.F90
@@ -16,6 +16,8 @@
 ! !REVISION HISTORY:
 ! 18 Mar 2015: James Geiger, initial code (based on merra-land)
 ! 08 Dec 2015: James Geiger, update timing logic
+! 13 Sep 2024: Sujay Kumar, Initial code for using dynamic lapse rate
+! 31 Oct 2024: David Mocko, Final code for using dynamic lapse rate
 !
 ! !INTERFACE:
 subroutine get_merra2(n, findex)
@@ -170,10 +172,14 @@ subroutine get_merra2(n, findex)
   real*8            :: time1, time2, timenow
   real              :: gmt1, gmt2
   real              :: ts1, ts2
+  integer           :: gid
 
   integer           :: hr_int1, hr_int2
   integer           :: movetime  ! Flag to move bookend2 files to bookend1
 
+  character(len=LIS_CONST_PATH_LEN) :: lapseratefname
+  character*8                       :: fdate
+  
 ! _________________________________________________________
 
 ! Please note that the timing logic has been tested only for
@@ -307,8 +313,14 @@ subroutine get_merra2(n, findex)
      do kk= merra2_struc(n)%st_iterid, merra2_struc(n)%en_iterid
         call merra2files(n,kk,findex,merra2_struc(n)%merra2dir, yr1, mo1, da1, &
              slvname, flxname, lfoname, radname)
+
+        write(unit=fdate, fmt='(i4.4,i2.2,i2.2)') yr1,mo1,da1
+        lapseratefname = trim(merra2_struc(n)%dynlapseratedir)//&
+             '/MERRA2.lapse_rate.hourly.'//&
+             trim(fdate)//'.global.nc'
+
         call read_merra2(n, order, mo1, &
-             findex, slvname, flxname, lfoname, radname,&
+             findex, slvname, flxname, lfoname, radname, lapseratefname, &
              merra2_struc(n)%merraforc1(kk,:,:,:), ferror)
      enddo
   endif
@@ -319,14 +331,23 @@ subroutine get_merra2(n, findex)
      if ( movetime == 1 ) then
         merra2_struc(n)%merraforc1 = merra2_struc(n)%merraforc2
         merra2_struc(n)%merraforc2 = LIS_rc%udef
+        if (merra2_struc(n)%usedynlapserate.eq.1) then
+           merra2_struc(n)%lapserate1 = merra2_struc(n)%lapserate2
+        endif
      endif
 
      order = 2
      do kk= merra2_struc(n)%st_iterid, merra2_struc(n)%en_iterid
         call merra2files(n,kk,findex,merra2_struc(n)%merra2dir, yr2, mo2, da2, &
              slvname, flxname, lfoname, radname)
+
+        write(unit=fdate, fmt='(i4.4,i2.2,i2.2)') yr2,mo2,da2
+        lapseratefname = trim(merra2_struc(n)%dynlapseratedir)//&
+             '/MERRA2.lapse_rate.hourly.'//&
+             trim(fdate)//'.global.nc'
+
         call read_merra2(n, order, mo2,&
-             findex, slvname, flxname, lfoname, radname, &
+             findex, slvname, flxname, lfoname, radname, lapseratefname, &
              merra2_struc(n)%merraforc2(kk,:,:,:), ferror)
      enddo
   endif
@@ -429,8 +450,36 @@ subroutine get_merra2(n, findex)
 
   endif
 
-end subroutine get_merra2
+  LIS_forc(n,findex)%lapseRate(:) = -0.0065
 
+  if ((merra2_struc(n)%usedynlapserate.eq.1).and.                      &
+     ((LIS_rc%met_ecor(findex).eq."lapse-rate").or.                    &
+      (LIS_rc%met_ecor(findex).eq."lapse-rate and slope-aspect").or.   &
+      (LIS_rc%met_ecor(findex).eq."micromet"))) then
+      if ((LIS_rc%hr.eq.0).and.(LIS_rc%mn.le.int(LIS_rc%ts/60.0))) then
+        do r=1,LIS_rc%lnr(n)
+           do c=1,LIS_rc%lnc(n)
+              if(LIS_domain(n)%gindex(c,r).ne.-1) then
+                 gid = LIS_domain(n)%gindex(c,r)
+                 LIS_forc(n,findex)%lapseRate(gid) = &
+                     merra2_struc(n)%lapserate2(gid,LIS_rc%hr+1)
+              endif
+           enddo
+        enddo
+     else
+        do r=1,LIS_rc%lnr(n)
+           do c=1,LIS_rc%lnc(n)
+              if(LIS_domain(n)%gindex(c,r).ne.-1) then
+                 gid = LIS_domain(n)%gindex(c,r)
+                 LIS_forc(n,findex)%lapseRate(gid) = &
+                     merra2_struc(n)%lapserate1(gid,LIS_rc%hr+1)
+              endif
+           enddo
+        enddo
+     endif
+  endif
+
+end subroutine get_merra2
 
 !BOP
 ! !ROUTINE: merra2files

--- a/lis/metforcing/merra2/get_merra2.F90
+++ b/lis/metforcing/merra2/get_merra2.F90
@@ -27,7 +27,7 @@ subroutine get_merra2(n, findex)
   use LIS_logMod
   use LIS_metforcingMod
   use merra2_forcingMod
-  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN, LIS_CONST_LAPSE_RATE
 
   implicit none
 
@@ -450,7 +450,7 @@ subroutine get_merra2(n, findex)
 
   endif
 
-  LIS_forc(n,findex)%lapseRate(:) = -0.0065
+  LIS_forc(n,findex)%lapseRate(:) = LIS_CONST_LAPSE_RATE
 
   if ((merra2_struc(n)%usedynlapserate.eq.1).and.                      &
      ((LIS_rc%met_ecor(findex).eq."lapse-rate").or.                    &

--- a/lis/metforcing/merra2/merra2_forcingMod.F90
+++ b/lis/metforcing/merra2/merra2_forcingMod.F90
@@ -11,6 +11,11 @@ module merra2_forcingMod
 !BOP
 ! !MODULE: merra2_forcingMod
 !
+! !REVISION HISTORY:
+! 18 Mar 2015: James Geiger, initial code (based on merra-land)
+! 13 Sep 2024: Sujay Kumar, Initial code for using dynamic lapse rate
+! 31 Oct 2024: David Mocko, Final code for using dynamic lapse rate
+!
 ! !DESCRIPTION:
 !  This module contains variables and data structures that are used
 !  for the implementation of the MERRA2 forcing data.
@@ -98,6 +103,7 @@ module merra2_forcingMod
      integer                :: findtime1, findtime2
      logical                :: startFlag, dayFlag
      real, allocatable      :: merraforc1(:,:,:,:), merraforc2(:,:,:,:)
+     real, allocatable      :: lapserate1(:,:), lapserate2(:,:)
 
      integer            :: nvars
      integer            :: uselml
@@ -125,6 +131,9 @@ module merra2_forcingMod
      real, allocatable       :: merraxrange(:,:,:,:)
      real, allocatable       :: merracdf(:,:,:,:)
      integer, allocatable    :: rseed(:,:)
+     integer                 :: usedynlapserate
+     character(len=LIS_CONST_PATH_LEN) :: dynlapseratedir
+     
   end type merra2_type_dec
 
   type(merra2_type_dec), allocatable :: merra2_struc(:)
@@ -263,6 +272,11 @@ contains
                trim(LIS_rc%met_interp(findex))//&
                ' for MERRA2 forcing is not supported'
           call LIS_endrun()
+       endif
+
+       if (merra2_struc(n)%usedynlapserate.eq.1) then
+          allocate(merra2_struc(n)%lapserate1(LIS_rc%ngrid(n),24))
+          allocate(merra2_struc(n)%lapserate2(LIS_rc%ngrid(n),24))
        endif
 
        call LIS_registerAlarm("MERRA2 forcing alarm",&

--- a/lis/metforcing/merra2/read_merra2.F90
+++ b/lis/metforcing/merra2/read_merra2.F90
@@ -29,6 +29,7 @@ subroutine read_merra2(n, order, month, findex,  &
   use LIS_FORC_AttributesMod
   use LIS_metforcingMod, only : LIS_forc
   use merra2_forcingMod, only : merra2_struc
+  use LIS_constantsMod, only : LIS_CONST_LAPSE_RATE
 #if (defined USE_NETCDF3 || defined USE_NETCDF4) 
   use netcdf
 #endif
@@ -251,8 +252,8 @@ subroutine read_merra2(n, order, month, findex,  &
         else
            write(LIS_logunit,*) '[WARN] Could not find ',trim(lapseratefname)
            write(LIS_logunit,*) '[WARN] Using static lapse rate.'
-           merra2_struc(n)%lapserate1 = -0.0065
-           merra2_struc(n)%lapserate2 = -0.0065
+           merra2_struc(n)%lapserate1 = LIS_CONST_LAPSE_RATE
+           merra2_struc(n)%lapserate2 = LIS_CONST_LAPSE_RATE
         endif
      endif
      
@@ -772,6 +773,7 @@ subroutine interp_lapserate_var(n,order,input_var)
   use LIS_logMod
   use LIS_spatialDownscalingMod
   use merra2_forcingMod, only : merra2_struc
+  use LIS_constantsMod, only : LIS_CONST_LAPSE_RATE
 #if(defined USE_NETCDF3 || defined USE_NETCDF4)      
   use netcdf
 #endif
@@ -834,7 +836,7 @@ subroutine interp_lapserate_var(n,order,input_var)
                     merra2_struc(n)%lapserate1(gid,t) = &
                          output_var(c+(r-1)*LIS_rc%lnc(n),t)/1000.0
                  else
-                     merra2_struc(n)%lapserate1(gid,t) = -0.0065
+                     merra2_struc(n)%lapserate1(gid,t) = LIS_CONST_LAPSE_RATE
                  endif
               endif
            enddo
@@ -849,7 +851,7 @@ subroutine interp_lapserate_var(n,order,input_var)
                     merra2_struc(n)%lapserate2(gid,t) = &
                          output_var(c+(r-1)*LIS_rc%lnc(n),t)/1000.0
                  else
-                     merra2_struc(n)%lapserate2(gid,t) = -0.0065
+                     merra2_struc(n)%lapserate2(gid,t) = LIS_CONST_LAPSE_RATE
                  endif
               endif
            enddo

--- a/lis/metforcing/merra2/read_merra2.F90
+++ b/lis/metforcing/merra2/read_merra2.F90
@@ -15,11 +15,14 @@
 ! 
 ! !REVISION HISTORY:
 ! 18 Mar 2015: James Geiger, initial code (based on merra-land)
+! 13 Sep 2024: Sujay Kumar, Initial code for using dynamic lapse rate
+! 31 Oct 2024: David Mocko, Final code for using dynamic lapse rate
 !
 ! !INTERFACE:
-subroutine read_merra2(n, order, month, findex,          &
-                       slvname, flxname, lfoname, radname, &
-                       merraforc, ferror)
+subroutine read_merra2(n, order, month, findex,  &
+     slvname, flxname, lfoname, radname,         &
+     lapseratefname,                             &
+     merraforc, ferror)
 ! !USES:
   use LIS_coreMod,       only : LIS_rc, LIS_domain, LIS_masterproc
   use LIS_logMod
@@ -40,6 +43,7 @@ subroutine read_merra2(n, order, month, findex,          &
   character(len=*), intent(in) :: flxname
   character(len=*), intent(in) :: lfoname
   character(len=*), intent(in) :: radname
+  character(len=*), intent(in) :: lapseratefname
   real, intent(inout)          :: merraforc(merra2_struc(n)%nvars, 24, &
        LIS_rc%lnc(n)*LIS_rc%lnr(n))
   integer, intent(out)         :: ferror          
@@ -114,7 +118,12 @@ subroutine read_merra2(n, order, month, findex,          &
   real      :: pardf(merra2_struc(n)%ncold, merra2_struc(n)%nrold,24)
   real      :: hlml(merra2_struc(n)%ncold, merra2_struc(n)%nrold,24)
 !  real      :: emis(merra2_struc(n)%ncold, merra2_struc(n)%nrold,24)
-! __________________________________________________________________________
+
+  integer                           :: ftn_drate
+  integer                           :: lapserateid
+  real, allocatable                 :: lapse_rate_in(:,:,:)
+
+!_______________________________________________________________________
 
 #if (defined USE_NETCDF3) 
   write(LIS_logunit,*) "[ERR] MERRA2 reader requires NetCDF4"
@@ -214,6 +223,39 @@ subroutine read_merra2(n, order, month, findex,          &
      call interp_merra2_var(n,findex,month,uwind, 5, .false., merraforc)
      call interp_merra2_var(n,findex,month,vwind, 6, .false., merraforc)
      call interp_merra2_var(n,findex,month,ps,    7, .false., merraforc)
+
+     if ((merra2_struc(n)%usedynlapserate.eq.1).and.                   &
+        ((LIS_rc%met_ecor(findex).eq."lapse-rate").or.                 &
+         (LIS_rc%met_ecor(findex).eq."lapse-rate and slope-aspect").or.&
+         (LIS_rc%met_ecor(findex).eq."micromet"))) then
+        inquire(file=trim(lapseratefname),exist=file_exists)
+        if (file_exists) then
+           write(LIS_logunit,*) 'Reading ',trim(lapseratefname)
+
+           allocate(lapse_rate_in(merra2_struc(n)%ncold,merra2_struc(n)%nrold,24))
+
+           call LIS_verify(nf90_open(path=trim(lapseratefname),        &
+                    mode=NF90_NOWRITE,ncid=ftn_drate),                 &
+                    'nf90_open failed for '//trim(lapseratefname))
+           call LIS_verify(nf90_inq_varid(ftn_drate,                   &
+                    'lapse_rate',lapserateid),                         &
+                    'nf90_inq_varid failed for lapse_rate')
+           call LIS_verify(nf90_get_var(ftn_drate,                     &
+                    lapserateid,lapse_rate_in),                        &
+                    'nf90_get_var failed for lapse_rate')
+           call LIS_verify(nf90_close(ftn_drate),'nf90_close failed')
+
+           call interp_lapserate_var(n,order,lapse_rate_in)
+
+           deallocate(lapse_rate_in)
+        else
+           write(LIS_logunit,*) '[WARN] Could not find ',trim(lapseratefname)
+           write(LIS_logunit,*) '[WARN] Using static lapse rate.'
+           merra2_struc(n)%lapserate1 = -0.0065
+           merra2_struc(n)%lapserate2 = -0.0065
+        endif
+     endif
+     
   else
      write(LIS_logunit,*) '[ERR] ',trim(slvname)//' does not exist'
      call LIS_endrun()
@@ -716,6 +758,106 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
   enddo
   
 end subroutine interp_merra2_var
+
+!BOP
+! 
+! !ROUTINE: interp_lapserate_var
+! \label{interp_lapserate_var}
+! 
+! !INTERFACE: 
+subroutine interp_lapserate_var(n,order,input_var)
+
+! !USES: 
+  use LIS_coreMod
+  use LIS_logMod
+  use LIS_spatialDownscalingMod
+  use merra2_forcingMod, only : merra2_struc
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)      
+  use netcdf
+#endif
+  implicit none
+
+! !ARGUMENTS:
+  integer, intent(in)    :: n, order
+  real,    intent(in)    :: input_var(merra2_struc(n)%ncold, &
+       merra2_struc(n)%nrold,24)
+
+  !
+! !DESCRIPTION: 
+!  This subroutine spatially interpolates a MERRA2 field
+!  to the LIS running domain
+! 
+!EOP
+
+  integer   :: t,c,r,k,iret
+  integer   :: doy
+  integer   :: ftn,gid
+  real      :: f (merra2_struc(n)%ncold*merra2_struc(n)%nrold)
+  logical*1 :: lb(merra2_struc(n)%ncold*merra2_struc(n)%nrold)
+  logical*1 :: lo(LIS_rc%lnc(n)*LIS_rc%lnr(n))
+  integer   :: input_size
+  real      :: output_var(LIS_rc%lnc(n)*LIS_rc%lnr(n),24)
+
+! _____________________________________________________________
+
+  input_size = merra2_struc(n)%ncold*merra2_struc(n)%nrold
+
+  do t=1,24
+     lb = .true.
+     do r=1,merra2_struc(n)%nrold
+        do c=1,merra2_struc(n)%ncold
+           k= c+(r-1)*merra2_struc(n)%ncold
+           f(k) = input_var(c,r,t)
+           if ( f(k) == 1.e+15 ) then
+              f(k)  = LIS_rc%udef
+              lb(k) = .false.
+           endif
+        enddo
+     enddo
+
+     call bilinear_interp(LIS_rc%gridDesc(n,:),lb,f,lo,&
+          output_var(:,t), &
+          merra2_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n), &
+          LIS_domain(n)%lat, LIS_domain(n)%lon,&
+          merra2_struc(n)%w111,merra2_struc(n)%w121,&
+          merra2_struc(n)%w211,merra2_struc(n)%w221,&
+          merra2_struc(n)%n111,merra2_struc(n)%n121,&
+          merra2_struc(n)%n211,merra2_struc(n)%n221,&
+          LIS_rc%udef, iret)
+
+     if (order.eq.1) then
+        do r=1,LIS_rc%lnr(n)
+           do c=1,LIS_rc%lnc(n)
+              if(LIS_domain(n)%gindex(c,r).ne.-1) then
+                 gid = LIS_domain(n)%gindex(c,r)
+                 if(.not.isNaN(output_var(c+(r-1)*LIS_rc%lnc(n),t))) then
+                    merra2_struc(n)%lapserate1(gid,t) = &
+                         output_var(c+(r-1)*LIS_rc%lnc(n),t)/1000.0
+                 else
+                     merra2_struc(n)%lapserate1(gid,t) = -0.0065
+                 endif
+              endif
+           enddo
+        enddo
+     endif
+     if (order.eq.2) then
+        do r=1,LIS_rc%lnr(n)
+           do c=1,LIS_rc%lnc(n)
+              if(LIS_domain(n)%gindex(c,r).ne.-1) then
+                 gid = LIS_domain(n)%gindex(c,r)
+                 if(.not.isNaN(output_var(c+(r-1)*LIS_rc%lnc(n),t))) then
+                    merra2_struc(n)%lapserate2(gid,t) = &
+                         output_var(c+(r-1)*LIS_rc%lnc(n),t)/1000.0
+                 else
+                     merra2_struc(n)%lapserate2(gid,t) = -0.0065
+                 endif
+              endif
+           enddo
+        enddo
+     endif
+  enddo
+
+end subroutine interp_lapserate_var
 
 #if 0 
 !BOP


### PR DESCRIPTION
This commit adds the reading and application of pre-generated hourly MERRA-2 lapse rate maps.  This optional config will use these dynamic lapse rates in place of the static lapse rate (of -6.5 K/km) from the "lapse-rate" topographic correction.

Sujay Kumar wrote the initial version of this code, and David Mocko and Sujay worked together to fix some code issues, add code fault tolerance, and add the ability to output dynamic lapse rate on the output grid.

For now, this code should remain in the eis-freshwater2 branch, and should not be merged into the main branch yet.

Credit where credit is due:

@sujayvkumar Added the initial implementation.  See commits b2d501aa5cbd99fc90f114bbaa94a6de662bcba2 and c9ac3fb333b5626931a2ccb96a7a6d0a1b436172

@Kristen-M-Whitney Performed code testing and helped to pre-generate the hourly MERRA-2 dynamic lapse rates.

Testcase to come.