### PR TITLE
Add lislog messages when writing binary and distributed binary restarts

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_writerst.F90
@@ -111,9 +111,13 @@ subroutine NoahMP401_writerst(n)
        if(wformat .eq. "binary") then
           if (LIS_masterproc) then
              call LIS_releaseUnitNumber(ftn)
+             write(LIS_logunit, *)&
+                  "[INFO] Noah-MP.4.0.1 archive restart written: ",trim(filen)
           endif
        elseif(wformat.eq."distributed binary") then
           call LIS_releaseUnitNumber(ftn)
+          write(LIS_logunit, *)&
+                  "[INFO] Noah-MP.4.0.1 archive restart written: ",trim(filenp)
        elseif(wformat .eq. "netcdf") then
           if(LIS_masterproc) then
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)


### PR DESCRIPTION
This commit adds the writing of lislog messages when writing binary and distributed binary restart files in Noah-MP-4.0.1 LSM.

Resolves: #1637
