### PR TITLE
Fix LDT MERRA-2 metforcing unnecessary memory allocation and logs

### DIFF
--- a/ldt/metforcing/merra2/merra2_forcingMod.F90
+++ b/ldt/metforcing/merra2/merra2_forcingMod.F90
@@ -267,19 +267,27 @@ contains
       merra2_struc(n)%startFlag = .true.
       merra2_struc(n)%dayFlag = .true.
 
-      allocate(merra2_struc(n)%merraforc1(&
+      if (trim(LDT_rc%runmode) == "Metforce processing" .or. &
+          trim(LDT_rc%runmode) == "Metforce temporal downscaling" .or. &
+          trim(LDT_rc%runmode) == "Statistical downscaling of met forcing") then
+         allocate(merra2_struc(n)%merraforc1(&
            LDT_rc%met_nf(findex), 24, &
            LDT_rc%lnc(n)*LDT_rc%lnr(n)))
-      allocate(merra2_struc(n)%merraforc2(&
+         allocate(merra2_struc(n)%merraforc2(&
            LDT_rc%met_nf(findex), 24, &
            LDT_rc%lnc(n)*LDT_rc%lnr(n)))
 
-      merra2_struc(n)%merraforc1 = LDT_rc%udef
-      merra2_struc(n)%merraforc2 = LDT_rc%udef
+         merra2_struc(n)%merraforc1 = LDT_rc%udef
+         merra2_struc(n)%merraforc2 = LDT_rc%udef
+      endif
     enddo
 
-    write(LDT_logunit,*)"[INFO] MERRA-2 time interp option :: ",&
-       trim(LDT_rc%met_tinterp(findex))
+    if (trim(LDT_rc%runmode) == "Metforce processing" .or. &
+        trim(LDT_rc%runmode) == "Metforce temporal downscaling" .or. &
+        trim(LDT_rc%runmode) == "Statistical downscaling of met forcing") then
+       write(LDT_logunit,*)"[INFO] MERRA-2 time interp option :: ",&
+             trim(LDT_rc%met_tinterp(findex))
+    endif
 
   end subroutine init_merra2
 end module merra2_forcingMod

--- a/ldt/metforcing/merra2/readcrd_merra2.F90
+++ b/ldt/metforcing/merra2/readcrd_merra2.F90
@@ -67,7 +67,7 @@ subroutine readcrd_merra2()
   do n=1,LDT_rc%nnest
      write(LDT_logunit,*) 'Using MERRA2 forcing'
      write(LDT_logunit,*) 'MERRA2 forcing directory: ',&
-          merra2_struc(n)%merra2DIR
+           trim(merra2_struc(n)%merra2DIR)
 
      merra2_struc(n)%merra2time1 = 3000.0
      merra2_struc(n)%merra2time2 = 0.0


### PR DESCRIPTION
### Description

Fix LDT MERRA-2 metforcing unnecessary memory allocation and logs

This commit fixes a possible unneeded memory allocation in the LDT MERRA-2 metforcing reader.  Now, the forcing variables are only allocated when LDT is run in one of these three modes:

"Metforce processing"
"Metforce temporal downscaling"
"Statistical downscaling of met forcing"

Also, minor clean-ups are made to log messages for this metforcing.

Resolves: #1634
(cherry picked from commit ae30c77480a6fcc78952d03a1086fda6ad657d64)

See PR #1636.



Replace this text with a concise description of *what* was changed and *why*.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->


