### PR TITLE
Changes to support WIGOS in autotuning.

### DIFF
--- a/lis/metforcing/usaf/USAF_OBAMod.F90
+++ b/lis/metforcing/usaf/USAF_OBAMod.F90
@@ -14,6 +14,7 @@
 ! 22 Jun 2017  Initial version.........................Eric Kemp/SSAI/NASA
 ! 07 Sep 2018  Changed EMK_ prefix to USAF_............Eric Kemp/SSAI/NASA
 ! 29 Nov 2023  Add QC flags............................Eric Kemp/SSAI/NASA
+! 03 Dec 2024  Extend character ID for WIGOS...........Eric Kemp/SSAI/NASA
 !
 ! DESCRIPTION:
 ! Contains data structure and methods for collecting observed, background,
@@ -32,8 +33,8 @@ module USAF_OBAMod
    type OBA
       private
       integer :: nobs
-      character*10, allocatable :: networks(:)
-      character*10, allocatable :: platforms(:)
+      character*32, allocatable :: networks(:)
+      character*32, allocatable :: platforms(:)
       real, allocatable :: latitudes(:) ! Latitude of observation (deg N)
       real, allocatable :: longitudes(:) ! Longitude of observation (deg E)
       real, allocatable :: O(:) ! Observation values
@@ -75,14 +76,14 @@ contains
 
    !---------------------------------------------------------------------------
    ! Constructor
-   function newOBA(nest,maxobs) result(this)
-      
+   function newOBA(nest, maxobs) result(this)
+
       ! Imports
       use AGRMET_forcingMod, only : agrmet_struc
 
       ! Defaults
       implicit none
-      
+
       ! Arguments
       integer,intent(in) :: nest
       integer,intent(in), optional :: maxobs
@@ -145,8 +146,8 @@ contains
 
    !---------------------------------------------------------------------------
    ! Add new diagnostics from one observation to the data structure.
-   subroutine assignOBA(this,network,platform,latitude,longitude,O,B,A, &
-        qc, set_qc_good)
+   subroutine assignOBA(this, network, platform, latitude, longitude, &
+        O, B, A, qc, set_qc_good)
 
       ! Imports
       use LIS_logmod, only : LIS_logunit
@@ -156,8 +157,8 @@ contains
 
       ! Arguments
       type(OBA), intent(inout) :: this
-      character(len=10), intent(in) :: network
-      character(len=10), intent(in) :: platform
+      character(len=32), intent(in) :: network
+      character(len=32), intent(in) :: platform
       real, intent(in) :: latitude
       real, intent(in) :: longitude
       real, intent(in) :: O
@@ -201,7 +202,7 @@ contains
 
    !---------------------------------------------------------------------------
    ! Write diagnostic output to ASCII file.
-   subroutine writeToFile(this,filename)
+   subroutine writeToFile(this, filename)
 
       ! Imports
       use LIS_logMod, only: LIS_getNextUnitNumber, LIS_releaseUnitNumber, &
@@ -225,7 +226,7 @@ contains
       iunit = LIS_getNextUnitNumber()
 
       ! Open output file
-      open( unit = iunit, &
+      open(unit = iunit, &
            file=trim(filename), &
            iostat = istat)
 
@@ -240,7 +241,7 @@ contains
               trim(this%platforms(j)), this%latitudes(j), &
               this%longitudes(j),&
               this%O(j), this%B(j), this%A(j), qc_string(this%qc(j)+1)
-1000     format(a10,1x,a10,1x,f8.3,1x,f8.3,1x,f8.3,1x,f8.3,1x,f8.3,1x,a11)
+1000     format(a32,1x,a32,1x,f8.3,1x,f8.3,1x,f8.3,1x,f8.3,1x,f8.3,1x,a11)
       end do ! j
 
       ! Close file
@@ -250,7 +251,7 @@ contains
 
    !---------------------------------------------------------------------------
    ! Creates filename for OBA statistics
-   subroutine makeFilename(pathOBA,yyyymmddhh,accum,filename)
+   subroutine makeFilename(pathOBA, yyyymmddhh, accum, filename)
 
       ! Defaults
       implicit none

--- a/lis/utils/usaf/retune_bratseth/scripts/create_blacklist.py
+++ b/lis/utils/usaf/retune_bratseth/scripts/create_blacklist.py
@@ -24,6 +24,7 @@ REVISION HISTORY:
 16 Dec 2020: Eric Kemp. Reorganized most driver code into new function that
              can be called directly (via Python module import) instead of
              via shell call.
+10 Dec 2024: Eric Kemp. Updates to support WIGOS.
 """
 
 # Standard modules
@@ -122,14 +123,15 @@ def create_blacklist(cfgfile, blacklistfilename, yyyymmddhh, dayrange):
             with open(file, "r", encoding="ascii") as infile:
                 lines = infile.readlines()
             for line in lines[1:]:
-                network = line.split()[0]
-                platform = line.split()[1]
+                network = line[0:31].lstrip()
+                platform = line[32:64].lstrip()
                 if is_sat(platform):
                     continue
                 if platform not in data:
                     data[platform] = []
-                obs = line.split()[4]
-                back = line.split()[5]
+                obs = line[65:].split()[2]
+                back = line[65:].split()[3]
+
                 data[platform].append(f"{network}:{obs}:{back}")
 
         # Now, loop through each station and calculate the mean OMB.

--- a/lis/utils/usaf/retune_bratseth/src/USAF_ReportsMod.F90
+++ b/lis/utils/usaf/retune_bratseth/src/USAF_ReportsMod.F90
@@ -7,7 +7,6 @@
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
-
 !
 !
 ! MODULE: USAF_ReportsMod
@@ -17,6 +16,7 @@
 !
 ! REVISION HISTORY:
 ! 26 Oct 2020:  Eric Kemp.  Initial specification.
+! 03 Dec 2024:  Eric Kemp.  Extended station/platform IDs for WIGOS.
 !
 module USAF_ReportsMod
 
@@ -28,8 +28,8 @@ module USAF_ReportsMod
   type Reports
      private
      integer :: nobs
-     character(len=10), allocatable :: networks(:)
-     character(len=10), allocatable :: platforms(:)
+     character(len=32), allocatable :: networks(:)
+     character(len=32), allocatable :: platforms(:)
      character(len=10), allocatable :: yyyymmddhh(:)
      real, allocatable :: latitudes(:)
      real, allocatable :: longitudes(:)
@@ -121,8 +121,8 @@ contains
 
     ! Arguments
     type(Reports), intent(inout) :: this
-    character(len=10), intent(in) :: network
-    character(len=10), intent(in) :: platform
+    character(len=32), intent(in) :: network
+    character(len=32), intent(in) :: platform
     character(len=10), intent(in) :: yyyymmddhh
     real, intent(in) :: latitude
     real, intent(in) :: longitude
@@ -167,8 +167,8 @@ contains
     ! Arguments
     type(Reports), intent(in) :: this
     integer, intent(in) :: index
-    character(len=10), optional, intent(out) :: network
-    character(len=10), optional, intent(out) :: platform
+    character(len=32), optional, intent(out) :: network
+    character(len=32), optional, intent(out) :: platform
     character(len=10), optional, intent(out) :: yyyymmddhh
     real, optional, intent(out) :: latitude
     real, optional, intent(out) :: longitude
@@ -240,8 +240,8 @@ contains
   subroutine getListOfNetworksAndPlatforms(this, networks, platforms)
     implicit none
     type(Reports), intent(in) :: this
-    character(len=10), allocatable, intent(inout) :: networks(:)
-    character(len=10), allocatable, intent(inout) :: platforms(:)
+    character(len=32), allocatable, intent(inout) :: networks(:)
+    character(len=32), allocatable, intent(inout) :: platforms(:)
     integer :: i
     if (this%nobs .eq. 0) return
     allocate(networks(this%nobs))

--- a/lis/utils/usaf/retune_bratseth/src/USAF_sharedMod.F90
+++ b/lis/utils/usaf/retune_bratseth/src/USAF_sharedMod.F90
@@ -16,6 +16,7 @@
 !
 ! REVISION HISTORY:
 ! 26 Oct 2020:  Eric Kemp.  Initial specification.
+! 10 Dec 2024:  Eric Kemp.  Updates for WIGOS.
 !
 module USAF_sharedMod
 
@@ -121,13 +122,13 @@ contains
   subroutine fetch_blacklist(blacklist_file, blacklist_stns, nstns)
 
     use esmf
-    
+
     ! Defaults
     implicit none
 
     ! Arguments
     character(len=*), intent(in) :: blacklist_file
-    character(len=9), allocatable, intent(inout) :: blacklist_stns(:)
+    character(len=32), allocatable, intent(inout) :: blacklist_stns(:)
     integer, intent(inout) :: nstns
 
     ! Local variables
@@ -179,15 +180,16 @@ contains
        read(unit=15, fmt='(A)', end=200) line
        if (line(1:1) .eq. "#") cycle
        i = i + 1
-       do j = 1, 9
-          if (line(j:j) .eq. ' ') exit
+       do j = 1, 34
+          if (line(j:j) .eq. '#') exit
        end do
-       blacklist_stns(i) = trim(line(1:j))
+       if ((j-2) < 1) cycle
+       blacklist_stns(i) = trim(line(1:j-2))
     end do
 200 continue
 
     ! Finish up
-    close(unit=10)
+    close(unit=15)
 
   end subroutine fetch_blacklist
 

--- a/lis/utils/usaf/retune_bratseth/src/procOBA_NWP.F90
+++ b/lis/utils/usaf/retune_bratseth/src/procOBA_NWP.F90
@@ -19,6 +19,7 @@
 ! 26 0ct 2020:  Eric Kemp.  Initial Specification. Multi-process
 !   MPI doesn't work yet, just use single process.
 ! 15 Dec 2020:  Eric Kemp.  Added user-defined logfile name.
+! 10 Dec 2024:  Eric Kemp.  Updates for WIGOS.
 
 program main
 
@@ -72,7 +73,7 @@ program main
    integer :: num_args
    logical :: use_blacklist
    character(len=255) :: blacklist_file
-   character(len=9), allocatable :: blacklist_stns(:)
+   character(len=32), allocatable :: blacklist_stns(:)
    integer :: nstns
    character(len=255) :: logname
 
@@ -730,7 +731,7 @@ contains
       logical, external :: is_obtype ! Function
       logical, intent(in) :: use_blacklist
       integer, intent(in) :: nstns
-      character(len=9), allocatable, intent(in) ::  blacklist_stns(:)
+      character(len=32), allocatable, intent(in) ::  blacklist_stns(:)
 
       ! Local variables
       type(esmf_time) :: curtime
@@ -742,9 +743,9 @@ contains
       integer :: istat
       integer :: iunit_input
       type(Reports) :: R_obs
-      character(len=80) :: line
-      character(len=10) :: platform, platform_i,platform_j
-      character(len=10) :: network
+      character(len=123) :: line
+      character(len=32) :: platform, platform_i, platform_j
+      character(len=32) :: network
       real :: latitude, longitude, lat_i, lon_i, lat_j, lon_j
       real :: O, B, A, O_i, B_i, O_j, B_j
       integer :: nobs
@@ -832,7 +833,7 @@ contains
                if (istat .ne. 0) exit
                if (line(2:2) .eq. '#') cycle
                read(line, &
-                    '(A10,1x,A10,1x,F8.3,1x,F8.3,1x,F8.3,1x,F8.3,1x,F8.3)') &
+                    '(A32,1x,A32,1x,F8.3,1x,F8.3,1x,F8.3,1x,F8.3,1x,F8.3)') &
                     network, platform, latitude, longitude, O, B, A
 
                ! Only save requested obtype
@@ -842,11 +843,10 @@ contains
                skip = .false.
                if (use_blacklist) then
                   do istn = 1, nstns
-                     !print*, "EMK: blacklist, platform = ", &
-                     !     trim(blacklist_stns(istn)), " ", adjustl(platform)
                      if (trim(blacklist_stns(istn)) .eq. &
                           adjustl(platform)) then
-                        !print*, "[INFO] Skipping blacklisted station ", &
+
+                        !write(6,*) "[INFO] Skipping blacklisted station ", &
                         !     adjustl(platform)
                         count_skips = count_skips + 1
                         skip = .true.
@@ -876,10 +876,10 @@ contains
 
          ! Update semivariogram sums and counts
          nobs = getNobs(R_obs)
-         if (myid .eq. 0) then
-            !print*, '[INFO] Working with ', nobs, ' ', trim(obtype), &
-            !     '/NWP matches...'
-         end if
+         !if (myid .eq. 0) then
+         !   write(6,*) '[INFO] Working with ', nobs, ' ', trim(obtype), &
+         !        '/NWP matches...'
+         !end if
          t0 = mpi_wtime()
          do j = 1,nobs
 
@@ -899,10 +899,10 @@ contains
 
             t1 = mpi_wtime()
 
-            do i = j+1,nobs
+            do i = j+1, nobs
 
                ! See if current processor is responsible for this j ob.
-               call pick_proc(id,id_incr, numprocs)
+               call pick_proc(id, id_incr, numprocs)
                if (id .ne. myid) cycle
 
                call getReport(R_obs,i, platform=platform_i,&

--- a/lis/utils/usaf/retune_bratseth/src/procOBA_Sat.F90
+++ b/lis/utils/usaf/retune_bratseth/src/procOBA_Sat.F90
@@ -18,6 +18,7 @@
 ! REVISION HISTORY:
 ! 26 0ct 2020:  Eric Kemp.  Initial Specification.  Multi-process
 !   MPI doesn't work yet, just use single process.
+! 10 Dec 2024:  Eric Kemp.  Updates for WIGOS.
 !
 program main
 
@@ -60,7 +61,7 @@ program main
    type(ESMF_TimeInterval) :: deltatime
    type(ESMF_VM) :: vm
    integer :: icount
-   integer, parameter :: maxlen_sattype = 9
+   integer, parameter :: maxlen_sattype = 32
    character(len=maxlen_sattype) :: sattype
    integer, parameter :: max_sattypes = 4
    character(len=maxlen_sattype) :: sattypes(max_sattypes)
@@ -75,7 +76,7 @@ program main
    real :: dist_thresh
    logical :: use_blacklist
    character(len=255) :: blacklist_file
-   character(len=9), allocatable :: blacklist_stns(:)
+   character(len=32), allocatable :: blacklist_stns(:)
    integer :: nstns
    character(len=255) :: logname
 
@@ -908,7 +909,7 @@ contains
       logical, external :: is_sattype ! Function
       logical, intent(in) :: use_blacklist
       integer, intent(in) :: nstns
-      character(len=9), allocatable, intent(in) ::  blacklist_stns(:)
+      character(len=32), allocatable, intent(in) ::  blacklist_stns(:)
 
       ! Local variables
       type(esmf_time) :: curtime
@@ -920,9 +921,9 @@ contains
       integer :: istat
       integer :: iunit_input
       type(Reports) :: R_gages_sat, R_matches
-      character(len=80) :: line
-      character(len=10) :: platform, platform_k, platform_kk
-      character(len=10) :: network, network_k, network_kk, network_new
+      character(len=123) :: line
+      character(len=32) :: platform, platform_k, platform_kk
+      character(len=32) :: network, network_k, network_kk, network_new
       real :: latitude, longitude, lat_k, lon_k, lat_kk, lon_kk
       real :: O, B, A, O_k, B_k, O_kk, B_kk, B_new
       real :: min_dist_k_kk, dist_k_kk
@@ -1015,7 +1016,7 @@ contains
                if (istat .ne. 0) exit
                if (line(2:2) .eq. '#') cycle
                read(line, &
-                    '(A10,1x,A10,1x,F8.3,1x,F8.3,1x,F8.3,1x,F8.3,1x,F8.3)') &
+                    '(A32,1x,A32,1x,F8.3,1x,F8.3,1x,F8.3,1x,F8.3,1x,F8.3)') &
                     network, platform, latitude, longitude, O, B, A
                if (is_gage(adjustl(network))) then
 
@@ -1049,9 +1050,9 @@ contains
                end if
             end do
             close(unit=iunit_input)
-            !print*, "[INFO] Skipped ", count_skips, " blacklisted stations"
-            !print*, '[INFO] Working with ', icount_gages, ' gages'
-            !print*, '[INFO] Working with ', icount_sat, ' ', trim(sattype), &
+            !write(6,*) "[INFO] Skipped ", count_skips, " blacklisted stations"
+            !write(6,*) '[INFO] Working with ', icount_gages, ' gages'
+            !write(6,*) '[INFO] Working with ', icount_sat, ' ', trim(sattype), &
             !     ' obs'
          end if
 


### PR DESCRIPTION

### Description

Changes to support WIGOS in Bratseth autotuning.  (IOW, support for 32-character IDs.)

Identical results are found for gage-nwp, rh2m, spd10m, and t2m, using 28 days of OBA files produced ending 1 Sep 2024.  (Pre-WIGOS OBA files were generated during the LISF 7.6 FOC work.)

NOTE:  Differences are noted in the IMERG data counts in the WIGOS OBA files.  I believe this is due to changes in the IMERG file archives between the FOC work (in Sep) and the WIGOS work (in Dec).  I want to rerun the FOC OBA LIS version, but that must wait until after Christmas Break.


