### PR TITLE
Updated codes for ESPC-D file (SST) 

### DIFF
--- a/ldt/USAFSI/USAFSI_espcdMod.F90
+++ b/ldt/USAFSI/USAFSI_espcdMod.F90
@@ -11,7 +11,8 @@
 ! MODULE: USAFSI_espcdMod
 !
 ! REVISION HISTORY:
-! 17 Jul 2024  Eric Kemp  First version.  (Based on USAF_gofsMod.F90)
+! 17 Jul 2024  Eric Kemp      First version.  (Based on USAF_gofsMod.F90)
+! 16 Dec 2024  Yeosang Yoon   Updated ESPC-D SST file format (depth dimensions)
 !
 ! DESCRIPTION:
 ! Source code for reading US Navy ESPC-D data.
@@ -504,7 +505,7 @@ contains
 
        if (lens(1) .ne. nlon .or. &
             lens(2) .ne. nlat .or. &
-            lens(3) .ne. 1 .or. &
+            lens(3) .ne. 2 .or. &          !depth=2, updated 2024/10/31 
             lens(4) .ne. 1) then
           message(1) = &
                '[WARN] CANNOT GET DIMENSIONS FOR water_temp IN FILE'

--- a/ldt/USAFSI/USAFSI_run.F90
+++ b/ldt/USAFSI/USAFSI_run.F90
@@ -359,11 +359,12 @@ subroutine USAFSI_run(n)
         end if
 
         ! RETRIEVE FRACTIONAL SNOW DATA.
-        if (usafsi_settings%usefrac) then
-           write (LDT_logunit,*) &
-                '[INFO] CALLING GETFRAC TO GET FRACTIONAL SNOW DATA'
-           call getfrac (date10, fracdir)
-        end if
+        usafsi_settings%usefrac = .false.  ! YY: no longer in use
+        !if (usafsi_settings%usefrac) then
+        !   write (LDT_logunit,*) &
+        !        '[INFO] CALLING GETFRAC TO GET FRACTIONAL SNOW DATA'
+        !   call getfrac (date10, fracdir)
+        !end if
 
         ! RETRIEVE SURFACE OBSERVATIONS.
         write (LDT_logunit,*) &


### PR DESCRIPTION
### Description

The code has been updated to reflect recent changes in variable metadata and dimensions in the ESPC-D SST file (https://github.com/NASA-LIS/LISF/issues/1654). Also comment out 'GETFRAC' due to unuse this.

This is a cherry-pick of the two commits in PR #1655.



