### PR TITLE
Fix for Routing 2d ensemble gridspace output

### DIFF
--- a/lis/core/LIS_domainMod.F90
+++ b/lis/core/LIS_domainMod.F90
@@ -2979,7 +2979,7 @@ end subroutine LIS_quilt_b_domain
           deallocate(locallon)
 
        else
-          write(LIS_logunit,*) '[ERR] ',LIS_rc%paramfile(n), ' does not exist'
+          write(LIS_logunit,*) '[ERR] ',trim(LIS_rc%paramfile(n)), ' does not exist'
           write(LIS_logunit,*) '[ERR] program stopping ...'
           call LIS_endrun
        endif

--- a/lis/core/LIS_historyMod.F90
+++ b/lis/core/LIS_historyMod.F90
@@ -7295,7 +7295,7 @@ contains
                    var1_ens(i,m) = -9999.0
                 else
                    var1_ens(i,m) = &
-                        var(t)*LIS_domain(n)%tile(t)%fgrd
+                        var(t)*LIS_routing(n)%tile(t)%fgrd
                 endif
              enddo
           enddo

--- a/lis/metforcing/genMetForc/get_metForcGenerated.F90
+++ b/lis/metforcing/genMetForc/get_metForcGenerated.F90
@@ -142,7 +142,7 @@ subroutine get_metForcGenerated(n, findex)
         LIS_rc%rstflag(n) == 1 ) then
       LIS_rc%rstflag(n) = 0
       retrieve_file2 = .true.
-      write(LIS_logunit,*)" [ERR] Currently Forcing 1 File is NOT opened in first timestep ..."
+      write(LIS_logunit,*)" [INFO] Forcing 1 file is NOT opened in first timestep ..."
    endif
 
 !- Retrieve LDT-generated Forcing File 2:


### PR DESCRIPTION
 This commit to the LISF Public 7.5 branch includes:
  - Fix for the HyMAP / Routing - 2d ensemble gridspace output option in LIS.
  - Update to message header in LIS general metforcing reader to alert user about 1st forcing file not being used on initialization.
  - Included "trim" function when LDT input file is missing in lis.config file and 'err' message to user.

This commit fixes the issues reported in #1576 and #1656:
https://github.com/NASA-LIS/LISF/discussions/1576
https://github.com/NASA-LIS/LISF/issues/1656

### Testcase

Testcase for this bug fix can be found here on Discover:
/discover/nobackup/karsenau/LISF_PR/LIS_HYMAP2dens_Fix

Slurm script set up for a Milan / SLES-15 run.


