### PR TITLE
Fix for soil texture force-fill exclusion in LDT

### DIFF
--- a/ldt/configs/ldt.config.adoc
+++ b/ldt/configs/ldt.config.adoc
@@ -1633,7 +1633,7 @@ Soil texture spatial transform:     none
 
 `Soil texture fill value for Antarctica:` indicates which soil texture value to be used if an arbitrary value fill is needed south of 60S. If not specified, value of `Soil texture fill value:` will be used.
 
-`Soil texture force exclusion of water points during fill:` indicates whether to force exclusion of water points when filling soil texture. Required when using STATSGOFAO south of 60S (texture is set to all water) and multiple surface model types are used.
+`Soil texture force exclusion of water points during fill:` indicates whether to force exclusion of water points when filling soil texture. Required when using STATSGOFAO, south of 60S (i.e., texture is set to all water), and multiple surface model types (e.g., LSM and Openwater) are used.
 
 [cols="<,<",]
 |===
@@ -1759,7 +1759,7 @@ Curvature number of bands:     1
 
 Topography maps
 
-`Elevation map:` specifies the elevation of the LIS grid. If the elevation map type selected is SRTM_Native, then the elevation file entry is actually just the directory path, which contains the tiled SRTM elevation files.
+`Elevation map:` specifies the elevation of the LIS grid. If the elevation map type selected is SRTM_Native, then the elevation file entry is actually just the directory path, which contains the tiled SRTM elevation files. Note: The SRTM tiles only go to 60deg S, and south of that the associated SRTM reader can fill in with GTOPO30 Antarctica tile files.
 
 `Slope map:` specifies the slope of the LIS grid. If the slope map type selected is SRTM_Native, then the file entry is actually just the directory path, which contains the tiled SRTM elevation files.  
 

--- a/ldt/core/LDT_soilsMod.F90
+++ b/ldt/core/LDT_soilsMod.F90
@@ -479,7 +479,7 @@ module LDT_soilsMod
     enddo
 
  !- Soil texture:
-    if( check_data) then 
+    if( check_data ) then 
 
       do n=1,LDT_rc%nnest
          if( INDEX(LDT_LSMparam_struc(n)%texture%source,"STATSGO") > 0 ) then
@@ -537,9 +537,9 @@ module LDT_soilsMod
          end if
 
          ! EMK...Allow option to force exclusion of water points when
-         ! filling soil texture.  Necessary when using STATSGOFAO south of
-         ! 60S (texture set to all water) and multiple surface model types
-         ! are used.
+         ! filling soil texture.  Necessary when using STATSGOFAO, south of
+         ! 60S (i.e., texture set to all water) and multiple surface model types
+         ! (e.g., LSM and Openwater) are used.
          ! If option not specified, set to false.
 
          call ESMF_ConfigFindLabel(LDT_config, &
@@ -549,7 +549,17 @@ module LDT_soilsMod
             call ESMF_ConfigGetAttribute(LDT_config, soiltext%force_exclude_water, &
                  label="Soil texture force exclusion of water points during fill:",rc=rc)
          else
-            soiltext%force_exclude_water = .false.
+            if(( INDEX(LDT_LSMparam_struc(1)%texture%source,"STATSGO") > 0 ) .and. &
+               ( LDT_rc%nsf_model_types > 1 )) then
+               write(LDT_logunit,*) "[INFO] Setting 'Soil texture force exclusion of water points during fill:'"
+               write(LDT_logunit,*) "     to '.true.', since STATSGOFAO and surface model types > 1 in ldt.config file."
+               soiltext%force_exclude_water = .true.
+            else
+               write(LDT_logunit,*) "[INFO] Setting 'Soil texture force exclusion of water points during fill:'"
+               write(LDT_logunit,*) "     to '.false.', since it is not specified in the ldt.config file and "
+               write(LDT_logunit,*) "     STATSGOFAO is not present nor surface model types > 1."
+               soiltext%force_exclude_water = .false.
+            endif
          end if
 
        elseif( soiltext%filltype == "none" ) then
@@ -1239,9 +1249,9 @@ module LDT_soilsMod
          end if
 
          ! EMK...Allow option to force exclusion of water points when
-         ! filling soil texture.  Necessary when using STATSGOFAO south of
-         ! 60S (texture set to all water) and multiple surface model types
-         ! are used.
+         ! filling soil texture.  Necessary when using STATSGOFAO, south of
+         ! 60S (i.e., texture set to all water) and multiple surface model types
+         ! (e.g., LSM and Openwater) are used.
          ! If option not specified, set to false.
 
          call ESMF_ConfigFindLabel(LDT_config, &
@@ -1251,7 +1261,17 @@ module LDT_soilsMod
             call ESMF_ConfigGetAttribute(LDT_config, soiltext%force_exclude_water, &
                  label="Soil texture force exclusion of water points during fill:",rc=rc)
          else
-            soiltext%force_exclude_water = .false.
+            if(( INDEX(LDT_LSMparam_struc(1)%texture%source,"STATSGO") > 0 ) .and. &
+               ( LDT_rc%nsf_model_types > 1 )) then
+               write(LDT_logunit,*) "[INFO] Setting 'Soil texture force exclusion of water points during fill:'"
+               write(LDT_logunit,*) "     to '.true.', since STATSGOFAO and surface model types > 1 in ldt.config file."
+               soiltext%force_exclude_water = .true.
+            else
+               write(LDT_logunit,*) "[INFO] Setting 'Soil texture force exclusion of water points during fill:'"
+               write(LDT_logunit,*) "     to '.false.', since it is not specified in the ldt.config file and "
+               write(LDT_logunit,*) "     STATSGOFAO is not present nor surface model types > 1."
+               soiltext%force_exclude_water = .false.
+            endif
          end if
 
        elseif( soiltext%filltype == "none" ) then

--- a/ldt/params/topo/read_SRTM_Native_aspect.F90
+++ b/ldt/params/topo/read_SRTM_Native_aspect.F90
@@ -41,6 +41,10 @@ subroutine read_SRTM_Native_aspect( n, num_bins, fgrd, aspectave )
 !  This subroutine retrieves static elevation data from the SRTM source
 !  and reprojects it to the latlon projection. 
 !
+!  NOTE:  SRTM "Native" ~1km files do not include areas south of 60degS.
+!         GTOPO30 elevation tiles can be read in, since they include points
+!         south of 60degS (Antarctica).
+!
 !  Source information:
 !   http://dds.cr.usgs.gov/srtm/version2_1/SRTM30/
 !

--- a/ldt/params/topo/read_SRTM_Native_elev.F90
+++ b/ldt/params/topo/read_SRTM_Native_elev.F90
@@ -40,6 +40,10 @@ subroutine read_SRTM_Native_elev( n, num_bins, fgrd, elevave )
 !  This subroutine retrieves static elevation data from the SRTM source
 !  and reprojects it to the latlon projection. 
 !
+!  NOTE:  SRTM "Native" ~1km files do not include areas south of 60degS.
+!         GTOPO30 elevation tiles can be read in, since they include points
+!         south of 60degS (Antarctica).
+!
 !  Source information:
 !   http://dds.cr.usgs.gov/srtm/version2_1/SRTM30/
 !

--- a/ldt/params/topo/read_SRTM_Native_slope.F90
+++ b/ldt/params/topo/read_SRTM_Native_slope.F90
@@ -41,6 +41,10 @@ subroutine read_SRTM_Native_slope( n, num_bins, fgrd, slopeave )
 !  This subroutine retrieves static elevation data from the SRTM source
 !  and reprojects it to the latlon projection. 
 !
+!  NOTE:  SRTM "Native" ~1km files do not include areas south of 60degS.
+!         GTOPO30 elevation tiles can be read in, since they include points
+!         south of 60degS (Antarctica).
+!
 !  Source information:
 !   http://dds.cr.usgs.gov/srtm/version2_1/SRTM30/
 !


### PR DESCRIPTION
 Implemented fix in LDT to address when the
  Soil texture force exclusion of water points during fill is not
  set in the ldt.config file, even though STATSGOFAO soil texture
  and more than 1 surface model type are selected.

 The default value is set to "false", which causes a mismatch for
  points north of -60S in STATSGOFAO soil texture and when surface
  type, e.g., open water, are selected -- and causes LIS run to fail.

 This is issue is documented in the LISF GitHub issue #1658.

 In addition, some additional info has been included in ldt.config.adoc
   and some additional comment notes for SRTM30 native topo readers
   for dealing with points south of -60S.


### Testcase

Test case for this PR and fix can be found here:
/discover/nobackup/karsenau/LISF_PR/LDT_SText_ForceOpt_Fix

Tester is able to run the LDT step in:
/discover/nobackup/karsenau/LISF_PR/LDT_SText_ForceOpt_Fix/LDT_Run

with ldt.config_test

Then run a final test of that file in a LIS test case setup, with the lis.config_test file provided.  All input files are provided.
MERRA2 input forcing is symlinked in directory:  lisdata



