### PR TITLE
Update to S2S run - group jobs option

### DIFF
--- a/lis/utils/usaf/s2s/s2s_app/s2s_run.sh
+++ b/lis/utils/usaf/s2s/s2s_app/s2s_run.sh
@@ -19,7 +19,8 @@
 #                              SHARED FUNCTIONS
 ######################################################################
 SOURCE_ONLY='N'
-GROUP_JOBS='Y'
+# Option for grouping tasks in slurm jobs (N="off"; Y="on"):
+GROUP_JOBS='N'
 submit_job(){
     if [[ $1 == "" ]] || [[ $1 == ":" ]]; then
 	submit_ID="`sbatch $2 |  cut -d' ' -f4`"


### PR DESCRIPTION
 Update for the S2S run main script for submitting
  either grouped tasks for individiual slurm jobs
  or individual task per slurm job.

 Set the "GROUP_JOBS" option to "N" as new default, vs. "Y".

 Commit for latest LISF 557 WW 7.5 branch and 7.5.20 release.


