### PR TITLE
Add forecast runmode for NoahMP401 and Openwater

### DIFF
--- a/lis/plugins/LIS_lsm_pluginMod.F90
+++ b/lis/plugins/LIS_lsm_pluginMod.F90
@@ -706,6 +706,8 @@ subroutine LIS_lsm_plugin
         trim(LIS_agrmetrunId)//char(0),noahmp401_f2t)
    call registerlsmf2t(trim(LIS_noahmp401Id)//"+"//&
         trim(LIS_smootherDAId)//char(0),noahmp401_f2t)
+   call registerlsmf2t(trim(LIS_noahmp401Id)//"+"//&
+        trim(LIS_forecastrunId)//char(0),noahmp401_f2t)
    call registerlsmrun(trim(LIS_noahmp401Id)//char(0),noahmp401_main)
    call registerlsmrestart(trim(LIS_noahmp401Id)//char(0),noahmp401_readrst)
    call registerlsmdynsetup(trim(LIS_noahmp401Id)//char(0),noahmp401_dynsetup)

--- a/lis/plugins/LIS_openwatermodel_pluginMod.F90
+++ b/lis/plugins/LIS_openwatermodel_pluginMod.F90
@@ -156,6 +156,8 @@ subroutine LIS_openwatermodel_plugin
         trim(LIS_retroId)//char(0),templateOpenWater_f2t)
    call registeropenwaterf2t(trim(LIS_templateOpenWaterId)//"+"//&
         trim(LIS_agrmetrunId)//char(0),templateOpenWater_f2t)
+   call registeropenwaterf2t(trim(LIS_templateOpenWaterId)//"+"//&
+        trim(LIS_forecastrunId)//char(0),templateOpenWater_f2t)
    call registeropenwaterwrst(trim(LIS_templateOpenWaterId)//char(0),&
         templateOpenWater_writerst)
    call registeropenwaterfinalize(trim(LIS_templateOpenWaterId)//char(0),&


### PR DESCRIPTION
 Adding forecast (e.g., ESP) runmode plugin entries for:
   - Noah-MP.4.0.1
   - Openwater surface model type

 Targeted for LIS "master" branch as new feature.

Test case for these added options can be found here:

/discover/nobackup/karsenau/LISF_PR/LIS_NMP401-Fcst-Openwater

