### PR TITLE
Add CERES SWdown metforcing reader for NLDAS-3

### DIFF
--- a/lis/make/default.cfg
+++ b/lis/make/default.cfg
@@ -267,6 +267,11 @@ enabled: True
 macro: MF_NLDAS2
 path: metforcing/nldas2
 
+[NLDAS3SW]
+enabled: True
+macro: MF_NLDAS3SW
+path: metforcing/nldas3sw
+
 [GEIS]
 enabled: True
 macro: MF_GEIS

--- a/lis/metforcing/nldas3sw/0Intro_nldas3sw.txt
+++ b/lis/metforcing/nldas3sw/0Intro_nldas3sw.txt
@@ -1,0 +1,17 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!
+!BOP
+!\section{NLDAS3SW}
+!These routines read in the CERES hourly SWdown 4-km binary data
+!for interpolation and slope-aspect corrections down to the 1-km
+!NLDAS-3 grid.
+!
+!EOP

--- a/lis/metforcing/nldas3sw/finalize_nldas3sw.F90
+++ b/lis/metforcing/nldas3sw/finalize_nldas3sw.F90
@@ -1,0 +1,70 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: finalize_nldas3sw
+!  \label{finalize_nldas3sw}
+!
+! !REVISION HISTORY:
+! 27 Dec 2024: David Mocko, Initial Specification
+!                           (derived from finalize_nldas20.F90)
+!
+! !INTERFACE:
+subroutine finalize_nldas3sw(findex)
+! !USES:
+  use LIS_coreMod,         only : LIS_rc
+  use nldas3sw_forcingMod, only : nldas3sw_struc
+
+  implicit none
+! !ARGUMENTS:
+  integer   :: findex
+!
+! !DESCRIPTION:
+!  Routine to cleanup NLDAS-3 SWdown forcing related memory allocations.
+!
+!EOP
+  integer   :: n
+
+  do n = 1,LIS_rc%nnest
+     if (trim(LIS_rc%met_interp(findex)).eq."bilinear") then
+        deallocate(nldas3sw_struc(n)%n111)
+        deallocate(nldas3sw_struc(n)%n121)
+        deallocate(nldas3sw_struc(n)%n211)
+        deallocate(nldas3sw_struc(n)%n221)
+        deallocate(nldas3sw_struc(n)%w111)
+        deallocate(nldas3sw_struc(n)%w121)
+        deallocate(nldas3sw_struc(n)%w211)
+        deallocate(nldas3sw_struc(n)%w221)
+     elseif (trim(LIS_rc%met_interp(findex)).eq."budget-bilinear")     &
+          then
+        deallocate(nldas3sw_struc(n)%n111)
+        deallocate(nldas3sw_struc(n)%n121)
+        deallocate(nldas3sw_struc(n)%n211)
+        deallocate(nldas3sw_struc(n)%n221)
+        deallocate(nldas3sw_struc(n)%w111)
+        deallocate(nldas3sw_struc(n)%w121)
+        deallocate(nldas3sw_struc(n)%w211)
+        deallocate(nldas3sw_struc(n)%w221)
+        deallocate(nldas3sw_struc(n)%n112)
+        deallocate(nldas3sw_struc(n)%n122)
+        deallocate(nldas3sw_struc(n)%n212)
+        deallocate(nldas3sw_struc(n)%n222)
+        deallocate(nldas3sw_struc(n)%w112)
+        deallocate(nldas3sw_struc(n)%w122)
+        deallocate(nldas3sw_struc(n)%w212)
+        deallocate(nldas3sw_struc(n)%w222)
+     elseif(trim(LIS_rc%met_interp(findex)).eq."neighbor") then
+        deallocate(nldas3sw_struc(n)%n113)
+     endif
+
+  enddo
+  deallocate(nldas3sw_struc)
+
+end subroutine finalize_nldas3sw
+

--- a/lis/metforcing/nldas3sw/get_ceres_filenames.F90
+++ b/lis/metforcing/nldas3sw/get_ceres_filenames.F90
@@ -1,0 +1,77 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: ceres_nldas3swfile
+! \label{ceres_nldas3swfile}
+!
+! !REVISION HISTORY:
+! 27 Dec 2024: David Mocko, Initial Specification
+!                           (derived from get_netcdf4_filenames.F90)
+!
+! !INTERFACE:
+subroutine ceres_nldas3swfile(n,kk,findex,filename,                    &
+                              nldas3swdir,yr,mo,da,doy,hr)
+! !USES:
+  use LIS_coreMod
+  use LIS_logMod
+
+  implicit none
+! !ARGUMENTS:
+  integer                       :: n
+  integer                       :: kk
+  integer                       :: findex
+  character(len=*), intent(out) :: filename
+  character(len=*), intent(in)  :: nldas3swdir
+  integer, intent(in)           :: yr,mo,da,doy,hr
+!
+! !DESCRIPTION:
+!   This subroutine assembles CERES 4-km binary filename
+!     for 1 hour file intervals.
+!
+!  The arguments are:
+!  \begin{description}
+!  \item[nldas3swdir]
+!    Name of the CERES SWdown directory
+!  \item[yr]
+!    year
+!  \item[mo]
+!   month
+!  \item[da]
+!   day of month
+!  \item[doy]
+!   Julian day of year (needed for subdirectory structure)
+!  \item[hr]
+!   hour of day
+!   \item[filename]
+!   name of the timestamped CERES 4-km binary filename
+!  \end{description}
+!
+!EOP
+  character*4  :: fyr
+  character*3  :: fdoy
+  character*2  :: fmo, fda, fhr
+  integer      :: doy2
+
+!=== end variable definition ===========================================
+
+  if (LIS_rc%forecastMode.eq.0) then !hindcast run
+     write(unit=fyr, fmt="(i4.4)") yr
+     write(unit=fdoy,fmt="(i3.3)") doy
+     write(unit=fmo, fmt="(i2.2)") mo
+     write(unit=fda, fmt="(i2.2)") da
+     write(unit=fhr, fmt="(i2.2)") hr
+
+!=== Assemble CERES 4-km binary filename
+     filename = trim(nldas3swdir)//"/"//fyr//"/"//                     &
+                    "NLDAS3_INSOL_DAILY_"//fyr//fdoy//".dat"
+  endif
+
+end subroutine ceres_nldas3swfile
+

--- a/lis/metforcing/nldas3sw/get_nldas3sw.F90
+++ b/lis/metforcing/nldas3sw/get_nldas3sw.F90
@@ -1,0 +1,227 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: get_nldas3sw
+! \label{get_nldas3sw}
+!
+! !REVISION HISTORY:
+! 27 Dec 2024: David Mocko, Initial Specification
+!                           (derived from get_nldas20.F90)
+!
+! !INTERFACE:
+subroutine get_nldas3sw(n,findex)
+! !USES:
+  use LIS_coreMod, only         : LIS_rc
+  use LIS_timeMgrMod,     only  : LIS_tick
+  use LIS_metforcingMod,  only  : LIS_forc
+  use LIS_logMod,         only  : LIS_logunit,LIS_endrun
+  use LIS_constantsMod,   only  : LIS_CONST_PATH_LEN
+  use nldas3sw_forcingMod, only : nldas3sw_struc
+
+  implicit none
+! !ARGUMENTS:
+  integer, intent(in) :: n
+  integer, intent(in) :: findex
+!
+! !DESCRIPTION:
+!  Opens, reads, and interpolates hourly 4-km CERES SWdown forcing.
+!  At the beginning of a simulation, the code reads the most recent
+!  past data (nearest hourly interval), and the nearest future data.
+!  These two datasets are used to temporally interpolate the data to
+!  the current model timestep.  The strategy for missing data is to
+!  go backwards up to 10 days to get forcing at the same time of day.
+!
+!  The arguments are:
+!  \begin{description}
+!  \item[n]
+!    index of the nest
+!  \end{description}
+!
+!  The routines invoked are:
+!  \begin{description}
+!  \item[LIS\_tick](\ref{LIS_tick}) \newline
+!    determines the forcing data times
+!  \item[ceres\_nldas3swfile](\ref{ceres_nldas3swfile}) \newline
+!    Puts together appropriate timestamped CERES filename
+!  \item[read\_nldas3sw](\ref{read_nldas3sw}) \newline
+!    Reads and Interpolates CERES SWdown data to LIS grid
+!  \end{description}
+!
+!EOP
+  integer :: c,f,ferrora,ferror,try
+  integer :: order
+  real*8  :: time1,time2,timenow
+  real*8  :: dtime1, dtime2
+  integer :: yr1,mo1,da1,hr1,mn1,ss1,doy1
+  integer :: yr2,mo2,da2,hr2,mn2,ss2,doy2
+  character(len=LIS_CONST_PATH_LEN) :: name_a
+  real    :: gmt1,gmt2,ts1,ts2
+  integer :: movetime       ! 1=move time 2 data into time 1
+
+  external :: ceres_nldas3swfile
+  external :: read_nldas3sw
+
+!=== End Variable Definition ===========================================
+  try = -999
+
+!=== Assumption will be not to find or move any data
+  nldas3sw_struc(n)%findtime1 = 0
+  nldas3sw_struc(n)%findtime2 = 0
+  movetime = 0
+
+!=== Determine Required CERES Data Times (The previous hour and the future hour)
+  yr1 = LIS_rc%yr
+  mo1 = LIS_rc%mo
+  da1 = LIS_rc%da
+  hr1 = LIS_rc%hr
+  mn1 = LIS_rc%mn
+  ss1 = 0
+  ts1 = 0
+  call LIS_tick(timenow,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+
+  if (LIS_rc%ts.gt.3600) then
+     write(LIS_logunit,*)                                              &
+          "[ERR] The model timestep is > forcing data timestep"
+     write(LIS_logunit,*)                                              &
+          "[ERR] LIS does not support this mode currently"
+     write(LIS_logunit,*) "[ERR] Program stopping ..."
+     call LIS_endrun()
+  endif
+
+  if (mod(nint(LIS_rc%ts),3600).eq.0) then
+     if (timenow.ge.nldas3sw_struc(n)%nldas3swtime2) then
+        yr1 = LIS_rc%yr
+        mo1 = LIS_rc%mo
+        da1 = LIS_rc%da
+        hr1 = LIS_rc%hr
+        mn1 = 0
+        ss1 = 0
+        ts1 = -60*60     !previous hour
+        call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+
+        yr2 = LIS_rc%yr
+        mo2 = LIS_rc%mo
+        da2 = LIS_rc%da
+        hr2 = LIS_rc%hr
+        mn2 = 0
+        ss2 = 0
+        ts2 = 0          !current hour
+        call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+        movetime = 1
+        nldas3sw_struc(n)%findtime2 = 1
+     endif
+  else
+     if (timenow.ge.nldas3sw_struc(n)%nldas3swtime2) then
+        yr1 = LIS_rc%yr
+        mo1 = LIS_rc%mo
+        da1 = LIS_rc%da
+        hr1 = LIS_rc%hr
+        mn1 = 0
+        ss1 = 0
+        ts1 = 0          !current hour
+        call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+
+        yr2 = LIS_rc%yr
+        mo2 = LIS_rc%mo
+        da2 = LIS_rc%da
+        hr2 = LIS_rc%hr
+        mn2 = 0
+        ss2 = 0
+        ts2 = 60*60      !next hour
+        call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+
+        movetime = 1
+        nldas3sw_struc(n)%findtime2 = 1
+     endif
+  endif
+
+! Beginning of the run
+  if ((LIS_rc%tscount(n).eq.1).or.(LIS_rc%rstflag(n).eq.1)) then
+     nldas3sw_struc(n)%findtime1 = 1
+     nldas3sw_struc(n)%findtime2 = 1
+     movetime = 0
+     LIS_rc%rstflag(n) = 0
+  endif
+
+  if (movetime.eq.1) then
+     nldas3sw_struc(n)%nldas3swtime1 = nldas3sw_struc(n)%nldas3swtime2
+     do f = 1,LIS_rc%met_nf(findex)
+        do c = 1,LIS_rc%ngrid(n)
+           nldas3sw_struc(n)%metdata1(f,c) =                           &
+                             nldas3sw_struc(n)%metdata2(f,c)
+        enddo
+     enddo
+  endif                     !end of movetime=1
+
+! The following looks back 10 days, at the same hour to fill data gaps.
+  if (nldas3sw_struc(n)%findtime1.eq.1) then
+     ferrora = 0
+     ferror = 0
+     try = 0
+     ts1 = -60*60*24
+     do
+        if (ferror.ne.0) exit
+        try = try + 1
+!- Obtaining CERES SWdown file:
+        call ceres_nldas3swfile(n,1,findex,name_a,                     &
+                nldas3sw_struc(n)%nldas3swfordir,yr1,mo1,da1,doy1,hr1)
+        write(unit=LIS_logunit,fmt=*)                                  &
+                "[INFO] getting CERES file: ",trim(name_a)
+        order = 1
+        call read_nldas3sw(n,1,findex,order,hr1,name_a,ferrora)
+
+        ferror = ferrora
+        if (ferror.ge.0) nldas3sw_struc(n)%nldas3swtime1 = time1
+        call LIS_tick(dtime1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+        if (try.gt.11) then
+           write(LIS_logunit,*)                                        &
+                "[ERR] CERES data gap exceeds 10 days on file 1"
+           write(LIS_logunit,*) "[ERR] Program stopping ..."
+           call LIS_endrun()
+        endif
+     enddo
+!=== end of data search
+  endif                     !end of LIS_rc%findtime=1
+
+  if (nldas3sw_struc(n)%findtime2.eq.1) then
+! The following looks back 10 days, at the same hour to fill data gaps.
+     ferrora = 0
+     ferror = 0
+     try = 0
+     ts2 = -60*60*24
+     do
+        if (ferror.ne.0) exit
+        try = try+1
+
+ !- Obtaining CERES SWdown file:
+        call ceres_nldas3swfile(n,1,findex,name_a,                     &
+                nldas3sw_struc(n)%nldas3swfordir,yr2,mo2,da2,doy2,hr2)
+        write(unit=LIS_logunit,fmt=*)                                  &
+                "[INFO] getting CERES file: ",trim(name_a)
+        order = 2
+        call read_nldas3sw(n,1,findex,order,hr2,name_a,ferrora)
+
+        ferror = ferrora
+        if (ferror.ge.0) then
+           nldas3sw_struc(n)%nldas3swtime2 = time2
+        endif
+        call LIS_tick(dtime2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+        if (try.gt.11) then
+           write(LIS_logunit,*)                                        &
+                "[ERR] CERES data gap exceeds 10 days on file 2"
+           write(LIS_logunit,*) "[ERR] Program stopping ..."
+           call LIS_endrun()
+        endif
+     enddo
+!=== end of data search
+  endif                     ! end of findtime2=1
+
+end subroutine get_nldas3sw
+

--- a/lis/metforcing/nldas3sw/nldas3sw_forcingMod.F90
+++ b/lis/metforcing/nldas3sw/nldas3sw_forcingMod.F90
@@ -1,0 +1,276 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+module nldas3sw_forcingMod
+!BOP
+! !MODULE: nldas3sw_forcingMod
+!
+! !REVISION HISTORY:
+! 27 Dec 2024: David Mocko, Initial Specification
+!                           (derived from nldas20_forcingMod.F90)
+!
+! !USES:
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
+  implicit none
+
+  PRIVATE
+!-----------------------------------------------------------------------------
+! !PUBLIC MEMBER FUNCTIONS:
+!-----------------------------------------------------------------------------
+  public :: init_nldas3sw    !defines the native resolution of the input data
+!-----------------------------------------------------------------------------
+! !PUBLIC TYPES:
+!-----------------------------------------------------------------------------
+  public :: nldas3sw_struc
+!
+! !DESCRIPTION:
+!  This module contains variables and data structures that are used for
+!  the reading of the CERES hourly 4-km SWdown data, for the downscaling
+!  and slope-aspect correction down to the NLDAS-3 1-km grid.
+!
+!  The implementation in LIS has the derived data type {\tt nldas3sw\_struc}
+!  that includes the variables that specify the runtime options, and the
+!  weights and neighbor information to be used for spatial interpolation.
+!  They are described below:
+!  \begin{description}
+!  \item[ncold]
+!    Number of columns (along the east west dimension) for the input data
+!  \item[nrold]
+!    Number of rows (along the north south dimension) for the input data
+!  \item[nldas3swtime1]
+!    The nearest, previous hourly instance of the incoming
+!    data (as a real time).
+!  \item[nldas3swtime2]
+!    The nearest, next hourly instance of the incoming
+!    data (as a real time).
+!  \item[nldas3swfordir]
+!    Directory containing the CERES 4-km binary input data
+!  \item[mi]
+!    Number of points in the input grid
+!  \item[n111,n121,n211,n221]
+!    Arrays containing the neighbor information of the input grid
+!    for each grid point in LIS, for bilinear interpolation.
+!  \item[w111,w121,w211,w221]
+!    Arrays containing the weights of the input grid
+!    for each grid point in LIS, for bilinear interpolation.
+!  \item[n122,n122,n212,n222]
+!    Arrays containing the neighbor information of the input grid
+!    for each grid point in LIS, for conservative interpolation.
+!  \item[w112,w122,w212,w222]
+!    Arrays containing the weights of the input grid
+!    for each grid point in LIS, for conservative interpolation.
+!  \item[n113]
+!    Arrays containing the neighbor information of the input grid
+!    for each grid point in LIS, for nearest neighbor interpolation.
+!  \item[findtime1, findtime2]
+!   boolean flags to indicate which time is to be read for
+!   temporal interpolation.
+!  \end{description}
+!
+!EOP
+  type, public :: nldas3sw_type_dec
+     real         :: ts
+     integer      :: ncold, nrold
+     real*8       :: nldas3swtime1,nldas3swtime2
+     character(len=LIS_CONST_PATH_LEN) :: nldas3swfordir
+
+     real                   :: gridDesc(50)
+     integer                :: mi
+     integer, allocatable   :: n111(:)
+     integer, allocatable   :: n121(:)
+     integer, allocatable   :: n211(:)
+     integer, allocatable   :: n221(:)
+     real, allocatable      :: w111(:),w121(:)
+     real, allocatable      :: w211(:),w221(:)
+     integer, allocatable   :: n112(:,:)
+     integer, allocatable   :: n122(:,:)
+     integer, allocatable   :: n212(:,:)
+     integer, allocatable   :: n222(:,:)
+     real, allocatable      :: w112(:,:),w122(:,:)
+     real, allocatable      :: w212(:,:),w222(:,:)
+     integer, allocatable   :: n113(:)
+     integer                :: findtime1,findtime2
+     real, allocatable      :: metdata1(:,:)
+     real, allocatable      :: metdata2(:,:)
+
+  end type nldas3sw_type_dec
+
+  type(nldas3sw_type_dec), allocatable :: nldas3sw_struc(:)
+
+contains
+!BOP
+!
+! !ROUTINE: init_nldas3sw
+! \label{init_nldas3sw}
+!
+! !INTERFACE:
+  subroutine init_nldas3sw(findex)
+! !USES:
+    use LIS_coreMod,    only            : LIS_rc
+    use LIS_timeMgrMod, only            : LIS_update_timestep
+    use LIS_logMod,     only            : LIS_logunit,LIS_endrun
+    use map_utils,      only            : proj_latlon
+
+    implicit none
+! !ARGUMENTS:
+    integer, intent(in) :: findex
+!
+! !DESCRIPTION:
+!  Defines the native resolution of the input forcing for CERES
+!  SWdown data.  The grid description arrays are based on the
+!  binary data and followed in the LIS interpolation schemes
+!  (see Section~\ref{interp}).
+!
+!  The routines invoked are:
+!  \begin{description}
+!   \item[readcrd\_nldas3sw](\ref{readcrd_nldas3sw}) \newline
+!     reads the runtime options specified for NLDAS-3 SWdown data
+!   \item[bilinear\_interp\_input](\ref{bilinear_interp_input}) \newline
+!    computes the neighbor, weights for bilinear interpolation
+!   \item[conserv\_interp\_input](\ref{conserv_interp_input}) \newline
+!    computes the neighbor, weights for conservative interpolation
+!  \end{description}
+!
+!EOP
+    integer :: n
+
+    external :: readcrd_nldas3sw
+    external :: bilinear_interp_input
+    external :: conserv_interp_input
+    external :: neighbor_interp_input
+
+    allocate(nldas3sw_struc(LIS_rc%nnest))
+    call readcrd_nldas3sw()
+
+    do n = 1,LIS_rc%nnest
+       nldas3sw_struc(n)%ts = 3600
+       call LIS_update_timestep(LIS_rc,n,nldas3sw_struc(n)%ts)
+    enddo
+
+    LIS_rc%met_nf(findex) = 1
+
+! Set CERES 4-km grid dimensions and extent information:
+    nldas3sw_struc(:)%ncold = 2925
+    nldas3sw_struc(:)%nrold = 1625
+
+    do n = 1,LIS_rc%nnest
+
+! Regular retrospective or non-forecast mode:
+       allocate(nldas3sw_struc(n)%metdata1(LIS_rc%met_nf(findex),      &
+                LIS_rc%ngrid(n)))
+       allocate(nldas3sw_struc(n)%metdata2(LIS_rc%met_nf(findex),      &
+                LIS_rc%ngrid(n)))
+
+       nldas3sw_struc(n)%metdata1 = 0
+       nldas3sw_struc(n)%metdata2 = 0
+       nldas3sw_struc(n)%gridDesc = 0
+       nldas3sw_struc(n)%findtime1 = 0
+       nldas3sw_struc(n)%findtime2 = 0
+       nldas3sw_struc(n)%gridDesc(1) = 0
+       nldas3sw_struc(n)%gridDesc(2) = nldas3sw_struc(n)%ncold
+       nldas3sw_struc(n)%gridDesc(3) = nldas3sw_struc(n)%nrold
+       nldas3sw_struc(n)%gridDesc(4) = 7.02
+       nldas3sw_struc(n)%gridDesc(5) = -168.98
+       nldas3sw_struc(n)%gridDesc(6) = 128
+       nldas3sw_struc(n)%gridDesc(7) = 71.98
+       nldas3sw_struc(n)%gridDesc(8) = -52.02
+       nldas3sw_struc(n)%gridDesc(9) = 0.04
+       nldas3sw_struc(n)%gridDesc(10) = 0.04
+       nldas3sw_struc(n)%gridDesc(20) = 64
+
+! Check for grid and interp option selected:
+       if ((nldas3sw_struc(n)%gridDesc(9).eq.LIS_rc%gridDesc(n,9)).and.&
+         (nldas3sw_struc(n)%gridDesc(10).eq.LIS_rc%gridDesc(n,10)).and.&
+            (LIS_rc%gridDesc(n,1).eq.proj_latlon).and.                 &
+            (LIS_rc%met_interp(findex).ne."neighbor")) then
+          write(LIS_logunit,*)                                         &
+               "[ERR] The NLDAS grid was selected for the LIS domain;"
+          write(LIS_logunit,*)                                         &
+               "[ERR] however, 'bilinear', 'budget-bilinear', or some"
+          write(LIS_logunit,*)                                         &
+               "[ERR] other unknown option was selected to spatially"
+          write(LIS_logunit,*)                                         &
+               "[ERR] downscale the grid, which will cause errors"
+          write(LIS_logunit,*)                                         &
+               "[ERR] during runtime.  Please select 'neighbor'."
+          write(LIS_logunit,*) "[ERR] Program stopping ..."
+          call LIS_endrun()
+       endif
+
+       nldas3sw_struc(n)%mi = nldas3sw_struc(n)%ncold*nldas3sw_struc(n)%nrold
+
+! Setting up weights for spatial interpolation:
+       select case(LIS_rc%met_interp(findex))
+
+       case ("bilinear")
+          allocate(nldas3sw_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+          call bilinear_interp_input(n,nldas3sw_struc(n)%gridDesc(:),  &
+               nldas3sw_struc(n)%n111,nldas3sw_struc(n)%n121,          &
+               nldas3sw_struc(n)%n211,nldas3sw_struc(n)%n221,          &
+               nldas3sw_struc(n)%w111,nldas3sw_struc(n)%w121,          &
+               nldas3sw_struc(n)%w211,nldas3sw_struc(n)%w221)
+
+       case ("budget-bilinear")
+          allocate(nldas3sw_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(nldas3sw_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+
+          call bilinear_interp_input(n,nldas3sw_struc(n)%gridDesc(:),  &
+               nldas3sw_struc(n)%n111,nldas3sw_struc(n)%n121,          &
+               nldas3sw_struc(n)%n211,nldas3sw_struc(n)%n221,          &
+               nldas3sw_struc(n)%w111,nldas3sw_struc(n)%w121,          &
+               nldas3sw_struc(n)%w211,nldas3sw_struc(n)%w221)
+
+          allocate(nldas3sw_struc(n)%n112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(nldas3sw_struc(n)%n122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(nldas3sw_struc(n)%n212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(nldas3sw_struc(n)%n222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(nldas3sw_struc(n)%w112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(nldas3sw_struc(n)%w122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(nldas3sw_struc(n)%w212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(nldas3sw_struc(n)%w222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+
+          call conserv_interp_input(n,nldas3sw_struc(n)%gridDesc(:),   &
+               nldas3sw_struc(n)%n112,nldas3sw_struc(n)%n122,          &
+               nldas3sw_struc(n)%n212,nldas3sw_struc(n)%n222,          &
+               nldas3sw_struc(n)%w112,nldas3sw_struc(n)%w122,          &
+               nldas3sw_struc(n)%w212,nldas3sw_struc(n)%w222)
+
+       case ("neighbor")
+          allocate(nldas3sw_struc(n)%n113(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          call neighbor_interp_input(n,nldas3sw_struc(n)%gridDesc(:),  &
+               nldas3sw_struc(n)%n113)
+
+       case default
+          write(LIS_logunit,*)                                         &
+               "[ERR] Interpolation option not specified for NLDAS-3 SW"
+          write(LIS_logunit,*) "[ERR] Program stopping ..."
+          call LIS_endrun()
+       end select
+
+    enddo
+
+  end subroutine init_nldas3sw
+
+end module nldas3sw_forcingMod
+

--- a/lis/metforcing/nldas3sw/read_nldas3sw.F90
+++ b/lis/metforcing/nldas3sw/read_nldas3sw.F90
@@ -1,0 +1,305 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
+!BOP
+! !ROUTINE: read_nldas3sw
+!  \label{read_nldas3sw}
+!
+! !REVISION HISTORY:
+! 27 Dec 2024: David Mocko, Initial Specification
+!                           (derived from read_nldas20a.F90)
+!
+! !INTERFACE:
+subroutine read_nldas3sw(n,kk,findex,order,hour,name,ferror)
+! !USES:
+  use LIS_coreMod
+  use LIS_logMod, only          : LIS_logunit,LIS_verify,LIS_warning,  &
+                             LIS_getNextUnitNumber,LIS_releaseUnitNumber
+  use LIS_metforcingMod, only   : LIS_forc
+  use nldas3sw_forcingMod, only : nldas3sw_struc
+
+  implicit none
+! !ARGUMENTS:
+  integer, intent(in)          :: n
+  integer, intent(in)          :: kk     ! Forecast member index
+  integer, intent(in)          :: findex ! Forcing index
+  integer, intent(in)          :: order
+  integer, intent(in)          :: hour
+  character(len=*), intent(in) :: name
+  integer, intent(out)         :: ferror
+!
+! !DESCRIPTION:
+!  For the given time, reads values from CERES 4-km binary data,
+!  and interpolates to the LIS domain.
+!
+!  The arguments are:
+!  \begin{description}
+!  \item[n]
+!    index of the nest
+!  \item[kk]
+!    forecast member index
+!  \item[findex]
+!    forcing index
+!  \item[order]
+!    flag indicating which data to be read (order=1, read the previous
+!    hourly instance, order=2, read the next hourly instance)
+!  \item[hour]
+!    current hour
+!  \item[name]
+!    name of the CERES file
+!  \item[ferror]
+!    flag to indicate success of the call (=1 indicates success)
+!  \end{description}
+!
+!  The routines invoked are:
+!  \begin{description}
+!  \item[interp\_nldas3sw](\ref{interp_nldas3sw}) \newline
+!    spatially interpolates the CERES SWdown
+!  \end{description}
+!
+!EOP
+  integer                :: iv,ftn
+  integer                :: nldas3sw,paramid
+  integer                :: k,t,c,r,iret,rc
+  real, parameter        :: missingValue = -9999.0
+  integer, parameter     :: nvars = 1
+  logical                :: pcp_flag
+  logical                :: file_exists
+  character(len=20)      :: input_varname(nvars)
+  logical*1, allocatable :: lb(:)
+  real, allocatable      :: f(:)
+  real, allocatable      :: nldas3sw_forcing(:,:)
+  real                   :: varfield(LIS_rc%lnc(n),LIS_rc%lnr(n))
+  real :: dummy(nldas3sw_struc(n)%ncold,nldas3sw_struc(n)%nrold)
+
+  ferror = 1
+  iv = 0
+
+  input_varname(1)  = "SWdown"
+
+  nldas3sw = (nldas3sw_struc(n)%ncold*nldas3sw_struc(n)%nrold)
+
+  allocate(nldas3sw_forcing(nldas3sw_struc(n)%ncold*nldas3sw_struc(n)%nrold,nvars))
+
+  varfield = 0
+  ferror = 1
+
+  inquire(file=name,exist=file_exists)
+  if (file_exists) then
+     ftn = LIS_getNextUnitNumber()
+     open(ftn,file=name,form='unformatted',access='direct',            &
+          recl=4*nldas3sw_struc(n)%ncold*nldas3sw_struc(n)%nrold,      &
+          convert='little_endian',status='old',iostat=iret)
+     if (iret.ne.0) then
+        write(LIS_logunit,*) "[WARN] Could not open file: ",trim(name)
+        ferror = 0
+        return
+     endif
+
+     allocate(lb(nldas3sw_struc(n)%ncold*nldas3sw_struc(n)%nrold))
+     allocate(f(nldas3sw_struc(n)%ncold*nldas3sw_struc(n)%nrold))
+
+     do k = 1,nvars
+        read(ftn,rec=hour+1) dummy
+
+!        write(LIS_logunit,*) "[INFO] Read field: ",input_varname(k)
+
+        f = LIS_rc%udef     ! Initialize forcing
+        t = 0
+        do r = 1,nldas3sw_struc(n)%nrold
+           do c = 1,nldas3sw_struc(n)%ncold
+              t = t + 1
+              f(t) = dummy(c,r)
+              if (isnan(f(t))) f(t) = LIS_rc%udef
+           enddo
+        enddo
+
+        lb = .false.
+        do t = 1,nldas3sw
+           if (f(t).ne.missingValue) then
+              nldas3sw_forcing(t,k) = f(t)
+              lb(t) = .true.
+           else
+              nldas3sw_forcing(t,k) = LIS_rc%udef
+           endif
+        enddo
+     enddo
+     deallocate(f)
+
+     close(ftn)
+     call LIS_releaseUnitNumber(ftn)
+
+     do iv = 1,nvars
+        pcp_flag = .false.
+        call interp_nldas3sw(n,findex,pcp_flag,nldas3sw,               &
+             nldas3sw_forcing(:,iv),                                   &
+             lb,LIS_rc%gridDesc(n,:),                                  &
+             LIS_rc%lnc(n),LIS_rc%lnr(n),varfield)
+
+        do r = 1,LIS_rc%lnr(n)
+           do c = 1,LIS_rc%lnc(n)
+              if (LIS_domain(n)%gindex(c,r).ne.-1) then
+                 if (order.eq.1) then
+                    nldas3sw_struc(n)%metdata1(iv,                     &
+                         LIS_domain(n)%gindex(c,r)) = varfield(c,r)
+                 elseif (order.eq.2) then
+                    nldas3sw_struc(n)%metdata2(iv,                     &
+                         LIS_domain(n)%gindex(c,r)) = varfield(c,r)
+                 endif
+              endif
+           enddo
+        enddo
+
+     enddo
+     deallocate(lb)
+  else
+     write(LIS_logunit,*) "[WARN] Could not find file: ",trim(name)
+     ferror = 0
+  endif
+
+  deallocate(nldas3sw_forcing)
+
+end subroutine read_nldas3sw
+
+!BOP
+! !ROUTINE: interp_nldas3sw
+! \label{interp_nldas3sw}
+!
+! !REVISION HISTORY:
+! 27 Dec 2024: David Mocko, Initial Specification
+!                           (derived from read_nldas20a.F90)
+!
+! !INTERFACE:
+subroutine interp_nldas3sw(n,findex,pcp_flag,input_size,               &
+                        input_data,input_bitmap,lis_gds,nc,nr,output_2d)
+! !USES:
+  use LIS_coreMod, only         : LIS_rc,LIS_domain
+  use nldas3sw_forcingMod, only : nldas3sw_struc
+
+  implicit none
+! !ARGUMENTS:
+  integer, intent(in)   :: n
+  integer, intent(in)   :: findex
+  logical, intent(in)   :: pcp_flag
+  integer, intent(in)   :: input_size
+  real, intent(in)      :: input_data(input_size)
+  logical*1, intent(in) :: input_bitmap(input_size)
+  real, intent(in)      :: lis_gds(50)
+  integer, intent(in)   :: nc
+  integer, intent(in)   :: nr
+  real, intent(inout)   :: output_2d(nc,nr)
+!
+! !DESCRIPTION:
+!   This subroutine interpolates a given CERES SWdown field to the LIS grid.
+!  The arguments are:
+!  \begin{description}
+!  \item[n]
+!    index of the nest
+!  \item[findex]
+!    forcing index
+!  \item[pcp_flag]
+!    flag indicating if it is a precip field
+!  \item[input\_size]
+!    number of elements in the input grid
+!  \item[input\_bitmap]
+!    input bitmap
+!  \item[lis\_gds]
+!    array description of the LIS grid
+!  \item[nc]
+!    number of columns (in the east-west dimension) in the LIS grid
+!  \item[nr]
+!    number of rows (in the north-south dimension) in the LIS grid
+!  \item[output\_2d]
+!    output interpolated field
+!  \end{description}
+!
+!  The routines invoked are:
+!  \begin{description}
+!  \item[bilinear\_interp](\ref{bilinear_interp}) \newline
+!    spatially interpolate the forcing data using bilinear interpolation
+!  \item[conserv\_interp](\ref{conserv_interp}) \newline
+!    spatially interpolate the forcing data using conservative interpolation
+!  \item[neighbor\_interp](\ref{neighbor_interp}) \newline
+!    spatially interpolate the forcing data using nearest neighbor interpolation
+! \end{description}
+!
+!EOP
+  integer :: iret
+  integer :: mo
+  integer :: count1,i,j
+  real, dimension(nc*nr) :: output_data
+  logical*1 :: output_bitmap(nc*nr)
+
+!=== End variable declarations
+
+  mo = nc*nr
+!-----------------------------------------------------------------------
+! Initialize output bitmap.
+!-----------------------------------------------------------------------
+  output_bitmap = .true.
+
+!-----------------------------------------------------------------------
+! Interpolate to LIS grid
+!-----------------------------------------------------------------------
+  select case(LIS_rc%met_interp(findex))
+
+  case("bilinear")
+     call bilinear_interp(lis_gds,input_bitmap,input_data,             &
+          output_bitmap,output_data,nldas3sw_struc(n)%mi,mo,           &
+          LIS_domain(n)%lat,LIS_domain(n)%lon,                         &
+          nldas3sw_struc(n)%w111,nldas3sw_struc(n)%w121,               &
+          nldas3sw_struc(n)%w211,nldas3sw_struc(n)%w221,               &
+          nldas3sw_struc(n)%n111,nldas3sw_struc(n)%n121,               &
+          nldas3sw_struc(n)%n211,nldas3sw_struc(n)%n221,               &
+          LIS_rc%udef,iret)
+
+  case("budget-bilinear")
+     if (pcp_flag) then
+        call conserv_interp(lis_gds,input_bitmap,input_data,           &
+             output_bitmap,output_data,nldas3sw_struc(n)%mi,mo,        &
+             LIS_domain(n)%lat,LIS_domain(n)%lon,                      &
+             nldas3sw_struc(n)%w112,nldas3sw_struc(n)%w122,            &
+             nldas3sw_struc(n)%w212,nldas3sw_struc(n)%w222,            &
+             nldas3sw_struc(n)%n112,nldas3sw_struc(n)%n122,            &
+             nldas3sw_struc(n)%n212,nldas3sw_struc(n)%n222,            &
+             LIS_rc%udef,iret)
+
+     else
+        call bilinear_interp(lis_gds,input_bitmap,input_data,          &
+             output_bitmap,output_data,nldas3sw_struc(n)%mi,mo,        &
+             LIS_domain(n)%lat,LIS_domain(n)%lon,                      &
+             nldas3sw_struc(n)%w111,nldas3sw_struc(n)%w121,            &
+             nldas3sw_struc(n)%w211,nldas3sw_struc(n)%w221,            &
+             nldas3sw_struc(n)%n111,nldas3sw_struc(n)%n121,            &
+             nldas3sw_struc(n)%n211,nldas3sw_struc(n)%n221,            &
+             LIS_rc%udef,iret)
+     endif
+
+  case("neighbor")
+     call neighbor_interp(lis_gds,input_bitmap,input_data,             &
+          output_bitmap,output_data,nldas3sw_struc(n)%mi,mo,           &
+          LIS_domain(n)%lat,LIS_domain(n)%lon,                         &
+          nldas3sw_struc(n)%n113,LIS_rc%udef,iret)
+
+  end select
+
+!-----------------------------------------------------------------------
+! convert the interpolated data to 2d.
+!-----------------------------------------------------------------------
+  count1 = 0
+  do j = 1,nr
+     do i = 1,nc
+        output_2d(i,j) = output_data(i+count1)
+     enddo
+     count1 = count1 + nc
+  enddo
+
+end subroutine interp_nldas3sw
+

--- a/lis/metforcing/nldas3sw/readcrd_nldas3sw.F90
+++ b/lis/metforcing/nldas3sw/readcrd_nldas3sw.F90
@@ -1,0 +1,58 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+!
+! !ROUTINE: readcrd_nldas3sw
+!  \label{readcrd_nldas3sw}
+!
+! !REVISION HISTORY:
+! 27 Dec 2024: David Mocko, Initial Specification
+!                           (derived from readcrd_nldas20.F90)
+!
+! !INTERFACE:
+subroutine readcrd_nldas3sw()
+! !USES:
+  use ESMF
+  use LIS_coreMod, only         : LIS_rc,LIS_config
+  use LIS_logMod,  only         : LIS_logunit,LIS_verify,LIS_endrun
+  use nldas3sw_forcingMod, only : nldas3sw_struc
+
+  implicit none
+!
+! !DESCRIPTION:
+!  This routine reads the options specific to NLDAS-3 SWdown
+!  forcing from the LIS configuration file.
+!
+!EOP
+  integer :: n,rc
+
+  call ESMF_ConfigFindLabel(LIS_config,                                &
+                           "CERES SWdown forcing directory:",rc=rc)
+  call LIS_verify(rc,"CERES SWdown forcing directory: not defined")
+
+  do n = 1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,                          &
+                                 nldas3sw_struc(n)%nldas3swfordir,rc=rc)
+  enddo
+
+  write(unit=LIS_logunit,fmt=*)                                        &
+       "[INFO] Using CERES 4-km SWdown data for NLDAS-3"
+
+  do n = 1,LIS_rc%nnest
+     write(unit=LIS_logunit,fmt=*)                                     &
+          "[INFO] CERES SWdown forcing directory: ",                   &
+          trim(nldas3sw_struc(n)%nldas3swfordir)
+
+     nldas3sw_struc(n)%nldas3swtime1 = 3000.0
+     nldas3sw_struc(n)%nldas3swtime2 = 0.0
+  enddo
+
+end subroutine readcrd_nldas3sw
+

--- a/lis/metforcing/nldas3sw/reset_nldas3sw.F90
+++ b/lis/metforcing/nldas3sw/reset_nldas3sw.F90
@@ -1,0 +1,39 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: reset_nldas3sw
+!  \label{reset_nldas3sw}
+!
+! !REVISION HISTORY:
+! 27 Dec 2024: David Mocko, Initial Specification
+!                           (derived from reset_nldas20.F90)
+!
+! !INTERFACE:
+subroutine reset_nldas3sw()
+! !USES:
+  use LIS_coreMod,         only : LIS_rc
+  use nldas3sw_forcingMod, only : nldas3sw_struc
+
+  implicit none
+!
+! !DESCRIPTION:
+!  Routine to reset CERES SWdown forcing related memory allocations.
+!
+!EOP
+  integer   :: n
+  integer   :: findex
+
+  do n = 1,LIS_rc%nnest
+     nldas3sw_struc(n)%nldas3swtime1 = 3000.0
+     nldas3sw_struc(n)%nldas3swtime2 = 0.0
+  enddo
+
+end subroutine reset_nldas3sw
+

--- a/lis/metforcing/nldas3sw/timeinterp_nldas3sw.F90
+++ b/lis/metforcing/nldas3sw/timeinterp_nldas3sw.F90
@@ -1,0 +1,117 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: timeinterp_nldas3sw
+! \label{timeinterp_nldas3sw}
+!
+! !REVISION HISTORY:
+! 27 Dec 2024: David Mocko, Initial Specification
+!                           (derived from timeinterp_nldas20.F90)
+!
+! !INTERFACE:
+subroutine timeinterp_nldas3sw(n,findex)
+! !USES:
+  use ESMF
+  use LIS_FORC_AttributesMod
+  use LIS_coreMod,        only  : LIS_rc,LIS_domain
+  use LIS_metforcingMod,  only  : LIS_forc,LIS_FORC_Base_State
+  use LIS_timeMgrMod,     only  : LIS_tick,LIS_time2date
+  use LIS_logMod,         only  : LIS_logunit,LIS_verify,LIS_endrun
+  use nldas3sw_forcingMod, only : nldas3sw_struc
+
+  implicit none
+! !ARGUMENTS:
+  integer, intent(in) :: n
+  integer, intent(in) :: findex
+!
+! !DESCRIPTION:
+!  Linear interpolation available for SWdown, but should not be
+!  used in LIS.  Simply read in hourly 4-km CERES SWdown data,
+!  and write hourly 1-km NLDAS-3 SWdown data in the lis.config.
+!
+!  The routines invoked are:
+!  \begin{description}
+!   \item[LIS\_time2date](\ref{LIS_time2date}) \newline
+!    converts the time to a date format
+!   \item[LIS\_tick](\ref{LIS_tick}) \newline
+!    advances or retracts time by the specified amount
+!  \end{description}
+!
+!EOP
+  real    :: wt1,wt2,gmt1,gmt2,tempbts
+  integer :: t
+  integer :: bdoy,byr,bmo,bda,bhr,bmn
+  real*8  :: btime,newtime1,newtime2
+  real    :: tempgmt1,tempgmt2
+  integer :: tempbdoy,tempbyr,tempbmo,tempbda,tempbhr,tempbmn
+  integer :: tempbss
+
+  integer          :: status
+  type(ESMF_Field) :: swdField
+  real, pointer    :: swd(:)
+
+!________________________________________
+
+  btime = nldas3sw_struc(n)%nldas3swtime1
+  call LIS_time2date(btime,bdoy,gmt1,byr,bmo,bda,bhr,bmn)
+
+  tempbdoy = bdoy
+  tempgmt1 = gmt1
+  tempbyr = byr
+  tempbmo = bmo
+  tempbda = bda
+  tempbhr = bhr
+  if (tempbhr.eq.24) tempbhr = 0
+  tempbmn = bmn
+  tempbss = 0
+  tempbts = 0
+  call LIS_tick(newtime1,tempbdoy,tempgmt1,tempbyr,tempbmo,tempbda,    &
+                tempbhr,tempbmn,tempbss,tempbts)
+
+  btime = nldas3sw_struc(n)%nldas3swtime2
+  call LIS_time2date(btime,bdoy,gmt2,byr,bmo,bda,bhr,bmn)
+  tempbdoy = bdoy
+  tempgmt2 = gmt2
+  tempbyr = byr
+  tempbmo = bmo
+  tempbda = bda
+  tempbhr = bhr
+  if (tempbhr.eq.24) tempbhr = 0
+  tempbmn = bmn
+  tempbss = 0
+  tempbts = 0
+  call LIS_tick(newtime2,tempbdoy,tempgmt2,tempbyr,tempbmo,tempbda,    &
+                tempbhr,tempbmn,tempbss,tempbts)
+
+!=== Interpolate Data in time
+  wt1 = (nldas3sw_struc(n)%nldas3swtime2 - LIS_rc%time) /              &
+        (nldas3sw_struc(n)%nldas3swtime2 - nldas3sw_struc(n)%nldas3swtime1)
+  wt2 = 1.0 - wt1
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                    &
+       LIS_FORC_SWdown%varname(1),swdField,rc=status)
+  call LIS_verify(status,                                              &
+       "[ERR] Enable SWdown in the forcing variables list")
+
+  call ESMF_FieldGet(swdField,localDE=0,farrayPtr=swd,rc=status)
+  call LIS_verify(status)
+
+  do t = 1,LIS_rc%ntiles(n)
+     if ((nldas3sw_struc(n)%metdata1(1,t).ne.LIS_rc%udef).and.         &
+             (nldas3sw_struc(n)%metdata2(1,t).ne.LIS_rc%udef)) then
+        swd(t) = (nldas3sw_struc(n)%metdata1(1,t)*wt1) +               &
+                 (nldas3sw_struc(n)%metdata2(1,t)*wt2)
+     else
+        swd(t) = 0.0
+     endif
+  enddo
+
+end subroutine timeinterp_nldas3sw
+

--- a/lis/plugins/LIS_metforcing_pluginMod.F90
+++ b/lis/plugins/LIS_metforcing_pluginMod.F90
@@ -208,6 +208,10 @@ subroutine LIS_metforcing_plugin
    use nldas2_forcingMod
 #endif
 
+#if ( defined MF_NLDAS3SW )
+   use nldas3sw_forcingMod
+#endif
+
 #if ( defined MF_GEIS )
    use geis_forcingMod
 #endif   
@@ -502,6 +506,13 @@ subroutine LIS_metforcing_plugin
    external timeinterp_nldas2
    external finalize_nldas2
    external reset_nldas2
+#endif
+
+#if ( defined MF_NLDAS3SW )
+   external get_nldas3sw
+   external timeinterp_nldas3sw
+   external finalize_nldas3sw
+   external reset_nldas3sw
 #endif
 
 #if ( defined MF_GEIS )
@@ -973,6 +984,16 @@ subroutine LIS_metforcing_plugin
                                   timeinterp_nldas2)
    call registerfinalmetforc(trim(LIS_nldas2Id)//char(0),finalize_nldas2)
    call registerresetmetforc(trim(LIS_nldas2Id)//char(0),reset_nldas2)
+#endif
+
+#if ( defined MF_NLDAS3SW )
+! - NLDAS-3 SWdown Forcing:
+   call registerinitmetforc(trim(LIS_nldas3swId)//char(0),init_nldas3sw)
+   call registerretrievemetforc(trim(LIS_nldas3swId)//char(0),get_nldas3sw)
+   call registertimeinterpmetforc(trim(LIS_nldas3swId)//char(0), &
+                                  timeinterp_nldas3sw)
+   call registerfinalmetforc(trim(LIS_nldas3swId)//char(0),finalize_nldas3sw)
+   call registerresetmetforc(trim(LIS_nldas3swId)//char(0),reset_nldas3sw)
 #endif
 
 #if ( defined MF_GEIS )

--- a/lis/plugins/LIS_pluginIndices.F90
+++ b/lis/plugins/LIS_pluginIndices.F90
@@ -131,6 +131,7 @@ module LIS_pluginIndices
    character*50, public,  parameter :: LIS_agrmetId          = "AGRMET"
    character*50, public,  parameter :: LIS_princetonId       = "PRINCETON"
    character*50, public,  parameter :: LIS_nldas2Id          = "NLDAS2"
+   character*50, public,  parameter :: LIS_nldas3SWId        = "NLDAS-3 SWdown"
    character*50, public,  parameter :: LIS_geisId            = "Global EIS"
 
    character*50, public,  parameter :: LIS_gldasId           = "GLDAS"

--- a/lis/surfacemodels/land/template/template_f2t.F90
+++ b/lis/surfacemodels/land/template/template_f2t.F90
@@ -163,11 +163,11 @@ subroutine template_f2t(n)
      endif
      if(LIS_FORC_Psurf%selectOpt.eq.1) then
        template_struc(n)%template(t)%psurf=psurf(tid)
-     endif
-     if(pcp(tid).ne.LIS_rc%udef) then
-        template_struc(n)%template(t)%rainf=pcp(tid)
-     else
-        template_struc(n)%template(t)%rainf=0.0
+        if(pcp(tid).ne.LIS_rc%udef) then
+           template_struc(n)%template(t)%rainf=pcp(tid)
+        else
+           template_struc(n)%template(t)%rainf=0.0
+        endif
      endif
      if(LIS_FORC_CRainf%selectOpt.eq.1) then 
         if(cpcp(tid).ne.LIS_rc%udef) then 


### PR DESCRIPTION
This commit adds a metforcing reader for the CERES SWdown product over the NLDAS-3 domain.  The product is binary little_endian real*4 hourly at 4-km over the domain.

This metforcing reader will read in the product and enable interpolation and slope-aspect corrections to the running grid.  Primarily, it will be run on the 1-km NLDAS-3 grid.

Note that this metforcing reader should NOT be merged into the main branch at this time.

Resolves: #1668
