### PR TITLE
Fix template LSM crash if Rainf is not selected as forcing variable

### DIFF
--- a/lis/surfacemodels/land/template/template_f2t.F90
+++ b/lis/surfacemodels/land/template/template_f2t.F90
@@ -164,10 +164,12 @@ subroutine template_f2t(n)
      if(LIS_FORC_Psurf%selectOpt.eq.1) then
        template_struc(n)%template(t)%psurf=psurf(tid)
      endif
-     if(pcp(tid).ne.LIS_rc%udef) then
-        template_struc(n)%template(t)%rainf=pcp(tid)
-     else
-        template_struc(n)%template(t)%rainf=0.0
+     if(LIS_FORC_Rainf%selectOpt.eq.1) then 
+        if(pcp(tid).ne.LIS_rc%udef) then
+           template_struc(n)%template(t)%rainf=pcp(tid)
+        else
+           template_struc(n)%template(t)%rainf=0.0
+        endif
      endif
      if(LIS_FORC_CRainf%selectOpt.eq.1) then 
         if(cpcp(tid).ne.LIS_rc%udef) then 


### PR DESCRIPTION
Fix template LSM crash if Rainf is not selected as forcing variable

Resolves: #1670
