### PR TITLE
Amended FOC files for option to switch to SMAP L2 DA.

### DIFF
--- a/lis/configs/557WW-7.6-FOC/NRT/lis.config.foc.nrt.jules50.76
+++ b/lis/configs/557WW-7.6-FOC/NRT/lis.config.foc.nrt.jules50.76
@@ -72,6 +72,9 @@ Number of application models:           0
 #Data assimilation options
 Number of data assimilation instances:                3
 Data assimilation algorithm:                          "EnKF"                                  "EnKF"                                  "EnKF"
+
+# NOTE:  NEXT LINE IS FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE NEXT LINE.
 Data assimilation set:                                "USAFSI"                                "SMOPS-ASCAT soil moisture"             "SMAP_E_OPL soil moisture"
 
 Data assimilation exclude analysis increments:        0                                       0                                       0
@@ -128,12 +131,23 @@ SMOPS ASCAT use realtime data:                                  1
 SMOPS ASCAT soil moisture use scaled standard deviation model:  0
 SMOPS ASCAT CDF read option:                                    1
 
+# NOTE:  BELOW SETTINGS ARE FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE SMAP_E_OPL ENTRIES BELOW.
 SMAP_E_OPL soil moisture data directory:              ./input/SMAP_E_OPL
 SMAP_E_OPL model CDF file:                            ./input/cdf/jules50_cdf_200obs.nc
 SMAP_E_OPL observation CDF file:                      ./input/cdf/SMAP_cdf_10km_30obs.nc
 SMAP_E_OPL soil moisture number of bins in the CDF:             100
 SMAP_E_OPL soil moisture use scaled standard deviation model:   0
 SMAP_E_OPL CDF read option:                                     1
+
+# NOTE: ALTERNATE SETTINGS FOR SMAP L2.  UNCOMMENT BELOW SETTINGS IF SMAP L2 IS TO BE USED.
+#Data assimilation set:                                "USAFSI"                                "SMOPS-ASCAT soil moisture"             "SMAP(NRT) soil moisture"
+#SMAP(NRT) soil moisture data directory: ./input/SMAP_L2
+#SMAP(NRT) model CDF file:               ./input/cdf/jules50_cdf_200obs.nc
+#SMAP(NRT) observation CDF file:         ./input/cdf/SMAP_cdf_10km_30obs.nc
+#SMAP(NRT) soil moisture number of bins in the CDF:            100
+#SMAP(NRT) soil moisture use scaled standard deviation model:    0
+#SMAP(NRT) CDF read option:                                      1
 
 #------------------------DOMAIN SPECIFICATION--------------------------
 #The following options list the choice of parameter maps to be used

--- a/lis/configs/557WW-7.6-FOC/NRT/lis.config.foc.nrt.noah39.76
+++ b/lis/configs/557WW-7.6-FOC/NRT/lis.config.foc.nrt.noah39.76
@@ -72,6 +72,9 @@ Number of application models:           0
 #Data assimilation options
 Number of data assimilation instances:                3
 Data assimilation algorithm:                          "EnKF"                                  "EnKF"                                  "EnKF"
+
+# NOTE:  NEXT LINE IS FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE NEXT LINE.
 Data assimilation set:                                "USAFSI"                                "SMOPS-ASCAT soil moisture"             "SMAP_E_OPL soil moisture"
 
 Data assimilation exclude analysis increments:        0                                       0                                       0
@@ -128,12 +131,23 @@ SMOPS ASCAT use realtime data:                                  1
 SMOPS ASCAT soil moisture use scaled standard deviation model:  0
 SMOPS ASCAT CDF read option:                                    1
 
+# NOTE:  BELOW SETTINGS ARE FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE SMAP_E_OPL ENTRIES BELOW.
 SMAP_E_OPL soil moisture data directory:              ./input/SMAP_E_OPL
 SMAP_E_OPL model CDF file:                            ./input/cdf/noah39_cdf_200obs.nc
 SMAP_E_OPL observation CDF file:                      ./input/cdf/SMAP_cdf_10km_30obs.nc
 SMAP_E_OPL soil moisture number of bins in the CDF:             100
 SMAP_E_OPL soil moisture use scaled standard deviation model:   0
 SMAP_E_OPL CDF read option:                                     1
+
+# NOTE: ALTERNATE SETTINGS FOR SMAP L2.  UNCOMMENT BELOW SETTINGS IF SMAP L2 IS TO BE USED.
+#Data assimilation set:                                "USAFSI"                                "SMOPS-ASCAT soil moisture"             "SMAP(NRT) soil moisture"
+#SMAP(NRT) soil moisture data directory: ./input/SMAP_L2
+#SMAP(NRT) model CDF file:               ./input/cdf/noah39_cdf_200obs.nc
+#SMAP(NRT) observation CDF file:         ./input/cdf/SMAP_cdf_10km_30obs.nc
+#SMAP(NRT) soil moisture number of bins in the CDF:            100
+#SMAP(NRT) soil moisture use scaled standard deviation model:    0
+#SMAP(NRT) CDF read option:                                      1
 
 #------------------------DOMAIN SPECIFICATION--------------------------
 #The following options list the choice of parameter maps to be used

--- a/lis/configs/557WW-7.6-FOC/NRT/lis.config.foc.nrt.noahmp401.76
+++ b/lis/configs/557WW-7.6-FOC/NRT/lis.config.foc.nrt.noahmp401.76
@@ -72,6 +72,9 @@ Number of application models:           0
 #Data assimilation options
 Number of data assimilation instances:                3
 Data assimilation algorithm:                          "EnKF"                                  "EnKF"                                  "EnKF"
+
+# NOTE:  NEXT LINE IS FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE NEXT LINE.
 Data assimilation set:                                "USAFSI"                                "SMOPS-ASCAT soil moisture"             "SMAP_E_OPL soil moisture"
 
 Data assimilation exclude analysis increments:        0                                       0                                       0
@@ -128,12 +131,23 @@ SMOPS ASCAT use realtime data:                                  1
 SMOPS ASCAT soil moisture use scaled standard deviation model:  0
 SMOPS ASCAT CDF read option:                                    1
 
+# NOTE:  BELOW SETTINGS ARE FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE SMAP_E_OPL ENTRIES BELOW.
 SMAP_E_OPL soil moisture data directory:              ./input/SMAP_E_OPL
 SMAP_E_OPL model CDF file:                            ./input/cdf/noahmp401_cdf_200obs.nc
 SMAP_E_OPL observation CDF file:                      ./input/cdf/SMAP_cdf_10km_30obs.nc
 SMAP_E_OPL soil moisture number of bins in the CDF:             100
 SMAP_E_OPL soil moisture use scaled standard deviation model:   0
 SMAP_E_OPL CDF read option:                                     1
+
+# NOTE: ALTERNATE SETTINGS FOR SMAP L2.  UNCOMMENT BELOW SETTINGS IF SMAP L2 IS TO BE USED.
+#Data assimilation set:                                "USAFSI"                                "SMOPS-ASCAT soil moisture"             "SMAP(NRT) soil moisture"
+#SMAP(NRT) soil moisture data directory: ./input/SMAP_L2
+#SMAP(NRT) model CDF file:               ./input/cdf/noahmp401_cdf_200obs.nc
+#SMAP(NRT) observation CDF file:         ./input/cdf/SMAP_cdf_10km_30obs.nc
+#SMAP(NRT) soil moisture number of bins in the CDF:            100
+#SMAP(NRT) soil moisture use scaled standard deviation model:    0
+#SMAP(NRT) CDF read option:                                      1
 
 #------------------------DOMAIN SPECIFICATION--------------------------
 #The following options list the choice of parameter maps to be used

--- a/lis/configs/557WW-7.6-FOC/NRT_STREAMFLOW/lis.config.foc.nrt_streamflow.noah39.hymap.76
+++ b/lis/configs/557WW-7.6-FOC/NRT_STREAMFLOW/lis.config.foc.nrt_streamflow.noah39.hymap.76
@@ -71,6 +71,9 @@ Number of application models:           0
 #Data assimilation options
 Number of data assimilation instances:                3
 Data assimilation algorithm:                          "EnKF"                                     "EnKF"                                     "EnKF"
+
+# NOTE:  NEXT LINE IS FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE NEXT LINE.
 Data assimilation set:                                "USAFSI"                                   "SMOPS-ASCAT soil moisture"                "SMAP_E_OPL soil moisture"
 Data assimilation exclude analysis increments:        0                                          0                                          0
 Data assimilation number of observation types:        1                                          1                                          1
@@ -126,12 +129,23 @@ SMOPS ASCAT use realtime data:                                  1
 SMOPS ASCAT soil moisture use scaled standard deviation model:  0
 SMOPS ASCAT CDF read option:                                    1
 
+# NOTE:  BELOW SETTINGS ARE FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE SMAP_E_OPL ENTRIES BELOW.
 SMAP_E_OPL soil moisture data directory:                      ./input/SMAP_E_OPL/noah39
 SMAP_E_OPL soil moisture use scaled standard deviation model: 0
 SMAP_E_OPL model CDF file:                                   ./input/cdf/noah39_cdf_200obs.nc
 SMAP_E_OPL observation CDF file:                             ./input/cdf/SMAP_cdf_10km_30obs.nc
 SMAP_E_OPL soil moisture number of bins in the CDF:          100
 SMAP_E_OPL CDF read option:                                  1
+
+# NOTE: ALTERNATE SETTINGS FOR SMAP L2.  UNCOMMENT BELOW SETTINGS IF SMAP L2 IS TO BE USED.
+#Data assimilation set:                                "USAFSI"                                "SMOPS-ASCAT soil moisture"             "SMAP(NRT) soil moisture"
+#SMAP(NRT) soil moisture data directory: ./input/SMAP_L2
+#SMAP(NRT) model CDF file:               ./input/cdf/noah39_cdf_200obs.nc
+#SMAP(NRT) observation CDF file:         ./input/cdf/SMAP_cdf_10km_30obs.nc
+#SMAP(NRT) soil moisture number of bins in the CDF:            100
+#SMAP(NRT) soil moisture use scaled standard deviation model:    0
+#SMAP(NRT) CDF read option:
 
 #------------------------DOMAIN SPECIFICATION--------------------------
 #The following options list the choice of parameter maps to be used

--- a/lis/configs/557WW-7.6-FOC/NRT_STREAMFLOW/lis.config.foc.nrt_streamflow.noah39.hymap.76
+++ b/lis/configs/557WW-7.6-FOC/NRT_STREAMFLOW/lis.config.foc.nrt_streamflow.noah39.hymap.76
@@ -145,7 +145,7 @@ SMAP_E_OPL CDF read option:                                  1
 #SMAP(NRT) observation CDF file:         ./input/cdf/SMAP_cdf_10km_30obs.nc
 #SMAP(NRT) soil moisture number of bins in the CDF:            100
 #SMAP(NRT) soil moisture use scaled standard deviation model:    0
-#SMAP(NRT) CDF read option:
+#SMAP(NRT) CDF read option:                                      1
 
 #------------------------DOMAIN SPECIFICATION--------------------------
 #The following options list the choice of parameter maps to be used

--- a/lis/configs/557WW-7.6-FOC/NRT_STREAMFLOW/lis.config.foc.nrt_streamflow.noah39.rapid.76
+++ b/lis/configs/557WW-7.6-FOC/NRT_STREAMFLOW/lis.config.foc.nrt_streamflow.noah39.rapid.76
@@ -71,6 +71,9 @@ Number of application models:           0
 #Data assimilation options
 Number of data assimilation instances:                3
 Data assimilation algorithm:                          "EnKF"                                     "EnKF"                                     "EnKF"
+
+# NOTE:  NEXT LINE IS FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE NEXT LINE.
 Data assimilation set:                                "USAFSI"                                   "SMOPS-ASCAT soil moisture"                "SMAP_E_OPL soil moisture"
 Data assimilation exclude analysis increments:        0                                          0                                          0
 Data assimilation number of observation types:        1                                          1                                          1
@@ -126,12 +129,23 @@ SMOPS ASCAT use realtime data:                                  1
 SMOPS ASCAT soil moisture use scaled standard deviation model:  0
 SMOPS ASCAT CDF read option:                                    1
 
+# NOTE:  BELOW SETTINGS ARE FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE SMAP_E_OPL ENTRIES BELOW.
 SMAP_E_OPL soil moisture data directory:                      ./input/SMAP_E_OPL/noah39
 SMAP_E_OPL soil moisture use scaled standard deviation model: 0
 SMAP_E_OPL model CDF file:                                   ./input/cdf/noah39_cdf_200obs.nc
 SMAP_E_OPL observation CDF file:                             ./input/cdf/SMAP_cdf_10km_30obs.nc
 SMAP_E_OPL soil moisture number of bins in the CDF:          100
 SMAP_E_OPL CDF read option:                                  1
+
+# NOTE: ALTERNATE SETTINGS FOR SMAP L2.  UNCOMMENT BELOW SETTINGS IF SMAP L2 IS TO BE USED.
+#Data assimilation set:                                "USAFSI"                                "SMOPS-ASCAT soil moisture"             "SMAP(NRT) soil moisture"
+#SMAP(NRT) soil moisture data directory: ./input/SMAP_L2
+#SMAP(NRT) model CDF file:               ./input/cdf/noah39_cdf_200obs.nc
+#SMAP(NRT) observation CDF file:         ./input/cdf/SMAP_cdf_10km_30obs.nc
+#SMAP(NRT) soil moisture number of bins in the CDF:            100
+#SMAP(NRT) soil moisture use scaled standard deviation model:    0
+#SMAP(NRT) CDF read option:                                      1
 
 #------------------------DOMAIN SPECIFICATION--------------------------
 #The following options list the choice of parameter maps to be used

--- a/lis/configs/557WW-7.6-FOC/NRT_STREAMFLOW/lis.config.foc.nrt_streamflow.noahmp401.hymap.76
+++ b/lis/configs/557WW-7.6-FOC/NRT_STREAMFLOW/lis.config.foc.nrt_streamflow.noahmp401.hymap.76
@@ -71,6 +71,9 @@ Number of application models:           0
 #Data assimilation options
 Number of data assimilation instances:                3
 Data assimilation algorithm:                          "EnKF"                                     "EnKF"                                     "EnKF"
+
+# NOTE:  NEXT LINE IS FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE NEXT LINE.
 Data assimilation set:                                "USAFSI"                                   "SMOPS-ASCAT soil moisture"                "SMAP_E_OPL soil moisture"
 Data assimilation exclude analysis increments:        0                                          0                                          0
 Data assimilation number of observation types:        1                                          1                                          1
@@ -126,12 +129,23 @@ SMOPS ASCAT use realtime data:                                  1
 SMOPS ASCAT soil moisture use scaled standard deviation model:  0
 SMOPS ASCAT CDF read option:                                    1
 
+# NOTE:  BELOW SETTINGS ARE FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE SMAP_E_OPL ENTRIES BELOW.
 SMAP_E_OPL soil moisture data directory:                      ./input/SMAP_E_OPL/noahmp401
 SMAP_E_OPL soil moisture use scaled standard deviation model: 0
 SMAP_E_OPL model CDF file:                                   ./input/cdf/noahmp401_cdf_200obs.nc
 SMAP_E_OPL observation CDF file:                             ./input/cdf/SMAP_cdf_10km_30obs.nc
 SMAP_E_OPL soil moisture number of bins in the CDF:          100
 SMAP_E_OPL CDF read option:                                  1
+
+# NOTE: ALTERNATE SETTINGS FOR SMAP L2.  UNCOMMENT BELOW SETTINGS IF SMAP L2 IS TO BE USED.
+#Data assimilation set:                                "USAFSI"                                "SMOPS-ASCAT soil moisture"             "SMAP(NRT) soil moisture"
+#SMAP(NRT) soil moisture data directory: ./input/SMAP_L2
+#SMAP(NRT) model CDF file:               ./input/cdf/noahmp401_cdf_200obs.nc
+#SMAP(NRT) observation CDF file:         ./input/cdf/SMAP_cdf_10km_30obs.nc
+#SMAP(NRT) soil moisture number of bins in the CDF:            100
+#SMAP(NRT) soil moisture use scaled standard deviation model:    0
+#SMAP(NRT) CDF read option:                                      1
 
 #------------------------DOMAIN SPECIFICATION--------------------------
 #The following options list the choice of parameter maps to be used

--- a/lis/configs/557WW-7.6-FOC/NRT_STREAMFLOW/lis.config.foc.nrt_streamflow.noahmp401.rapid.76
+++ b/lis/configs/557WW-7.6-FOC/NRT_STREAMFLOW/lis.config.foc.nrt_streamflow.noahmp401.rapid.76
@@ -71,6 +71,9 @@ Number of application models:           0
 #Data assimilation options
 Number of data assimilation instances:                3
 Data assimilation algorithm:                          "EnKF"                                     "EnKF"                                     "EnKF"
+
+# NOTE:  NEXT LINE IS FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE NEXT LINE.
 Data assimilation set:                                "USAFSI"                                   "SMOPS-ASCAT soil moisture"                "SMAP_E_OPL soil moisture"
 Data assimilation exclude analysis increments:        0                                          0                                          0
 Data assimilation number of observation types:        1                                          1                                          1
@@ -126,12 +129,23 @@ SMOPS ASCAT use realtime data:                                  1
 SMOPS ASCAT soil moisture use scaled standard deviation model:  0
 SMOPS ASCAT CDF read option:                                    1
 
+# NOTE:  BELOW SETTINGS ARE FOR ASSIMILATING SMAP_E_OPL RETRIEVALS.  ALTERNATE SETTINGS FOR ASSIMILATING SMAP L2 ARE GIVEN BELOW.
+#        IF SMAP L2 IS TO BE USED, COMMENT OUT THE SMAP_E_OPL ENTRIES BELOW.
 SMAP_E_OPL soil moisture data directory:                      ./input/SMAP_E_OPL/noahmp401
 SMAP_E_OPL soil moisture use scaled standard deviation model: 0
 SMAP_E_OPL model CDF file:                                   ./input/cdf/noahmp401_cdf_200obs.nc
 SMAP_E_OPL observation CDF file:                             ./input/cdf/SMAP_cdf_10km_30obs.nc
 SMAP_E_OPL soil moisture number of bins in the CDF:          100
 SMAP_E_OPL CDF read option:                                  1
+
+# NOTE: ALTERNATE SETTINGS FOR SMAP L2.  UNCOMMENT BELOW SETTINGS IF SMAP L2 IS TO BE USED.
+#Data assimilation set:                                "USAFSI"                                "SMOPS-ASCAT soil moisture"             "SMAP(NRT) soil moisture"
+#SMAP(NRT) soil moisture data directory: ./input/SMAP_L2
+#SMAP(NRT) model CDF file:               ./input/cdf/noahmp401_cdf_200obs.nc
+#SMAP(NRT) observation CDF file:         ./input/cdf/SMAP_cdf_10km_30obs.nc
+#SMAP(NRT) soil moisture number of bins in the CDF:            100
+#SMAP(NRT) soil moisture use scaled standard deviation model:    0
+#SMAP(NRT) CDF read option:                                      1
 
 #------------------------DOMAIN SPECIFICATION--------------------------
 #The following options list the choice of parameter maps to be used


### PR DESCRIPTION

### Description

The FOC files are configured to use SMAP_E_OPL.  New SMAP L2 DA settings are added but commented out. Comments are also aded to make changes to the config files to pivot to SMAP L2 if needed.

