### PR TITLE
Fix to compile LIS with "WRF coupling: Off"

### DIFF
--- a/lis/core/LIS_surfaceModelMod.F90
+++ b/lis/core/LIS_surfaceModelMod.F90
@@ -8,6 +8,7 @@
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
 #include "LIS_misc.h"
+#include "LIS_plugins.h"
 ! Macros for tracing - Requires ESMF 7_1_0+
 #ifdef ESMF_TRACE
 #define TRACE_ENTER(region) call ESMF_TraceRegionEnter(region)
@@ -1171,12 +1172,15 @@ contains
 ! 
 ! !INTERFACE:
   subroutine surfaceModel_setexport_noesmf(n)
+#if (defined RM_WRF_COUPLING)
 ! !USES:    
     use LIS_LMLCMod
     use LISWRFGridCompMod, only : LISWRF_export
     use LIS_historyMod, only : LIS_tile2grid
+#endif
 ! !ARGUMENTS: 
     integer, intent(in) :: n 
+#if (defined RM_WRF_COUPLING)
 ! !DESCRIPTION:
 !
 !EOP
@@ -1237,6 +1241,7 @@ contains
     call LIS_tile2grid(n,LISWRF_export(n)%xland,LISWRF_export(n)%xland_t)
     TRACE_EXIT("sf_setexp")
 
+#endif
   end subroutine surfaceModel_setexport_noesmf
 
 end module LIS_surfaceModelMod

--- a/lis/make/default.cfg
+++ b/lis/make/default.cfg
@@ -1207,12 +1207,13 @@ path: surfacemodels/land/clm2,
       surfacemodels/land/clm2/main,
       surfacemodels/land/clm2/biogeophys,
       surfacemodels/land/clm2/ecosysdyn,
-      surfacemodels/land/clm2/csm_share,
-      surfacemodels/land/clm2/cpl_wrf_noesmf
-dependent_comps: virtual_da
+      surfacemodels/land/clm2/csm_share
+dependent_comps: virtual_da,
+                 WRF coupling
 virtual_da path: surfacemodels/land/clm2/da_lst,
                  surfacemodels/land/clm2/da_snow,
                  surfacemodels/land/clm2/da_soilm
+WRF coupling path: surfacemodels/land/clm2/cpl_wrf_noesmf
 
 [VIC.4.1.1]
 enabled: True
@@ -1684,8 +1685,9 @@ virtual_da path: surfacemodels/land/jules.5.x/da_soilm,
 enabled: True
 macro: SM_CABLE
 path: surfacemodels/land/cable,
-      surfacemodels/land/cable/physics,
-      surfacemodels/land/cable/cpl_wrf_noesmf
+      surfacemodels/land/cable/physics
+dependent_comps: WRF coupling
+WRF coupling path: surfacemodels/land/cable/cpl_wrf_noesmf
 
 [FASST]
 enabled: False


### PR DESCRIPTION
### Description

This fix allows one to compile LIS with `WRF coupling: Off` set in the user.cfg file.

Note that both the GCE coupling runmode and the NUOPC coupling runmode depend on code in the the WRF coupling runmode.  So to use either of those runmodes, you must enable "WRF coupling", which is its default setting.

Note 1) that both the GCE coupling runmode and the NUOPC coupling runmode are not enabled by default and 2) that both require special build commands.




