### PR TITLE
Fix and simplify targets for compiling LIS as library

### DIFF
--- a/lis/make/Makefile
+++ b/lis/make/Makefile
@@ -64,25 +64,11 @@ include ./configure.lis
 LIS: $(OBJS)
 	 $(FC) -o $@ $(OBJS) $(FOPTS) $(LDFLAGS)
 
-LIBTARGET    =  lislib
-TARGETDIR    =  ./
-$(LIBTARGET) : 
-		gmake -i -r lis_contrib ; \
-		$(AR) lislib.a $(OBJS)  ; \
+lislib: $(OBJS)
+	$(AR) ru lislib.a $(OBJS)
 
-LIBTARGET    =  explis
-TARGETDIR    =  ./
-$(LIBTARGET) : 
-		gmake -i -r lis_contrib                  ; \
-		$(AR) -ru ../../main/libwrflib.a $(OBJS) ; \
-
-LIBTARGET    =  gcelis
-TARGETDIR    =  ./
-$(LIBTARGET) : 
-		gmake -i -r lis_contrib ; \
-		$(AR) lislib.a $(OBJS)  ; \
-
-lis_contrib: $(OBJS)
+explis: $(OBJS)
+	$(AR) ru ../../main/libwrflib.a $(OBJS)
 
 .PHONY: debug
 debug:


### PR DESCRIPTION
### Description

`make lislib`, `make gcelis`, and `make explis` are used to compile LIS as a library instead of an executable.  This library used to couple LIS to another system like WRF.

Note that the gcelis target was removed.  It was identical to the lislib target.

Note that the explis target requires a WRF setup.
