### PR TITLE
Add NoahMP groundwater coupling through NUOPC Cap

### DIFF
--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -870,6 +870,11 @@ if ($ENV{WRF_HYDRO} eq '1') {
    $use_wrf_hydro = 1;
 }
 
+# PARFLOW does not prompt user
+if ($ENV{PARFLOW} eq '1') {
+   $use_parflow = 1;
+}
+
 # MPDECOMP2 does not prompt user
 if ($ENV{MPDECOMP2} eq '1') {
    $use_mpdecomp2 = 1;
@@ -1083,6 +1088,11 @@ if($use_esmf_trace == 1){
 if ($use_wrf_hydro == 1) {
    $fflags77 = $fflags77." -DWRF_HYDRO";
    $fflags = $fflags." -DWRF_HYDRO";
+}
+
+if ($use_parflow == 1) {
+   $fflags77 = $fflags77." -DPARFLOW";
+   $fflags = $fflags." -DPARFLOW";
 }
 
 if ($use_mpdecomp2 == 1) {

--- a/lis/core/LIS_coreMod.F90
+++ b/lis/core/LIS_coreMod.F90
@@ -885,13 +885,13 @@ contains
     deallocate(LIS_patch_deltas)
     if ( fin_esmf ) then
        call ESMF_Finalize(endflag=ESMF_END_KEEPMPI, rc=ierr)
-    endif
 #if ( defined COUPLED)
 #else
 #if ( defined SPMD )
     call MPI_FINALIZE(ierr)
 #endif
 #endif
+    endif
   end subroutine spmd_finalize
 
 !BOP

--- a/lis/core/LIS_histDataMod.F90
+++ b/lis/core/LIS_histDataMod.F90
@@ -426,6 +426,9 @@ module LIS_histDataMod
   public ::   LIS_MOC_CHV2    
   public ::   LIS_MOC_CHB2    
   public ::   LIS_MOC_FPICE   
+  public ::   LIS_MOC_QINSUR
+  public ::   LIS_MOC_ETRANI
+  public ::   LIS_MOC_WTRFLX
   ! end Noahmp
  
   ! RUC 
@@ -933,6 +936,9 @@ module LIS_histDataMod
     integer ::  LIS_MOC_CHV2    = -9999
     integer ::  LIS_MOC_CHB2    = -9999
     integer ::  LIS_MOC_FPICE   = -9999
+    integer ::  LIS_MOC_QINSUR = -9999
+    integer ::  LIS_MOC_ETRANI = -9999
+    integer ::  LIS_MOC_WTRFLX = -9999
 !  <- end Noah MP  ->
 
 !   <- RUC -> 
@@ -4988,6 +4994,42 @@ contains
         call register_dataEntry(LIS_MOC_LSM_COUNT, LIS_MOC_FPICE, &
             LIS_histData(n)%head_lsm_list,&
             n, 1, ntiles,(/"-"/), 1, (/"-"/),1,1,1,&
+            model_patch=.true.)
+    endif
+
+    Call ESMF_ConfigFindLabel(modelSpecConfig, "QInSur:", rc = rc)
+    Call get_moc_attributes(modelSpecConfig, LIS_histData(n)%head_lsm_list, &
+         "QInSur",&
+         "water_input_soil",&
+         "water input on soil surface",rc)
+    if ( rc == 1 ) then
+       call register_dataEntry(LIS_MOC_LSM_COUNT, LIS_MOC_QINSUR, &
+            LIS_histData(n)%head_lsm_list,&
+            n, 2, ntiles,(/"kg/m2s","kg/m2 "/),2,(/"UP","DN"/),2,1,1,&
+            model_patch=.true.)
+    endif
+
+    Call ESMF_ConfigFindLabel(modelSpecConfig, "ETranI:", rc = rc)
+    Call get_moc_attributes(modelSpecConfig, LIS_histData(n)%head_lsm_list, &
+         "ETranI",&
+         "transpiration_rate_soil",&
+         "transpiration rate soil",rc)
+    if ( rc == 1 ) then
+       call register_dataEntry(LIS_MOC_LSM_COUNT, LIS_MOC_ETRANI, &
+            LIS_histData(n)%head_lsm_list,&
+            n, 3, ntiles,(/"kg/m2s","mm/hr ","W/m2  "/),2,(/"UP","DN"/),2,1,1,&
+            model_patch=.true.)
+    endif
+
+    Call ESMF_ConfigFindLabel(modelSpecConfig, "WtrFlx:", rc = rc)
+    Call get_moc_attributes(modelSpecConfig, LIS_histData(n)%head_lsm_list, &
+         "WtrFlx",&
+         "total_water_flux",&
+         "total water flux",rc)
+    if ( rc == 1 ) then
+       call register_dataEntry(LIS_MOC_LSM_COUNT, LIS_MOC_WTRFLX, &
+            LIS_histData(n)%head_lsm_list,&
+            n, 2, ntiles,(/"kg/m2s","kg/m2 "/),2,(/"UP","DN"/),2,1,1,&
             model_patch=.true.)
     endif
     !<- end NoahMP ->

--- a/lis/core/LIS_runmode_FTable.c
+++ b/lis/core/LIS_runmode_FTable.c
@@ -42,6 +42,24 @@ struct rmoderunnode
 } ;
 struct rmoderunnode* rmoderun_table = NULL; 
 
+struct rmodestepnode
+{
+  char *name;
+  void (*func)();
+
+  struct rmodestepnode* next;
+} ;
+struct rmodestepnode* rmodestep_table = NULL;
+
+struct rmoderesetnode
+{
+  char *name;
+  void (*func)();
+
+  struct rmoderesetnode* next;
+} ;
+struct rmoderesetnode* rmodereset_table = NULL;
+
 struct rmodefinalnode
 { 
   char *name;
@@ -200,6 +218,155 @@ void FTN(lisrun)(char *j,int len)
     }
   }
   current->func(); 
+}
+
+//BOP
+// !ROUTINE: registerlisstep
+// \label{registerlisstep}
+//
+// !INTERFACE:
+void FTN(registerlisstep)(char *j, void (*func)(),int len)
+//
+// !DESCRIPTION:
+//  Makes an entry in the registry for the LIS
+//  single step run method for a certain running mode.
+//
+// The arguments are:
+// \begin{description}
+//  \item[j]
+//   name of the running mode
+// \end{description}
+//EOP
+{
+  int len1;
+  struct rmodestepnode* current;
+  struct rmodestepnode* pnode;
+  // create node
+
+  len1 = len + 1; // ensure that there is space for terminating null
+  pnode=(struct rmodestepnode*) malloc(sizeof(struct rmodestepnode));
+  pnode->name=(char*) calloc(len1,sizeof(char));
+  strncpy(pnode->name,j,len);
+  pnode->func = func;
+  pnode->next = NULL;
+
+  if(rmodestep_table == NULL){
+    rmodestep_table = pnode;
+  }
+  else{
+    current = rmodestep_table;
+    while(current->next!=NULL){
+      current = current->next;
+    }
+    current->next = pnode;
+  }
+}
+//BOP
+// !ROUTINE: lisstep
+// \label{lisstep}
+//
+// !INTERFACE:
+void FTN(lisstep)(char *j,int len)
+//
+// !DESCRIPTION:
+//  Invokes the LIS single step run method from the registry
+//  for the specified running mode
+//
+// The arguments are:
+// \begin{description}
+//  \item[j]
+//   name of the running mode
+// \end{description}
+//EOP
+{
+  struct rmodestepnode* current;
+
+  current = rmodestep_table;
+  while(strcmp(current->name,j)!=0){
+    current = current->next;
+    if(current==NULL) {
+      printf("****************Error****************************\n");
+      printf("run step routine for runmode %s is not defined\n",j);
+      printf("program will seg fault.....\n");
+      printf("****************Error****************************\n");
+    }
+  }
+  current->func();
+}
+
+
+//BOP
+// !ROUTINE: registerlisreset
+// \label{registerlisreset}
+//
+// !INTERFACE:
+void FTN(registerlisreset)(char *j, void (*func)(),int len)
+//
+// !DESCRIPTION:
+//  Makes an entry in the registry for the LIS
+//  reset run method for a certain running mode.
+//
+// The arguments are:
+// \begin{description}
+//  \item[j]
+//   name of the running mode
+// \end{description}
+//EOP
+{
+  int len1;
+  struct rmoderesetnode* current;
+  struct rmoderesetnode* pnode;
+  // create node
+
+  len1 = len + 1; // ensure that there is space for terminating null
+  pnode=(struct rmoderesetnode*) malloc(sizeof(struct rmoderesetnode));
+  pnode->name=(char*) calloc(len1,sizeof(char));
+  strncpy(pnode->name,j,len);
+  pnode->func = func;
+  pnode->next = NULL;
+
+  if(rmodereset_table == NULL){
+    rmodereset_table = pnode;
+  }
+  else{
+    current = rmodereset_table;
+    while(current->next!=NULL){
+      current = current->next;
+    }
+    current->next = pnode;
+  }
+}
+//BOP
+// !ROUTINE: lisreset
+// \label{lisreset}
+//
+// !INTERFACE:
+void FTN(lisreset)(char *j,int len)
+//
+// !DESCRIPTION:
+//  Invokes the LIS reset run method from the registry
+//  for the specified running mode
+//
+// The arguments are:
+// \begin{description}
+//  \item[j]
+//   name of the running mode
+// \end{description}
+//EOP
+{
+  struct rmoderesetnode* current;
+
+  current = rmodereset_table;
+  while(strcmp(current->name,j)!=0){
+    current = current->next;
+    if(current==NULL) {
+      printf("****************Error****************************\n");
+      printf("reset run routine for runmode %s is not defined\n",j);
+      printf("program will seg fault.....\n");
+      printf("****************Error****************************\n");
+    }
+  }
+  current->func();
 }
 
 //BOP

--- a/lis/plugins/LIS_lsmcpl_pluginMod.F90
+++ b/lis/plugins/LIS_lsmcpl_pluginMod.F90
@@ -216,6 +216,9 @@ subroutine LIS_lsmcpl_plugin
     call registerlsmcplsetexport(trim(LIS_noah33Id)//"+"//&
                                  trim(LIS_retroId)//char(0), &
                                  noah33_setwrfexport)
+    call registerlsmcplsetexport(trim(LIS_noah33Id)//"+"//&
+                                 trim(LIS_smootherDAId)//char(0), &
+                                 noah33_setwrfexport)
 #endif
 
 #if ( defined SM_NOAHMP_3_6 )
@@ -228,6 +231,9 @@ subroutine LIS_lsmcpl_plugin
     call registerlsmcplsetexport(trim(LIS_noahmp36Id)//"+"//&
                                  trim(LIS_retroId)//char(0), &
                                  noahMP36_setwrfexport)
+    call registerlsmcplsetexport(trim(LIS_noahmp36Id)//"+"//&
+                                 trim(LIS_smootherDAId)//char(0), &
+                                 noahMP36_setwrfexport)
 #endif
 
 #if ( defined SM_NOAHMP_4_0_1 )
@@ -239,6 +245,9 @@ subroutine LIS_lsmcpl_plugin
                                  noahMP401_setwrfexport)
     call registerlsmcplsetexport(trim(LIS_noahmp401Id)//"+"//&
                                  trim(LIS_retroId)//char(0), &
+                                 noahMP401_setwrfexport)
+    call registerlsmcplsetexport(trim(LIS_noahmp401Id)//"+"//&
+                                 trim(LIS_smootherDAId)//char(0), &
                                  noahMP401_setwrfexport)
 #endif
 

--- a/lis/plugins/LIS_runmode_pluginMod.F90
+++ b/lis/plugins/LIS_runmode_pluginMod.F90
@@ -95,8 +95,9 @@ subroutine LIS_runmode_plugin
    use LIS_pluginIndices
 
 #if ( defined RM_RETROSPECTIVE )
-   use retrospective_runMod,  only : lis_init_retrospective, &
-                                     lis_run_retrospective,  &
+   use retrospective_runMod,  only : lis_init_retrospective,  &
+                                     lis_run_retrospective,   &
+                                     lis_step_retrospective, &
                                      lis_final_retrospective
 #endif
 
@@ -119,8 +120,10 @@ subroutine LIS_runmode_plugin
 #endif
 
 #if ( defined RM_ENSEMBLE_SMOOTHER )
-   use smootherDA_runMod,     only : lis_init_smootherDA, &
-                                     lis_run_smootherDA,  &
+   use smootherDA_runMod,     only : lis_init_smootherDA,  &
+                                     lis_run_smootherDA,   &
+                                     lis_step_smootherDA, &
+                                     lis_reset_smootherDA, &
                                      lis_final_smootherDA
 #endif
 
@@ -134,6 +137,7 @@ subroutine LIS_runmode_plugin
 #if ( defined RM_RETROSPECTIVE )
    call registerlisinit(trim(LIS_retroId)//char(0),lis_init_retrospective)
    call registerlisrun(trim(LIS_retroId)//char(0),lis_run_retrospective)
+   call registerlisstep(trim(LIS_retroId)//char(0),lis_step_retrospective)
    call registerlisfinalize(trim(LIS_retroId)//char(0),lis_final_retrospective)
 #endif
 
@@ -160,6 +164,8 @@ subroutine LIS_runmode_plugin
 #if ( defined RM_ENSEMBLE_SMOOTHER )
    call registerlisinit(trim(LIS_smootherDAId)//char(0),lis_init_smootherDA)
    call registerlisrun(trim(LIS_smootherDAId)//char(0),lis_run_smootherDA)
+   call registerlisstep(trim(LIS_smootherDAId)//char(0),lis_step_smootherDA)
+   call registerlisreset(trim(LIS_smootherDAId)//char(0),lis_reset_smootherDA)
    call registerlisfinalize(trim(LIS_smootherDAId)//char(0), &
                             lis_final_smootherDA)
 #endif

--- a/lis/runmodes/nuopc_cpl_mode/LIS_NUOPC_DataCopy.F90
+++ b/lis/runmodes/nuopc_cpl_mode/LIS_NUOPC_DataCopy.F90
@@ -2358,6 +2358,7 @@ contains
           do tile=1,LIS_rc%ntiles(nest)
             col = LIS_domain(nest)%tile(tile)%col
             row = LIS_domain(nest)%tile(tile)%row
+            ens = LIS_domain(nest)%tile(tile)%ensem
             if (farray(col,row,ens) .ne. real(MISSINGVALUE,ESMF_KIND_FIELD)) then
               NoahMP36_struc(nest)%noahmp36(tile)%sh2o(3) = farray(col,row,ens)
             endif
@@ -2497,6 +2498,7 @@ contains
           do tile=1,LIS_rc%ntiles(nest)
             col = LIS_domain(nest)%tile(tile)%col
             row = LIS_domain(nest)%tile(tile)%row
+            ens = LIS_domain(nest)%tile(tile)%ensem
             NoahMP36_struc(nest)%noahmp36(tile)%sh2o(3) = farray(col,row,ens)
           enddo
         case ('liquid_fraction_of_soil_moisture_layer_4')

--- a/lis/runmodes/nuopc_cpl_mode/LIS_NUOPC_Gluecode.F90
+++ b/lis/runmodes/nuopc_cpl_mode/LIS_NUOPC_Gluecode.F90
@@ -227,7 +227,7 @@ module LIS_NUOPC_Gluecode
     type(LIS_FieldHookup), allocatable :: hookup(:)
   end type
 
-  type(LIS_Field),dimension(78)  :: LIS_FieldList = (/ &
+  type(LIS_Field),dimension(83)  :: LIS_FieldList = (/ &
     LIS_Field(stdName='2m_air_temperature', &
       stateName='t2_f', &
       ampValue=1.d0, meanValue=0.d0, &
@@ -546,7 +546,27 @@ module LIS_NUOPC_Gluecode
    LIS_Field(stdName='accum_plant_transpiration', &
       stateName='ett', &
       ampValue=1.d0, meanValue=0.d0, &
-      units='W m-2',transferOffer='will provide')/)
+      units='W m-2',transferOffer='will provide'), &
+   LIS_Field(stdName='total_water_flux_layer_1', &
+      stateName='wtrflx1', &
+      ampValue=1.d0, meanValue=0.d0, &
+      units='kg m-2 s-1',transferOffer='will provide'), &
+   LIS_Field(stdName='total_water_flux_layer_2', &
+      stateName='wtrflx2', &
+      ampValue=1.d0, meanValue=0.d0, &
+      units='kg m-2 s-1',transferOffer='will provide'), &
+   LIS_Field(stdName='total_water_flux_layer_3', &
+      stateName='wtrflx3', &
+      ampValue=1.d0, meanValue=0.d0, &
+      units='kg m-2 s-1',transferOffer='will provide'), &
+   LIS_Field(stdName='total_water_flux_layer_4', &
+      stateName='wtrflx4', &
+      ampValue=1.d0, meanValue=0.d0, &
+      units='kg m-2 s-1',transferOffer='will provide'), &
+   LIS_Field(stdName='ground_water_storage', &
+      stateName='wa', &
+      ampValue=1.d0, meanValue=0.d0, &
+      units='mm',transferOffer='will provide')/)
 
 !EOP
 
@@ -616,7 +636,7 @@ contains
 
     if(.not.LIS_initialized) then
        if (present(configFile)) LIS_rc%lis_config_file = trim(configFile)
-       call LIS_config_init(vm=vm) ! "retrospective"
+       call LIS_config_init(vm=vm)
        call LIS_domain_init
        call LIS_createTmnUpdate
        call LIS_param_init
@@ -625,7 +645,7 @@ contains
 
        LIS_rc%met_nf(:) = 9 ! WRFout sets to 17
 
-       call LIS_metforcing_init            ! "retrospective"
+       call LIS_metforcing_init
        call LIS_irrigation_init
        call LIS_initDAObservations
        call LIS_routing_init
@@ -1680,6 +1700,49 @@ contains
           LIS_FieldList(fIndex)%adExport=.TRUE.
           LIS_FieldList(fIndex)%hookup(nIndex)%exportArray=>LISWRF_export(nIndex)%soldrain
           LIS_FieldList(fIndex)%hookup(nIndex)%exportArray_t=>LISWRF_export(nIndex)%soldrain_t
+#endif
+#ifdef PARFLOW
+        case ('total_water_flux_layer_1')              ! (?)
+!          if (allocated(#NOTAVAILABLE#%varname)) &
+!            LIS_FieldList(fIndex)%lisForcVarname=#NOTAVAILABLE#%varname(1)
+!          LIS_FieldList(fIndex)%reqImport=(#NOTAVAILABLE#%selectOpt == 1)
+!          LIS_FieldList(fIndex)%adImport=.FALSE.
+          LIS_FieldList(fIndex)%adExport=.TRUE.
+          LIS_FieldList(fIndex)%hookup(nIndex)%exportArray=>LISWRF_export(nIndex)%wtrflx1
+          LIS_FieldList(fIndex)%hookup(nIndex)%exportArray_t=>LISWRF_export(nIndex)%wtrflx1_t
+        case ('total_water_flux_layer_2')              ! (?)
+!          if (allocated(#NOTAVAILABLE#%varname)) &
+!            LIS_FieldList(fIndex)%lisForcVarname=#NOTAVAILABLE#%varname(1)
+!          LIS_FieldList(fIndex)%reqImport=(#NOTAVAILABLE#%selectOpt == 1)
+!          LIS_FieldList(fIndex)%adImport=.FALSE.
+          LIS_FieldList(fIndex)%adExport=.TRUE.
+          LIS_FieldList(fIndex)%hookup(nIndex)%exportArray=>LISWRF_export(nIndex)%wtrflx2
+          LIS_FieldList(fIndex)%hookup(nIndex)%exportArray_t=>LISWRF_export(nIndex)%wtrflx2_t
+        case ('total_water_flux_layer_3')              ! (?)
+!          if (allocated(#NOTAVAILABLE#%varname)) &
+!            LIS_FieldList(fIndex)%lisForcVarname=#NOTAVAILABLE#%varname(1)
+!          LIS_FieldList(fIndex)%reqImport=(#NOTAVAILABLE#%selectOpt == 1)
+!          LIS_FieldList(fIndex)%adImport=.FALSE.
+          LIS_FieldList(fIndex)%adExport=.TRUE.
+          LIS_FieldList(fIndex)%hookup(nIndex)%exportArray=>LISWRF_export(nIndex)%wtrflx3
+          LIS_FieldList(fIndex)%hookup(nIndex)%exportArray_t=>LISWRF_export(nIndex)%wtrflx3_t
+        case ('total_water_flux_layer_4')              ! (?)
+!          if (allocated(#NOTAVAILABLE#%varname)) &
+!            LIS_FieldList(fIndex)%lisForcVarname=#NOTAVAILABLE#%varname(1)
+!          LIS_FieldList(fIndex)%reqImport=(#NOTAVAILABLE#%selectOpt == 1)
+!          LIS_FieldList(fIndex)%adImport=.FALSE.
+          LIS_FieldList(fIndex)%adExport=.TRUE.
+          LIS_FieldList(fIndex)%hookup(nIndex)%exportArray=>LISWRF_export(nIndex)%wtrflx4
+          LIS_FieldList(fIndex)%hookup(nIndex)%exportArray_t=>LISWRF_export(nIndex)%wtrflx4_t
+        case ('ground_water_storage')              ! (?)
+!          if (allocated(#NOTAVAILABLE#%varname)) &
+!            LIS_FieldList(fIndex)%lisForcVarname=#NOTAVAILABLE#%varname(1)
+          LIS_FieldList(fIndex)%adImport = .TRUE.
+          LIS_FieldList(fIndex)%directConn = .TRUE.
+          LIS_FieldList(fIndex)%sharedMem = .TRUE.
+!          LIS_FieldList(fIndex)%adExport=.FALSE.
+!          LIS_FieldList(fIndex)%hookup(nIndex)%exportArray=>LISWRF_export(nIndex)%%#NOTAVAILABLE#
+!          LIS_FieldList(fIndex)%hookup(nIndex)%exportArray_t=>LISWRF_export(nIndex)%%#NOTAVAILABLE#_t
 #endif
 #ifdef GSM_EXTLND
         case ('accum_plant_transpiration')              ! (77)

--- a/lis/runmodes/nuopc_cpl_mode/LIS_NUOPC_Gluecode.F90
+++ b/lis/runmodes/nuopc_cpl_mode/LIS_NUOPC_Gluecode.F90
@@ -650,12 +650,7 @@ contains
 !EOP
 !
 ! !LOCAL VARIABLES:
-    type(ESMF_Time)             :: currTime
-    type(ESMF_Time)             :: stopTime
-    type(ESMF_TimeInterval)     :: timeStep
-    integer                     :: yy, mm, dd, h, m, s
-
-    ! used for field conversions
+    type(ESMF_TimeInterval)        :: timeStep
     type(ESMF_StateItem_Flag)      :: itemType
     type(ESMF_Grid)                :: grid
     type(ESMF_Field)               :: exportField
@@ -663,7 +658,6 @@ contains
     integer                        :: elb(2), eub(2)
     integer                        :: i, j
     integer                        :: timeStepSecs
-
     integer                        :: sIndex
 
     rc = ESMF_SUCCESS
@@ -671,19 +665,6 @@ contains
 #ifdef DEBUG
     call ESMF_LogWrite(MODNAME//": entered "//METHOD, ESMF_LOGMSG_INFO)
 #endif
-
-    ! use incoming clock
-    call ESMF_ClockGet(clock, currTime=currTime, timeStep=timeStep, rc=rc)
-    if(ESMF_STDERRORCHECK(rc)) return
-
-    ! LIS time manager expects end of the interval
-    stopTime = currTime + timeStep
-
-    ! Confirm if the timemgr should receive current time or stop time
-    call ESMF_TimeGet(stopTime, yy=yy, mm=mm, dd=dd, h=h, m=m, s=s, rc=rc)
-    if(ESMF_STDERRORCHECK(rc)) return
-
-    call LIS_timemgr_set(LIS_rc, yy, mm, dd, h, m, s, 0, 0.0)
 
     T_ENTER("datacopy")
     do sIndex=1, size(impStateList)
@@ -694,6 +675,8 @@ contains
 
     call lisstep(trim(LIS_rc%runmode)//char(0))
 
+    call ESMF_ClockGet(clock, timeStep=timeStep, rc=rc)
+    if(ESMF_STDERRORCHECK(rc)) return
     call ESMF_TimeIntervalGet(timeStep, s=timeStepSecs, rc=rc)
     if(ESMF_STDERRORCHECK(rc)) return
 

--- a/lis/runmodes/nuopc_cpl_mode/Makefile
+++ b/lis/runmodes/nuopc_cpl_mode/Makefile
@@ -143,6 +143,17 @@ override ESMF_CXXCOMPILECPPFLAGS += -DWRF_HYDRO
 endif
 endif
 
+# #################################
+# Compile with PARFLOW directives
+# #################################
+
+ifneq ($(PARFLOW),)
+ifneq ($(PARFLOW),0)
+override ESMF_F90COMPILECPPFLAGS += -DPARFLOW
+override ESMF_CXXCOMPILECPPFLAGS += -DPARFLOW
+endif
+endif
+
 # ##################################
 # Compile with GSM_EXTLND directives
 # ##################################

--- a/lis/runmodes/retrospective/retrospective_runMod.F90
+++ b/lis/runmodes/retrospective/retrospective_runMod.F90
@@ -111,9 +111,7 @@ contains
 ! !INTERFACE:
   subroutine lis_run_retrospective
 ! !USES:
-    use LIS_coreMod,           only : LIS_rc, LIS_endofrun, &
-                                      LIS_ticktime
-    use LIS_logMod,            only : LIS_logunit
+    use LIS_coreMod,           only : LIS_rc, LIS_endofrun
 !
 ! !DESCRIPTION:
 !
@@ -128,9 +126,7 @@ contains
     integer :: n
 
     do while (.NOT. LIS_endofrun())
-       call LIS_ticktime
        call lis_step_retrospective()
-       flush(LIS_logunit)
     enddo
   end subroutine lis_run_retrospective
 
@@ -140,7 +136,7 @@ contains
 ! !INTERFACE:
   subroutine lis_step_retrospective
 ! !USES:
-    use LIS_coreMod,           only : LIS_rc, LIS_timetoRunNest
+    use LIS_coreMod,           only : LIS_rc, LIS_ticktime, LIS_timetoRunNest
     use LIS_surfaceModelMod,   only : LIS_surfaceModel_f2t, LIS_surfaceModel_run,&
                                       LIS_surfaceModel_output, LIS_surfaceModel_writerestart, &
                                       LIS_surfaceModel_perturb_states
@@ -155,6 +151,7 @@ contains
     use LIS_irrigationMod,     only : LIS_irrigation_run,LIS_irrigation_output
     use LIS_appMod,            only : LIS_runAppModel, LIS_outputAppModel
     use LIS_RTMMod,            only : LIS_RTM_run, LIS_RTM_output
+    use LIS_logMod,            only : LIS_logunit
 !
 ! !DESCRIPTION:
 ! 
@@ -212,6 +209,8 @@ contains
 !EOP
     integer :: n
 
+    call LIS_ticktime
+
 ! Run each nest separately
     do n=1,LIS_rc%nnest
        if(LIS_timeToRunNest(n)) then
@@ -239,6 +238,7 @@ contains
           call LIS_outputAppModel(n)
        endif
     enddo
+    flush(LIS_logunit)
   end subroutine lis_step_retrospective
 
 !BOP

--- a/lis/runmodes/retrospective/retrospective_runMod.F90
+++ b/lis/runmodes/retrospective/retrospective_runMod.F90
@@ -24,6 +24,7 @@ module retrospective_runMod
 !   
 ! !REVISION HISTORY: 
 !  21Oct05    Sujay Kumar  Initial Specification
+!  25Feb25    Dan Rosen    Add Step Subroutine
 ! 
 !
   implicit none
@@ -34,6 +35,7 @@ module retrospective_runMod
 !-----------------------------------------------------------------------------
   public :: LIS_init_retrospective  !init method for retrospective mode
   public :: LIS_run_retrospective   !run method for retrospective mode
+  public :: LIS_step_retrospective  !step method for retrospective mode
   public :: LIS_final_retrospective !finalize method for retrospective mode
 
 !EOP  
@@ -109,8 +111,36 @@ contains
 ! !INTERFACE:
   subroutine lis_run_retrospective
 ! !USES:
-    use LIS_coreMod,           only : LIS_rc, LIS_endofrun, LIS_timetoRunNest, &
+    use LIS_coreMod,           only : LIS_rc, LIS_endofrun, &
                                       LIS_ticktime
+    use LIS_logMod,            only : LIS_logunit
+!
+! !DESCRIPTION:
+!
+!  This is the run method for LIS in a retrospective running mode.
+!  The following calls are invoked from this method.
+! \begin{description}
+!  \item[LIS\_endofrun] (\ref{LIS_endofrun}) \newline
+!    check to see if the end of simulation has reached
+! \end{description}
+!
+!EOP
+    integer :: n
+
+    do while (.NOT. LIS_endofrun())
+       call LIS_ticktime
+       call lis_step_retrospective()
+       flush(LIS_logunit)
+    enddo
+  end subroutine lis_run_retrospective
+
+!BOP
+! !ROUTINE: lis_step_retrospective
+!
+! !INTERFACE:
+  subroutine lis_step_retrospective
+! !USES:
+    use LIS_coreMod,           only : LIS_rc, LIS_timetoRunNest
     use LIS_surfaceModelMod,   only : LIS_surfaceModel_f2t, LIS_surfaceModel_run,&
                                       LIS_surfaceModel_output, LIS_surfaceModel_writerestart, &
                                       LIS_surfaceModel_perturb_states
@@ -125,15 +155,12 @@ contains
     use LIS_irrigationMod,     only : LIS_irrigation_run,LIS_irrigation_output
     use LIS_appMod,            only : LIS_runAppModel, LIS_outputAppModel
     use LIS_RTMMod,            only : LIS_RTM_run, LIS_RTM_output
-    use LIS_logMod,            only : LIS_logunit
 !
 ! !DESCRIPTION:
 ! 
-!  This is the run method for LIS in a retrospective running mode. 
+!  This is the step method for LIS in a retrospective running mode.
 !  The following calls are invoked from this method. 
 ! \begin{description} 
-!  \item[LIS\_endofrun] (\ref{LIS_endofrun}) \newline
-!    check to see if the end of simulation has reached
 !  \item[LIS\_ticktime] (\ref{LIS_ticktime}) \newline
 !    advance model clock
 !  \item[LIS\_timeToRunNest] (\ref{LIS_timeToRunNest}) \newline
@@ -185,38 +212,34 @@ contains
 !EOP
     integer :: n
 
-    do while (.NOT. LIS_endofrun())
-! Run each nest separately 
-       call LIS_ticktime 
-       do n=1,LIS_rc%nnest
-          if(LIS_timeToRunNest(n)) then 
-             call LIS_setDynparams(n)
-             call LIS_get_met_forcing(n)
-             call LIS_perturb_forcing(n)
-             call LIS_irrigation_run(n)
-             call LIS_surfaceModel_f2t(n)  
-             call LIS_surfaceModel_run(n)
-             call LIS_surfaceModel_perturb_states(n)
-             call LIS_readDAobservations(n)
-             call LIS_perturb_DAobservations(n)   
-             call LIS_perturb_writerestart(n)
-             call LIS_dataassim_run(n)
-             call LIS_dataassim_output(n)
-             call LIS_surfaceModel_output(n)
-             call LIS_surfaceModel_writerestart(n)
-             call LIS_irrigation_output(n)
-             call LIS_routing_run(n)
-             call LIS_routing_writeoutput(n)
-             call LIS_routing_writerestart(n)
-             call LIS_RTM_run(n)
-             call LIS_RTM_output(n)
-             call LIS_runAppModel(n)             
-             call LIS_outputAppModel(n)
-          endif
-       enddo
-       flush(LIS_logunit)
+! Run each nest separately
+    do n=1,LIS_rc%nnest
+       if(LIS_timeToRunNest(n)) then
+          call LIS_setDynparams(n)
+          call LIS_get_met_forcing(n)
+          call LIS_perturb_forcing(n)
+          call LIS_irrigation_run(n)
+          call LIS_surfaceModel_f2t(n)
+          call LIS_surfaceModel_run(n)
+          call LIS_surfaceModel_perturb_states(n)
+          call LIS_readDAobservations(n)
+          call LIS_perturb_DAobservations(n)
+          call LIS_perturb_writerestart(n)
+          call LIS_dataassim_run(n)
+          call LIS_dataassim_output(n)
+          call LIS_surfaceModel_output(n)
+          call LIS_surfaceModel_writerestart(n)
+          call LIS_irrigation_output(n)
+          call LIS_routing_run(n)
+          call LIS_routing_writeoutput(n)
+          call LIS_routing_writerestart(n)
+          call LIS_RTM_run(n)
+          call LIS_RTM_output(n)
+          call LIS_runAppModel(n)
+          call LIS_outputAppModel(n)
+       endif
     enddo
-  end subroutine lis_run_retrospective
+  end subroutine lis_step_retrospective
 
 !BOP
 ! !ROUTINE: lis_final_retrospective

--- a/lis/runmodes/smootherDA/smootherDA_runMod.F90
+++ b/lis/runmodes/smootherDA/smootherDA_runMod.F90
@@ -19,6 +19,7 @@ module smootherDA_runMod
 !   
 ! !REVISION HISTORY: 
 !  21Oct05    Sujay Kumar  Initial Specification
+!  25Feb25    Dan Rosen    Add Step and Reset Subroutines
 ! 
 !
   use ESMF
@@ -30,6 +31,8 @@ module smootherDA_runMod
 !-----------------------------------------------------------------------------
   public :: lis_init_smootherDA  !init method for optimization-uncertainty modeling mode
   public :: lis_run_smootherDA   !run method for optimization-uncertainty modeling mode
+  public :: lis_step_smootherDA  !step method for optimization-uncertainty modeling mode
+  public :: lis_reset_smootherDA !reset method for optimization-uncertainty modeling mode
   public :: lis_final_smootherDA !finalize method for optimization-uncertainty modeling mode
 !EOP  
 contains
@@ -97,6 +100,8 @@ contains
     call LIS_routing_readrestart
     call LIS_core_init
 
+    LIS_rc%DAincrMode(:) = 0
+
   end subroutine lis_init_smootherDA
 
 !BOP
@@ -104,6 +109,41 @@ contains
 !
 ! !INTERFACE:
   subroutine lis_run_smootherDA
+! !USES:
+    use LIS_coreMod
+    use LIS_timeMgrMod
+    use LIS_logMod
+
+!
+! !DESCRIPTION:
+!
+!  This is the run method for LIS in a smootherDA running mode.
+!
+!  NOTES:
+!  If the endtime is set to exactly the beginning of a month,
+!  the GRACE analysis will not be applied to the last month
+!  of the simulation. The recommended workaround is to specify
+!  the end time to be not exactly at the end of the month.
+!
+!EOP
+    integer           :: n
+
+    do while (.NOT. LIS_endofrun())
+       do while(.NOT.LIS_endofTimeWindow())
+          call LIS_ticktime
+          call lis_step_smootherDA
+          flush(LIS_logunit)
+       enddo
+       call lis_reset_smootherDA()
+    enddo
+
+  end subroutine lis_run_smootherDA
+
+!BOP
+! !ROUTINE: lis_step_smootherDA
+!
+! !INTERFACE:
+  subroutine lis_step_smootherDA
 ! !USES:
     use LIS_coreMod
     use LIS_timeMgrMod
@@ -116,56 +156,67 @@ contains
     use LIS_dataAssimMod
     use LIS_routingMod
     use LIS_irrigationMod
-    use LIS_logMod
 
 !
 ! !DESCRIPTION:
-! 
-!  This is the run method for LIS in a smootherDA running mode. 
+!
+!  This is the step method for LIS in a smootherDA running mode.
 !
 !  NOTES: 
-!  If the endtime is set to exactly the beginning of a month, 
-!  the GRACE analysis will not be applied to the last month
-!  of the simulation. The recommended workaround is to specify
-!  the end time to be not exactly at the end of the month. 
 !
 !EOP
     integer           :: n 
 
-    LIS_rc%DAincrMode(:) = 0 
-    
-    call LIS_surfaceModel_readrestart
-    do while (.NOT. LIS_endofrun())
-       do while(.NOT.LIS_endofTimeWindow())
-          call LIS_ticktime
-          do n=1,LIS_rc%nnest
-             if(LIS_timeToRunNest(n)) then
-                call LIS_setDynparams(n)
-                call LIS_get_met_forcing(n)
-                call LIS_perturb_forcing(n)
-                call LIS_irrigation_run(n)
-                call LIS_surfaceModel_f2t(n)  
-                call LIS_surfaceModel_run(n)
-                call LIS_surfaceModel_diagnoseVarsForDA(n)
-                call LIS_surfaceModel_perturb_states(n)
-                call LIS_readDAobservations(n)
-                call LIS_perturb_DAobservations(n)
-                call LIS_perturb_writerestart(n)
-                call LIS_dataassim_run(n)
-                call LIS_dataassim_output(n)
-                call LIS_surfaceModel_output(n)  
-                call LIS_surfaceModel_writerestart(n)
-                call LIS_irrigation_output(n)
-                call LIS_routing_run(n)
-                call LIS_routing_writeoutput(n)
-                call LIS_routing_writerestart(n)
-                call updateIncrementsFlag(n)
-             endif
-          enddo
-          flush(LIS_logunit)
-       enddo
+    do n=1,LIS_rc%nnest
+       if(LIS_timeToRunNest(n)) then
+          call LIS_setDynparams(n)
+          call LIS_get_met_forcing(n)
+          call LIS_perturb_forcing(n)
+          call LIS_irrigation_run(n)
+          call LIS_surfaceModel_f2t(n)
+          call LIS_surfaceModel_run(n)
+          call LIS_surfaceModel_diagnoseVarsForDA(n)
+          call LIS_surfaceModel_perturb_states(n)
+          call LIS_readDAobservations(n)
+          call LIS_perturb_DAobservations(n)
+          call LIS_perturb_writerestart(n)
+          call LIS_dataassim_run(n)
+          call LIS_dataassim_output(n)
+          call LIS_surfaceModel_output(n)
+          call LIS_surfaceModel_writerestart(n)
+          call LIS_irrigation_output(n)
+          call LIS_routing_run(n)
+          call LIS_routing_writeoutput(n)
+          call LIS_routing_writerestart(n)
+          call updateIncrementsFlag(n)
+       endif
+    enddo
 
-       if(LIS_rc%endtime.ne.1) then 
+  end subroutine lis_step_smootherDA
+
+!BOP
+! !ROUTINE: lis_reset_smootherDA
+!
+! !INTERFACE:
+  subroutine lis_reset_smootherDA
+! !USES:
+    use LIS_coreMod
+    use LIS_timeMgrMod
+    use LIS_surfaceModelMod
+    use LIS_paramsMod
+    use LIS_metforcingMod
+    use LIS_perturbMod
+    use LIS_routingMod
+
+!
+! !DESCRIPTION:
+!
+!  This is the reset clock method for LIS in a smootherDA running mode.
+!
+!  NOTES:
+!
+!EOP
+       if(LIS_rc%endtime.ne.1) then
           call LIS_resetClockForTimeWindow(LIS_rc)
           call LIS_param_reset
           call LIS_metforcing_reset
@@ -175,9 +226,8 @@ contains
 
           LIS_rc%iterationId(:) = LIS_rc%iterationId(:) + 1
        endif
-    enddo
 
-  end subroutine lis_run_smootherDA
+  end subroutine lis_reset_smootherDA
 
   subroutine updateIncrementsFlag(n)
     use LIS_timeMgrMod

--- a/lis/runmodes/smootherDA/smootherDA_runMod.F90
+++ b/lis/runmodes/smootherDA/smootherDA_runMod.F90
@@ -112,7 +112,6 @@ contains
 ! !USES:
     use LIS_coreMod
     use LIS_timeMgrMod
-    use LIS_logMod
 
 !
 ! !DESCRIPTION:
@@ -130,9 +129,7 @@ contains
 
     do while (.NOT. LIS_endofrun())
        do while(.NOT.LIS_endofTimeWindow())
-          call LIS_ticktime
           call lis_step_smootherDA
-          flush(LIS_logunit)
        enddo
        call lis_reset_smootherDA()
     enddo
@@ -156,6 +153,7 @@ contains
     use LIS_dataAssimMod
     use LIS_routingMod
     use LIS_irrigationMod
+    use LIS_logMod
 
 !
 ! !DESCRIPTION:
@@ -166,6 +164,8 @@ contains
 !
 !EOP
     integer           :: n 
+
+    call LIS_ticktime
 
     do n=1,LIS_rc%nnest
        if(LIS_timeToRunNest(n)) then
@@ -191,7 +191,7 @@ contains
           call updateIncrementsFlag(n)
        endif
     enddo
-
+    flush(LIS_logunit)
   end subroutine lis_step_smootherDA
 
 !BOP

--- a/lis/runmodes/wrf_cpl_mode/LISWRFGridCompMod.F90
+++ b/lis/runmodes/wrf_cpl_mode/LISWRFGridCompMod.F90
@@ -115,6 +115,12 @@ module LISWRFGridCompMod
          allocate(LISWRF_export(n)%infxsrt(LIS_rc%lnc(n),LIS_rc%lnr(n)))
          allocate(LISWRF_export(n)%soldrain(LIS_rc%lnc(n),LIS_rc%lnr(n)))
 #endif
+#ifdef PARFLOW
+         allocate(LISWRF_export(n)%wtrflx1(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+         allocate(LISWRF_export(n)%wtrflx2(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+         allocate(LISWRF_export(n)%wtrflx3(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+         allocate(LISWRF_export(n)%wtrflx4(LIS_rc%lnc(n),LIS_rc%lnr(n)))
+#endif
 
 !Export states
          allocate(LISWRF_export(n)%avgsurft_t(LIS_rc%ntiles(n)))
@@ -159,6 +165,12 @@ module LISWRFGridCompMod
 #ifdef WRF_HYDRO
          allocate(LISWRF_export(n)%infxsrt_t(LIS_rc%ntiles(n)))
          allocate(LISWRF_export(n)%soldrain_t(LIS_rc%ntiles(n)))
+#endif
+#ifdef PARFLOW
+         allocate(LISWRF_export(n)%wtrflx1_t(LIS_rc%ntiles(n)))
+         allocate(LISWRF_export(n)%wtrflx2_t(LIS_rc%ntiles(n)))
+         allocate(LISWRF_export(n)%wtrflx3_t(LIS_rc%ntiles(n)))
+         allocate(LISWRF_export(n)%wtrflx4_t(LIS_rc%ntiles(n)))
 #endif
       enddo
     end subroutine LISWRF_alloc_states
@@ -236,6 +248,12 @@ module LISWRFGridCompMod
          LISWRF_export(n)%infxsrt = LIS_rc%udef
          LISWRF_export(n)%soldrain = LIS_rc%udef
 #endif
+#ifdef PARFLOW
+         LISWRF_export(n)%wtrflx1 = LIS_rc%udef
+         LISWRF_export(n)%wtrflx2 = LIS_rc%udef
+         LISWRF_export(n)%wtrflx3 = LIS_rc%udef
+         LISWRF_export(n)%wtrflx4 = LIS_rc%udef
+#endif
 
 !Export states
          LISWRF_export(n)%avgsurft_t = LIS_rc%udef
@@ -280,6 +298,12 @@ module LISWRFGridCompMod
 #ifdef WRF_HYDRO
          LISWRF_export(n)%infxsrt_t = LIS_rc%udef
          LISWRF_export(n)%soldrain_t = LIS_rc%udef
+#endif
+#ifdef PARFLOW
+         LISWRF_export(n)%wtrflx1_t = LIS_rc%udef
+         LISWRF_export(n)%wtrflx2_t = LIS_rc%udef
+         LISWRF_export(n)%wtrflx3_t = LIS_rc%udef
+         LISWRF_export(n)%wtrflx4_t = LIS_rc%udef
 #endif
       enddo
     end subroutine LISWRF_reset_states

--- a/lis/runmodes/wrf_cpl_mode/LISWRFexport_module.F90
+++ b/lis/runmodes/wrf_cpl_mode/LISWRFexport_module.F90
@@ -67,6 +67,12 @@ module LISWRFexport_module
      real, allocatable :: infxsrt(:,:)
      real, allocatable :: soldrain(:,:)
 #endif
+#ifdef PARFLOW
+     real, allocatable :: wtrflx1(:,:)
+     real, allocatable :: wtrflx2(:,:)
+     real, allocatable :: wtrflx3(:,:)
+     real, allocatable :: wtrflx4(:,:)
+#endif
 
      real, allocatable :: avgsurft_t(:)
      real, allocatable :: qh_t(:)
@@ -110,6 +116,12 @@ module LISWRFexport_module
 #ifdef WRF_HYDRO
      real, allocatable :: infxsrt_t(:)
      real, allocatable :: soldrain_t(:)
+#endif
+#ifdef PARFLOW
+     real, allocatable :: wtrflx1_t(:)
+     real, allocatable :: wtrflx2_t(:)
+     real, allocatable :: wtrflx3_t(:)
+     real, allocatable :: wtrflx4_t(:)
 #endif
   end type liswrfexport
 

--- a/lis/surfacemodels/land/noah.3.3/cpl_wrf_noesmf/noah33_setwrfexport.F90
+++ b/lis/surfacemodels/land/noah.3.3/cpl_wrf_noesmf/noah33_setwrfexport.F90
@@ -58,6 +58,28 @@ subroutine noah33_setwrfexport(n)
   call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%soldrain_t,&
        noah33_struc(n)%noah%soldrain1rt)
 #endif
+#ifdef PARFLOW
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     temp(i) = noah33_struc(n)%noah(i)%wtrflx(1)
+  enddo
+  call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%wtrflx1_t,&
+       temp)
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     temp(i) = noah33_struc(n)%noah(i)%wtrflx(2)
+  enddo
+  call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%wtrflx2_t,&
+       temp)
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     temp(i) = noah33_struc(n)%noah(i)%wtrflx(3)
+  enddo
+  call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%wtrflx3_t,&
+       temp)
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     temp(i) = noah33_struc(n)%noah(i)%wtrflx(4)
+  enddo
+  call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%wtrflx4_t,&
+       temp)
+#endif
 
   do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
      temp(i) = noah33_struc(n)%noah(i)%smc(1)

--- a/lis/surfacemodels/land/noah.3.3/module_sf_noah33lsm.F90
+++ b/lis/surfacemodels/land/noah.3.3/module_sf_noah33lsm.F90
@@ -104,6 +104,9 @@ CONTAINS
                        ,SFHEAD1RT                                       &    !I
                        ,INFXS1RT,ETPND1                                 &    !P
 #endif
+#ifdef PARFLOW
+                       ,PCPDRP                                          &    !O
+#endif
                        )
 ! ----------------------------------------------------------------------
 ! SUBROUTINE SFLX - UNIFIED NOAHLSM VERSION 1.0 JULY 2007
@@ -363,6 +366,10 @@ CONTAINS
       REAL :: ALBEDOMIN, ALBEDOMAX
       REAL :: EMISSMIN,  EMISSMAX
       REAL :: Z0MIN,     Z0MAX
+#endif
+
+#ifdef PARFLOW
+      REAL,INTENT(OUT)   :: PCPDRP
 #endif
 
 ! ----------------------------------------------------------------------
@@ -863,6 +870,9 @@ CONTAINS
 #ifdef WRF_HYDRO
                             ,SFHEAD1RT,INFXS1RT,ETPND1                   &
 #endif
+#ifdef PARFLOW
+                            ,PCPDRP                                      &
+#endif
                             )
             ETA_KINEMATIC = ETA
             TSOIL = T1
@@ -882,6 +892,9 @@ CONTAINS
                          VEGTYP,TSOIL                                    &
 #ifdef WRF_HYDRO
                          ,SFHEAD1RT,INFXS1RT,ETPND1                      &
+#endif
+#ifdef PARFLOW
+                         ,PCPDRP                                         &
 #endif
                          )
             ETA_KINEMATIC =  ESNOW + ETNS
@@ -2084,6 +2097,9 @@ CONTAINS
 !DJG NDHMS/WRF-Hydro edit...
                          ,SFHEAD1RT,INFXS1RT,ETPND1                     &
 #endif
+#ifdef PARFLOW
+                         ,PCPDRP                                        &
+#endif
                          )
 
 ! ----------------------------------------------------------------------
@@ -2118,6 +2134,10 @@ CONTAINS
       REAL, DIMENSION(1:NSOIL) :: ET1
       REAL                 :: EC1,EDIR1,ETT1,DF1,ETA1,ETP1,PRCP1,YY,    &
                               YYNUM,ZZ1
+
+#ifdef PARFLOW
+      REAL, INTENT(OUT)    :: PCPDRP
+#endif
 
 ! ----------------------------------------------------------------------
 ! EXECUTABLE CODE BEGINS HERE:
@@ -2166,6 +2186,9 @@ CONTAINS
 #ifdef WRF_HYDRO
                       ,SFHEAD1RT,INFXS1RT                               &
 #endif
+#ifdef PARFLOW
+                      ,PCPDRP                                           &
+#endif
                       )
 
 ! ----------------------------------------------------------------------
@@ -2195,6 +2218,9 @@ CONTAINS
                       DRIP                                              &
 #ifdef WRF_HYDRO
                       ,SFHEAD1RT,INFXS1RT                               &
+#endif
+#ifdef PARFLOW
+                      ,PCPDRP                                           &
 #endif
                       )
 
@@ -2733,6 +2759,9 @@ CONTAINS
 #ifdef WRF_HYDRO
      &                   ,SFHEAD1RT,INFXS1RT                            &
 #endif
+#ifdef PARFLOW
+     &                   ,PCPDRP                                        &
+#endif
      &                   )
 
 ! ----------------------------------------------------------------------
@@ -2757,7 +2786,12 @@ CONTAINS
       REAL, DIMENSION(1:NSOIL), INTENT(INOUT):: SMC, SH2O
       REAL, DIMENSION(1:NSOIL)             :: AI, BI, CI, STCF,RHSTS, RHSTT, &
                                               SICE, SH2OA, SH2OFG
-      REAL                  :: DUMMY, EXCESS,FRZFACT,PCPDRP,RHSCT,TRHSCT
+      REAL                  :: DUMMY, EXCESS,FRZFACT,RHSCT,TRHSCT
+#ifdef PARFLOW
+      REAL,    INTENT(OUT)  :: PCPDRP
+#else
+      REAL                  :: PCPDRP
+#endif
       REAL :: FAC2
       REAL :: FLIMIT
 #ifdef WRF_HYDRO
@@ -3033,6 +3067,9 @@ CONTAINS
 #ifdef WRF_HYDRO
                           ,SFHEAD1RT,INFXS1RT,ETPND1                    &
 #endif
+#ifdef PARFLOW
+                          ,PCPDRP                                       &
+#endif
                           )
 
 ! ----------------------------------------------------------------------
@@ -3067,6 +3104,9 @@ CONTAINS
       REAL, INTENT(OUT)     :: DEW,DRIP,EC,EDIR, ETNS, ESNOW,ETT,       &
                                FLX1,FLX3, RUNOFF1,RUNOFF2,RUNOFF3,      &
                                SSOIL,SNOMLT
+#ifdef PARFLOW
+      REAL, INTENT(OUT)                       :: PCPDRP
+#endif
       REAL, DIMENSION(1:NSOIL),INTENT(IN)     :: RTDIS,ZSOIL
       REAL, DIMENSION(1:NSOIL),INTENT(OUT)    :: ET
       REAL, DIMENSION(1:NSOIL), INTENT(INOUT) :: SMC,SH2O,STC
@@ -3371,6 +3411,9 @@ CONTAINS
                       DRIP                                              &
 #ifdef WRF_HYDRO
                       ,SFHEAD1RT,INFXS1RT                               &
+#endif
+#ifdef PARFLOW
+                      ,PCPDRP                                           &
 #endif
                       )
 ! ----------------------------------------------------------------------

--- a/lis/surfacemodels/land/noah.3.3/noah33_lsmMod.F90
+++ b/lis/surfacemodels/land/noah.3.3/noah33_lsmMod.F90
@@ -201,6 +201,9 @@ contains
           allocate(noah33_struc(n)%noah(i)%smc(noah33_struc(n)%nslay))
           allocate(noah33_struc(n)%noah(i)%sh2o(noah33_struc(n)%nslay))
           allocate(noah33_struc(n)%noah(i)%relsmc(noah33_struc(n)%nslay))
+#ifdef PARFLOW
+          allocate(noah33_struc(n)%noah(i)%wtrflx(noah33_struc(n)%nslay))
+#endif
        enddo
        noah33_struc(n)%forc_count = 0 
        do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
@@ -228,6 +231,9 @@ contains
           noah33_struc(n)%noah(i)%sfhead1rt = 0
           noah33_struc(n)%noah(i)%infxs1rt = 0
           noah33_struc(n)%noah(i)%soldrain1rt = 0
+#endif
+#if PARFLOW
+          noah33_struc(n)%noah(i)%wtrflx = LIS_rc%udef
 #endif
           
        enddo

--- a/lis/surfacemodels/land/noah.3.3/noah33_main.F90
+++ b/lis/surfacemodels/land/noah.3.3/noah33_main.F90
@@ -125,6 +125,9 @@ subroutine noah33_main(n)
 !   which is not currently implemented within LIS without WRF_HYDRO:
   real        :: etpnd1
 #endif
+#ifdef PARFLOW
+  real        :: pcpdrp
+#endif
   real        :: snomlt    ! snow melt (m) (water equivalent)
   real        :: sncovr    ! fractional snow cover (unitless fraction, 0-1)
 !  real        :: runoff1   ! ground surface runoff (m s-1)
@@ -733,6 +736,9 @@ subroutine noah33_main(n)
         print*, 'b  INFXS1RT = ', noah33_struc(n)%noah(t)%infxs1rt
         print*, 'b  SOLDRAIN1RT = ', noah33_struc(n)%noah(t)%soldrain1rt
 #endif
+#ifdef PARFLOW
+        print*, 'b  WATERFLUX = ', noah33_struc(n)%noah(t)%wtrflx
+#endif
         print *,' '
         print *,'CALLING SFLX'
         print *,' '
@@ -798,6 +804,9 @@ subroutine noah33_main(n)
                 ,noah33_struc(n)%noah(t)%infxs1rt &
                 ,etpnd1 &
 #endif
+#ifdef PARFLOW
+                ,pcpdrp &
+#endif
                 )
 
 !     if(LIS_localPet.eq.8) then 
@@ -815,6 +824,12 @@ subroutine noah33_main(n)
            noah33_struc(n)%noah(t)%z0_old = noah33_struc(n)%noah(t)%z0
 #ifdef WRF_HYDRO
            noah33_struc(n)%noah(t)%soldrain1rt = noah33_struc(n)%noah(t)%runoff2*dt*1000.0
+#endif
+#ifdef PARFLOW
+           noah33_struc(n)%noah(t)%wtrflx(1) = - ((edir + et(1))/LVH2O) + pcpdrp
+           do i=2,noah33_struc(n)%nslay
+             noah33_struc(n)%noah(t)%wtrflx(i) = (et(i)/LVH2O)
+           enddo
 #endif
 #if _DEBUG_PRINT_
         print *,' '
@@ -919,6 +934,9 @@ subroutine noah33_main(n)
         print*, 'a  SFHEAD1RT = ', noah33_struc(n)%noah(t)%sfhead1rt
         print*, 'a  INFXS1RT = ', noah33_struc(n)%noah(t)%infxs1rt
         print*, 'a  SOLDRAIN1RT = ', noah33_struc(n)%noah(t)%soldrain1rt
+#endif
+#ifdef PARFLOW
+        print*, 'a  WATERFLUX = ', noah33_struc(n)%noah(t)%wtrflx
 #endif
 #endif
         elseif(ice.eq.1) then 

--- a/lis/surfacemodels/land/noah.3.3/noah33_module.F90
+++ b/lis/surfacemodels/land/noah.3.3/noah33_module.F90
@@ -93,6 +93,8 @@ module noah33_module
 !   \item[relsmc]
 !    Volumetric relative soil moisture $(m^3/m^3)$
 !    (smc - smcwlt) / (porosity - smcwlt)
+!   \item[wtrflx]
+!    total water flux. unit: kg m-2 s-1
 !   \end{description}
 !
 ! !REVISION HISTORY:
@@ -245,6 +247,9 @@ module noah33_module
      real :: sfhead1rt
      real :: infxs1rt
      real :: soldrain1rt
+#endif
+#ifdef PARFLOW
+     real,allocatable :: wtrflx(:)
 #endif
   end type noah33dec
 

--- a/lis/surfacemodels/land/noahmp.3.6/NoahMP36_lsmMod.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/NoahMP36_lsmMod.F90
@@ -292,6 +292,9 @@ contains
                 allocate(NOAHMP36_struc(n)%noahmp36(t)%zss( NOAHMP36_struc(n)%nsoil + NOAHMP36_struc(n)%nsnow))
                 allocate(NOAHMP36_struc(n)%noahmp36(t)%snowice(NOAHMP36_struc(n)%nsnow))
                 allocate(NOAHMP36_struc(n)%noahmp36(t)%snowliq(NOAHMP36_struc(n)%nsnow))
+#ifdef PARFLOW
+                allocate(NOAHMP36_struc(n)%noahmp36(t)%wtrflx(NOAHMP36_struc(n)%nsoil))
+#endif
             enddo
 !            ! allocate memory for intiali state variables
 !            allocate(NOAHMP36_struc(n)%init_stc( NOAHMP36_struc(n)%nsoil))
@@ -317,6 +320,9 @@ contains
             !   NOAHMP36_struc(n)%noahmp36(t)%sfhead1rt = 0.0
                 NOAHMP36_struc(n)%noahmp36(t)%infxs1rt = 0.0
                 NOAHMP36_struc(n)%noahmp36(t)%soldrain1rt = 0.0
+#endif
+#if PARFLOW
+                NOAHMP36_struc(n)%noahmp36(t)%wtrflx = 0.0
 #endif
                 
                 NOAHMP36_struc(n)%noahmp36(t)%albd = -9999.0

--- a/lis/surfacemodels/land/noahmp.3.6/NoahMP36_module.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/NoahMP36_module.F90
@@ -440,6 +440,8 @@ module NoahMP36_module
 !     wood to non-wood ratio
 !   \item[MRP]
 !     microbial respiration parameter. unit: umol co2 /kg c/ s
+!   \item[wtrflx]
+!    total water flux. unit: kg m-2 s-1
 !   \end{description}
 !
 ! !REVISION HISTORY:
@@ -679,6 +681,9 @@ module NoahMP36_module
      ! used for constraints on calibratable parameters for OPTUE ! SY
      !-------------------------------------------------------------------------
      real               :: smcdry ! SY: Not used by NoahMP3.6 from REDPRM, but read in from table
+#ifdef PARFLOW
+     real, pointer      :: wtrflx(:)
+#endif
 
   end type noahmp36dec
 end module NoahMP36_module

--- a/lis/surfacemodels/land/noahmp.3.6/cpl_wrf_noesmf/noahMP36_setwrfexport.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/cpl_wrf_noesmf/noahMP36_setwrfexport.F90
@@ -121,6 +121,25 @@ subroutine noahMP36_setwrfexport(n)
   enddo
   call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%sh2o4_t,temp)
 
+#ifdef PARFLOW
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     temp(i) = NOAHMP36_struc(n)%noahmp36(i)%wtrflx(1)
+  enddo
+  call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%wtrflx1_t,temp)
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     temp(i) = NOAHMP36_struc(n)%noahmp36(i)%wtrflx(2)
+  enddo
+  call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%wtrflx2_t,temp)
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     temp(i) = NOAHMP36_struc(n)%noahmp36(i)%wtrflx(3)
+  enddo
+  call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%wtrflx3_t,temp)
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     temp(i) = NOAHMP36_struc(n)%noahmp36(i)%wtrflx(4)
+  enddo
+  call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%wtrflx4_t,temp)
+#endif
+
   deallocate(temp)
 
 end subroutine noahMP36_setwrfexport

--- a/lis/surfacemodels/land/noahmp.3.6/module_sf_noahmplsm_36.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/module_sf_noahmplsm_36.F90
@@ -159,6 +159,7 @@ use ESMF
   INTEGER :: OPT_BTR != 1    !(suggested 1)
 
 ! options for runoff and groundwater
+! 0 -> OFF ;
 ! 1 -> TOPMODEL with groundwater (Niu et al. 2007 JGR) ;
 ! 2 -> TOPMODEL with an equilibrium water table (Niu et al. 2005 JGR) ;
 ! 3 -> original surface and subsurface runoff (free drainage)
@@ -168,7 +169,7 @@ use ESMF
   INTEGER :: OPT_RUN != 1    !(suggested 1)
 
 ! options for surface layer drag coeff (CH & CM)
-! 1->M-O ; 2->original Noah (Chen97); 3->MYJ consistent; 4->YSU consistent. 
+! 0->OFF; 1->M-O ; 2->original Noah (Chen97); 3->MYJ consistent; 4->YSU consistent. 
 
   INTEGER :: OPT_SFC != 1    !(1 or 2 or 3 or 4)
 
@@ -654,6 +655,9 @@ contains
 #ifdef WRF_HYDRO
                    ,SFCHEADRT                                                  & ! IN/OUT :
 #endif
+#ifdef PARFLOW
+                   ,QINSUR,ETRANI                                              & ! OUT :
+#endif
                    )
 
 ! --------------------------------------------------------------------------------------------------
@@ -711,6 +715,11 @@ contains
 
 #ifdef WRF_HYDRO
   REAL                           , INTENT(INOUT)    :: sfcheadrt
+#endif
+
+#ifdef PARFLOW
+  REAL                           , INTENT(OUT)    :: QINSUR !water input on soil surface [m/s]
+  REAL, DIMENSION(       1:NSOIL), INTENT(OUT)    :: ETRANI !evapotranspiration from soil layers (mm/s)
 #endif
 
 ! input/output : need arbitary intial values
@@ -1018,6 +1027,9 @@ contains
                  rivsto,fldsto,fldfrc       &
 #ifdef WRF_HYDRO
                         ,sfcheadrt                     &
+#endif
+#ifdef PARFLOW
+                 ,QINSUR,ETRANI                                   & !out
 #endif
                  )  !out
 
@@ -6680,6 +6692,9 @@ END SUBROUTINE ALBEDO_UPD
 #ifdef WRF_HYDRO
                         ,sfcheadrt                     &
 #endif
+#ifdef PARFLOW
+                    ,QINSUR,ETRANI                                   & !out
+#endif
                     )  !out
 ! ----------------------------------------------------------------------  
 ! Code history:
@@ -6768,14 +6783,22 @@ END SUBROUTINE ALBEDO_UPD
 
 ! local
   INTEGER                                        :: IZ
+#ifdef PARFLOW
+  REAL,                            INTENT(OUT)   :: QINSUR  !water input on soil surface [m/s]
+#else
   REAL                                           :: QINSUR  !water input on soil surface [m/s]
+#endif
   REAL                                           :: QRAIN   !rain at ground srf (mm) [+]
   REAL                                           :: QSEVA   !soil surface evap rate [mm/s]
   REAL                                           :: QSDEW   !soil surface dew rate [mm/s]
   REAL                                           :: QSNFRO  !snow surface frost rate[mm/s]
   REAL                                           :: QSNSUB  !snow surface sublimation rate [mm/s]
   REAL                                           :: SNOWHIN !snow depth increasing rate (m/s)
+#ifdef PARFLOW
+  REAL, DIMENSION(       1:NSOIL), INTENT(OUT)   :: ETRANI  !evapotranspiration from soil layers (mm/s)
+#else
   REAL, DIMENSION(       1:NSOIL)                :: ETRANI  !transpiration rate (mm/s) [+]
+#endif
   REAL, DIMENSION(       1:NSOIL)                :: WCND   !hydraulic conductivity (m/s)
   REAL                                           :: QDRAIN  !soil-bottom free drainage [mm/s] 
   REAL                                           :: SNOFLOW !glacier flow [mm/s]
@@ -6803,7 +6826,8 @@ END SUBROUTINE ALBEDO_UPD
                   FROZEN_CANOPY,                                 & !in     
                   CANLIQ ,CANICE ,TV     ,                 & !inout
                   CMC    ,ECAN   ,ETRAN  ,QRAIN  ,QSNOW  , & !out
-                  SNOWHIN,FWET   ,FPICE   )                           !out
+                  SNOWHIN,FWET   ,FPICE                    & !out
+                  )
 
 ! sublimation, frost, evaporation, and dew
 
@@ -6873,12 +6897,15 @@ END SUBROUTINE ALBEDO_UPD
        IF(WSLAKE >= WSLMAX) RUNSRF = QINSUR*1000.             !mm/s
        WSLAKE = WSLAKE + (QINSUR-QSEVA)*1000.*DT -RUNSRF*DT   !mm
     ELSE                                                      ! soil
-
-       CALL      SOILWATER (NSOIL  ,NSNOW  ,DT     ,ZSOIL  ,DZSNSO , & !in
+       IF(OPT_RUN == 0) THEN
+         RUNSRF = 0.
+       ELSE
+         CALL    SOILWATER (NSOIL  ,NSNOW  ,DT     ,ZSOIL  ,DZSNSO , & !in
                             QINSUR ,QSEVA  ,ETRANI ,SICE   ,ILOC   , JLOC , & !in
                             SH2O   ,SMC    ,ZWT    ,VEGTYP ,ISURBAN, & !inout
                            SMCWTD, DEEPRECH                       , & !inout
                             RUNSRF ,QDRAIN ,RUNSUB ,WCND   ,FCRMAX )   !out
+       END IF
  
        IF(OPT_RUN == 1) THEN 
           CALL GROUNDWATER (NSNOW  ,NSOIL  ,DT     ,SICE   ,ZSOIL  , & !in
@@ -6925,7 +6952,8 @@ END SUBROUTINE ALBEDO_UPD
                        FROZEN_CANOPY,                                 & !in      
                        CANLIQ ,CANICE ,TV     ,                 & !inout
                        CMC    ,ECAN   ,ETRAN  ,QRAIN  ,QSNOW  , & !out
-                       SNOWHIN,FWET   ,FPICE   )                           !out
+                       SNOWHIN,FWET   ,FPICE                    & !out
+                       )
 
 ! ------------------------ code history ------------------------------
 ! canopy hydrology

--- a/lis/surfacemodels/land/noahmp.3.6/module_sf_noahmplsm_36.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/module_sf_noahmplsm_36.F90
@@ -169,7 +169,7 @@ use ESMF
   INTEGER :: OPT_RUN != 1    !(suggested 1)
 
 ! options for surface layer drag coeff (CH & CM)
-! 0->OFF; 1->M-O ; 2->original Noah (Chen97); 3->MYJ consistent; 4->YSU consistent. 
+! 1->M-O ; 2->original Noah (Chen97); 3->MYJ consistent; 4->YSU consistent.
 
   INTEGER :: OPT_SFC != 1    !(1 or 2 or 3 or 4)
 
@@ -6952,8 +6952,7 @@ END SUBROUTINE ALBEDO_UPD
                        FROZEN_CANOPY,                                 & !in      
                        CANLIQ ,CANICE ,TV     ,                 & !inout
                        CMC    ,ECAN   ,ETRAN  ,QRAIN  ,QSNOW  , & !out
-                       SNOWHIN,FWET   ,FPICE                    & !out
-                       )
+                       SNOWHIN,FWET   ,FPICE   )                           !out
 
 ! ------------------------ code history ------------------------------
 ! canopy hydrology

--- a/lis/surfacemodels/land/noahmp.3.6/noahmp_driver_36.F90
+++ b/lis/surfacemodels/land/noahmp.3.6/noahmp_driver_36.F90
@@ -58,7 +58,11 @@ subroutine noahmp_driver_36(iloc, jloc, &
                             chleaf  , chuc    , chv2    , chb2    , fpice   , &
                             !ag (12Sep2019)
                             rivsto, fldsto, fldfrc, &
-                            sfcheadrt)  ! out 
+                            sfcheadrt                                                   & ! out :
+#ifdef PARFLOW
+                            ,qinsur,etrani                                              & ! out :
+#endif
+                            )
   
   ! use LIS_FORC_AttributesMod 
   use LIS_constantsMod, only: LIS_CONST_PATH_LEN
@@ -300,6 +304,10 @@ subroutine noahmp_driver_36(iloc, jloc, &
   real, intent(inout) :: fldsto               ! flood storage
   real, intent(inout) :: fldfrc               ! flood storage
   real, intent(inout) :: sfcheadrt            ! extra output for WRF-HYDRO [m] 
+#ifdef PARFLOW
+  real, intent(out)   :: qinsur               ! water input on soil surface [m/s]
+  real, intent(out)   :: etrani(nsoil)        ! evapotranspiration from soil layers [mm s-1]
+#endif
 
   ! external function
   real, external      :: month_d_36
@@ -386,6 +394,11 @@ subroutine noahmp_driver_36(iloc, jloc, &
 !  jloc = 1 
 #ifndef WRF_HYDRO
   sfcheadrt = 0.0 
+#endif
+
+#ifdef PARFLOW
+  qinsur = 0.0
+  etrani = 0.0
 #endif
 
   if (opt_sfc == 3) then
@@ -589,6 +602,9 @@ subroutine noahmp_driver_36(iloc, jloc, &
                rivsto  , fldsto, fldfrc            &
 #ifdef WRF_HYDRO
                ,sfcheadrt                                                  & ! in/out :
+#endif
+#ifdef PARFLOW
+               ,qinsur,etrani                                              & ! out :
 #endif
                )
 

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_lsmMod.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_lsmMod.F90
@@ -277,6 +277,9 @@ contains
                 allocate(NOAHMP401_struc(n)%noahmp401(t)%snowliq(NOAHMP401_struc(n)%nsnow))
                 allocate(NOAHMP401_struc(n)%noahmp401(t)%smoiseq(NOAHMP401_struc(n)%nsoil))
                 allocate(NOAHMP401_struc(n)%noahmp401(t)%gecros_state(60))
+#ifdef PARFLOW
+                allocate(NOAHMP401_struc(n)%noahmp401(t)%wtrflx(NOAHMP401_struc(n)%nsoil))
+#endif
             enddo
 
             ! initialize forcing variables to zeros
@@ -295,6 +298,9 @@ contains
                 NOAHMP401_struc(n)%noahmp401(t)%rivsto = 0.0
                 NOAHMP401_struc(n)%noahmp401(t)%fldsto = 0.0
                 NOAHMP401_struc(n)%noahmp401(t)%fldfrc = 0.0
+#ifdef PARFLOW
+                NOAHMP401_struc(n)%noahmp401(t)%wtrflx = 0.0
+#endif
             enddo ! end of tile (t) loop
 
             !------------------------------------------------------------------------

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
@@ -242,9 +242,9 @@ subroutine NoahMP401_main(n)
     ! Code added by David Mocko 04/25/2019
     real                 :: startsm, startswe, startint, startgw, endsm
 
-    real                 :: tmp_sfcheadrt          ! extra input  for WRF-HYDRO [m]
-    real                 :: tmp_infxs1rt           ! extra output for WRF-HYDRO [m]
-    real                 :: tmp_soldrain1rt        ! extra output for WRF-HYDRO [m]
+    real, dimension(1,1) :: tmp_sfcheadrt          ! extra input  for WRF-HYDRO [m]
+    real, dimension(1,1) :: tmp_infxs1rt           ! extra output for WRF-HYDRO [m]
+    real, dimension(1,1) :: tmp_soldrain1rt        ! extra output for WRF-HYDRO [m]
 #ifdef PARFLOW
     real                 :: tmp_qinsur             ! water input on soil surface [m/s]
     real,allocatable     :: tmp_etrani(:)          ! evapotranspiration from soil layers [mm s-1]
@@ -575,7 +575,7 @@ subroutine NoahMP401_main(n)
             tmp_grain           = NOAHMP401_struc(n)%noahmp401(t)%grain
             tmp_gdd             = NOAHMP401_struc(n)%noahmp401(t)%gdd
             tmp_pgs             = NOAHMP401_struc(n)%noahmp401(t)%pgs
-            tmp_sfcheadrt       = NoahMP401_struc(n)%noahmp401(t)%sfcheadrt
+            tmp_sfcheadrt(1,1)  = NoahMP401_struc(n)%noahmp401(t)%sfcheadrt
 #ifdef PARFLOW
             tmp_etrani(:)       = 0
 #endif
@@ -882,8 +882,8 @@ subroutine NoahMP401_main(n)
             NOAHMP401_struc(n)%noahmp401(t)%chuc      = tmp_chuc
             NOAHMP401_struc(n)%noahmp401(t)%chv2      = tmp_chv2
             NOAHMP401_struc(n)%noahmp401(t)%chb2      = tmp_chb2
-            NOAHMP401_struc(n)%noahmp401(t)%infxs1rt  = tmp_infxs1rt
-            NOAHMP401_struc(n)%noahmp401(t)%soldrain1rt  = tmp_soldrain1rt
+            NOAHMP401_struc(n)%noahmp401(t)%infxs1rt  = tmp_infxs1rt(1,1)
+            NOAHMP401_struc(n)%noahmp401(t)%soldrain1rt  = tmp_soldrain1rt(1,1)
 #ifdef PARFLOW
             NOAHMP401_struc(n)%noahmp401(t)%wtrflx(1)    = (tmp_qinsur*1000.0) &
               - ((tmp_edir + tmp_etrani(1)))

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
@@ -241,10 +241,14 @@ subroutine NoahMP401_main(n)
     real                 :: TWS_out                ! terrestrial water storage [mm]
     ! Code added by David Mocko 04/25/2019
     real                 :: startsm, startswe, startint, startgw, endsm
-   
-    real, dimension(1,1) :: tmp_sfcheadrt          ! extra input  for WRF-HYDRO [m]
-    real, dimension(1,1) :: tmp_infxs1rt           ! extra output for WRF-HYDRO [m]
-    real, dimension(1,1) :: tmp_soldrain1rt        ! extra output for WRF-HYDRO [m]
+
+    real                 :: tmp_sfcheadrt          ! extra input  for WRF-HYDRO [m]
+    real                 :: tmp_infxs1rt           ! extra output for WRF-HYDRO [m]
+    real                 :: tmp_soldrain1rt        ! extra output for WRF-HYDRO [m]
+#ifdef PARFLOW
+    real                 :: tmp_qinsur             ! water input on soil surface [m/s]
+    real,allocatable     :: tmp_etrani(:)          ! evapotranspiration from soil layers [mm s-1]
+#endif
 
         !ag (05Jan2021)
     real                 :: tmp_rivsto
@@ -269,6 +273,9 @@ subroutine NoahMP401_main(n)
     allocate( tmp_snowliq( NOAHMP401_struc(n)%nsnow ) )
     allocate( tmp_smoiseq( NOAHMP401_struc(n)%nsoil ) )
     allocate( tmp_gecros_state( 60 ) )
+#ifdef PARFLOW
+    allocate( tmp_etrani( NOAHMP401_struc(n)%nsoil ) )
+#endif
 
     ! check NoahMP401 alarm. If alarm is ring, run model.
 
@@ -569,6 +576,9 @@ subroutine NoahMP401_main(n)
             tmp_gdd             = NOAHMP401_struc(n)%noahmp401(t)%gdd
             tmp_pgs             = NOAHMP401_struc(n)%noahmp401(t)%pgs
             tmp_sfcheadrt       = NoahMP401_struc(n)%noahmp401(t)%sfcheadrt
+#ifdef PARFLOW
+            tmp_etrani(:)       = 0
+#endif
 
 ! Calculate water storages at start of timestep
             startsm = 0.0
@@ -755,7 +765,12 @@ subroutine NoahMP401_main(n)
                                    NOAHMP401_struc(n)%noahmp401(t)%param, & ! out   - relative soil moisture [-]
                                    tmp_sfcheadrt         , & 
                                    tmp_infxs1rt          , &
-                                   tmp_soldrain1rt    ) ! out   - extra output for WRF-HYDRO [m]
+                                   tmp_soldrain1rt         & ! out   - extra output for WRF-HYDRO [m]
+#ifdef PARFLOW
+                                   ,tmp_qinsur             & ! out  - water input on soil surface [m/s]
+                                   ,tmp_etrani             & ! out  - evapotranspiration from soil layers [mm s-1]
+#endif
+                                   )
 
             ! save state variables from local variables to global variables
             NOAHMP401_struc(n)%noahmp401(t)%sfcrunoff       = tmp_sfcrunoff
@@ -867,8 +882,15 @@ subroutine NoahMP401_main(n)
             NOAHMP401_struc(n)%noahmp401(t)%chuc      = tmp_chuc
             NOAHMP401_struc(n)%noahmp401(t)%chv2      = tmp_chv2
             NOAHMP401_struc(n)%noahmp401(t)%chb2      = tmp_chb2
-            NOAHMP401_struc(n)%noahmp401(t)%infxs1rt  = tmp_infxs1rt(1,1)
-            NOAHMP401_struc(n)%noahmp401(t)%soldrain1rt  = tmp_soldrain1rt(1,1)
+            NOAHMP401_struc(n)%noahmp401(t)%infxs1rt  = tmp_infxs1rt
+            NOAHMP401_struc(n)%noahmp401(t)%soldrain1rt  = tmp_soldrain1rt
+#ifdef PARFLOW
+            NOAHMP401_struc(n)%noahmp401(t)%wtrflx(1)    = (tmp_qinsur*1000.0) &
+              - ((tmp_edir + tmp_etrani(1)))
+            do i=2, NOAHMP401_struc(n)%nsoil
+              NOAHMP401_struc(n)%noahmp401(t)%wtrflx(i)  = - (tmp_etrani(i))
+            enddo
+#endif
 
             ! EMK Update RHMin for 557WW
             if (tmp_tair .lt. &
@@ -1403,6 +1425,21 @@ subroutine NoahMP401_main(n)
                        value=tempval,unit='%',direction="-",surface_type=LIS_rc%lsm_index)
             enddo
 
+#ifdef PARFLOW
+            ! output variable: qinsur (unit=kg/m2). ***  water input on soil surface
+            call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_QINSUR, value = (tmp_qinsur*1000.0), &
+                                              vlevel=1, unit="kg m-2 s-1", direction="DN", surface_type = LIS_rc%lsm_index)
+
+            ! output variable: etrani (unit=kg/m2). ***  evapotranspiration from soil layers
+            ! output variable: wtrflx (unit=kg/m2). ***  total water flux
+            do i=1, NOAHMP401_struc(n)%nsoil
+                call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_ETRANI, value = tmp_etrani(i), &
+                                              vlevel=i, unit="kg m-2 s-1", direction="UP", surface_type = LIS_rc%lsm_index)
+                call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_WTRFLX, value = NOAHMP401_struc(n)%noahmp401(t)%wtrflx(i), &
+                                              vlevel=i, unit="kg m-2 s-1", direction="DN", surface_type = LIS_rc%lsm_index)
+            end do
+
+#endif
             ! reset forcing variables to zeros
             NOAHMP401_struc(n)%noahmp401(t)%tair = 0.0
             NOAHMP401_struc(n)%noahmp401(t)%psurf = 0.0
@@ -1431,6 +1468,9 @@ subroutine NoahMP401_main(n)
     deallocate( tmp_snowliq )
     deallocate( tmp_smoiseq )
     deallocate( tmp_gecros_state )
+#ifdef PARFLOW
+    deallocate( tmp_etrani )
+#endif
 
     ! EMK...See if noahmp401_struc(n)%noahmp401(t)%tair_agl_min needs to be 
     ! reset for calculating RHMin.  

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_module.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_module.F90
@@ -343,6 +343,8 @@ module NoahMP401_module
 !     veg 2m exchange coefficient. unit: -
 !   \item[chb2]
 !     bare 2m exchange coefficient. unit: -
+!   \item[wtrflx]
+!    total water flux. unit: kg m-2 s-1
 !   \end{description}
 !
 ! !REVISION HISTORY:
@@ -517,6 +519,9 @@ module NoahMP401_module
 	real               :: sfcheadrt
 	real               :: infxs1rt
 	real               :: soldrain1rt
+#ifdef PARFLOW
+        real, pointer      :: wtrflx(:)
+#endif
  
     end type noahmp401dec
 

--- a/lis/surfacemodels/land/noahmp.4.0.1/cpl_wrf_noesmf/noahMP401_setwrfexport.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/cpl_wrf_noesmf/noahMP401_setwrfexport.F90
@@ -119,6 +119,25 @@ subroutine noahMP401_setwrfexport(n)
      temp(i) = NOAHMP401_struc(n)%noahmp401(i)%sh2o(4)
   enddo
   call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%sh2o4_t,temp)
+#ifdef PARFLOW
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     temp(i) = NOAHMP401_struc(n)%noahmp401(i)%wtrflx(1)
+  enddo
+  call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%wtrflx1_t,temp)
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     temp(i) = NOAHMP401_struc(n)%noahmp401(i)%wtrflx(2)
+  enddo
+  call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%wtrflx2_t,temp)
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     temp(i) = NOAHMP401_struc(n)%noahmp401(i)%wtrflx(3)
+  enddo
+  call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%wtrflx3_t,temp)
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+     temp(i) = NOAHMP401_struc(n)%noahmp401(i)%wtrflx(4)
+  enddo
+  call LIS_patch2tile(n,LIS_rc%lsm_index,LISWRF_export(n)%wtrflx4_t,temp)
+#endif
+
   deallocate(temp)
 
 end subroutine noahMP401_setwrfexport

--- a/lis/surfacemodels/land/noahmp.4.0.1/phys/module_sf_noahmpdrv_401.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/phys/module_sf_noahmpdrv_401.F90
@@ -54,6 +54,9 @@ CONTAINS
 #ifdef WRF_HYDRO
                sfcheadrt,INFXSRT,soldrain,                                  &
 #endif
+#ifdef PARFLOW
+               QINSUR,ETRANI,                                               & ! out :
+#endif
                ids,ide,  jds,jde,  kds,kde,                    &
                ims,ime,  jms,jme,  kms,kme,                    &
                its,ite,  jts,jte,  kts,kte,                    &
@@ -150,6 +153,10 @@ CONTAINS
 
 #ifdef WRF_HYDRO
     REAL,    DIMENSION( ims:ime,          jms:jme ), INTENT(INOUT) ::  sfcheadrt,INFXSRT,soldrain   ! for WRF-Hydro
+#endif
+#ifdef PARFLOW
+    REAL,    DIMENSION( ims:ime,          jms:jme ), INTENT(OUT) :: QINSUR ! water input on soil surface [m/s]
+    REAL,    DIMENSION( ims:ime, 1:nsoil, jms:jme ), INTENT(OUT) :: ETRANI ! volumetric liquid soil moisture [m3/m3]
 #endif
 ! placeholders for 3D soil
 !    REAL,    DIMENSION( ims:ime, 1:nsoil, jms:jme ), INTENT(IN) ::  BEXP_3D   ! C-H B exponent
@@ -504,6 +511,11 @@ CONTAINS
     DO K = 2, NSOIL
        ZSOIL(K) = -DZS(K) + ZSOIL(K-1)
     END DO
+
+#ifdef PARFLOW
+    QINSUR = 0.0
+    ETRANI = 0.0
+#endif
 
     JLOOP : DO J=jts,jte
 
@@ -914,6 +926,9 @@ CONTAINS
             ,rivsto  , fldsto, fldfrc            &
 #ifdef WRF_HYDRO
             , sfcheadrt(i,j)                               &
+#endif
+#ifdef PARFLOW
+            , QINSUR(I,J), ETRANI(I,1:NSOIL,J)                          & ! OUT :
 #endif
             )            ! OUT :
                   


### PR DESCRIPTION
### Description
As part of the LIS-PARFLOW coupling effort this PR adds the capability of exporting water flux values to Parflow and importing the ground water storage from Parflow. It also splits the run routines for retrospective and smootherDA modes so that the NUOPC cap can call one run step at a time directly.

- Add water flux exports and ground water storage import to Noah and NoahMP LSMs.
- Add import and export fields to NUOPC cap
- Fix double MPI_Finalize for internal ESMF vs external ESMF
- Add NUOPC cap support for smootherDA
- Split run calls for retrospective and smootherDA to individual time steps

Resolves #1686 

### Testcases
executed using NASA Land Coupler (NLC) on Discover Milan Nodes
baseline NLC version: [4e6c1c](https://github.com/NASA-LIS/NASA-Land-Coupler/commit/4e6c1caa902bb71d8057be32fa84f06db6ee2f25)
baseline LISF version: [12d02d](https://github.com/NASA-LIS/LISF/tree/12d02d2831c652e646d2dd2af9f3fd44094c89c1)

**build**
1. git clone -b feature/lisf_upgrade --recursive https://github.com/esmf-org/NASA-Land-Coupler.git NLCwGWR
2. cd NLCwGWR
3. ./configure.sh --auto
4. ./build.sh

**run coupled_tuolumne.noahmp.nldas2**
1. ./setuprun.sh coupled_tuolumne.noahmp.nldas2
2. cd run/coupled_tuolumne.noahmp.nldas2
3. (edit lis.config so that Met forcing sources "NLDAS2 grib")
4. sbatch run

**run coupled_tuolumne.ens020.noahmp_v4.0.1_da.nldas2**
1. ./setuprun.sh coupled_tuolumne.ens020.noahmp_v4.0.1_da.nldas2
2. cd run/coupled_tuolumne.ens020.noahmp_v4.0.1_da.nldas2
3. (edit lis.config so that Met forcing sources "NLDAS2 grib")
4. sbatch run

**run coupled_lw.noahmp_v4.0.1.nldas2**
1. ./setuprun.sh --data-root=$WORKDIR/projects_parflow/data coupled_lw.noahmp_v4.0.1.nldas2
2. cd run/coupled_lw.noahmp_v4.0.1.nldas2
3. (edit lis.config so that Met forcing sources "NLDAS2 grib")
4. sbatch run

**run coupled_lw_ens.noahmp_v4.0.1.nldas2**
1. ./setuprun.sh --data-root=$WORKDIR/projects_parflow/data coupled_lw_ens.noahmp_v4.0.1.nldas2
2. cd run/coupled_lw_ens.noahmp_v4.0.1.nldas2
3. (edit lis.config so that Met forcing sources "NLDAS2 grib")
4. sbatch run

#### Bit-for-bit (LIS WRFHydro Coupling)

- coupled_tuolumne.ens020.noahmp_v4.0.1_da.nldas2 - two way coupled LIS-WRFHYDRO running ensemble disaggregation/aggregation through mediator -  retrospective mode
```
SUCCESS: coupled_tuolumne.ens020.noahmp_v4.0.1_da.nldas2 LIS_HIST_201403020000.d01.nc
SUCCESS: coupled_tuolumne.ens020.noahmp_v4.0.1_da.nldas2 LIS_HIST_201403030000.d01.nc
SUCCESS: coupled_tuolumne.ens020.noahmp_v4.0.1_da.nldas2 LIS_HIST_201406010000.d01.nc
```

- coupled_tuolumne.noahmp.nldas2 - two way coupled LIS-WRFHYDRO - retrospective mode
```
SUCCESS: coupled_tuolumne.noahmp.nldas2 LIS_HIST_201510020000.d01.nc
SUCCESS: coupled_tuolumne.noahmp.nldas2 LIS_HIST_201510030000.d01.nc
SUCCESS: coupled_tuolumne.noahmp.nldas2 LIS_HIST_201511010000.d01.nc
```

#### New Test Cases (LIS ParFlow Coupling)

- coupled_lw_ens.noahmp_v4.0.1.nldas2 - two way coupled LIS-PARFLOW running ensemble disaggregation/aggregation through mediator - ensemble smoother mode
```
NEW: coupled_lw_ens.noahmp_v4.0.1.nldas2 LIS_HIST_200501020000.d01.nc
```

- coupled_lw.noahmp_v4.0.1.nldas2 - two way coupled LIS-PARFLOW - retrospective mode
```
NEW: coupled_lw.noahmp_v4.0.1.nldas2 LIS_HIST_200501020000.d01.nc
NEW: coupled_lw.noahmp_v4.0.1.nldas2 LIS_HIST_200501030000.d01.nc
NEW: coupled_lw.noahmp_v4.0.1.nldas2 LIS_HIST_200501080000.d01.nc
```
