### PR TITLE
Fixed bug in reporting check for prior 12z analysis.

### DIFF
--- a/ldt/USAFSI/USAFSI_analysisMod.F90
+++ b/ldt/USAFSI/USAFSI_analysisMod.F90
@@ -2152,7 +2152,7 @@ contains
          write(LDT_logunit,*) &
               '[WARN] Cannot find prior USAFSI analysis'
          ierr = 2
-      ! EMK Bug fix:  Only return error for missing 12z analysis if
+      ! Only return error for missing 12z analysis if
       ! current cycle is 12z.  This avoids erroneously searching for
       ! 0.25 deg SNODEP data, and applying climo for missing or zero
       ! values.

--- a/ldt/USAFSI/USAFSI_analysisMod.F90
+++ b/ldt/USAFSI/USAFSI_analysisMod.F90
@@ -22,6 +22,7 @@
 !                        ESPC-D or GOFS data.  Also fixed uninitialized
 !                        variable.
 ! 15 Oct 2024  Eric Kemp Updated error_message logic.
+! 18 Mar 2025  Eric Kemp Fixed bug in checking for earlier 12Z analysis.
 !
 ! DESCRIPTION:
 ! Source code for Air Force snow depth analysis.
@@ -2151,10 +2152,11 @@ contains
          write(LDT_logunit,*) &
               '[WARN] Cannot find prior USAFSI analysis'
          ierr = 2
-      else if (.not. found_12z) then
-      !EMK The above else if looks wrong, but using the below, commented-out
-      !else if changes the answer.  For now, use the above.
-      !else if (.not. found_12z .and. runcycle .eq. 12) then
+      ! EMK Bug fix:  Only return error for missing 12z analysis if
+      ! current cycle is 12z.  This avoids erroneously searching for
+      ! 0.25 deg SNODEP data, and applying climo for missing or zero
+      ! values.
+      else if (.not. found_12z .and. runcycle .eq. 12) then
          write(LDT_logunit,*) &
               '[WARN] Cannot find prior 12Z USAFSI analysis'
          ierr = 1


### PR DESCRIPTION

### Description

Fixed bug in reporting check for prior 12z analysis.

This will change the final result of USAFSI.  With the bug, at 00Z, 06Z, and 18Z USAFSI will erroneously search for (nonexistant) 0.25 deg SNODEP data, and then apply climo data where |lat| > 40 deg to fill data voids or where zero snow is analyzed.  No change in behavior at 12Z, since USAFSI will actually check for (and should find) the prior 12Z analysis for updating snow and ice age.


