### PR TITLE
Add special support for LIS 7.5 SM DA

### DIFF
--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -875,6 +875,10 @@ if ($ENV{MPDECOMP2} eq '1') {
    $use_mpdecomp2 = 1;
 }
 
+# USAF_LIS75_SMDA does not prompt user
+if ($ENV{USAF_LIS75_SMDA} eq '1') {
+    #use_useaf_lis75_smda = 1;
+}
 if(defined($ENV{LIS_RPC})){
    $librpc = $ENV{LIS_RPC};
 }
@@ -1235,6 +1239,13 @@ else{
 
 printf misc_file "%s\n","#undef INC_WATER_PTS";
 printf misc_file "%s\n","#undef COUPLED";
+
+if ($use_usaf_lis75_smda == 1) {
+    printf misc_file "%s\n","#define USAF_LIS75_SMDA ";
+} else {
+    printf misc_file "%s\n","#undef USAF_LIS75_SMDA ";
+}
+
 close(misc_file);
 
 open(netcdf_file,">LIS_NetCDF_inc.h");

--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -835,14 +835,6 @@ if($use_petsc eq ""){
    $use_petsc=0;
 }
 
-print "Enable USAF LIS75 SM DA codes? (1-yes, 0-no, default=0): ";
-$use_usaf_lis75_smda=<stdin>;
-$use_usaf_lis75_smda=~s/ *#.*$//;
-chomp($use_usaf_lis75_smda);
-if($use_usaf_lis75_smda eq ""){
-   $use_usaf_lis75_smda=0;
-}
-
 if($use_petsc == 1) {
    if(defined($ENV{LIS_PETSC})){
       $sys_petsc_path = $ENV{LIS_PETSC};
@@ -859,6 +851,14 @@ if($use_petsc == 1) {
       print "--------------ERROR---------------------\n";
       exit 1;
    }
+}
+
+print "Enable USAF LIS75 SM DA codes? (1-yes, 0-no, default=0): ";
+$use_usaf_lis75_smda=<stdin>;
+$use_usaf_lis75_smda=~s/ *#.*$//;
+chomp($use_usaf_lis75_smda);
+if($use_usaf_lis75_smda eq ""){
+   $use_usaf_lis75_smda=0;
 }
 
 if(defined($ENV{LIS_JPEG})){

--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -883,10 +883,6 @@ if ($ENV{MPDECOMP2} eq '1') {
    $use_mpdecomp2 = 1;
 }
 
-# USAF_LIS75_SMDA does not prompt user
-if ($ENV{USAF_LIS75_SMDA} eq '1') {
-    #use_useaf_lis75_smda = 1;
-}
 if(defined($ENV{LIS_RPC})){
    $librpc = $ENV{LIS_RPC};
 }

--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -835,6 +835,14 @@ if($use_petsc eq ""){
    $use_petsc=0;
 }
 
+print "Enable USAF LIS75 SM DA codes? (1-yes, 0-no, default=0): ";
+$use_usaf_lis75_smda=<stdin>;
+$use_usaf_lis75_smda=~s/ *#.*$//;
+chomp($use_usaf_lis75_smda);
+if($use_usaf_lis75_smda eq ""){
+   $use_usaf_lis75_smda=0;
+}
+
 if($use_petsc == 1) {
    if(defined($ENV{LIS_PETSC})){
       $sys_petsc_path = $ENV{LIS_PETSC};

--- a/lis/surfacemodels/land/jules.5.0/da_soilm/jules50_setsoilm.F90
+++ b/lis/surfacemodels/land/jules.5.0/da_soilm/jules50_setsoilm.F90
@@ -27,7 +27,12 @@
 !    adjust the states 
 ! 8 May 2023: Mahdi Navari; Soil temperature bias bug fix
 !                           (add check for frozen soil)
- 
+! 06 May 2025: Eric Kemp; Added option to use older LIS 7.5 variant for
+!   USAF.
+
+#include "LIS_misc.h"
+#ifndef USAF_LIS75_SMDA
+
 ! !INTERFACE:
 subroutine jules50_setsoilm(n, LSM_State)
 ! !USES:
@@ -725,3 +730,697 @@ subroutine jules50_setsoilm(n, LSM_State)
   enddo
 end subroutine jules50_setsoilm
 
+#else
+
+! LIS 7.5 variant
+subroutine jules50_setsoilm(n, LSM_State)
+! !USES:
+  use ESMF
+  use LIS_coreMod
+  use LIS_logMod
+  use jules50_lsmMod
+ !MN: added to use LIS_sfmodel_struc
+  !use LIS_surfaceModelDataMod, only : LIS_sfmodel_struc
+  use jules_soil_mod, only:  dzsoil !
+  use jules_surface_mod,      only: l_aggregate    
+  implicit none
+! !ARGUMENTS: 
+  integer, intent(in)    :: n
+  type(ESMF_State)       :: LSM_State
+!
+! !DESCRIPTION:
+!  
+!  This routine assigns the soil moisture prognostic variables to JULES's
+!  model space. 
+! 
+!EOP
+  real                   :: MIN_THRESHOLD(jules50_struc(n)%sm_levels)   !Yonghwan Kwon
+  real                   :: MAX_THRESHOLD(jules50_struc(n)%sm_levels)
+  real                   :: sm_threshold(jules50_struc(n)%sm_levels)
+  type(ESMF_Field)       :: sm1Field
+  type(ESMF_Field)       :: sm2Field
+  type(ESMF_Field)       :: sm3Field
+  type(ESMF_Field)       :: sm4Field
+  real, pointer          :: soilm1(:)
+  real, pointer          :: soilm2(:)
+  real, pointer          :: soilm3(:)
+  real, pointer          :: soilm4(:)
+  integer                :: t, j,i, gid, m, t_unpert, row, col
+  integer                :: status
+  real                   :: delta(4)
+  real                   :: delta1,delta2,delta3,delta4 , lat, lon
+  real                   :: tmpval
+  real                   :: tmpval_u, tmpval_f  !Yonghwan Kwon
+  real                   :: timenow ! for print 
+  logical                :: bounds_violation
+  integer                :: nIter, N_ens
+  logical                :: update_flag(LIS_rc%ngrid(n))
+  logical                :: ens_flag(LIS_rc%nensem(n))
+! mn
+  real                   :: tmp(LIS_rc%nensem(n)), tmp0(LIS_rc%nensem(n))
+  real                   :: tmp1(LIS_rc%nensem(n)),tmp2(LIS_rc%nensem(n)),tmp3(LIS_rc%nensem(n)),tmp4(LIS_rc%nensem(n)),tmp5(LIS_rc%nensem(n)) ,tmp6(LIS_rc%nensem(n)) ,tmp7(LIS_rc%nensem(n)) ,tmp8(LIS_rc%nensem(n))  
+  logical                :: update_flag_tile(LIS_rc%npatch(n,LIS_rc%lsm_index))
+  logical                :: flag_ens(LIS_rc%ngrid(n))
+  logical                :: flag_tmp(LIS_rc%nensem(n))
+  logical                :: update_flag_ens(LIS_rc%ngrid(n))
+  logical                :: update_flag_new(LIS_rc%ngrid(n))
+  integer                :: pcount, icount
+  real                   :: MaxEnsSM1 ,MaxEnsSM2 ,MaxEnsSM3 ,MaxEnsSM4
+  real                   :: MinEnsSM1 ,MinEnsSM2 ,MinEnsSM3 ,MinEnsSM4 
+!  real                   :: MaxEns_p_s_sthu1, MaxEns_p_s_sthu2, MaxEns_p_s_sthu3, MaxEns_p_s_sthu4
+  real                   :: smc_rnd, smc_tmp 
+  real                   :: p_s_sthu_tmp, p_s_sthu_rnd 
+  INTEGER, DIMENSION (1) :: seed
+  !-----------------------------------------------------Yonghwan Kwon
+  !real, dimension(4)     :: frac_sthu_l, frac_sthf_l
+  real, dimension(jules50_struc(n)%sm_levels)  :: sat_p, p_s_sth, frac_sthu, frac_sthf
+  real, dimension(4)     :: delta_u, delta_f
+  real                   :: delta1_sthu, delta2_sthu, delta3_sthu, delta4_sthu
+  real                   :: delta1_sthf, delta2_sthf, delta3_sthf, delta4_sthf
+  integer                :: ilat, ilon
+  logical                :: violation_new 
+  !-----------------------------------------------------
+
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 1",sm1Field,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateSet: Soil Moisture Layer 1 failed in jules50_setsoilm")
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 2",sm2Field,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateSet: Soil Moisture Layer 2 failed in jules50_setsoilm")
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 3",sm3Field,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateSet: Soil Moisture Layer 3 failed in jules50_setsoilm")
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 4",sm4Field,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateSet: Soil Moisture Layer 4 failed in jules50_setsoilm")
+
+  call ESMF_FieldGet(sm1Field,localDE=0,farrayPtr=soilm1,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 1 failed in jules50_setsoilm")
+  call ESMF_FieldGet(sm2Field,localDE=0,farrayPtr=soilm2,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 2 failed in jules50_setsoilm")
+  call ESMF_FieldGet(sm3Field,localDE=0,farrayPtr=soilm3,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 3 failed in jules50_setsoilm")
+  call ESMF_FieldGet(sm4Field,localDE=0,farrayPtr=soilm4,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 4 failed in jules50_setsoilm")
+
+  update_flag = .true. 
+  update_flag_tile = .true. 
+
+! MN: NOTE: be careful with the unit. The unit of soil moisture diagnostic variable (smcl) [kg/m2]
+! differs from that of the prognostic variable (p_s_sthu, p_s_smvcst) [m3/m3].
+
+  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+
+     !-------------------------------------Yonghwan Kwon
+     do j=1,jules50_struc(n)%sm_levels  
+        MAX_THRESHOLD(j) = jules50_struc(n)%jules50(t)%p_s_smvcst(j) ! Volumetric saturation point (m^3 m-3 of soil)
+        MIN_THRESHOLD(j) = jules50_struc(n)%jules50(t)%p_s_smvcwt(j) ! Volumetric wilting point (m^3 m-3 of soil) !Yonghwan Kwon 
+        !sm_threshold(j)  = MAX_THRESHOLD(j) - MIN_THRESHOLD(j)      
+        sm_threshold(j)  = MAX_THRESHOLD(j)
+
+        sat_p(j) = jules50_struc(n)%jules50(t)%p_s_smvcst(j) ! Volumetric saturation point (m^3 m-3 of soil)
+        p_s_sth(j) = jules50_struc(n)%jules50(t)%p_s_sthu(j) + jules50_struc(n)%jules50(t)%p_s_sthf(j)  !saturated fraction
+     enddo     
+     !-------------------------------------
+     gid = LIS_domain(n)%gindex(&
+           LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col,&
+           LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row)
+
+     !MN: delta = X(+) - X(-)
+     !NOTE: "jules50_updatesoilm.F90" updates the soilmx(t)   
+     delta1 = (soilm1(t)-jules50_struc(n)%jules50(t)%smcl_soilt(1))* 1/dzsoil(1)*1/1000  ! [kg/m2]*1/m*1/(kg/m3) --> [m3/m3]
+     delta2 = (soilm2(t)-jules50_struc(n)%jules50(t)%smcl_soilt(2))* 1/dzsoil(2)*1/1000 
+     delta3 = (soilm3(t)-jules50_struc(n)%jules50(t)%smcl_soilt(3))* 1/dzsoil(3)*1/1000
+     delta4 = (soilm4(t)-jules50_struc(n)%jules50(t)%smcl_soilt(4))* 1/dzsoil(4)*1/1000
+     
+     ! MN: check MIN_THRESHOLD < volumetric liquid soil moisture < threshold 
+     ! unit conversion -->   ..%p_s_sthu(1)  *  ..%p_s_smvcst(1)-->   [-] * [m3/m3] 
+
+     if (jules50_struc(n)%jules50(t)%p_s_smvcst(1) == 0) then     !Yonghwan Kwon: set update_flag to false for glacier land 
+        update_flag(gid) = update_flag(gid).and.(.false.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.false.)
+     else      
+        ! frozen soil moisture content has been added (Yonghwan Kwon)
+        if (p_s_sth(1) * sat_p(1) + delta1.gt.MIN_THRESHOLD(1) .and.&
+            p_s_sth(1) * sat_p(1) + delta1.lt.sm_threshold(1)) then
+           update_flag(gid) = update_flag(gid).and.(.true.)
+           ! MN save the flag for each tile (col*row*ens)   PILDAS -->(64*44)*20
+           update_flag_tile(t) = update_flag_tile(t).and.(.true.)
+        else
+           update_flag(gid) = update_flag(gid).and.(.false.)
+           update_flag_tile(t) = update_flag_tile(t).and.(.false.)
+        endif
+
+        if (p_s_sth(2) * sat_p(2) + delta2.gt.MIN_THRESHOLD(2) .and.&
+            p_s_sth(2) * sat_p(2) + delta2.lt.sm_threshold(2)) then
+           update_flag(gid) = update_flag(gid).and.(.true.)
+           update_flag_tile(t) = update_flag_tile(t).and.(.true.)
+        else
+           update_flag(gid) = update_flag(gid).and.(.false.)
+           update_flag_tile(t) = update_flag_tile(t).and.(.false.)
+        endif
+
+        if (p_s_sth(3) * sat_p(3) + delta3.gt.MIN_THRESHOLD(3) .and.&
+            p_s_sth(3) * sat_p(3) + delta3.lt.sm_threshold(3)) then
+           update_flag(gid) = update_flag(gid).and.(.true.)
+           update_flag_tile(t) = update_flag_tile(t).and.(.true.)
+        else
+           update_flag(gid) = update_flag(gid).and.(.false.)
+           update_flag_tile(t) = update_flag_tile(t).and.(.false.)
+        endif
+
+        if (p_s_sth(4) * sat_p(4) + delta4.gt.MIN_THRESHOLD(4) .and.&
+            p_s_sth(4) * sat_p(4) + delta4.lt.sm_threshold(4)) then
+           update_flag(gid) = update_flag(gid).and.(.true.)
+           update_flag_tile(t) = update_flag_tile(t).and.(.true.)
+        else
+           update_flag(gid) = update_flag(gid).and.(.false.)
+           update_flag_tile(t) = update_flag_tile(t).and.(.false.)
+        endif
+     endif
+  enddo
+
+!-----------------------------------------------------------------------------------------
+! MN create new flag: if update flag for 50% of the ensemble members is true 
+! then update the stats 
+!-----------------------------------------------------------------------------------------
+  update_flag_ens = .true.
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index),LIS_rc%nensem(n)
+     gid = LIS_domain(n)%gindex(&
+           LIS_surface(n,LIS_rc%lsm_index)%tile(i)%col,&
+           LIS_surface(n,LIS_rc%lsm_index)%tile(i)%row) 
+     flag_tmp=update_flag_tile(i:i+LIS_rc%nensem(n)-1)
+     !flag_tmp=update_flag_tile((i-1)*LIS_rc%nensem(n)+1:(i)*LIS_rc%nensem(n))
+     pcount = COUNT(flag_tmp) ! Counts the number of .TRUE. elements
+     if (pcount.lt.LIS_rc%nensem(n)*0.5) then   ! 50%
+        update_flag_ens(gid)= .False.
+     endif
+     update_flag_new(gid)= update_flag(gid).or.update_flag_ens(gid)  ! new flag
+  enddo
+   
+  ! update step
+  ! loop over grid points 
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index),LIS_rc%nensem(n)     
+
+     gid =LIS_domain(n)%gindex(&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(i)%col,&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(i)%row)  
+     
+     !if(update_flag(gid)) then
+     if(update_flag_new(gid)) then 
+!-----------------------------------------------------------------------------------------
+! Update the states
+! case 1-1- if the update flag for a given grid and tile are TRUE --> apply the DA update    
+! case 1-2- if the update flag for a given grid is true but for the tile is FALSE --> 
+! set the update value for that ensemble memeber to the ens. mean  
+! case 2- if the update flag for a given grid is FALSE readjust the states
+!-----------------------------------------------------------------------------------------
+! store update value for cases that flag_tile & update_flag_new are TRUE
+! flag_tile = TRUE --> means both the min and max threshold has been satisfied
+
+! compute the ensemble min and max for case 1-2        
+        tmp1 = LIS_rc%udef
+        tmp2 = LIS_rc%udef
+        tmp3 = LIS_rc%udef
+        tmp4 = LIS_rc%udef
+
+        do m=1,LIS_rc%nensem(n)
+           t = i+m-1
+           !t = (i-1)*LIS_rc%nensem(n)+m
+           
+           if(update_flag_tile(t)) then
+              
+              tmp1(m) = soilm1(t) 
+              tmp2(m) = soilm2(t) 
+              tmp3(m) = soilm3(t) 
+              tmp4(m) = soilm4(t) 
+           endif
+        enddo
+
+        MaxEnsSM1 = -10000
+        MaxEnsSM2 = -10000
+        MaxEnsSM3 = -10000
+        MaxEnsSM4 = -10000
+
+        MinEnsSM1 = 10000
+        MinEnsSM2 = 10000
+        MinEnsSM3 = 10000
+        MinEnsSM4 = 10000
+
+        do m=1,LIS_rc%nensem(n)
+           if(tmp1(m).ne.LIS_rc%udef) then 
+              MaxEnsSM1 = max(MaxEnsSM1, tmp1(m)) ![kg/m2]
+              MaxEnsSM2 = max(MaxEnsSM2, tmp2(m))
+              MaxEnsSM3 = max(MaxEnsSM3, tmp3(m))
+              MaxEnsSM4 = max(MaxEnsSM4, tmp4(m))
+
+              MinEnsSM1 = min(MinEnsSM1, tmp1(m))
+              MinEnsSM2 = min(MinEnsSM2, tmp2(m))
+              MinEnsSM3 = min(MinEnsSM3, tmp3(m))
+              MinEnsSM4 = min(MinEnsSM4, tmp4(m))
+              
+           endif
+        enddo
+
+        ! loop over tile       
+        do m=1,LIS_rc%nensem(n)
+            t = i+m-1
+           !t = (i-1)*LIS_rc%nensem(n)+m
+
+           !-------------------------------------Yonghwan Kwon
+           do j=1,jules50_struc(n)%sm_levels
+              MAX_THRESHOLD(j) = jules50_struc(n)%jules50(t)%p_s_smvcst(j) ! Volumetric saturation point (m^3 m-3 of soil)
+              MIN_THRESHOLD(j) = jules50_struc(n)%jules50(t)%p_s_smvcwt(j) ! Volumetric wilting point (m^3 m-3 of soil) !Yonghwan Kwon 
+              !sm_threshold(j)  = MAX_THRESHOLD(j) - MIN_THRESHOLD(j)
+              sm_threshold(j)  = MAX_THRESHOLD(j)
+
+              sat_p(j) = jules50_struc(n)%jules50(t)%p_s_smvcst(j) ! Volumetric saturation point (m^3 m-3 of soil)
+              p_s_sth(j) = jules50_struc(n)%jules50(t)%p_s_sthu(j) + jules50_struc(n)%jules50(t)%p_s_sthf(j)  !saturated fraction
+           enddo
+           !-------------------------------------
+                      
+           ! MN check update status for each tile  
+           if(update_flag_tile(t)) then
+
+	      delta1 = (soilm1(t)-jules50_struc(n)%jules50(t)%smcl_soilt(1))* 1/dzsoil(1)*1/1000  ! [kg/m2]*1/m*1/(kg/m3) --> [m3/m3]
+	      delta2 = (soilm2(t)-jules50_struc(n)%jules50(t)%smcl_soilt(2))* 1/dzsoil(2)*1/1000 
+	      delta3 = (soilm3(t)-jules50_struc(n)%jules50(t)%smcl_soilt(3))* 1/dzsoil(3)*1/1000
+	      delta4 = (soilm4(t)-jules50_struc(n)%jules50(t)%smcl_soilt(4))* 1/dzsoil(4)*1/1000   
+ 
+              !------------------------------------- Yonghwan Kwon
+              ! Compute delta for unfrozen and frozen soil moiture (Yonghwan Kwon)
+              delta1_sthu = delta1 * (jules50_struc(n)%jules50(t)%p_s_sthu(1) / p_s_sth(1))  ![m3/m3]
+              delta1_sthf = delta1 * (jules50_struc(n)%jules50(t)%p_s_sthf(1) / p_s_sth(1))  ![m3/m3]
+              delta2_sthu = delta2 * (jules50_struc(n)%jules50(t)%p_s_sthu(2) / p_s_sth(2))  ![m3/m3]
+              delta2_sthf = delta2 * (jules50_struc(n)%jules50(t)%p_s_sthf(2) / p_s_sth(2))  ![m3/m3]
+              delta3_sthu = delta3 * (jules50_struc(n)%jules50(t)%p_s_sthu(3) / p_s_sth(3))  ![m3/m3]
+              delta3_sthf = delta3 * (jules50_struc(n)%jules50(t)%p_s_sthf(3) / p_s_sth(3))  ![m3/m3]
+              delta4_sthu = delta4 * (jules50_struc(n)%jules50(t)%p_s_sthu(4) / p_s_sth(4))  ![m3/m3]
+              delta4_sthf = delta4 * (jules50_struc(n)%jules50(t)%p_s_sthf(4) / p_s_sth(4))  ![m3/m3]
+
+              jules50_struc(n)%jules50(t)%p_s_sthu(1) = (jules50_struc(n)%jules50(t)%p_s_sthu(1) * sat_p(1)&
+                                                        + delta1_sthu)/sat_p(1) ! ([-]*[m3/m3] + [m3/m3])/[m3/m3] --> fraction
+              jules50_struc(n)%jules50(t)%p_s_sthf(1) = (jules50_struc(n)%jules50(t)%p_s_sthf(1) * sat_p(1)&
+                                                        + delta1_sthf)/sat_p(1) ! ([-]*[m3/m3] + [m3/m3])/[m3/m3] --> fraction
+              jules50_struc(n)%jules50(t)%smcl_soilt(1) = soilm1(t) ![kg/m2]
+
+              if(soilm1(t).lt.0) then 
+                 write(LIS_logunit, *) 'setsoilm1 ',t,soilm1(t)
+                 call LIS_endrun
+              endif
+	      ! I think the following sentence is redundant. 
+	      !Because both “update_flag_new” and “update_flag_tile” are TRUE 
+
+              !if(jules50_struc(n)%jules50(t)%p_s_sthu(2)+delta2.gt.MIN_THRESHOLD .and.&   
+              !     jules50_struc(n)%jules50(t)%p_s_sthu(2)+delta2.lt.sm_threshold) then 
+              !   jules50_struc(n)%jules50(t)%p_s_sthu(2) = jules50_struc(n)%jules50(t)%p_s_sthu(2)+&
+              !        soilm2(t)-jules50_struc(n)%jules50(t)%smcl_soilt(2)
+              jules50_struc(n)%jules50(t)%p_s_sthu(2) = (jules50_struc(n)%jules50(t)%p_s_sthu(2) * sat_p(2)&
+                                                        + delta2_sthu)/sat_p(2) ! ([-]*[m3/m3] + [m3/m3])/[m3/m3] --> fraction
+              jules50_struc(n)%jules50(t)%p_s_sthf(2) = (jules50_struc(n)%jules50(t)%p_s_sthf(2) * sat_p(2)&
+                                                        + delta2_sthf)/sat_p(2) ! ([-]*[m3/m3] + [m3/m3])/[m3/m3] --> fraction
+              jules50_struc(n)%jules50(t)%smcl_soilt(2) = soilm2(t)
+
+              if(soilm2(t).lt.0) then 
+                 write(LIS_logunit, *) 'setsoilm2 ',t,soilm2(t)
+                 call LIS_endrun
+              endif
+
+              !endif
+              !if(jules50_struc(n)%jules50(t)%p_s_sthu(3)+delta3.gt.MIN_THRESHOLD .and.&
+              !     jules50_struc(n)%jules50(t)%p_s_sthu(3)+delta3.lt.sm_threshold) then 
+              !   jules50_struc(n)%jules50(t)%p_s_sthu(3) = jules50_struc(n)%jules50(t)%p_s_sthu(3)+&
+              !        soilm3(t)-jules50_struc(n)%jules50(t)%smcl_soilt(3)
+              jules50_struc(n)%jules50(t)%p_s_sthu(3) = (jules50_struc(n)%jules50(t)%p_s_sthu(3) * sat_p(3)&
+                                                        + delta3_sthu)/sat_p(3) ! ([-]*[m3/m3] + [m3/m3])/[m3/m3] --> fraction
+              jules50_struc(n)%jules50(t)%p_s_sthf(3) = (jules50_struc(n)%jules50(t)%p_s_sthf(3) * sat_p(3)&
+                                                        + delta3_sthf)/sat_p(3) ! ([-]*[m3/m3] + [m3/m3])/[m3/m3] --> fraction
+              jules50_struc(n)%jules50(t)%smcl_soilt(3) = soilm3(t)
+
+              if(soilm3(t).lt.0) then 
+                 write(LIS_logunit, *) 'setsoilm3 ',t,soilm3(t)
+                 call LIS_endrun
+              endif
+
+              !endif
+              ! surface layer
+              !if(jules50_struc(n)%jules50(t)%p_s_sthu(4)+delta4.gt.MIN_THRESHOLD .and.&
+              !     jules50_struc(n)%jules50(t)%p_s_sthu(4)+delta4.lt.sm_threshold) then 
+              !   jules50_struc(n)%jules50(t)%p_s_sthu(4) = jules50_struc(n)%jules50(t)%p_s_sthu(4)+&
+              !        soilm4(t)-jules50_struc(n)%jules50(t)%smcl_soilt(4)
+              jules50_struc(n)%jules50(t)%p_s_sthu(4) = (jules50_struc(n)%jules50(t)%p_s_sthu(4) * sat_p(4)&
+                                                        + delta4_sthu)/sat_p(4) ! ([-]*[m3/m3] + [m3/m3])/[m3/m3] --> fraction
+              jules50_struc(n)%jules50(t)%p_s_sthf(4) = (jules50_struc(n)%jules50(t)%p_s_sthf(4) * sat_p(4)&
+                                                        + delta4_sthf)/sat_p(4) ! ([-]*[m3/m3] + [m3/m3])/[m3/m3] --> fraction
+              jules50_struc(n)%jules50(t)%smcl_soilt(4) = soilm4(t)
+
+              if(soilm4(t).lt.0) then 
+                 write(LIS_logunit, *) 'setsoilm4 ',t,soilm4(t)
+                 call LIS_endrun
+              endif
+              !endif
+           else 
+ 
+!-----------------------------------------------------------------------------------------  
+! USE ENSEMBLE MEAN VALUE 
+!-----------------------------------------------------------------------------------------
+              
+              ! Assume p_s_sthu = smc (i.e. ice content=0) 
+
+              !-----------------------------------------------------
+              ! Frozen soil moisture has been added (Yonghwan Kwon)
+              ! Compute fraction
+              do j=1,jules50_struc(n)%sm_levels
+                 frac_sthu(j) = jules50_struc(n)%jules50(t)%p_s_sthu(j) / p_s_sth(j)
+                 frac_sthf(j) = jules50_struc(n)%jules50(t)%p_s_sthf(j) / p_s_sth(j)
+              enddo
+              !-----------------------------------------------------
+
+              smc_tmp = (MaxEnsSM1 - MinEnsSM1)/2 + MinEnsSM1 ! [kg/m2]
+              jules50_struc(n)%jules50(t)%p_s_sthu(1) = (smc_tmp * 1/dzsoil(1)*1/1000 * frac_sthu(1)) / sat_p(1) 
+                                                                                ! ([kg/m2]*(1/m*1/(kg/m3)))/[m3/m3]--> fraction
+              jules50_struc(n)%jules50(t)%p_s_sthf(1) = (smc_tmp * 1/dzsoil(1)*1/1000 * frac_sthf(1)) / sat_p(1) 
+                                                                                ! ([kg/m2]*(1/m*1/(kg/m3)))/[m3/m3]--> fraction  !Yonghwan Kwon
+              jules50_struc(n)%jules50(t)%smcl_soilt(1) = smc_tmp
+
+              smc_tmp = (MaxEnsSM2 - MinEnsSM2)/2 + MinEnsSM2            
+              jules50_struc(n)%jules50(t)%p_s_sthu(2) = (smc_tmp * 1/dzsoil(2)*1/1000 * frac_sthu(2)) / sat_p(2)
+              jules50_struc(n)%jules50(t)%p_s_sthf(2) = (smc_tmp * 1/dzsoil(2)*1/1000 * frac_sthf(2)) / sat_p(2)
+              jules50_struc(n)%jules50(t)%smcl_soilt(2) = smc_tmp
+
+              smc_tmp = (MaxEnsSM3 - MinEnsSM3)/2 + MinEnsSM3
+              jules50_struc(n)%jules50(t)%p_s_sthu(3) = (smc_tmp * 1/dzsoil(3)*1/1000 * frac_sthu(3)) / sat_p(3)
+              jules50_struc(n)%jules50(t)%p_s_sthf(3) = (smc_tmp * 1/dzsoil(3)*1/1000 * frac_sthf(3)) / sat_p(3)
+              jules50_struc(n)%jules50(t)%smcl_soilt(3) = smc_tmp
+
+              smc_tmp = (MaxEnsSM4 - MinEnsSM4)/2 + MinEnsSM4
+              jules50_struc(n)%jules50(t)%p_s_sthu(4) = (smc_tmp * 1/dzsoil(4)*1/1000 * frac_sthu(4)) / sat_p(4)
+              jules50_struc(n)%jules50(t)%p_s_sthf(4) = (smc_tmp * 1/dzsoil(4)*1/1000 * frac_sthf(4)) / sat_p(4)
+              jules50_struc(n)%jules50(t)%smcl_soilt(4) = smc_tmp
+           endif ! flag for each tile           
+        enddo ! loop over tile
+        
+     else ! if update_flag_new(gid) is FALSE   
+        if(LIS_rc%pert_bias_corr.eq.1) then           
+
+!--------------------------------------------------------------------------
+! if no update is made, then we need to readjust the ensemble if pert bias
+! correction is turned on because the forcing perturbations may cause 
+! biases to persist. 
+!--------------------------------------------------------------------------
+           bounds_violation = .true. 
+           violation_new = .false.
+           nIter = 0
+           ens_flag = .true. 
+           
+           do while(bounds_violation) 
+              niter = niter + 1
+
+              !t_unpert = i*LIS_rc%nensem(n)
+	      t_unpert = i+LIS_rc%nensem(n)-1
+              !do j=1,4
+              do j=1,jules50_struc(n)%sm_levels  !Yonghwan Kwon
+                 delta_u(j) = 0.0
+                 delta_f(j) = 0.0
+                 do m=1,LIS_rc%nensem(n)-1
+                    t = i+m-1
+                    !t = (i-1)*LIS_rc%nensem(n)+m
+   
+                    if(m.ne.LIS_rc%nensem(n)) then 
+                    ! NOTE: be careful with the unit. do not change the unit of delta in the loop
+                    ! [m3w/m3s]  + ([-] - [-])*[m3/m3] 
+                       delta_u(j) = delta_u(j)+ & !  * 1/dzsoil(j)*1/1000 
+                                  (jules50_struc(n)%jules50(t)%p_s_sthu(j) - jules50_struc(n)%jules50(t_unpert)%p_s_sthu(j)) *&
+			          jules50_struc(n)%jules50(t)%p_s_smvcst(j)  !) &
+			          ! / (1/dzsoil(j)*1/1000) 
+                       delta_f(j) = delta_f(j)+ & !  
+                                  (jules50_struc(n)%jules50(t)%p_s_sthf(j) - jules50_struc(n)%jules50(t_unpert)%p_s_sthf(j)) *&
+                                  jules50_struc(n)%jules50(t)%p_s_smvcst(j) 
+                    endif
+                    
+                 enddo
+              enddo
+              
+              !do j=1,4
+              do j=1,jules50_struc(n)%sm_levels  !Yonghwan Kwon
+                 delta_u(j) = delta_u(j)/(LIS_rc%nensem(n)-1)
+                 delta_f(j) = delta_f(j)/(LIS_rc%nensem(n)-1)
+                 delta(j) = delta_u(j) + delta_f(j)
+                 do m=1,LIS_rc%nensem(n)-1
+                    t = i+m-1
+                    !t = (i-1)*LIS_rc%nensem(n)+m
+
+		    MAX_THRESHOLD(j) = jules50_struc(n)%jules50(t)%p_s_smvcst(j) ! assume it is the same for all layers [m3/m3]
+                    MIN_THRESHOLD(j) = jules50_struc(n)%jules50(t)%p_s_smvcwt(j) ! Volumetric wilting point (m^3 m-3 of soil) !Yonghwan Kwon 
+                    !sm_threshold(j)  = MAX_THRESHOLD(j) - MIN_THRESHOLD(j)
+                    sm_threshold(j)  = MAX_THRESHOLD(j)
+
+                    sat_p(j) = jules50_struc(n)%jules50(t)%p_s_smvcst(j) ! Volumetric saturation point (m^3 m-3 of soil) !Yonghwan Kwon
+                    p_s_sth(j) = jules50_struc(n)%jules50(t)%p_s_sthu(j) + jules50_struc(n)%jules50(t)%p_s_sthf(j)  !saturated fraction (Yonghwan Kwon)
+
+                    !-----------------------------------------------------
+                    ! Frozen soil moisture has been added (Yonghwan Kwon)
+                    ! Compute fraction
+     
+                    if (p_s_sth(j) > 0) then
+                       frac_sthu(j) = jules50_struc(n)%jules50(t)%p_s_sthu(j) / p_s_sth(j)
+                       frac_sthf(j) = jules50_struc(n)%jules50(t)%p_s_sthf(j) / p_s_sth(j)
+                    else
+                       frac_sthu(j) = 0
+                       frac_sthf(j) = 0
+                    endif
+                    !-----------------------------------------------------
+                    
+                    tmpval = p_s_sth(j) * sat_p(j) - delta(j) !* 1/dzsoil(j)*1/1000 ! [-][m3/m3]-[m3/m3] --> [m3/m3]                    
+                    if(tmpval.le.MIN_THRESHOLD(j)) then 
+
+                       if (sat_p(j) == 0) then
+                          jules50_struc(n)%jules50(t)%p_s_sthu(j) = 0
+                       else
+                          jules50_struc(n)%jules50(t)%p_s_sthu(j) = &
+                               (max(jules50_struc(n)%jules50(t_unpert)%p_s_sthu(j)*sat_p(j),&
+                                    0.1*MIN_THRESHOLD(j)*frac_sthu(j))) / sat_p(j) ! max( [-][m3/m3] , [m3/m3] ) / [m3/m3] --> fraction
+                          jules50_struc(n)%jules50(t)%p_s_sthf(j) = &
+                               (max(jules50_struc(n)%jules50(t_unpert)%p_s_sthf(j)*sat_p(j),&
+                                    0.1*MIN_THRESHOLD(j)*frac_sthf(j))) / sat_p(j) ! max( [-][m3/m3] , [m3/m3] ) / [m3/m3] --> fraction 
+                       endif
+                       jules50_struc(n)%jules50(t)%smcl_soilt(j) = &
+                              (jules50_struc(n)%jules50(t)%p_s_sthu(j) + jules50_struc(n)%jules50(t)%p_s_sthf(j)) * sat_p(j)&
+                              /(1/dzsoil(j)*1/1000)
+
+
+                       !jules50_struc(n)%jules50(t)%smcl_soilt(j) = & 
+                       !     (max(jules50_struc(n)%jules50(t_unpert)%smcl_soilt(j)&
+                       !	        *1/dzsoil(j)*1/1000,&
+                       !          0.1*MIN_THRESHOLD(j))) / (1/dzsoil(j)*1/1000) ! max( [kg/m2]*[1/m]*[1/kg/m3] , [m3/m3] ) / ([1/m][kg/m3]) --> [kg/m2]
+
+                       ens_flag(m) = .false. 
+
+                    elseif(tmpval.gt.sm_threshold(j)) then  ! MN ge --> gt
+
+                       if (sat_p(j) == 0) then
+                          jules50_struc(n)%jules50(t)%p_s_sthu(j) = 0
+                       else
+                          jules50_struc(n)%jules50(t)%p_s_sthu(j) = &
+                               (min(jules50_struc(n)%jules50(t_unpert)%p_s_sthu(j)*sat_p(j),&
+                                   sm_threshold(j)*frac_sthu(j))) / sat_p(j) ! min( [-][m3/m3] , [m3/m3] ) / [m3/m3] --> fraction 
+                          jules50_struc(n)%jules50(t)%p_s_sthf(j) = &
+                               (min(jules50_struc(n)%jules50(t_unpert)%p_s_sthf(j)*sat_p(j),&
+                                   sm_threshold(j)*frac_sthf(j))) / sat_p(j) ! min( [-][m3/m3] , [m3/m3] ) / [m3/m3] --> fraction  
+                       endif
+                       jules50_struc(n)%jules50(t)%smcl_soilt(j) = &
+                              (jules50_struc(n)%jules50(t)%p_s_sthu(j) + jules50_struc(n)%jules50(t)%p_s_sthf(j)) * sat_p(j)&
+                              /(1/dzsoil(j)*1/1000)
+
+                       !jules50_struc(n)%jules50(t)%smcl_soilt(j) = &
+                       !     (min(jules50_struc(n)%jules50(t_unpert)%smcl_soilt(j)&
+                       !	        *1/dzsoil(j)*1/1000,&
+                       !         sm_threshold(j))) / (1/dzsoil(j)*1/1000) ! min( [kg/m2]*[1/m]*[1/kg/m3] , [m3/m3] ) / ([1/m][kg/m3]) --> [kg/m2]
+
+                       ens_flag(m) = .false. 
+                    endif
+                 enddo
+              enddo
+              
+
+
+
+!--------------------------------------------------------------------------
+! Recalculate the deltas and adjust the ensemble
+!--------------------------------------------------------------------------
+              !do j=1,4
+              do j=1,jules50_struc(n)%sm_levels  !Yonghwan Kwon
+                 delta_u(j) = 0.0
+                 delta_f(j) = 0.0
+                 do m=1,LIS_rc%nensem(n)-1
+                    t = i+m-1
+
+                    !t = (i-1)*LIS_rc%nensem(n)+m
+                    if(m.ne.LIS_rc%nensem(n)) then 
+		       ! NOTE: be careful with the unit. do not change the unit of delta in the loop
+                       ! [m3w/m3s]  + ([-] - [-])*[m3/m3] --> [m3/m3]
+                       delta_u(j) = delta_u(j)+ & !  * 1/dzsoil(j)*1/1000 
+                            (jules50_struc(n)%jules50(t)%p_s_sthu(j) - jules50_struc(n)%jules50(t_unpert)%p_s_sthu(j)) * &
+                                jules50_struc(n)%jules50(t)%p_s_smvcst(j)  !) &
+                                ! / (1/dzsoil(j)*1/1000)
+                       delta_f(j) = delta_f(j)+ & !  * 1/dzsoil(j)*1/1000 
+                            (jules50_struc(n)%jules50(t)%p_s_sthf(j) - jules50_struc(n)%jules50(t_unpert)%p_s_sthf(j)) * &
+                                jules50_struc(n)%jules50(t)%p_s_smvcst(j)  !) &
+                                ! / (1/dzsoil(j)*1/1000)
+                    endif
+                 enddo
+              enddo
+              
+              !do j=1,4
+              do j=1,jules50_struc(n)%sm_levels  !Yonghwan Kwon
+                 delta_u(j) =delta_u(j)/(LIS_rc%nensem(n)-1)  !Yonghwan Kwon
+                 delta_f(j) =delta_f(j)/(LIS_rc%nensem(n)-1)  !Yonghwan Kwon
+                 delta(j) = delta_u(j) + delta_f(j)  !Yonghwan Kwon
+                 do m=1,LIS_rc%nensem(n)-1
+                    t = i+m-1
+                    !t = (i-1)*LIS_rc%nensem(n)+m
+                    
+                    MAX_THRESHOLD(j) = jules50_struc(n)%jules50(t)%p_s_smvcst(j) ! assume it is the same for all layers [m3/m3]
+                    MIN_THRESHOLD(j) = jules50_struc(n)%jules50(t)%p_s_smvcwt(j) ! Volumetric wilting point (m^3 m-3 of soil) !Yonghwan Kwon 
+                    !sm_threshold(j)  = MAX_THRESHOLD(j) - MIN_THRESHOLD(j)
+                    sm_threshold(j)  = MAX_THRESHOLD(j)
+
+                    sat_p(j) = jules50_struc(n)%jules50(t)%p_s_smvcst(j) ! Volumetric saturation point (m^3 m-3 of soil) !Yonghwan Kwon
+                    p_s_sth(j) = jules50_struc(n)%jules50(t)%p_s_sthu(j) + jules50_struc(n)%jules50(t)%p_s_sthf(j)  !saturated fraction (Yonghwan Kwon)
+
+                    !-----------------------------------------------------
+                    ! Frozen soil moisture has been added (Yonghwan Kwon)
+                    ! Compute fraction
+
+                    if (p_s_sth(j) > 0) then
+                       frac_sthu(j) = jules50_struc(n)%jules50(t)%p_s_sthu(j) / p_s_sth(j)
+                       frac_sthf(j) = jules50_struc(n)%jules50(t)%p_s_sthf(j) / p_s_sth(j)
+                    else
+                       frac_sthu(j) = 0
+                       frac_sthf(j) = 0
+                    endif
+                    !-----------------------------------------------------
+
+                    if(ens_flag(m)) then 
+                       tmpval = p_s_sth(j) * sat_p(j) - delta(j) !* 1/dzsoil(j)*1/1000 ! [-][m3/m3]-[m3/m3] --> [m3/m3] 
+                       tmpval_u = jules50_struc(n)%jules50(t)%p_s_sthu(j) * sat_p(j) - delta_u(j)
+                       tmpval_f = jules50_struc(n)%jules50(t)%p_s_sthf(j) * sat_p(j) - delta_f(j)
+
+!if (t .gt.600 .and. t.lt.613 .and. j==1) then
+!WRITE (*, '(A55 , 1x, 6(F10.6,1x) )')'2 tmpval, tmpval_u, tmpval_f, smc, sthu, sthf, MIN, MAX',tmpval,tmpval_u,tmpval_f, &
+!jules50_struc(n)%jules50(t)%smcl_soilt(1) *1/dzsoil(1)*1/1000 , & ! MN
+!jules50_struc(n)%jules50(t)%p_s_sthu(1) * sat_p(1), &! MN
+!jules50_struc(n)%jules50(t)%p_s_sthf(1) * sat_p(1), &! MN
+!MIN_THRESHOLD(j) , MAX_THRESHOLD(j)
+!endif
+
+                       if(.not.(tmpval.le.0.0 .or.tmpval.gt.(MAX_THRESHOLD(j)))) then 
+                          if(.not.(tmpval_u.lt.0.0 .or.tmpval_u.gt.(MAX_THRESHOLD(j)))) then 
+                             if(.not.(tmpval_f.lt.0.0 .or.tmpval_f.gt.(MAX_THRESHOLD(j)))) then
+                                jules50_struc(n)%jules50(t)%p_s_sthu(j) = &
+                                   (jules50_struc(n)%jules50(t)%p_s_sthu(j) * sat_p(j)&
+                                    - delta_u(j)) / sat_p(j) !([-][m3/m3]-[m3/m3]) / [m3/m3] --> [-]
+                                jules50_struc(n)%jules50(t)%p_s_sthf(j) = &
+                                   (jules50_struc(n)%jules50(t)%p_s_sthf(j) * sat_p(j)&
+                                    - delta_f(j)) / sat_p(j) !([-][m3/m3]-[m3/m3]) / [m3/m3] --> [-]
+
+                                jules50_struc(n)%jules50(t)%smcl_soilt(j) = &
+                                   jules50_struc(n)%jules50(t)%smcl_soilt(j) - delta(j)/(1/dzsoil(j)*1/1000) ! [kg/m2] - [m3/m3] / ([1/m]*[1/kg/m3]) --> [kg/m2]
+
+                                !jules50_struc(n)%jules50(t)%smcl_soilt(j) = &
+                                !   (jules50_struc(n)%jules50(t)%p_s_sthu(j) + jules50_struc(n)%jules50(t)%p_s_sthf(j)) * sat_p(j)&
+                                !   /(1/dzsoil(j)*1/1000)
+
+                                bounds_violation = .false.
+                             endif
+                          endif
+                       endif           
+                    endif
+
+                    p_s_sth(j) = jules50_struc(n)%jules50(t)%p_s_sthu(j) + jules50_struc(n)%jules50(t)%p_s_sthf(j)
+                    tmpval = p_s_sth(j) * sat_p(j) ! [-][m3/m3]
+                    
+                    if(tmpval.le.0.0 .or.&
+                         tmpval.gt.(MAX_THRESHOLD(j))) then 
+                       bounds_violation = .true.
+                    else
+                       bounds_violation = .false.
+                    endif
+
+                    if (sat_p(j) == 0) then
+                       bounds_violation = .false.
+                       !glacier grid -> does not conduct assimilation
+                    endif
+
+                 enddo
+              enddo
+              
+              if(nIter.gt.10.and.bounds_violation) then
+
+!--------------------------------------------------------------------------
+! All else fails, set to the bounds
+!--------------------------------------------------------------------------
+                 
+!                 write(LIS_logunit,*) '[ERR] Ensemble structure violates physical bounds '
+!                 write(LIS_logunit,*) '[ERR] Please adjust the perturbation settings ..'
+                 !do j=1,4
+                 do j=1,jules50_struc(n)%sm_levels !Yonghwan Kwon
+                    do m=1,LIS_rc%nensem(n)
+                       t = i+m-1
+                       !t = (i-1)*LIS_rc%nensem(n)+m
+                      
+                       MAX_THRESHOLD(j) = jules50_struc(n)%jules50(t)%p_s_smvcst(j) ! assume it is the same for all layers [m3/m3]
+                       MIN_THRESHOLD(j) = jules50_struc(n)%jules50(t)%p_s_smvcwt(j) ! Volumetric wilting point (m^3 m-3 of soil) !Yonghwan Kwon 
+
+                       sat_p(j) = jules50_struc(n)%jules50(t)%p_s_smvcst(j) ! Volumetric saturation point (m^3 m-3 of soil) !Yonghwan Kwon
+                       p_s_sth(j) = jules50_struc(n)%jules50(t)%p_s_sthu(j) + jules50_struc(n)%jules50(t)%p_s_sthf(j)  !saturated fraction (Yonghwan Kwon)
+ 
+                       !-----------------------------------------------------
+                       ! Frozen soil moisture has been added (Yonghwan Kwon)
+                       ! Compute fraction
+
+                       if (p_s_sth(j) > 0) then
+                          frac_sthu(j) = jules50_struc(n)%jules50(t)%p_s_sthu(j) / p_s_sth(j)
+                          frac_sthf(j) = jules50_struc(n)%jules50(t)%p_s_sthf(j) / p_s_sth(j)
+                       else
+                          frac_sthu(j) = 0
+                          frac_sthf(j) = 0
+                       endif
+                       !-----------------------------------------------------
+
+                       if (p_s_sth(j) * sat_p(j).gt.MAX_THRESHOLD(j).or.&  
+                          jules50_struc(n)%jules50(t)%smcl_soilt(j) * &
+                             1/dzsoil(j)*1/1000.gt.MAX_THRESHOLD(j)) then
+                       
+                          jules50_struc(n)%jules50(t)%p_s_sthu(j) = MAX_THRESHOLD(j)*frac_sthu(j) / sat_p(j) ! [m3/m3]/[m3/m3] --> [-] 
+                          jules50_struc(n)%jules50(t)%p_s_sthf(j) = MAX_THRESHOLD(j)*frac_sthf(j) / sat_p(j) ! [m3/m3]/[m3/m3] --> [-] 
+                          jules50_struc(n)%jules50(t)%smcl_soilt(j) = MAX_THRESHOLD(j) / (1/dzsoil(j)*1/1000)   ! [m3w/m3s] / ([1/m1s][m3w/kg]) --> kg/m2s
+                       endif
+
+                       if (p_s_sth(j) * sat_p(j).lt.MIN_THRESHOLD(j).or.&                       
+                          jules50_struc(n)%jules50(t)%smcl_soilt(j)* &
+                             1/dzsoil(j)*1/1000.lt.MIN_THRESHOLD(j)) then
+                     
+                          jules50_struc(n)%jules50(t)%p_s_sthu(j) = 0.1*MIN_THRESHOLD(j)*frac_sthu(j) / sat_p(j) ! [m3/m3]/[m3/m3] --> [-]
+                          jules50_struc(n)%jules50(t)%p_s_sthf(j) = 0.1*MIN_THRESHOLD(j)*frac_sthf(j) / sat_p(j) ! [m3/m3]/[m3/m3] --> [-]
+                          jules50_struc(n)%jules50(t)%smcl_soilt(j) = 0.1*MIN_THRESHOLD(j) / (1/dzsoil(j)*1/1000)   ! [m3w/m3s] / ([1/m1s][m3w/kg]) --> kg/m2s
+                       endif
+                    enddo
+!                 call LIS_endrun()
+                 enddo
+
+                 bounds_violation = .false.
+              endif
+              
+           end do
+
+        endif
+     endif
+  enddo
+end subroutine jules50_setsoilm
+
+#endif

--- a/lis/surfacemodels/land/noah.3.9/da_soilm/noah39_setsoilm.F90
+++ b/lis/surfacemodels/land/noah.3.9/da_soilm/noah39_setsoilm.F90
@@ -629,6 +629,8 @@ subroutine noah39_setsoilm(n, LSM_State)
 !  integer :: svk_col,svk_row,ii,jj
 !  real    :: svk_statebf(LIS_rc%lnc(n),LIS_rc%lnr(n))
 
+  write(LIS_logunit,*)'Using LIS 7.5 noah39_setsoilm...'
+  
   call ESMF_StateGet(LSM_State,"Soil Moisture Layer 1",sm1Field,rc=status)
   call LIS_verify(status,&
        "ESMF_StateSet: Soil Moisture Layer 1 failed in noah39_setsoilm")

--- a/lis/surfacemodels/land/noah.3.9/da_soilm/noah39_setsoilm.F90
+++ b/lis/surfacemodels/land/noah.3.9/da_soilm/noah39_setsoilm.F90
@@ -19,6 +19,11 @@
 ! 11 Apr 2024: Mahdi Navari; Fix bug related to computing delta. The bug fix sets 
 !                    the code to use total soil moisture (smc) if the ground 
 !                    is frozen, rather than the liquid part of soil moisture (sh2o).
+! 06 May 2025: Eric Kemp; Add option to use LIS 7.5 version, for USAF.
+
+#include "LIS_misc.h"
+#ifndef USAF_LIS75_SMDA
+
 ! !INTERFACE:
 subroutine noah39_setsoilm(n, LSM_State)
 ! !USES:
@@ -560,3 +565,523 @@ subroutine noah39_setsoilm(n, LSM_State)
  
 end subroutine noah39_setsoilm
 
+#else
+
+! LIS 7.5 version
+!
+! !INTERFACE:
+subroutine noah39_setsoilm(n, LSM_State)
+! !USES:
+  use ESMF
+  use LIS_coreMod 
+  use LIS_logMod
+  use noah39_lsmMod
+
+  implicit none
+! !ARGUMENTS: 
+  integer, intent(in)    :: n
+  type(ESMF_State)       :: LSM_State
+!
+! !DESCRIPTION:
+!  
+!  This routine assigns the soil moisture prognostic variables to noah's
+!  model space. 
+! 
+!EOP
+
+  real, parameter        :: MIN_THRESHOLD = 0.02 
+  real                   :: MAX_threshold
+  real                   :: sm_threshold
+  type(ESMF_Field)       :: sm1Field
+  type(ESMF_Field)       :: sm2Field
+  type(ESMF_Field)       :: sm3Field
+  type(ESMF_Field)       :: sm4Field
+  real, pointer          :: soilm1(:)
+  real, pointer          :: soilm2(:)
+  real, pointer          :: soilm3(:)
+  real, pointer          :: soilm4(:)
+  integer                :: t, j,i, gid, m, t_unpert, LIS_localP, row , col
+  integer                :: status
+  real                   :: delta(4)
+  real                   :: delta1,delta2,delta3,delta4
+  real                   :: tmpval
+  logical                :: bounds_violation
+  integer                :: nIter
+  logical                :: update_flag(LIS_rc%ngrid(n))
+  logical                :: ens_flag(LIS_rc%nensem(n))
+! mn
+  real                   :: tmp(LIS_rc%nensem(n)), tmp0(LIS_rc%nensem(n))
+  real                   :: tmp1(LIS_rc%nensem(n)),tmp2(LIS_rc%nensem(n)),tmp3(LIS_rc%nensem(n)),tmp4(LIS_rc%nensem(n)) 
+  logical                :: update_flag_tile(LIS_rc%npatch(n,LIS_rc%lsm_index))
+  logical                :: flag_ens(LIS_rc%ngrid(n))
+  logical                :: flag_tmp(LIS_rc%nensem(n))
+  logical                :: update_flag_ens(LIS_rc%ngrid(n))
+  logical                :: update_flag_new(LIS_rc%ngrid(n))
+  integer                :: pcount, icount
+  real                   :: MaxEnsSM1 ,MaxEnsSM2 ,MaxEnsSM3 ,MaxEnsSM4
+  real                   :: MinEnsSM1 ,MinEnsSM2 ,MinEnsSM3 ,MinEnsSM4 
+  real                   :: MaxEns_sh2o1, MaxEns_sh2o2, MaxEns_sh2o3, MaxEns_sh2o4
+  real                   :: smc_rnd, smc_tmp 
+  real                   :: sh2o_tmp, sh2o_rnd 
+  INTEGER, DIMENSION (1) :: seed 
+  real                   :: lat , lon 
+  
+!  integer :: svk_col,svk_row,ii,jj
+!  real    :: svk_statebf(LIS_rc%lnc(n),LIS_rc%lnr(n))
+
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 1",sm1Field,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateSet: Soil Moisture Layer 1 failed in noah39_setsoilm")
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 2",sm2Field,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateSet: Soil Moisture Layer 2 failed in noah39_setsoilm")
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 3",sm3Field,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateSet: Soil Moisture Layer 3 failed in noah39_setsoilm")
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 4",sm4Field,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateSet: Soil Moisture Layer 4 failed in noah39_setsoilm")
+
+  call ESMF_FieldGet(sm1Field,localDE=0,farrayPtr=soilm1,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 1 failed in noah39_setsoilm")
+  call ESMF_FieldGet(sm2Field,localDE=0,farrayPtr=soilm2,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 2 failed in noah39_setsoilm")
+  call ESMF_FieldGet(sm3Field,localDE=0,farrayPtr=soilm3,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 3 failed in noah39_setsoilm")
+  call ESMF_FieldGet(sm4Field,localDE=0,farrayPtr=soilm4,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 4 failed in noah39_setsoilm")
+
+  update_flag = .true. 
+  update_flag_tile = .true. 
+
+  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+  
+!    sm_threshold_lo = noah39_struc(n)%noah(t)%smcdry
+     MAX_THRESHOLD = noah39_struc(n)%noah(t)%smcmax
+     sm_threshold  = MAX_THRESHOLD-MIN_THRESHOLD       
+     
+     gid = LIS_domain(n)%gindex(&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col,&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row) 
+
+
+
+
+!	if ( LIS_localPet == 0 ) then
+!	if (gid ==139027) then
+
+!	row =  LIS_surface(n, LIS_rc%lsm_index)%tile(t)%row
+!	col =  LIS_surface(n, LIS_rc%lsm_index)%tile(t)%col
+!	      print*, 'LIS_localPet == 0' ,t, gid, row, col, &
+!	          LIS_domain(n)%grid(LIS_domain(n)%gindex(col, row))%lat ,&
+!	          LIS_domain(n)%grid(LIS_domain(n)%gindex(col, row))%lon
+!	endif
+!	endif
+
+  !if (gid == 11380) then
+      !print*,'here'
+      !print*, t, gid,  LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col,&
+      !    LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row 
+  !endif     
+     !MN: delta = X(+) - X(-)
+     !NOTE: "noah_updatesoilm.F90" updates the soilm_(t)     
+     delta1 = soilm1(t)-noah39_struc(n)%noah(t)%smc(1)
+     delta2 = soilm2(t)-noah39_struc(n)%noah(t)%smc(2)
+     delta3 = soilm3(t)-noah39_struc(n)%noah(t)%smc(3)
+     delta4 = soilm4(t)-noah39_struc(n)%noah(t)%smc(4)
+     
+     ! MN: check    MIN_THRESHOLD < volumetric liquid soil moisture < threshold 
+     if(noah39_struc(n)%noah(t)%sh2o(1)+delta1.gt.MIN_THRESHOLD .and.&
+          noah39_struc(n)%noah(t)%sh2o(1)+delta1.lt.&
+          sm_threshold) then 
+        update_flag(gid) = update_flag(gid).and.(.true.)
+        ! MN save the flag for each tile (col*row*ens)   (64*44)*20
+        update_flag_tile(t) = update_flag_tile(t).and.(.true.)
+     else
+        update_flag(gid) = update_flag(gid).and.(.false.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.false.)
+     endif
+     if(noah39_struc(n)%noah(t)%sh2o(2)+delta2.gt.MIN_THRESHOLD .and.&
+          noah39_struc(n)%noah(t)%sh2o(2)+delta2.lt.sm_threshold) then 
+        update_flag(gid) = update_flag(gid).and.(.true.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.true.)
+     else
+        update_flag(gid) = update_flag(gid).and.(.false.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.false.)
+     endif
+     if(noah39_struc(n)%noah(t)%sh2o(3)+delta3.gt.MIN_THRESHOLD .and.&
+          noah39_struc(n)%noah(t)%sh2o(3)+delta3.lt.sm_threshold) then 
+        update_flag(gid) = update_flag(gid).and.(.true.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.true.)
+     else
+        update_flag(gid) = update_flag(gid).and.(.false.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.false.)
+     endif
+     if(noah39_struc(n)%noah(t)%sh2o(4)+delta4.gt.MIN_THRESHOLD .and.&
+          noah39_struc(n)%noah(t)%sh2o(4)+delta4.lt.sm_threshold) then 
+        update_flag(gid) = update_flag(gid).and.(.true.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.true.)
+     else
+        update_flag(gid) = update_flag(gid).and.(.false.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.false.)
+     endif
+
+   enddo
+
+!-----------------------------------------------------------------------------------------
+! MN create new flag: if update flag for 50% of the ensemble members is true 
+! then update the stats 
+!-----------------------------------------------------------------------------------------
+   update_flag_ens = .true.  
+   do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index),LIS_rc%nensem(n)
+     gid = LIS_domain(n)%gindex(&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(i)%col,&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(i)%row) 
+      flag_tmp=update_flag_tile(i:i+LIS_rc%nensem(n)-1)
+      !flag_tmp=update_flag_tile((i-1)*LIS_rc%nensem(n)+1:(i)*LIS_rc%nensem(n))
+      pcount = COUNT(flag_tmp) ! Counts the number of .TRUE. elements
+      if (pcount.lt.LIS_rc%nensem(n)*0.5) then   ! 50%
+         update_flag_ens(gid)= .False.
+      endif
+      update_flag_new(gid)= update_flag(gid).or.update_flag_ens(gid)  ! new flag
+   enddo
+   
+  ! update step
+  ! loop over grid points 
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index),LIS_rc%nensem(n)
+
+     gid = LIS_domain(n)%gindex(&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(i)%col,&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(i)%row) 
+
+     if(update_flag_new(gid)) then 
+!-----------------------------------------------------------------------------------------
+! 1- update the states
+! 1-1- if update flag for tile is TRUE --> apply the DA update    
+! 1-2- if update flag for tile is FALSE --> resample the states  
+! 2- adjust the sataes
+!-----------------------------------------------------------------------------------------
+! store update value for  cases that flag_tile & update_flag_new are TRUE
+! flag_tile = TRUE --> means met the both min and max threshold 
+
+        tmp1 = LIS_rc%udef
+        tmp2 = LIS_rc%udef
+        tmp3 = LIS_rc%udef
+        tmp4 = LIS_rc%udef
+
+        do m=1,LIS_rc%nensem(n)
+           t = i+m-1
+           !t = (i-1)*LIS_rc%nensem(n)+m
+           
+           if(update_flag_tile(t)) then
+              
+              tmp1(m) = soilm1(t) !noah39_struc(n)%noah(t)%smc(1)
+              tmp2(m) = soilm2(t) !noah39_struc(n)%noah(t)%smc(2)
+              tmp3(m) = soilm3(t) !noah39_struc(n)%noah(t)%smc(3)
+              tmp4(m) = soilm4(t) !noah39_struc(n)%noah(t)%smc(4)
+
+           endif
+        enddo
+        
+        MaxEnsSM1 = -10000
+        MaxEnsSM2 = -10000
+        MaxEnsSM3 = -10000
+        MaxEnsSM4 = -10000
+
+        MinEnsSM1 = 10000
+        MinEnsSM2 = 10000
+        MinEnsSM3 = 10000
+        MinEnsSM4 = 10000
+
+        do m=1,LIS_rc%nensem(n)
+           if(tmp1(m).ne.LIS_rc%udef) then 
+              MaxEnsSM1 = max(MaxEnsSM1, tmp1(m))
+              MaxEnsSM2 = max(MaxEnsSM2, tmp2(m))
+              MaxEnsSM3 = max(MaxEnsSM3, tmp3(m))
+              MaxEnsSM4 = max(MaxEnsSM4, tmp4(m))
+
+              MinEnsSM1 = min(MinEnsSM1, tmp1(m))
+              MinEnsSM2 = min(MinEnsSM2, tmp2(m))
+              MinEnsSM3 = min(MinEnsSM3, tmp3(m))
+              MinEnsSM4 = min(MinEnsSM4, tmp4(m))
+              
+           endif
+        enddo
+
+
+       tmp0 = LIS_rc%udef
+
+
+        ! loop over ensemble       
+        do m=1,LIS_rc%nensem(n)
+           t = i+m-1
+           !t = (i-1)*LIS_rc%nensem(n)+m
+
+           MAX_THRESHOLD = noah39_struc(n)%noah(t)%smcmax
+           sm_threshold  = MAX_THRESHOLD-MIN_THRESHOLD       
+                      
+           ! MN check update status for each tile  
+           if(update_flag_tile(t)) then
+              
+              delta1 = soilm1(t)-noah39_struc(n)%noah(t)%smc(1)
+              delta2 = soilm2(t)-noah39_struc(n)%noah(t)%smc(2)
+              delta3 = soilm3(t)-noah39_struc(n)%noah(t)%smc(3)
+              delta4 = soilm4(t)-noah39_struc(n)%noah(t)%smc(4)
+              
+              noah39_struc(n)%noah(t)%sh2o(1) = noah39_struc(n)%noah(t)%sh2o(1)+&
+                   delta1
+              noah39_struc(n)%noah(t)%smc(1) = soilm1(t)
+              if(soilm1(t).lt.0) then 
+                 print*, 'setsoilm1 ',t,soilm1(t)
+                 stop
+              endif
+              if(noah39_struc(n)%noah(t)%sh2o(2)+delta2.gt.MIN_THRESHOLD .and.&
+                   noah39_struc(n)%noah(t)%sh2o(2)+delta2.lt.sm_threshold) then 
+                 noah39_struc(n)%noah(t)%sh2o(2) = noah39_struc(n)%noah(t)%sh2o(2)+&
+                      soilm2(t)-noah39_struc(n)%noah(t)%smc(2)
+                 noah39_struc(n)%noah(t)%smc(2) = soilm2(t)
+                 if(soilm2(t).lt.0) then 
+                    print*, 'setsoilm2 ',t,soilm2(t)
+                    stop
+                 endif
+              endif
+              if(noah39_struc(n)%noah(t)%sh2o(3)+delta3.gt.MIN_THRESHOLD .and.&
+                   noah39_struc(n)%noah(t)%sh2o(3)+delta3.lt.sm_threshold) then 
+                 noah39_struc(n)%noah(t)%sh2o(3) = noah39_struc(n)%noah(t)%sh2o(3)+&
+                      soilm3(t)-noah39_struc(n)%noah(t)%smc(3)
+                 noah39_struc(n)%noah(t)%smc(3) = soilm3(t)
+                 if(soilm3(t).lt.0) then 
+                    print*, 'setsoilm3 ',t,soilm3(t)
+                    stop
+                 endif
+              endif
+              ! surface layer
+              if(noah39_struc(n)%noah(t)%sh2o(4)+delta4.gt.MIN_THRESHOLD .and.&
+                   noah39_struc(n)%noah(t)%sh2o(4)+delta4.lt.sm_threshold) then 
+                 noah39_struc(n)%noah(t)%sh2o(4) = noah39_struc(n)%noah(t)%sh2o(4)+&
+                      soilm4(t)-noah39_struc(n)%noah(t)%smc(4)
+                 noah39_struc(n)%noah(t)%smc(4) = soilm4(t)
+                 if(soilm4(t).lt.0) then 
+                    print*, 'setsoilm4 ',t,soilm4(t)
+                    stop
+                 endif
+              endif
+              
+              
+!-----------------------------------------------------------------------------------------
+! randomly resample the smc from [MIN_THRESHOLD,  Max value from DA @ that tiem step]
+!-----------------------------------------------------------------------------------------
+           else 
+              
+!-----------------------------------------------------------------------------------------  
+! set the soil moisture to the ensemble mean  
+!-----------------------------------------------------------------------------------------
+              
+              ! use mean value
+              ! Assume sh2o = smc (i.e. ice content=0) 
+              smc_tmp = (MaxEnsSM1 - MinEnsSM1)/2 + MinEnsSM1
+              noah39_struc(n)%noah(t)%sh2o(1) = smc_tmp 
+              noah39_struc(n)%noah(t)%smc(1) = smc_tmp
+              
+              smc_tmp = (MaxEnsSM2 - MinEnsSM2)/2 + MinEnsSM2            
+              noah39_struc(n)%noah(t)%sh2o(2) = smc_tmp
+              noah39_struc(n)%noah(t)%smc(2) = smc_tmp
+              
+              smc_tmp = (MaxEnsSM3 - MinEnsSM3)/2 + MinEnsSM3
+              noah39_struc(n)%noah(t)%sh2o(3) = smc_tmp
+              noah39_struc(n)%noah(t)%smc(3) = smc_tmp
+              
+              smc_tmp = (MaxEnsSM4 - MinEnsSM4)/2 + MinEnsSM4
+              noah39_struc(n)%noah(t)%sh2o(4) = smc_tmp
+              noah39_struc(n)%noah(t)%smc(4) = smc_tmp
+ 
+              
+	      !MN  4 print 	
+	      tmp0(m) = noah39_struc(n)%noah(t)%smc(1)
+                          
+           endif ! flag for each tile
+        enddo ! loop over tile
+ 
+     else ! if update_flag_new(gid) is FALSE   
+        if(LIS_rc%pert_bias_corr.eq.1) then           
+!--------------------------------------------------------------------------
+! if no update is made, then we need to readjust the ensemble if pert bias
+! correction is turned on because the forcing perturbations may cause 
+! biases to persist. 
+!--------------------------------------------------------------------------
+           bounds_violation = .true. 
+           nIter = 0
+           ens_flag = .true. 
+           
+           do while(bounds_violation) 
+              niter = niter + 1
+              !t_unpert = i*LIS_rc%nensem(n)
+	      t_unpert = i+LIS_rc%nensem(n)-1
+              do j=1,4
+                 delta(j) = 0.0
+                 do m=1,LIS_rc%nensem(n)-1
+                    t = i+m-1
+                    !t = (i-1)*LIS_rc%nensem(n)+m
+                    
+                    if(m.ne.LIS_rc%nensem(n)) then 
+                       delta(j) = delta(j) + &
+                            (noah39_struc(n)%noah(t)%sh2o(j) - &
+                            noah39_struc(n)%noah(t_unpert)%sh2o(j))
+                    endif
+                    
+                 enddo
+              enddo
+              
+              do j=1,4
+                 delta(j) =delta(j)/(LIS_rc%nensem(n)-1)
+                 do m=1,LIS_rc%nensem(n)-1
+                    t = i+m-1
+                    !t = (i-1)*LIS_rc%nensem(n)+m
+                    MAX_THRESHOLD = noah39_struc(n)%noah(t)%smcmax
+                    sm_threshold  = MAX_THRESHOLD-MIN_THRESHOLD
+                    
+                    tmpval = noah39_struc(n)%noah(t)%sh2o(j) - &
+                         delta(j)
+                    if(tmpval.le.MIN_THRESHOLD) then 
+                       noah39_struc(n)%noah(t)%sh2o(j) = &
+                            max(noah39_struc(n)%noah(t_unpert)%sh2o(j),&
+                            MIN_THRESHOLD)
+                       noah39_struc(n)%noah(t)%smc(j) = &
+                            max(noah39_struc(n)%noah(t_unpert)%smc(j),&
+                            MIN_THRESHOLD)
+                       ens_flag(m) = .false. 
+                    elseif(tmpval.ge.sm_threshold) then
+                       noah39_struc(n)%noah(t)%sh2o(j) = &
+                            min(noah39_struc(n)%noah(t_unpert)%sh2o(j),&
+                            sm_threshold)
+                       noah39_struc(n)%noah(t)%smc(j) = &
+                            min(noah39_struc(n)%noah(t_unpert)%smc(j),&
+                            sm_threshold)
+                       ens_flag(m) = .false. 
+                    endif
+                 enddo
+              enddo
+              
+!--------------------------------------------------------------------------
+! Recalculate the deltas and adjust the ensemble
+!--------------------------------------------------------------------------
+              do j=1,4
+                 delta(j) = 0.0
+                 do m=1,LIS_rc%nensem(n)-1
+                    t = i+m-1
+                    !t = (i-1)*LIS_rc%nensem(n)+m
+                    if(m.ne.LIS_rc%nensem(n)) then 
+                       delta(j) = delta(j) + &
+                            (noah39_struc(n)%noah(t)%sh2o(j) - &
+                            noah39_struc(n)%noah(t_unpert)%sh2o(j))
+                    endif
+                 enddo
+              enddo
+              
+              do j=1,4
+                 delta(j) =delta(j)/(LIS_rc%nensem(n)-1)
+                 do m=1,LIS_rc%nensem(n)-1
+                    t = i+m-1
+                    !t = (i-1)*LIS_rc%nensem(n)+m
+                    
+                    if(ens_flag(m)) then 
+                       tmpval = noah39_struc(n)%noah(t)%sh2o(j) - &
+                            delta(j)
+                       MAX_THRESHOLD = noah39_struc(n)%noah(t)%smcmax
+                       if(.not.(tmpval.le.0.0 .or.&
+                            tmpval.gt.(MAX_THRESHOLD))) then 
+                          
+                          noah39_struc(n)%noah(t)%smc(j) = &
+                               noah39_struc(n)%noah(t)%smc(j) - delta(j)
+                          noah39_struc(n)%noah(t)%sh2o(j) = &
+                               noah39_struc(n)%noah(t)%sh2o(j) - delta(j)
+                          bounds_violation = .false.
+                       endif
+                    endif
+                    
+                    tmpval = noah39_struc(n)%noah(t)%sh2o(j)
+                    MAX_THRESHOLD = noah39_struc(n)%noah(t)%smcmax
+                    
+                    if(tmpval.le.0.0 .or.&
+                         tmpval.gt.(MAX_THRESHOLD)) then 
+                       bounds_violation = .true. 
+                    else
+                       bounds_violation = .false.
+                    endif
+                 enddo
+              enddo
+              
+              if(nIter.gt.10.and.bounds_violation) then 
+!--------------------------------------------------------------------------
+! All else fails, set to the bounds
+!--------------------------------------------------------------------------
+                 
+!                 write(LIS_logunit,*) '[ERR] Ensemble structure violates physical bounds '
+!                 write(LIS_logunit,*) '[ERR] Please adjust the perturbation settings ..'
+                 do j=1,4
+                    do m=1,LIS_rc%nensem(n)
+                       t = i+m-1
+                       !t = (i-1)*LIS_rc%nensem(n)+m
+                       
+                       MAX_THRESHOLD = noah39_struc(n)%noah(t)%smcmax
+                       
+                       if(noah39_struc(n)%noah(t)%sh2o(j).gt.MAX_THRESHOLD.or.&
+                            noah39_struc(n)%noah(t)%smc(j).gt.MAX_THRESHOLD) then                        
+                          noah39_struc(n)%noah(t)%sh2o(j) = MAX_THRESHOLD
+                          noah39_struc(n)%noah(t)%smc(j) = MAX_THRESHOLD
+                       endif
+                       
+                       if(noah39_struc(n)%noah(t)%sh2o(j).lt.MIN_THRESHOLD.or.&
+                            noah39_struc(n)%noah(t)%smc(j).lt.MIN_THRESHOLD) then                        
+                          noah39_struc(n)%noah(t)%sh2o(j) = MIN_THRESHOLD
+                          noah39_struc(n)%noah(t)%smc(j) = MIN_THRESHOLD
+                       endif
+!                    print*, i, m
+!                    print*, 'smc',t, noah39_struc(n)%noah(t)%smc(:)
+!                    print*, 'sh2o ',t,noah39_struc(n)%noah(t)%sh2o(:)
+!                    print*, 'max ',t,MAX_THRESHOLD !noah39_struc(n)%noah(t)%smcmax
+                    enddo
+!                 call LIS_endrun()
+                 enddo
+              endif
+              
+           end do
+        endif
+     endif
+  enddo
+
+#if 0 
+  svk_statebf = 0.0
+  
+  do t = 1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+
+     svk_col = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col
+     svk_row = LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row
+     
+     svk_statebf(svk_col,svk_row) =  svk_statebf(svk_col,svk_row) + &
+          noah39_struc(n)%noah(t)%smc(1)
+  enddo
+
+  do jj=1,LIS_rc%lnr(n)
+     do ii=1,LIS_rc%lnc(n)
+        if(svk_statebf(ii,jj).gt.0) then 
+           svk_statebf(ii,jj) = svk_statebf(ii,jj)/LIS_rc%nensem(n)
+        endif
+     enddo
+  enddo
+
+  open(100,file='stateupd.bin',form='unformatted')
+  write(100) svk_statebf
+  close(100)
+!  stop
+#endif
+
+!stop 666
+ 
+end subroutine noah39_setsoilm
+
+#endif

--- a/lis/surfacemodels/land/noahmp.4.0.1/da_soilm/noahmp401_setsoilm.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/da_soilm/noahmp401_setsoilm.F90
@@ -99,7 +99,7 @@ subroutine NoahMP401_setsoilm(n, LSM_State)
   real                   :: smc_rnd, smc_tmp 
   real                   :: sh2o_tmp, sh2o_rnd 
   INTEGER, DIMENSION (1) :: seed 
-
+  
   call ESMF_StateGet(LSM_State,"Soil Moisture Layer 1",sm1Field,rc=status)
   call LIS_verify(status,&
        "ESMF_StateSet: Soil Moisture Layer 1 failed in NoahMP401_setsoilm")
@@ -595,6 +595,8 @@ subroutine NoahMP401_setsoilm(n, LSM_State)
   real                   :: smc_rnd, smc_tmp 
   real                   :: sh2o_tmp, sh2o_rnd 
   INTEGER, DIMENSION (1) :: seed 
+
+  write(LIS_logunit,*)'Using LIS 7.5 noahmp401_setsoilm...'
 
   call ESMF_StateGet(LSM_State,"Soil Moisture Layer 1",sm1Field,rc=status)
   call LIS_verify(status,&

--- a/lis/surfacemodels/land/noahmp.4.0.1/da_soilm/noahmp401_setsoilm.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/da_soilm/noahmp401_setsoilm.F90
@@ -33,8 +33,14 @@
 ! 10 Apr 2024: Mahdi Navari; Fix bug related to computing delta. The bug fix sets 
 !                    the code to use total soil moisture (smc) if the ground 
 !                    is frozen, rather than the liquid part of soil moisture (sh2o).
+! 05 May 2025: Eric Kemp; Add option to compiler older LIS 7.5 version of
+!   SMDA code for USAF.
 !
 ! !INTERFACE:
+
+#include "LIS_misc.h"
+#ifndef USAF_LIS75_SMDA
+
 subroutine NoahMP401_setsoilm(n, LSM_State)
 ! !USES:
   use ESMF
@@ -525,3 +531,492 @@ subroutine NoahMP401_setsoilm(n, LSM_State)
 
 end subroutine NoahMP401_setsoilm
 
+#else
+
+! LISF 7.5 version
+
+! !INTERFACE:
+subroutine NoahMP401_setsoilm(n, LSM_State)
+! !USES:
+  use ESMF
+  use LIS_coreMod
+  use LIS_logMod
+  use NoahMP401_lsmMod
+  !use module_sf_noahlsm_36  !MN
+  !use module_sf_noahmpdrv_401, only: parameters
+  use NOAHMP_TABLES_401, ONLY : SMCMAX_TABLE,SMCWLT_TABLE
+
+
+  implicit none
+! !ARGUMENTS: 
+  integer, intent(in)    :: n
+  type(ESMF_State)       :: LSM_State
+!
+! !DESCRIPTION:
+!  
+!  This routine assigns the soil moisture prognostic variables to noah's
+!  model space. 
+! 
+!EOP
+  real, parameter        :: MIN_THRESHOLD = 0.02 
+  real                   :: MAX_threshold
+  real                   :: sm_threshold
+  type(ESMF_Field)       :: sm1Field
+  type(ESMF_Field)       :: sm2Field
+  type(ESMF_Field)       :: sm3Field
+  type(ESMF_Field)       :: sm4Field
+  real, pointer          :: soilm1(:)
+  real, pointer          :: soilm2(:)
+  real, pointer          :: soilm3(:)
+  real, pointer          :: soilm4(:)
+  integer                :: t, j,i, gid, m, t_unpert
+  integer                :: status
+  real                   :: delta(4)
+  real                   :: delta1,delta2,delta3,delta4
+  real                   :: tmpval
+  logical                :: bounds_violation
+  integer                :: nIter
+  logical                :: update_flag(LIS_rc%ngrid(n))
+  logical                :: ens_flag(LIS_rc%nensem(n))
+! mn
+  integer                :: SOILTYP           ! soil type index [-]
+  real                   :: SMCMAX , SMCWLT
+  real                   :: tmp(LIS_rc%nensem(n)), tmp0(LIS_rc%nensem(n))
+  real                   :: tmp1(LIS_rc%nensem(n)),tmp2(LIS_rc%nensem(n)),tmp3(LIS_rc%nensem(n)),tmp4(LIS_rc%nensem(n)) 
+  logical                :: update_flag_tile(LIS_rc%npatch(n,LIS_rc%lsm_index))
+  logical                :: flag_ens(LIS_rc%ngrid(n))
+  logical                :: flag_tmp(LIS_rc%nensem(n))
+  logical                :: update_flag_ens(LIS_rc%ngrid(n))
+  logical                :: update_flag_new(LIS_rc%ngrid(n))
+  integer                :: RESULT, pcount, icount
+  real                   :: MaxEnsSM1 ,MaxEnsSM2 ,MaxEnsSM3 ,MaxEnsSM4
+  real                   :: MinEnsSM1 ,MinEnsSM2 ,MinEnsSM3 ,MinEnsSM4 
+  real                   :: MaxEns_sh2o1, MaxEns_sh2o2, MaxEns_sh2o3, MaxEns_sh2o4
+  real                   :: smc_rnd, smc_tmp 
+  real                   :: sh2o_tmp, sh2o_rnd 
+  INTEGER, DIMENSION (1) :: seed 
+
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 1",sm1Field,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateSet: Soil Moisture Layer 1 failed in NoahMP401_setsoilm")
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 2",sm2Field,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateSet: Soil Moisture Layer 2 failed in NoahMP401_setsoilm")
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 3",sm3Field,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateSet: Soil Moisture Layer 3 failed in NoahMP401_setsoilm")
+  call ESMF_StateGet(LSM_State,"Soil Moisture Layer 4",sm4Field,rc=status)
+  call LIS_verify(status,&
+       "ESMF_StateSet: Soil Moisture Layer 4 failed in NoahMP401_setsoilm")
+
+  call ESMF_FieldGet(sm1Field,localDE=0,farrayPtr=soilm1,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 1 failed in NoahMP401_setsoilm")
+  call ESMF_FieldGet(sm2Field,localDE=0,farrayPtr=soilm2,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 2 failed in NoahMP401_setsoilm")
+  call ESMF_FieldGet(sm3Field,localDE=0,farrayPtr=soilm3,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 3 failed in NoahMP401_setsoilm")
+  call ESMF_FieldGet(sm4Field,localDE=0,farrayPtr=soilm4,rc=status)
+  call LIS_verify(status,&
+       "ESMF_FieldGet: Soil Moisture Layer 4 failed in NoahMP401_setsoilm")
+
+  update_flag = .true. 
+  update_flag_tile= .true. 
+
+  do t=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
+  
+ ! MN: NOTE: SMCMAX and SMCWLT are not stored in the data structure but we 
+ !       can get module variables MAXSMC and WLTSMC from the module_sf_noahlsm_36    
+ !       In NoahMP401 module variables MAXSMC and WLTSMC from module_sf_noahmpdrv_401      
+     SOILTYP = noahmp401_struc(n)%noahmp401(t)%soiltype        
+     MAX_THRESHOLD = SMCMAX_TABLE(SOILTYP)   ! MAXSMC (SOILTYP)
+     sm_threshold = SMCMAX_TABLE(SOILTYP) - 0.02  ! MAXSMC (SOILTYP) - 0.02
+     
+     gid = LIS_domain(n)%gindex(&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(t)%col,&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(t)%row) 
+     
+     !MN: delta = X(+) - X(-)
+     !NOTE: "noahmp401_updatesoilm.F90" updates the soilm_(t)     
+     delta1 = soilm1(t)-noahmp401_struc(n)%noahmp401(t)%smc(1)
+     delta2 = soilm2(t)-noahmp401_struc(n)%noahmp401(t)%smc(2)
+     delta3 = soilm3(t)-noahmp401_struc(n)%noahmp401(t)%smc(3)
+     delta4 = soilm4(t)-noahmp401_struc(n)%noahmp401(t)%smc(4)
+
+     ! MN: check    MIN_THRESHOLD < volumetric liquid soil moisture < threshold 
+     if(noahmp401_struc(n)%noahmp401(t)%sh2o(1)+delta1.gt.MIN_THRESHOLD .and.&
+          noahmp401_struc(n)%noahmp401(t)%sh2o(1)+delta1.lt.&
+          sm_threshold) then 
+        update_flag(gid) = update_flag(gid).and.(.true.)
+        ! MN save the flag for each tile (col*row*ens)   (64*44)*20
+        update_flag_tile(t) = update_flag_tile(t).and.(.true.)
+     else
+        update_flag(gid) = update_flag(gid).and.(.false.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.false.)
+     endif
+     if(noahmp401_struc(n)%noahmp401(t)%sh2o(2)+delta2.gt.MIN_THRESHOLD .and.&
+          noahmp401_struc(n)%noahmp401(t)%sh2o(2)+delta2.lt.sm_threshold) then 
+        update_flag(gid) = update_flag(gid).and.(.true.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.true.)
+     else
+        update_flag(gid) = update_flag(gid).and.(.false.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.false.)
+     endif
+     if(noahmp401_struc(n)%noahmp401(t)%sh2o(3)+delta3.gt.MIN_THRESHOLD .and.&
+          noahmp401_struc(n)%noahmp401(t)%sh2o(3)+delta3.lt.sm_threshold) then 
+        update_flag(gid) = update_flag(gid).and.(.true.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.true.)
+     else
+        update_flag(gid) = update_flag(gid).and.(.false.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.false.)
+     endif
+     if(noahmp401_struc(n)%noahmp401(t)%sh2o(4)+delta4.gt.MIN_THRESHOLD .and.&
+          noahmp401_struc(n)%noahmp401(t)%sh2o(4)+delta4.lt.sm_threshold) then 
+        update_flag(gid) = update_flag(gid).and.(.true.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.true.)
+     else
+        update_flag(gid) = update_flag(gid).and.(.false.)
+        update_flag_tile(t) = update_flag_tile(t).and.(.false.)
+     endif
+  enddo
+
+!-----------------------------------------------------------------------------------------
+! MN create new falg: if update falg for 50% of the ensemble members is true 
+! then update the state variabels 
+!-----------------------------------------------------------------------------------------
+  update_flag_ens = .True.
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index),LIS_rc%nensem(n)
+     gid = LIS_domain(n)%gindex(&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(i)%col,&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(i)%row) 
+      flag_tmp=update_flag_tile(i:i+LIS_rc%nensem(n)-1)
+      !flag_tmp=update_flag_tile((i-1)*LIS_rc%nensem(n)+1:(i)*LIS_rc%nensem(n))
+      pcount = COUNT(flag_tmp) ! Counts the number of .TRUE. elements
+      if (pcount.lt.LIS_rc%nensem(n)*0.5) then   ! 50%
+         update_flag_ens(gid)= .False.
+      endif
+      update_flag_new(gid)= update_flag(gid).or.update_flag_ens(gid)  ! new flag
+  enddo 
+  
+  ! MN print 
+#if 0   
+if(i.eq.66) then !i=66  ! --> domain's center  1376
+  if(LIS_rc%hr.eq.12) then
+     write(2001,'(I4, 2x, 3(I2,x), 2x, 23(L1,2x))'),&
+          i, LIS_rc%mo, LIS_rc%da, LIS_rc%hr,update_flag_tile&
+          ((i-1)*LIS_rc%nensem(n)+1:(i)*LIS_rc%nensem(n)),&
+          update_flag_ens(i), update_flag_new(i), update_flag(i) 
+  endif !mn
+  endif
+#endif 
+  
+  ! update step
+  ! loop over grid points 
+  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index),LIS_rc%nensem(n)
+     
+     gid = LIS_domain(n)%gindex(&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(i)%col,&
+          LIS_surface(n,LIS_rc%lsm_index)%tile(i)%row) 
+     
+     !if(update_flag(gid)) then
+     if(update_flag_new(gid)) then 
+!-----------------------------------------------------------------------------------------
+       ! 1- update the states
+       ! 1-1- if update flag for tile is TRUE --> apply the DA update    
+       ! 1-2- if update flag for tile is FALSE --> resample the states  
+       ! 2- adjust the states
+!-----------------------------------------------------------------------------------------
+        ! store update value for  cases that update_flag_tile & update_flag_new are TRUE
+        ! update_flag_tile = TRUE --> means met the both min and max threshold
+      
+        tmp1 = LIS_rc%udef
+        tmp2 = LIS_rc%udef
+        tmp3 = LIS_rc%udef
+        tmp4 = LIS_rc%udef
+	!icount = 1
+        do m=1,LIS_rc%nensem(n)
+           t = i+m-1
+           !t = (i-1)*LIS_rc%nensem(n)+m
+ 
+	  if(update_flag_tile(t)) then
+          
+           tmp1(m) = soilm1(t) 
+           tmp2(m) = soilm2(t) 
+           tmp3(m) = soilm3(t) 
+           tmp4(m) = soilm4(t) 
+           !icount = icount + 1 
+          endif
+        enddo
+        
+        MaxEnsSM1 = -10000
+        MaxEnsSM2 = -10000
+        MaxEnsSM3 = -10000
+        MaxEnsSM4 = -10000
+
+        MinEnsSM1 = 10000
+        MinEnsSM2 = 10000
+        MinEnsSM3 = 10000
+        MinEnsSM4 = 10000
+
+        do m=1,LIS_rc%nensem(n)
+           if(tmp1(m).ne.LIS_rc%udef) then 
+              MaxEnsSM1 = max(MaxEnsSM1, tmp1(m))
+              MaxEnsSM2 = max(MaxEnsSM2, tmp2(m))
+              MaxEnsSM3 = max(MaxEnsSM3, tmp3(m))
+              MaxEnsSM4 = max(MaxEnsSM4, tmp4(m))
+
+              MinEnsSM1 = min(MinEnsSM1, tmp1(m))
+              MinEnsSM2 = min(MinEnsSM2, tmp2(m))
+              MinEnsSM3 = min(MinEnsSM3, tmp3(m))
+              MinEnsSM4 = min(MinEnsSM4, tmp4(m))
+              
+           endif
+        enddo
+
+        
+        ! loop over tile       
+        do m=1,LIS_rc%nensem(n)
+           t = i+m-1           
+           !t = (i-1)*LIS_rc%nensem(n)+m
+           
+           ! MN check update status for each tile  
+           if(update_flag_tile(t)) then
+              
+              delta1 = soilm1(t)-noahmp401_struc(n)%noahmp401(t)%smc(1)
+              delta2 = soilm2(t)-noahmp401_struc(n)%noahmp401(t)%smc(2)
+              delta3 = soilm3(t)-noahmp401_struc(n)%noahmp401(t)%smc(3)
+              delta4 = soilm4(t)-noahmp401_struc(n)%noahmp401(t)%smc(4)
+
+              noahmp401_struc(n)%noahmp401(t)%sh2o(1) = noahmp401_struc(n)%noahmp401(t)%sh2o(1)+&
+                   delta1
+              noahmp401_struc(n)%noahmp401(t)%smc(1) = soilm1(t)
+              if(soilm1(t).lt.0) then 
+                 print*, 'setsoilm1 ',t,soilm1(t)
+                 stop
+              endif
+              if(noahmp401_struc(n)%noahmp401(t)%sh2o(2)+delta2.gt.MIN_THRESHOLD .and.&
+                   noahmp401_struc(n)%noahmp401(t)%sh2o(2)+delta2.lt.sm_threshold) then 
+                 noahmp401_struc(n)%noahmp401(t)%sh2o(2) = noahmp401_struc(n)%noahmp401(t)%sh2o(2)+&
+                      soilm2(t)-noahmp401_struc(n)%noahmp401(t)%smc(2)
+                 noahmp401_struc(n)%noahmp401(t)%smc(2) = soilm2(t)
+                 if(soilm2(t).lt.0) then 
+                    print*, 'setsoilm2 ',t,soilm2(t)
+                    stop
+                 endif
+              endif
+  
+              if(noahmp401_struc(n)%noahmp401(t)%sh2o(3)+delta3.gt.MIN_THRESHOLD .and.&
+                   noahmp401_struc(n)%noahmp401(t)%sh2o(3)+delta3.lt.sm_threshold) then 
+                 noahmp401_struc(n)%noahmp401(t)%sh2o(3) = noahmp401_struc(n)%noahmp401(t)%sh2o(3)+&
+                      soilm3(t)-noahmp401_struc(n)%noahmp401(t)%smc(3)
+                 noahmp401_struc(n)%noahmp401(t)%smc(3) = soilm3(t)
+                 if(soilm3(t).lt.0) then 
+                    print*, 'setsoilm3 ',t,soilm3(t)
+                    stop
+                 endif
+              endif
+
+              if(noahmp401_struc(n)%noahmp401(t)%sh2o(4)+delta4.gt.MIN_THRESHOLD .and.&
+                   noahmp401_struc(n)%noahmp401(t)%sh2o(4)+delta4.lt.sm_threshold) then 
+                 noahmp401_struc(n)%noahmp401(t)%sh2o(4) = noahmp401_struc(n)%noahmp401(t)%sh2o(4)+&
+                      soilm4(t)-noahmp401_struc(n)%noahmp401(t)%smc(4)
+                 noahmp401_struc(n)%noahmp401(t)%smc(4) = soilm4(t)
+
+                 if(soilm4(t).lt.0) then 
+                    print*, 'setsoilm4 ',t,soilm4(t)
+                    stop
+                 endif
+              endif
+              
+              
+!-----------------------------------------------------------------------------------------              
+              ! randomly resample the smc from [MIN_THRESHOLD,  Max value from DA @ that tiem step]
+!-----------------------------------------------------------------------------------------
+           else 
+          
+!-----------------------------------------------------------------------------------------  
+! set the soil moisture to the ensemble mean  
+!-----------------------------------------------------------------------------------------
+              
+              ! use mean value
+              ! Assume sh2o = smc (i.e. ice content=0) 
+              smc_tmp = (MaxEnsSM1 - MinEnsSM1)/2 + MinEnsSM1
+              noahmp401_struc(n)%noahmp401(t)%sh2o(1) = smc_tmp 
+              noahmp401_struc(n)%noahmp401(t)%smc(1) = smc_tmp
+                          
+              smc_tmp = (MaxEnsSM2 - MinEnsSM2)/2 + MinEnsSM2            
+              noahmp401_struc(n)%noahmp401(t)%sh2o(2) = smc_tmp
+              noahmp401_struc(n)%noahmp401(t)%smc(2) = smc_tmp
+               
+              smc_tmp = (MaxEnsSM3 - MinEnsSM3)/2 + MinEnsSM3
+              noahmp401_struc(n)%noahmp401(t)%sh2o(3) = smc_tmp
+              noahmp401_struc(n)%noahmp401(t)%smc(3) = smc_tmp
+              
+              smc_tmp = (MaxEnsSM4 - MinEnsSM4)/2 + MinEnsSM4
+              noahmp401_struc(n)%noahmp401(t)%sh2o(4) = smc_tmp
+              noahmp401_struc(n)%noahmp401(t)%smc(4) = smc_tmp
+              
+ 
+           endif ! flag for each tile
+
+        enddo ! loop over tile
+       
+     else ! if update_flag_new(gid) is FALSE   
+        if(LIS_rc%pert_bias_corr.eq.1) then           
+           !--------------------------------------------------------------------------
+           ! if no update is made, then we need to readjust the ensemble if pert bias
+           ! correction is turned on because the forcing perturbations may cause 
+           ! biases to persist. 
+           !--------------------------------------------------------------------------
+           bounds_violation = .true. 
+           nIter = 0
+           ens_flag = .true. 
+           
+           do while(bounds_violation) 
+              niter = niter + 1
+              !t_unpert = i*LIS_rc%nensem(n)
+	      t_unpert = i+LIS_rc%nensem(n)-1
+              do j=1,4
+                 delta(j) = 0.0
+                 do m=1,LIS_rc%nensem(n)-1
+                     t = i+m-1
+                    !t = (i-1)*LIS_rc%nensem(n)+m
+                    
+                    if(m.ne.LIS_rc%nensem(n)) then 
+                       delta(j) = delta(j) + &
+                            (noahmp401_struc(n)%noahmp401(t)%sh2o(j) - &
+                            noahmp401_struc(n)%noahmp401(t_unpert)%sh2o(j))
+                    endif
+                    
+                 enddo
+              enddo
+              
+              do j=1,4
+                 delta(j) =delta(j)/(LIS_rc%nensem(n)-1)
+                 do m=1,LIS_rc%nensem(n)-1
+                     t = i+m-1
+                    !t = (i-1)*LIS_rc%nensem(n)+m
+                    SOILTYP = noahmp401_struc(n)%noahmp401(t)%soiltype  
+                    MAX_THRESHOLD = SMCMAX_TABLE(SOILTYP) 
+                    sm_threshold = SMCMAX_TABLE(SOILTYP)  - 0.02
+                    
+                    tmpval = noahmp401_struc(n)%noahmp401(t)%sh2o(j) - &
+                         delta(j)
+                    if(tmpval.le.MIN_THRESHOLD) then 
+                       noahmp401_struc(n)%noahmp401(t)%sh2o(j) = &
+                            max(noahmp401_struc(n)%noahmp401(t_unpert)%sh2o(j),&
+                            MIN_THRESHOLD)
+                       noahmp401_struc(n)%noahmp401(t)%smc(j) = &
+                            max(noahmp401_struc(n)%noahmp401(t_unpert)%smc(j),&
+                            MIN_THRESHOLD)
+                       ens_flag(m) = .false. 
+                    elseif(tmpval.ge.sm_threshold) then
+                       noahmp401_struc(n)%noahmp401(t)%sh2o(j) = &
+                            min(noahmp401_struc(n)%noahmp401(t_unpert)%sh2o(j),&
+                            sm_threshold)
+                       noahmp401_struc(n)%noahmp401(t)%smc(j) = &
+                            min(noahmp401_struc(n)%noahmp401(t_unpert)%smc(j),&
+                            sm_threshold)
+                       ens_flag(m) = .false. 
+                    endif
+                 enddo
+              enddo
+              
+              !--------------------------------------------------------------------------
+              ! Recalculate the deltas and adjust the ensemble
+              !--------------------------------------------------------------------------
+              do j=1,4
+                 delta(j) = 0.0
+                 do m=1,LIS_rc%nensem(n)-1
+                    t = i+m-1
+                    !t = (i-1)*LIS_rc%nensem(n)+m
+                    if(m.ne.LIS_rc%nensem(n)) then 
+                       delta(j) = delta(j) + &
+                            (noahmp401_struc(n)%noahmp401(t)%sh2o(j) - &
+                            noahmp401_struc(n)%noahmp401(t_unpert)%sh2o(j))
+                    endif
+                 enddo
+              enddo
+              
+              do j=1,4
+                 delta(j) =delta(j)/(LIS_rc%nensem(n)-1)
+                 do m=1,LIS_rc%nensem(n)-1
+                    t = i+m-1
+                    !t = (i-1)*LIS_rc%nensem(n)+m
+                    
+                    if(ens_flag(m)) then 
+                       tmpval = noahmp401_struc(n)%noahmp401(t)%sh2o(j) - &
+                            delta(j)
+                       SOILTYP = noahmp401_struc(n)%noahmp401(t)%soiltype  
+                       MAX_THRESHOLD = SMCMAX_TABLE(SOILTYP)  
+                       
+                       if(.not.(tmpval.le.0.0 .or.&
+                            tmpval.gt.(MAX_THRESHOLD))) then 
+                          
+                          noahmp401_struc(n)%noahmp401(t)%smc(j) = &
+                               noahmp401_struc(n)%noahmp401(t)%smc(j) - delta(j)
+                          noahmp401_struc(n)%noahmp401(t)%sh2o(j) = &
+                               noahmp401_struc(n)%noahmp401(t)%sh2o(j) - delta(j)
+                          bounds_violation = .false.
+                       endif
+                    endif
+                    
+                    tmpval = noahmp401_struc(n)%noahmp401(t)%sh2o(j)
+                    SOILTYP = noahmp401_struc(n)%noahmp401(t)%soiltype  
+                    MAX_THRESHOLD = SMCMAX_TABLE(SOILTYP)  
+                    
+                    if(tmpval.le.0.0 .or.&
+                         tmpval.gt.(MAX_THRESHOLD)) then 
+                       bounds_violation = .true. 
+                    else
+                       bounds_violation = .false.
+                    endif
+                 enddo
+              enddo
+              
+              if(nIter.gt.10.and.bounds_violation) then 
+                 !--------------------------------------------------------------------------
+                 ! All else fails, set to the bounds
+                 !--------------------------------------------------------------------------
+                 
+                 write(LIS_logunit,*) '[ERR] Ensemble structure violates physical bounds '
+                 write(LIS_logunit,*) '[ERR] Please adjust the perturbation settings ..'
+
+                 do j=1,4
+                    do m=1,LIS_rc%nensem(n)
+                       t = i+m-1
+                       !t = (i-1)*LIS_rc%nensem(n)+m
+                       
+                       SOILTYP = noahmp401_struc(n)%noahmp401(t)%soiltype  
+                       MAX_THRESHOLD = SMCMAX_TABLE(SOILTYP)           
+                       
+                       if(noahmp401_struc(n)%noahmp401(t)%sh2o(j).gt.MAX_THRESHOLD.or.&
+                            noahmp401_struc(n)%noahmp401(t)%smc(j).gt.MAX_THRESHOLD) then                        
+                          noahmp401_struc(n)%noahmp401(t)%sh2o(j) = MAX_THRESHOLD
+                          noahmp401_struc(n)%noahmp401(t)%smc(j) = MAX_THRESHOLD
+                       endif
+                       
+                       if(noahmp401_struc(n)%noahmp401(t)%sh2o(j).lt.MIN_THRESHOLD.or.&
+                            noahmp401_struc(n)%noahmp401(t)%smc(j).lt.MIN_THRESHOLD) then                        
+                          noahmp401_struc(n)%noahmp401(t)%sh2o(j) = MIN_THRESHOLD
+                          noahmp401_struc(n)%noahmp401(t)%smc(j) = MIN_THRESHOLD
+                       endif
+!                    print*, i, m
+!                    print*, 'smc',t, noahmp401_struc(n)%noahmp401(t)%smc(:)
+!                    print*, 'sh2o ',t,noahmp401_struc(n)%noahmp401(t)%sh2o(:)
+!                    print*, 'max ',t,MAX_THRESHOLD !noahmp401_struc(n)%noahmp401(t)%smcmax
+                    enddo
+!                  call LIS_endrun()
+                 enddo
+              endif          
+           end do
+        endif        
+     endif
+  enddo
+
+
+end subroutine NoahMP401_setsoilm
+
+#endif


### PR DESCRIPTION

### Description

Added code and new configure option to compile LIS 7.6 with 7.5 era soil moisture DA codes for Noah39, NoahMP401,
and Jules50.

This change is put in to ensure consistency in SM DA results in 7.6, which is disrupted by bug fixes.  While these bug fixes are probably valid, it requires a complete new spin-up going back to 2008 for a consistent SM anomaly reference.  This is a requirement for both the NRT SM GeoTIFF files and the S2S system.

The option to compile LIS 7.6 with 7.5 code is off by default, which should protect non-USAF users of LIS who don't have this consistency requirement.

Ultimately this is a kludge designed to buy time for creating a new spin-up.

