### PR TITLE
Minor fix to monthly S2S metric file string name reads

### DIFF
--- a/lis/utils/usaf/s2s/s2s_modules/s2smetric/metrics_library/convert_dyn_fcst_to_anom.py
+++ b/lis/utils/usaf/s2s/s2s_modules/s2smetric/metrics_library/convert_dyn_fcst_to_anom.py
@@ -78,10 +78,12 @@ elif DOMAIN_NAME == 'GLOBAL':
     CLIM_INFILE_TEMPLATE1 = \
         '{}/????{:02d}/{}/PS.557WW_SC.U_DI.C_GP.LIS-S2S-{}_GR.C0P25DEG_AR.GLOBAL_'
 
+# Account for monthly s2spost files only as s2spost weekly files are getting
+#  blended into this listing:
 TARGET_INFILE_TEMPLATE2 = \
-    'PA.ALL_DD.{:04d}{:02d}01_DT.0000_FP.{:04d}{:02d}??-{:04d}{:02d}??_DF.NC'
+    'PA.ALL_DD.{:04d}{:02d}01_DT.0000_FP.{:04d}{:02d}??-{:04d}{:02d}01_DF.NC'
 
-CLIM_INFILE_TEMPLATE2 = 'PA.ALL_DD.*{:02d}01_DT.0000_FP.*{:02d}??-*{:02d}??_DF.NC'
+CLIM_INFILE_TEMPLATE2 = 'PA.ALL_DD.*{:02d}01_DT.0000_FP.*{:02d}??-*{:02d}01_DF.NC'
 
 TARGET_INFILE_TEMPLATE = TARGET_INFILE_TEMPLATE1 + TARGET_INFILE_TEMPLATE2
 CLIM_INFILE_TEMPLATE = CLIM_INFILE_TEMPLATE1 + CLIM_INFILE_TEMPLATE2

--- a/lis/utils/usaf/s2s/s2s_modules/s2smetric/metrics_library/convert_dyn_fcst_to_sanom.py
+++ b/lis/utils/usaf/s2s/s2s_modules/s2smetric/metrics_library/convert_dyn_fcst_to_sanom.py
@@ -76,11 +76,13 @@ elif DOMAIN_NAME == 'GLOBAL':
     CLIM_INFILE_TEMPLATE1 = \
         '{}/????{:02d}/{}/PS.557WW_SC.U_DI.C_GP.LIS-S2S-{}_GR.C0P25DEG_AR.GLOBAL_'
 
+# Account for monthly s2spost files only as s2spost weekly files are getting
+#  blended into this listing:
 TARGET_INFILE_TEMPLATE2 = \
-    'PA.ALL_DD.{:04d}{:02d}01_DT.0000_FP.{:04d}{:02d}??-{:04d}{:02d}??_DF.NC'
+    'PA.ALL_DD.{:04d}{:02d}01_DT.0000_FP.{:04d}{:02d}??-{:04d}{:02d}01_DF.NC'
 TARGET_INFILE_TEMPLATE = TARGET_INFILE_TEMPLATE1 + TARGET_INFILE_TEMPLATE2
 
-CLIM_INFILE_TEMPLATE2 = 'PA.ALL_DD.*{:02d}01_DT.0000_FP.*{:02d}??-*{:02d}??_DF.NC'
+CLIM_INFILE_TEMPLATE2 = 'PA.ALL_DD.*{:02d}01_DT.0000_FP.*{:02d}??-*{:02d}01_DF.NC'
 
 CLIM_INFILE_TEMPLATE = CLIM_INFILE_TEMPLATE1 + CLIM_INFILE_TEMPLATE2
 ## String in this format allows the select all the files for the given month


### PR DESCRIPTION
 The s2smetric scripts use the ?? wildcard type for multiple dates,
  which was originally designed to capture just monthly entries.
  By including more files in the s2s postprocessed directories, e.g.,
  now representing week, the new files are getting accidentally merged
  into the monthly metric calculations.

 Changed the second book-end month in the routines from: ?? to “01”,
  since all months’ second bookend will always reflect the first or “01”
  of the next month.

<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Description

Replace this text with a concise description of *what* was changed and *why*.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->

### Testcase
<!-- Add path to testcase files and any special instructions below. -->
<!-- If testing is not required, delete this section. -->


