### PR TITLE
Bug fix: floating invalid error in daily stat 

### DIFF
--- a/lvt/core/LVT_TSMod.F90
+++ b/lvt/core/LVT_TSMod.F90
@@ -487,7 +487,7 @@ contains
     integer  :: nmu_m(1)
     real     :: mu_2
     integer  :: nmu
-    real     :: mean_v, med_v, sstd_v
+    real     :: mean_v, sstd_v
     real     :: ci_val
     integer  :: i,k,l,kk,tid
     integer  :: stid, m,t
@@ -666,7 +666,7 @@ contains
     real     :: ens_std
     real     :: ci_val,ci_val1
     integer  :: i,k,l,kk,tid
-    integer  :: stid, m,t
+    integer  :: m, t
     real     :: metric_tsdom(nsize_m)
     real     :: maxv, minv
     real     :: maxv1, minv1
@@ -894,7 +894,7 @@ contains
     real     :: mean_v, sstd_v
     real     :: ci_val
     integer  :: i,k,l,kk,tid
-    integer  :: stid, m,t
+    integer  :: m
     real     :: metric_tsdom(LVT_LIS_rc(1)%ntiles)
     real     :: maxv, minv
     integer  :: nensem


### PR DESCRIPTION
LVT crashes with floating invalid error when computing daily statistics with missing hourly data (Please see issue #1737)

### Description
A condition was added to verify whether the number of hourly data points for a given day is zero; if so, the daily mean is set to LVT_rc%udef


Resolves #1737 

### Testcase
/discover/nobackup/projects/usaf_lis/mnavari/AF/SMAP_E_OPL/analysis_mn/Compare_with_SMAP_L2_E_2025_4paper
(lvt.config.noah39 and run_lvt.j)


