### PR TITLE
Make sure all fields for water points are set to missing.

### DIFF
--- a/lis/core/LIS_historyMod.F90
+++ b/lis/core/LIS_historyMod.F90
@@ -3090,7 +3090,8 @@ contains
                       continue   
                    endif
                 else
-                   dataEntry%modelOutput(1,t,k) = LIS_rc%udef
+                   ! Handle all outputs
+                   dataEntry%modelOutput(:,t,k) = LIS_rc%udef
                 endif
              enddo
           enddo


### PR DESCRIPTION
### Description

Prior code only set the first 2D modelOutput field to missing, which causes problems when both instantaneous and time-averaged fields are requested for writing.


