### PR TITLE
Add GEOS-IT bias reader and extend MERRA-2 lapse rate handling for sub-global domains

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -352,6 +352,7 @@ Acceptable values for the sources are:
 |"`GFS`"                       | GFS
 |"`MERRA2`"                    | MERRA2
 |"`GEOS-IT`"                   | GEOS-IT
+|"`GEOS-ITbias`"               | GEOS-ITbias
 |"`CMAP`"                      | CMAP
 |"`TRMM 3B42RT`"               | TRMM 3B42RT
 |"`TRMM 3B42RTV7`"             | TRMM 3B42RTV7
@@ -5738,6 +5739,14 @@ Acceptable values are:
 `MERRA2 dynamic lapse rate data directory:` specifies the
 directory of the pre-computed MERRA-2 lapse rate dataset.
 
+`MERRA2 dynamic lapse rate filename prefix:` specifies the prefix
+of the pre-computed MERRA-2 lapse rate files. This is an optional
+config entry; if not present, the default is `/MERRA2.lapse_rate.hourly.`.
+
+`MERRA2 dynamic lapse rate filename suffix:` specifies the suffix
+of the pre-computed MERRA-2 lapse rate files. This is an optional
+config entry; if not present, the default is `.global.nc`.
+
 `MERRA2 apply double-sided dynamic lapse rate cutoff:` specifies whether
 to apply a double-sided cutoff to the dynamic lapse rate values. This is
 an optional config entry; if not present, the default is 0. If set to 1, 
@@ -5824,6 +5833,79 @@ Acceptable values are:
 GEOS-IT forcing directory:                  ./GEOS-IT
 GEOS-IT use lowest model level forcing:     1
 GEOS-IT use 2m wind fields:                 0 
+....
+
+[[sssec_forcings_GEOS-ITbias,GEOS-ITbias]]
+==== GEOS-ITbias
+
+`GEOS-ITbias forcing directory:` specifies the location of
+the GEOS-IT bias-corrected forcing files.
+
+`GEOS-ITbias apply dynamic lapse rates:` specifies whether to read
+in and apply the pre-computed GEOS-ITbias lapse rates.  This is an
+optional config entry; if not present, the default is 0.  Note
+that one of the two lapse-rate options for the topographic
+correction method for met forcing must be chosen for this
+config entry to be used.
+Acceptable values are:
+
+|====
+|Value | Description
+
+|0     | Do not apply GEOS-ITbias dynamic lapse rates (use static lapse rate).
+|1     | Apply GEOS-ITbias dynamic lapse rates
+|====
+
+`GEOS-ITbias dynamic lapse rate data directory:` specifies the
+directory of the pre-computed GEOS-ITbias lapse rate dataset.
+
+`GEOS-ITbias dynamic lapse rate filename prefix:` specifies the prefix
+of the pre-computed GEOS-ITbias lapse rate files. This is an optional
+config entry; if not present, the default is `/GEOS-ITbias.lapse_rate.hourly.`.
+
+`GEOS-ITbias dynamic lapse rate filename suffix:` specifies the suffix
+of the pre-computed MERRA-2 lapse rate files. This is an optional
+config entry; if not present, the default is `.global.nc`.
+
+`GEOS-ITbias apply double-sided dynamic lapse rate cutoff:` specifies whether
+to apply a double-sided cutoff to the dynamic lapse rate values. This is
+an optional config entry; if not present, the default is 0. If set to 1, 
+values above (below) the maximum (minimum) cutoff are replaced with the 
+maximum (minimum) cutoff value. Maximum and minimum cutoff values can
+optionally be set using the GEOS-ITbias maximum and minimum lapse rate cutoff
+aguments, or otherwise are assumed the default cutoff values, as described 
+below.
+
+|====
+|Value | Description
+
+|0     | Do not apply GEOS-ITbias double-sided dynamic lapse rate cutoff.
+|1     | Apply GEOS-ITbias double-sided dynamic lapse rate cutoff.
+|====
+
+`GEOS-ITbias maximum lapse rate cutoff (K/m):` specifies the maximum value
+for the GEOS-ITbias double-sided dynamic lapse rate cutoff range, in units
+of Kelvin per meter (K/m). This is an optional config entry; if
+not present, the default is set to 0.01 K/m. This is only applied if
+GEOS-ITbias apply double-sided dynamic lapse rate cutoff is turned on
+(i.e., set to a value of 1).
+
+`GEOS-ITbias minimum lapse rate cutoff (K/m):` specifies the minimum value
+for the GEOS-ITbias double-sided dynamic lapse rate cutoff range, in units
+of Kelvin per meter (K/m). This is an optional config entry; if
+not present, the default is set to -0.1 K/m. This is only applied if
+GEOS-ITbias apply double-sided dynamic lapse rate cutoff is turned on
+(i.e., set to a value of 1).
+
+.Example _lis.config_ entry
+
+....
+GEOS-ITbias forcing directory:                             ./GEOS-ITbias
+GEOS-ITbias apply dynamic lapse rates:                     1
+GEOS-ITbias dynamic lapse rate data directory:             ./GEOS-ITbias_lapse_rates
+GEOS-ITbias apply double-sided dynamic lapse rate cutoff:  1
+GEOS-ITbias maximum lapse rate cutoff (K/m):               0.009
+GEOS-ITbias minimum lapse rate cutoff (K/m):               -0.009
 ....
 
 [[sssec_forcings_ERA5,ERA5]]

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -5869,11 +5869,11 @@ config entry; if not present, the default is `.global.nc`.
 
 `GEOS-ITbias apply double-sided dynamic lapse rate cutoff:` specifies whether
 to apply a double-sided cutoff to the dynamic lapse rate values. This is
-an optional config entry; if not present, the default is 0. If set to 1, 
-values above (below) the maximum (minimum) cutoff are replaced with the 
+an optional config entry; if not present, the default is 0. If set to 1,
+values above (below) the maximum (minimum) cutoff are replaced with the
 maximum (minimum) cutoff value. Maximum and minimum cutoff values can
 optionally be set using the GEOS-ITbias maximum and minimum lapse rate cutoff
-aguments, or otherwise are assumed the default cutoff values, as described 
+aguments, or otherwise are assumed the default cutoff values, as described
 below.
 
 |====

--- a/lis/make/default.cfg
+++ b/lis/make/default.cfg
@@ -292,6 +292,11 @@ enabled: True
 macro: MF_GEOS_IT
 path: metforcing/geos_it
 
+[GEOS-ITbias]
+enabled: True
+macro: MF_GEOS_ITbias
+path: metforcing/geos_itbias
+
 [ERA5]
 enabled: True
 macro: MF_ERA5

--- a/lis/metforcing/geos_itbias/0Intro_geositbias.txt
+++ b/lis/metforcing/geos_itbias/0Intro_geositbias.txt
@@ -1,0 +1,14 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.4
+!
+! Copyright (c) 2022 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!
+!BOP
+!\section{GEOS-IT}
+!This section describes the implementation of the GEOS-IT forcing data.
+!EOP

--- a/lis/metforcing/geos_itbias/finalize_geositbias.F90
+++ b/lis/metforcing/geos_itbias/finalize_geositbias.F90
@@ -1,9 +1,9 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 ! NASA Goddard Space Flight Center
 ! Land Information System Framework (LISF)
-! Version 7.4
+! Version 7.5
 !
-! Copyright (c) 2022 United States Government as represented by the
+! Copyright (c) 2024 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------

--- a/lis/metforcing/geos_itbias/finalize_geositbias.F90
+++ b/lis/metforcing/geos_itbias/finalize_geositbias.F90
@@ -1,0 +1,71 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.4
+!
+! Copyright (c) 2022 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: finalize_geositbias
+! \label{finalize_geositbias}
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+!
+! !INTERFACE:
+      subroutine finalize_geositbias(findex)
+
+! !USES:
+      use LIS_coreMod,     only   : LIS_rc
+      use geositbias_forcingMod, only : geositbias_struc
+!
+! !DESCRIPTION:
+!  Routine to cleanup GEOS-ITbias forcing related memory allocations.
+!
+!EOP
+      implicit none
+
+      integer :: findex
+      integer :: n
+
+      do n = 1,LIS_rc%nnest
+         select case( LIS_rc%met_interp(findex) )
+
+         case( "bilinear" )
+            deallocate(geositbias_struc(n)%n111)
+            deallocate(geositbias_struc(n)%n121)
+            deallocate(geositbias_struc(n)%n211)
+            deallocate(geositbias_struc(n)%n221)
+            deallocate(geositbias_struc(n)%w111)
+            deallocate(geositbias_struc(n)%w121)
+            deallocate(geositbias_struc(n)%w211)
+            deallocate(geositbias_struc(n)%w221)
+
+         case( "budget-bilinear" )
+            deallocate(geositbias_struc(n)%n111)
+            deallocate(geositbias_struc(n)%n121)
+            deallocate(geositbias_struc(n)%n211)
+            deallocate(geositbias_struc(n)%n221)
+            deallocate(geositbias_struc(n)%w111)
+            deallocate(geositbias_struc(n)%w121)
+            deallocate(geositbias_struc(n)%w211)
+            deallocate(geositbias_struc(n)%w221)
+            deallocate(geositbias_struc(n)%n112)
+            deallocate(geositbias_struc(n)%n122)
+            deallocate(geositbias_struc(n)%n212)
+            deallocate(geositbias_struc(n)%n222)
+            deallocate(geositbias_struc(n)%w112)
+            deallocate(geositbias_struc(n)%w122)
+            deallocate(geositbias_struc(n)%w212)
+            deallocate(geositbias_struc(n)%w222)
+
+         case( "neighbor" )
+            deallocate(geositbias_struc(n)%n113)
+         end select
+      enddo
+      deallocate(geositbias_struc)
+
+      end subroutine finalize_geositbias
+

--- a/lis/metforcing/geos_itbias/finalize_geositbias.F90
+++ b/lis/metforcing/geos_itbias/finalize_geositbias.F90
@@ -13,59 +13,60 @@
 !
 ! !REVISION HISTORY:
 ! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+! 09 Jan 2026: Eric Kemp, reformatted.
 !
 ! !INTERFACE:
-      subroutine finalize_geositbias(findex)
+subroutine finalize_geositbias(findex)
 
 ! !USES:
-      use LIS_coreMod,     only   : LIS_rc
-      use geositbias_forcingMod, only : geositbias_struc
+  use LIS_coreMod,     only   : LIS_rc
+  use geositbias_forcingMod, only : geositbias_struc
 !
 ! !DESCRIPTION:
 !  Routine to cleanup GEOS-ITbias forcing related memory allocations.
 !
 !EOP
-      implicit none
+  implicit none
 
-      integer :: findex
-      integer :: n
+  integer :: findex
+  integer :: n
 
-      do n = 1,LIS_rc%nnest
-         select case( LIS_rc%met_interp(findex) )
+  do n = 1,LIS_rc%nnest
+     select case( LIS_rc%met_interp(findex) )
 
-         case( "bilinear" )
-            deallocate(geositbias_struc(n)%n111)
-            deallocate(geositbias_struc(n)%n121)
-            deallocate(geositbias_struc(n)%n211)
-            deallocate(geositbias_struc(n)%n221)
-            deallocate(geositbias_struc(n)%w111)
-            deallocate(geositbias_struc(n)%w121)
-            deallocate(geositbias_struc(n)%w211)
-            deallocate(geositbias_struc(n)%w221)
+     case( "bilinear" )
+        deallocate(geositbias_struc(n)%n111)
+        deallocate(geositbias_struc(n)%n121)
+        deallocate(geositbias_struc(n)%n211)
+        deallocate(geositbias_struc(n)%n221)
+        deallocate(geositbias_struc(n)%w111)
+        deallocate(geositbias_struc(n)%w121)
+        deallocate(geositbias_struc(n)%w211)
+        deallocate(geositbias_struc(n)%w221)
 
-         case( "budget-bilinear" )
-            deallocate(geositbias_struc(n)%n111)
-            deallocate(geositbias_struc(n)%n121)
-            deallocate(geositbias_struc(n)%n211)
-            deallocate(geositbias_struc(n)%n221)
-            deallocate(geositbias_struc(n)%w111)
-            deallocate(geositbias_struc(n)%w121)
-            deallocate(geositbias_struc(n)%w211)
-            deallocate(geositbias_struc(n)%w221)
-            deallocate(geositbias_struc(n)%n112)
-            deallocate(geositbias_struc(n)%n122)
-            deallocate(geositbias_struc(n)%n212)
-            deallocate(geositbias_struc(n)%n222)
-            deallocate(geositbias_struc(n)%w112)
-            deallocate(geositbias_struc(n)%w122)
-            deallocate(geositbias_struc(n)%w212)
-            deallocate(geositbias_struc(n)%w222)
+     case( "budget-bilinear" )
+        deallocate(geositbias_struc(n)%n111)
+        deallocate(geositbias_struc(n)%n121)
+        deallocate(geositbias_struc(n)%n211)
+        deallocate(geositbias_struc(n)%n221)
+        deallocate(geositbias_struc(n)%w111)
+        deallocate(geositbias_struc(n)%w121)
+        deallocate(geositbias_struc(n)%w211)
+        deallocate(geositbias_struc(n)%w221)
+        deallocate(geositbias_struc(n)%n112)
+        deallocate(geositbias_struc(n)%n122)
+        deallocate(geositbias_struc(n)%n212)
+        deallocate(geositbias_struc(n)%n222)
+        deallocate(geositbias_struc(n)%w112)
+        deallocate(geositbias_struc(n)%w122)
+        deallocate(geositbias_struc(n)%w212)
+        deallocate(geositbias_struc(n)%w222)
 
-         case( "neighbor" )
-            deallocate(geositbias_struc(n)%n113)
-         end select
-      enddo
-      deallocate(geositbias_struc)
+     case( "neighbor" )
+        deallocate(geositbias_struc(n)%n113)
+     end select
+  enddo
+  deallocate(geositbias_struc)
 
-      end subroutine finalize_geositbias
+end subroutine finalize_geositbias
 

--- a/lis/metforcing/geos_itbias/geositbias_forcingMod.F90
+++ b/lis/metforcing/geos_itbias/geositbias_forcingMod.F90
@@ -7,13 +7,14 @@
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
-      module geositbias_forcingMod
+module geositbias_forcingMod
 !BOP
 ! !MODULE: geositbias_forcingMod
 !
 ! !REVISION HISTORY:
-! 02 Oct 2025: Fadji Maina, initial code (based on geos-it) 
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
 ! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
+! 09 Jan 2026: Eric Kemp, reformatted.
 !
 ! !DESCRIPTION:
 !  This module contains variables and data structures that are used
@@ -62,70 +63,70 @@
 !  \end{description}
 !
 ! !USES:
-      use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
 
-      implicit none
+  implicit none
 
-      PRIVATE
+  PRIVATE
 !-----------------------------------------------------------------------------
 ! !PUBLIC MEMBER FUNCTIONS:
 !-----------------------------------------------------------------------------
-      public :: init_geositbias    ! defines the native resolution of the input data
+  public :: init_geositbias    ! defines the native resolution of the input data
 !-----------------------------------------------------------------------------
 ! !PUBLIC TYPES:
 !-----------------------------------------------------------------------------
-      public :: geositbias_struc
+  public :: geositbias_struc
 
 !EOP
-      type, public :: geositbias_type_dec
-      real         :: ts
-      integer      :: ncold, nrold
-      character(len=LIS_CONST_PATH_LEN) :: geositbiasdir   ! GEOS-ITbias Forcing Directory
-      real*8       :: geositbiastime1,geositbiastime2
-      logical      :: reset_flag
+  type, public :: geositbias_type_dec
+     real         :: ts
+     integer      :: ncold, nrold
+     character(len=LIS_CONST_PATH_LEN) :: geositbiasdir   ! GEOS-ITbias Forcing Directory
+     real*8       :: geositbiastime1,geositbiastime2
+     logical      :: reset_flag
 
-      integer                :: mi
-      integer, allocatable   :: n111(:)
-      integer, allocatable   :: n121(:)
-      integer, allocatable   :: n211(:)
-      integer, allocatable   :: n221(:)
-      real, allocatable      :: w111(:),w121(:)
-      real, allocatable      :: w211(:),w221(:)
+     integer                :: mi
+     integer, allocatable   :: n111(:)
+     integer, allocatable   :: n121(:)
+     integer, allocatable   :: n211(:)
+     integer, allocatable   :: n221(:)
+     real, allocatable      :: w111(:),w121(:)
+     real, allocatable      :: w211(:),w221(:)
 
-      integer, allocatable   :: n112(:,:)
-      integer, allocatable   :: n122(:,:)
-      integer, allocatable   :: n212(:,:)
-      integer, allocatable   :: n222(:,:)
-      real, allocatable      :: w112(:,:),w122(:,:)
-      real, allocatable      :: w212(:,:),w222(:,:)
-      integer, allocatable   :: n113(:)
-      integer                :: findtime1,findtime2
-      logical                :: startFlag,dayFlag
-      real, allocatable      :: geositbiasforc1(:,:,:),geositbiasforc2(:,:,:)
-      real, allocatable      :: lapserate1(:), lapserate2(:)
-      integer            :: nvars
-      integer            :: uselml
-      real*8             :: ringtime
-      integer            :: nIter,st_iterid,en_iterid
+     integer, allocatable   :: n112(:,:)
+     integer, allocatable   :: n122(:,:)
+     integer, allocatable   :: n212(:,:)
+     integer, allocatable   :: n222(:,:)
+     real, allocatable      :: w112(:,:),w122(:,:)
+     real, allocatable      :: w212(:,:),w222(:,:)
+     integer, allocatable   :: n113(:)
+     integer                :: findtime1,findtime2
+     logical                :: startFlag,dayFlag
+     real, allocatable      :: geositbiasforc1(:,:,:),geositbiasforc2(:,:,:)
+     real, allocatable      :: lapserate1(:), lapserate2(:)
+     integer            :: nvars
+     integer            :: uselml
+     real*8             :: ringtime
+     integer            :: nIter,st_iterid,en_iterid
 
-      real, allocatable :: metdata1(:,:,:)
-      real, allocatable :: metdata2(:,:,:)
+     real, allocatable :: metdata1(:,:,:)
+     real, allocatable :: metdata2(:,:,:)
 
-      integer                 :: use2mwind
-      character(len=LIS_CONST_PATH_LEN) :: scaleffile
-      integer, allocatable    :: rseed(:,:)
-      integer                 :: usedynlapserate
-      character(len=LIS_CONST_PATH_LEN) :: dynlapseratedir
-      character(len=LIS_CONST_PATH_LEN) :: dynlapseratepfx
-      character(len=LIS_CONST_PATH_LEN) :: dynlapseratesfx
-      integer                 :: applydynlapseratecutoff
-      real                    :: dynlapseratemincutoff
-      real                    :: dynlapseratemaxcutoff
-      end type geositbias_type_dec
+     integer                 :: use2mwind
+     character(len=LIS_CONST_PATH_LEN) :: scaleffile
+     integer, allocatable    :: rseed(:,:)
+     integer                 :: usedynlapserate
+     character(len=LIS_CONST_PATH_LEN) :: dynlapseratedir
+     character(len=LIS_CONST_PATH_LEN) :: dynlapseratepfx
+     character(len=LIS_CONST_PATH_LEN) :: dynlapseratesfx
+     integer                 :: applydynlapseratecutoff
+     real                    :: dynlapseratemincutoff
+     real                    :: dynlapseratemaxcutoff
+  end type geositbias_type_dec
 
-      type(geositbias_type_dec), allocatable :: geositbias_struc(:)
+  type(geositbias_type_dec), allocatable :: geositbias_struc(:)
 
-      contains
+contains
 
 !BOP
 !
@@ -137,17 +138,18 @@
 ! 20 Apr 2023: David Mocko,  initial code (based on merra2)
 !
 ! !INTERFACE:
-      subroutine init_geositbias(findex)
+  subroutine init_geositbias(findex)
 
 ! !USES:
-      use LIS_coreMod
-      use LIS_timeMgrMod
-      use LIS_logMod
-      use LIS_spatialDownscalingMod, only : LIS_init_pcpclimo_native
+    use LIS_coreMod
+    use LIS_timeMgrMod
+    use LIS_logMod
+    use LIS_spatialDownscalingMod, only : LIS_init_pcpclimo_native
 
-      implicit none
+    implicit none
+
 ! !AGRUMENTS:
-      integer, intent(in) :: findex
+    integer, intent(in) :: findex
 
 ! !DESCRIPTION:
 !  Defines the native resolution of the input forcing for GEOS-ITbias
@@ -165,149 +167,149 @@
 !    computes the neighbor, weights for conservative interpolation
 !  \end{description}
 !EOP
-      real :: gridDesci(LIS_rc%nnest,50)
-      integer :: n
+    real :: gridDesci(LIS_rc%nnest,50)
+    integer :: n
 
-      external :: readcrd_geositbias
-      external :: bilinear_interp_input
-      external :: conserv_interp_input
-      external :: neighbor_interp_input
-      external :: read_geositbias_elev
+    external :: readcrd_geositbias
+    external :: bilinear_interp_input
+    external :: conserv_interp_input
+    external :: neighbor_interp_input
+    external :: read_geositbias_elev
 
-      allocate(geositbias_struc(LIS_rc%nnest))
+    allocate(geositbias_struc(LIS_rc%nnest))
 
-      do n = 1,LIS_rc%nnest
-         geositbias_struc(n)%ncold = 187
-         geositbias_struc(n)%nrold = 131
-      enddo
+    do n = 1,LIS_rc%nnest
+       geositbias_struc(n)%ncold = 187
+       geositbias_struc(n)%nrold = 131
+    enddo
 
-      call readcrd_geositbias()
-      LIS_rc%met_nf(findex) = 4
+    call readcrd_geositbias()
+    LIS_rc%met_nf(findex) = 4
 
-      geositbias_struc%reset_flag = .false.
+    geositbias_struc%reset_flag = .false.
 
-      do n = 1, LIS_rc%nnest
-         geositbias_struc(n)%ts = 3600 !check
-         call LIS_update_timestep(LIS_rc,n,geositbias_struc(n)%ts)
-      enddo
+    do n = 1, LIS_rc%nnest
+       geositbias_struc(n)%ts = 3600 !check
+       call LIS_update_timestep(LIS_rc,n,geositbias_struc(n)%ts)
+    enddo
 
-      gridDesci = 0
-      do n = 1,LIS_rc%nnest
-         gridDesci(n,1)  = 0
-         gridDesci(n,2)  = geositbias_struc(n)%ncold
-         gridDesci(n,3)  = geositbias_struc(n)%nrold
-         gridDesci(n,4)  = 7.0
-         gridDesci(n,5)  = -168.75
-         gridDesci(n,6)  = 128
-         gridDesci(n,7)  = 72.0
-         gridDesci(n,8)  = -52.5
-         gridDesci(n,9)  = 0.625
-         gridDesci(n,10) = 0.5
-         gridDesci(n,20) = 0
+    gridDesci = 0
+    do n = 1,LIS_rc%nnest
+       gridDesci(n,1)  = 0
+       gridDesci(n,2)  = geositbias_struc(n)%ncold
+       gridDesci(n,3)  = geositbias_struc(n)%nrold
+       gridDesci(n,4)  = 7.0
+       gridDesci(n,5)  = -168.75
+       gridDesci(n,6)  = 128
+       gridDesci(n,7)  = 72.0
+       gridDesci(n,8)  = -52.5
+       gridDesci(n,9)  = 0.625
+       gridDesci(n,10) = 0.5
+       gridDesci(n,20) = 0
 
-         geositbias_struc(n)%mi = geositbias_struc(n)%ncold*geositbias_struc(n)%nrold
+       geositbias_struc(n)%mi = geositbias_struc(n)%ncold*geositbias_struc(n)%nrold
 
        ! Setting up weights for Interpolation
-         if (trim(LIS_rc%met_interp(findex)).eq."bilinear") then
-            allocate(geositbias_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            call bilinear_interp_input(n,gridDesci(n,:),               &
-                   geositbias_struc(n)%n111,geositbias_struc(n)%n121,          &
-                   geositbias_struc(n)%n211,geositbias_struc(n)%n221,          &
-                   geositbias_struc(n)%w111,geositbias_struc(n)%w121,          &
-                   geositbias_struc(n)%w211,geositbias_struc(n)%w221)
+       if (trim(LIS_rc%met_interp(findex)).eq."bilinear") then
+          allocate(geositbias_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          call bilinear_interp_input(n,gridDesci(n,:),               &
+               geositbias_struc(n)%n111,geositbias_struc(n)%n121,    &
+               geositbias_struc(n)%n211,geositbias_struc(n)%n221,    &
+               geositbias_struc(n)%w111,geositbias_struc(n)%w121,    &
+               geositbias_struc(n)%w211,geositbias_struc(n)%w221)
 
-         elseif (trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then
-            allocate(geositbias_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            allocate(geositbias_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            call bilinear_interp_input(n,gridDesci(n,:),               &
-                   geositbias_struc(n)%n111,geositbias_struc(n)%n121,          &
-                   geositbias_struc(n)%n211,geositbias_struc(n)%n221,          &
-                   geositbias_struc(n)%w111,geositbias_struc(n)%w121,          &
-                   geositbias_struc(n)%w211,geositbias_struc(n)%w221)
+       elseif (trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then
+          allocate(geositbias_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(geositbias_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          call bilinear_interp_input(n,gridDesci(n,:),               &
+               geositbias_struc(n)%n111,geositbias_struc(n)%n121,    &
+               geositbias_struc(n)%n211,geositbias_struc(n)%n221,    &
+               geositbias_struc(n)%w111,geositbias_struc(n)%w121,    &
+               geositbias_struc(n)%w211,geositbias_struc(n)%w221)
 
-            allocate(geositbias_struc(n)%n112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
-            allocate(geositbias_struc(n)%n122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
-            allocate(geositbias_struc(n)%n212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
-            allocate(geositbias_struc(n)%n222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
-            allocate(geositbias_struc(n)%w112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
-            allocate(geositbias_struc(n)%w122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
-            allocate(geositbias_struc(n)%w212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
-            allocate(geositbias_struc(n)%w222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
-            call conserv_interp_input(n,gridDesci(n,:),                &
-                   geositbias_struc(n)%n112,geositbias_struc(n)%n122,          &
-                   geositbias_struc(n)%n212,geositbias_struc(n)%n222,          &
-                   geositbias_struc(n)%w112,geositbias_struc(n)%w122,          &
-                   geositbias_struc(n)%w212,geositbias_struc(n)%w222)
+          allocate(geositbias_struc(n)%n112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(geositbias_struc(n)%n122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(geositbias_struc(n)%n212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(geositbias_struc(n)%n222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(geositbias_struc(n)%w112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(geositbias_struc(n)%w122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(geositbias_struc(n)%w212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(geositbias_struc(n)%w222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          call conserv_interp_input(n,gridDesci(n,:),                &
+               geositbias_struc(n)%n112,geositbias_struc(n)%n122,    &
+               geositbias_struc(n)%n212,geositbias_struc(n)%n222,    &
+               geositbias_struc(n)%w112,geositbias_struc(n)%w122,    &
+               geositbias_struc(n)%w212,geositbias_struc(n)%w222)
 
-         elseif (trim(LIS_rc%met_interp(findex)).eq."neighbor") then
-            allocate(geositbias_struc(n)%n113(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-            call neighbor_interp_input(n,gridDesci(n,:),               &
-                                       geositbias_struc(n)%n113)
+       elseif (trim(LIS_rc%met_interp(findex)).eq."neighbor") then
+          allocate(geositbias_struc(n)%n113(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          call neighbor_interp_input(n,gridDesci(n,:),               &
+               geositbias_struc(n)%n113)
 
-         else
-            write(LIS_logunit,*) '[ERR] Interpolation option '//       &
-                                  trim(LIS_rc%met_interp(findex))//    &
-                              ' for GEOS-ITbias forcing is not supported'
-            call LIS_endrun()
-         endif
+       else
+          write(LIS_logunit,*) '[ERR] Interpolation option '//       &
+               trim(LIS_rc%met_interp(findex))//                     &
+               ' for GEOS-ITbias forcing is not supported'
+          call LIS_endrun()
+       endif
 
-         if (geositbias_struc(n)%usedynlapserate.eq.1) then
-            allocate(geositbias_struc(n)%lapserate1(LIS_rc%ngrid(n)))
-            allocate(geositbias_struc(n)%lapserate2(LIS_rc%ngrid(n)))
-         endif
+       if (geositbias_struc(n)%usedynlapserate.eq.1) then
+          allocate(geositbias_struc(n)%lapserate1(LIS_rc%ngrid(n)))
+          allocate(geositbias_struc(n)%lapserate2(LIS_rc%ngrid(n)))
+       endif
 
-         call LIS_registerAlarm("GEOS-ITbias forcing alarm",86400.0,86400.0)
-         geositbias_struc(n)%startFlag = .true.
-         geositbias_struc(n)%dayFlag = .true.
+       call LIS_registerAlarm("GEOS-ITbias forcing alarm",86400.0,86400.0)
+       geositbias_struc(n)%startFlag = .true.
+       geositbias_struc(n)%dayFlag = .true.
 
-         geositbias_struc(n)%nvars = 4
+       geositbias_struc(n)%nvars = 4
 
-         allocate(geositbias_struc(n)%geositbiasforc1(1,                       &
-                  geositbias_struc(n)%nvars, LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-         allocate(geositbias_struc(n)%geositbiasforc2(1,&
-                  geositbias_struc(n)%nvars, LIS_rc%lnc(n)*LIS_rc%lnr(n)))
-         geositbias_struc(n)%st_iterid = 1
-         geositbias_struc(n)%en_iterId = 1
-         geositbias_struc(n)%nIter = 1
+       allocate(geositbias_struc(n)%geositbiasforc1(1,               &
+            geositbias_struc(n)%nvars, LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+       allocate(geositbias_struc(n)%geositbiasforc2(1,               &
+            geositbias_struc(n)%nvars, LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+       geositbias_struc(n)%st_iterid = 1
+       geositbias_struc(n)%en_iterId = 1
+       geositbias_struc(n)%nIter = 1
 
-         allocate(geositbias_struc(n)%metdata1(1,LIS_rc%met_nf(findex),    &
-                  LIS_rc%ngrid(n)))
-         allocate(geositbias_struc(n)%metdata2(1,LIS_rc%met_nf(findex),    &
-                  LIS_rc%ngrid(n)))
+       allocate(geositbias_struc(n)%metdata1(1,LIS_rc%met_nf(findex),    &
+            LIS_rc%ngrid(n)))
+       allocate(geositbias_struc(n)%metdata2(1,LIS_rc%met_nf(findex),    &
+            LIS_rc%ngrid(n)))
 
-         geositbias_struc(n)%metdata1 = 0
-         geositbias_struc(n)%metdata2 = 0
+       geositbias_struc(n)%metdata1 = 0
+       geositbias_struc(n)%metdata2 = 0
 
-         geositbias_struc(n)%geositbiasforc1 = LIS_rc%udef
-         geositbias_struc(n)%geositbiasforc2 = LIS_rc%udef
+       geositbias_struc(n)%geositbiasforc1 = LIS_rc%udef
+       geositbias_struc(n)%geositbiasforc2 = LIS_rc%udef
 
-         if (LIS_rc%met_ecor(findex).eq."lapse-rate" .or.             &
-             LIS_rc%met_ecor(findex).eq."lapse-rate and slope-aspect" .or. &
-             LIS_rc%met_ecor(findex) == "micromet" ) then
-            call read_geositbias_elev(n,findex)
-         endif
+       if (LIS_rc%met_ecor(findex).eq."lapse-rate" .or.             &
+            LIS_rc%met_ecor(findex).eq."lapse-rate and slope-aspect" .or. &
+            LIS_rc%met_ecor(findex) == "micromet" ) then
+          call read_geositbias_elev(n,findex)
+       endif
 
 ! Set up precipitation climate downscaling:
-         if (LIS_rc%pcp_downscale(findex).ne.0) then
-            call LIS_init_pcpclimo_native(n,findex,geositbias_struc(n)%ncold,&
-                                                   geositbias_struc(n)%nrold)
-         endif
+       if (LIS_rc%pcp_downscale(findex).ne.0) then
+          call LIS_init_pcpclimo_native(n,findex,geositbias_struc(n)%ncold,&
+               geositbias_struc(n)%nrold)
+       endif
 
-      enddo                     ! End nest loop
+    enddo                     ! End nest loop
 
-      end subroutine init_geositbias
-      end module geositbias_forcingMod
+  end subroutine init_geositbias
+end module geositbias_forcingMod
 

--- a/lis/metforcing/geos_itbias/geositbias_forcingMod.F90
+++ b/lis/metforcing/geos_itbias/geositbias_forcingMod.F90
@@ -166,10 +166,14 @@
 !  \end{description}
 !EOP
       real :: gridDesci(LIS_rc%nnest,50)
-      integer :: updoy,yr1,mo1,da1,hr1,mn1,ss1
-      real :: upgmt
       integer :: n
-      
+
+      external :: readcrd_geositbias
+      external :: bilinear_interp_input
+      external :: conserv_interp_input
+      external :: neighbor_interp_input
+      external :: read_geositbias_elev
+
       allocate(geositbias_struc(LIS_rc%nnest))
 
       do n = 1,LIS_rc%nnest
@@ -186,7 +190,7 @@
          geositbias_struc(n)%ts = 3600 !check
          call LIS_update_timestep(LIS_rc,n,geositbias_struc(n)%ts)
       enddo
-      
+
       gridDesci = 0
       do n = 1,LIS_rc%nnest
          gridDesci(n,1)  = 0

--- a/lis/metforcing/geos_itbias/geositbias_forcingMod.F90
+++ b/lis/metforcing/geos_itbias/geositbias_forcingMod.F90
@@ -1,0 +1,309 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.4
+!
+! Copyright (c) 2022 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+      module geositbias_forcingMod
+!BOP
+! !MODULE: geositbias_forcingMod
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it) 
+! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
+!
+! !DESCRIPTION:
+!  This module contains variables and data structures that are used
+!  for the implementation of the GEOS-ITbias forcing data.
+!  The data is global 0.625-degree lon. by 0.5-degree lat, in latlon
+!  projection, and at 1 hourly intervals. The derived data type
+!  {\tt geositbias\_struc}
+!  includes the variables that specify the runtime options, and the
+!  weights and neighbor information to be used for spatial interpolation.
+!  They are described below:
+!  \begin{description}
+!  \item[ncold]
+!    Number of columns (along the east west dimension) for the input data
+!  \item[nrold]
+!    Number of rows (along the north south dimension) for the input data
+!  \item[nmif]
+!    Number of forcing variables in the data
+!  \item[geositbiastime1]
+!    The nearest, previous 1 hour instance of the incoming
+!    data (as a real time).
+!  \item[geositbiastime2]
+!    The nearest, next 1 hour instance of the incoming
+!    data (as a real time).
+!  \item[geositbiasdir]
+!    Directory containing the input data
+!  \item[mi]
+!    Number of points in the input grid
+!  \item[n111,n121,n211,n221]
+!    Arrays containing the neighbor information of the input grid
+!    for each grid point in LIS, for bilinear interpolation.
+!  \item[w111,w121,w211,w221]
+!    Arrays containing the weights of the input grid
+!    for each grid point in LIS, for bilinear interpolation.
+!  \item[n122,n122,n212,n222]
+!    Arrays containing the neighbor information of the input grid
+!    for each grid point in LIS, for conservative interpolation.
+!  \item[w112,w122,w212,w222]
+!    Arrays containing the weights of the input grid
+!    for each grid point in LIS, for conservative interpolation.
+!  \item[n113]
+!    Arrays containing the neighbor information of the input grid
+!    for each grid point in LIS, for n. neighbor interpolation.
+!  \item[findtime1, findtime2]
+!   boolean flags to indicate which time is to be read for
+!   temporal interpolation.
+!  \end{description}
+!
+! !USES:
+      use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
+      implicit none
+
+      PRIVATE
+!-----------------------------------------------------------------------------
+! !PUBLIC MEMBER FUNCTIONS:
+!-----------------------------------------------------------------------------
+      public :: init_geositbias    ! defines the native resolution of the input data
+!-----------------------------------------------------------------------------
+! !PUBLIC TYPES:
+!-----------------------------------------------------------------------------
+      public :: geositbias_struc
+
+!EOP
+      type, public :: geositbias_type_dec
+      real         :: ts
+      integer      :: ncold, nrold
+      character(len=LIS_CONST_PATH_LEN) :: geositbiasdir   ! GEOS-ITbias Forcing Directory
+      real*8       :: geositbiastime1,geositbiastime2
+      logical      :: reset_flag
+
+      integer                :: mi
+      integer, allocatable   :: n111(:)
+      integer, allocatable   :: n121(:)
+      integer, allocatable   :: n211(:)
+      integer, allocatable   :: n221(:)
+      real, allocatable      :: w111(:),w121(:)
+      real, allocatable      :: w211(:),w221(:)
+
+      integer, allocatable   :: n112(:,:)
+      integer, allocatable   :: n122(:,:)
+      integer, allocatable   :: n212(:,:)
+      integer, allocatable   :: n222(:,:)
+      real, allocatable      :: w112(:,:),w122(:,:)
+      real, allocatable      :: w212(:,:),w222(:,:)
+      integer, allocatable   :: n113(:)
+      integer                :: findtime1,findtime2
+      logical                :: startFlag,dayFlag
+      real, allocatable      :: geositbiasforc1(:,:,:),geositbiasforc2(:,:,:)
+      real, allocatable      :: lapserate1(:), lapserate2(:)
+      integer            :: nvars
+      integer            :: uselml
+      real*8             :: ringtime
+      integer            :: nIter,st_iterid,en_iterid
+
+      real, allocatable :: metdata1(:,:,:)
+      real, allocatable :: metdata2(:,:,:)
+
+      integer                 :: use2mwind
+      character(len=LIS_CONST_PATH_LEN) :: scaleffile
+      integer, allocatable    :: rseed(:,:)
+      integer                 :: usedynlapserate
+      character(len=LIS_CONST_PATH_LEN) :: dynlapseratedir
+      character(len=LIS_CONST_PATH_LEN) :: dynlapseratepfx
+      character(len=LIS_CONST_PATH_LEN) :: dynlapseratesfx
+      integer                 :: applydynlapseratecutoff
+      real                    :: dynlapseratemincutoff
+      real                    :: dynlapseratemaxcutoff
+      end type geositbias_type_dec
+
+      type(geositbias_type_dec), allocatable :: geositbias_struc(:)
+
+      contains
+
+!BOP
+!
+! !ROUTINE: init_geositbias
+! \label{init_geositbias}
+!
+! !REVISION HISTORY:
+! 18 Mar 2015: James Geiger, initial code (based on merra-land)
+! 20 Apr 2023: David Mocko,  initial code (based on merra2)
+!
+! !INTERFACE:
+      subroutine init_geositbias(findex)
+
+! !USES:
+      use LIS_coreMod
+      use LIS_timeMgrMod
+      use LIS_logMod
+      use LIS_spatialDownscalingMod, only : LIS_init_pcpclimo_native
+
+      implicit none
+! !AGRUMENTS:
+      integer, intent(in) :: findex
+
+! !DESCRIPTION:
+!  Defines the native resolution of the input forcing for GEOS-ITbias
+!  data. The grid description arrays are based on the decoding
+!  schemes used by NCEP and followed in the LIS interpolation
+!  schemes (see Section~\ref{interp}).
+!
+!  The routines invoked are:
+!  \begin{description}
+!   \item[readcrd\_geositbias](\ref{readcrd_geositbias}) \newline
+!     reads the runtime options specified for GEOS-ITbias data
+!   \item[bilinear\_interp\_input](\ref{bilinear_interp_input}) \newline
+!    computes the neighbor, weights for bilinear interpolation
+!   \item[conserv\_interp\_input](\ref{conserv_interp_input}) \newline
+!    computes the neighbor, weights for conservative interpolation
+!  \end{description}
+!EOP
+      real :: gridDesci(LIS_rc%nnest,50)
+      integer :: updoy,yr1,mo1,da1,hr1,mn1,ss1
+      real :: upgmt
+      integer :: n
+      
+      allocate(geositbias_struc(LIS_rc%nnest))
+
+      do n = 1,LIS_rc%nnest
+         geositbias_struc(n)%ncold = 187
+         geositbias_struc(n)%nrold = 131
+      enddo
+
+      call readcrd_geositbias()
+      LIS_rc%met_nf(findex) = 4
+
+      geositbias_struc%reset_flag = .false.
+
+      do n = 1, LIS_rc%nnest
+         geositbias_struc(n)%ts = 3600 !check
+         call LIS_update_timestep(LIS_rc,n,geositbias_struc(n)%ts)
+      enddo
+      
+      gridDesci = 0
+      do n = 1,LIS_rc%nnest
+         gridDesci(n,1)  = 0
+         gridDesci(n,2)  = geositbias_struc(n)%ncold
+         gridDesci(n,3)  = geositbias_struc(n)%nrold
+         gridDesci(n,4)  = 7.0
+         gridDesci(n,5)  = -168.75
+         gridDesci(n,6)  = 128
+         gridDesci(n,7)  = 72.0
+         gridDesci(n,8)  = -52.5
+         gridDesci(n,9)  = 0.625
+         gridDesci(n,10) = 0.5
+         gridDesci(n,20) = 0
+
+         geositbias_struc(n)%mi = geositbias_struc(n)%ncold*geositbias_struc(n)%nrold
+
+       ! Setting up weights for Interpolation
+         if (trim(LIS_rc%met_interp(findex)).eq."bilinear") then
+            allocate(geositbias_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            call bilinear_interp_input(n,gridDesci(n,:),               &
+                   geositbias_struc(n)%n111,geositbias_struc(n)%n121,          &
+                   geositbias_struc(n)%n211,geositbias_struc(n)%n221,          &
+                   geositbias_struc(n)%w111,geositbias_struc(n)%w121,          &
+                   geositbias_struc(n)%w211,geositbias_struc(n)%w221)
+
+         elseif (trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then
+            allocate(geositbias_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            allocate(geositbias_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            call bilinear_interp_input(n,gridDesci(n,:),               &
+                   geositbias_struc(n)%n111,geositbias_struc(n)%n121,          &
+                   geositbias_struc(n)%n211,geositbias_struc(n)%n221,          &
+                   geositbias_struc(n)%w111,geositbias_struc(n)%w121,          &
+                   geositbias_struc(n)%w211,geositbias_struc(n)%w221)
+
+            allocate(geositbias_struc(n)%n112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+            allocate(geositbias_struc(n)%n122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+            allocate(geositbias_struc(n)%n212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+            allocate(geositbias_struc(n)%n222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+            allocate(geositbias_struc(n)%w112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+            allocate(geositbias_struc(n)%w122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+            allocate(geositbias_struc(n)%w212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+            allocate(geositbias_struc(n)%w222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+            call conserv_interp_input(n,gridDesci(n,:),                &
+                   geositbias_struc(n)%n112,geositbias_struc(n)%n122,          &
+                   geositbias_struc(n)%n212,geositbias_struc(n)%n222,          &
+                   geositbias_struc(n)%w112,geositbias_struc(n)%w122,          &
+                   geositbias_struc(n)%w212,geositbias_struc(n)%w222)
+
+         elseif (trim(LIS_rc%met_interp(findex)).eq."neighbor") then
+            allocate(geositbias_struc(n)%n113(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+            call neighbor_interp_input(n,gridDesci(n,:),               &
+                                       geositbias_struc(n)%n113)
+
+         else
+            write(LIS_logunit,*) '[ERR] Interpolation option '//       &
+                                  trim(LIS_rc%met_interp(findex))//    &
+                              ' for GEOS-ITbias forcing is not supported'
+            call LIS_endrun()
+         endif
+
+         if (geositbias_struc(n)%usedynlapserate.eq.1) then
+            allocate(geositbias_struc(n)%lapserate1(LIS_rc%ngrid(n)))
+            allocate(geositbias_struc(n)%lapserate2(LIS_rc%ngrid(n)))
+         endif
+
+         call LIS_registerAlarm("GEOS-ITbias forcing alarm",86400.0,86400.0)
+         geositbias_struc(n)%startFlag = .true.
+         geositbias_struc(n)%dayFlag = .true.
+
+         geositbias_struc(n)%nvars = 4
+
+         allocate(geositbias_struc(n)%geositbiasforc1(1,                       &
+                  geositbias_struc(n)%nvars, LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+         allocate(geositbias_struc(n)%geositbiasforc2(1,&
+                  geositbias_struc(n)%nvars, LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+         geositbias_struc(n)%st_iterid = 1
+         geositbias_struc(n)%en_iterId = 1
+         geositbias_struc(n)%nIter = 1
+
+         allocate(geositbias_struc(n)%metdata1(1,LIS_rc%met_nf(findex),    &
+                  LIS_rc%ngrid(n)))
+         allocate(geositbias_struc(n)%metdata2(1,LIS_rc%met_nf(findex),    &
+                  LIS_rc%ngrid(n)))
+
+         geositbias_struc(n)%metdata1 = 0
+         geositbias_struc(n)%metdata2 = 0
+
+         geositbias_struc(n)%geositbiasforc1 = LIS_rc%udef
+         geositbias_struc(n)%geositbiasforc2 = LIS_rc%udef
+
+         if (LIS_rc%met_ecor(findex).eq."lapse-rate" .or.             &
+             LIS_rc%met_ecor(findex).eq."lapse-rate and slope-aspect" .or. &
+             LIS_rc%met_ecor(findex) == "micromet" ) then
+            call read_geositbias_elev(n,findex)
+         endif
+
+! Set up precipitation climate downscaling:
+         if (LIS_rc%pcp_downscale(findex).ne.0) then
+            call LIS_init_pcpclimo_native(n,findex,geositbias_struc(n)%ncold,&
+                                                   geositbias_struc(n)%nrold)
+         endif
+
+      enddo                     ! End nest loop
+
+      end subroutine init_geositbias
+      end module geositbias_forcingMod
+

--- a/lis/metforcing/geos_itbias/geositbias_forcingMod.F90
+++ b/lis/metforcing/geos_itbias/geositbias_forcingMod.F90
@@ -1,9 +1,9 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 ! NASA Goddard Space Flight Center
 ! Land Information System Framework (LISF)
-! Version 7.4
+! Version 7.5
 !
-! Copyright (c) 2022 United States Government as represented by the
+! Copyright (c) 2024 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
@@ -207,7 +207,8 @@ contains
        gridDesci(n,10) = 0.5
        gridDesci(n,20) = 0
 
-       geositbias_struc(n)%mi = geositbias_struc(n)%ncold*geositbias_struc(n)%nrold
+       geositbias_struc(n)%mi = geositbias_struc(n)%ncold * &
+            geositbias_struc(n)%nrold
 
        ! Setting up weights for Interpolation
        if (trim(LIS_rc%met_interp(findex)).eq."bilinear") then

--- a/lis/metforcing/geos_itbias/geositbias_forcingMod.F90
+++ b/lis/metforcing/geos_itbias/geositbias_forcingMod.F90
@@ -19,12 +19,24 @@ module geositbias_forcingMod
 ! !DESCRIPTION:
 !  This module contains variables and data structures that are used
 !  for the implementation of the GEOS-ITbias forcing data.
-!  The data is global 0.625-degree lon. by 0.5-degree lat, in latlon
-!  projection, and at 1 hourly intervals. The derived data type
-!  {\tt geositbias\_struc}
-!  includes the variables that specify the runtime options, and the
-!  weights and neighbor information to be used for spatial interpolation.
-!  They are described below:
+!  GEOS-ITbias consists of bias-adjusted GEOS-IT surface forcing
+!  fields that are generated upstream of LIS. LIS does not perform
+!  the GEOS-IT to GEOS-ITbias adjustment; it reads the prepared
+!  GEOS-ITbias files and applies the requested LIS spatial
+!  interpolation and downscaling procedures.
+!
+!  The GEOS-ITbias files used by this reader contain four hourly
+!  surface forcing fields: 2-m air temperature, 2-m specific humidity,
+!  surface pressure, and downward longwave radiation. The fields are
+!  bias-adjusted using climatological reference datasets generated
+!  outside of LIS.
+!
+!  The data are on a 0.625-degree longitude by 0.5-degree latitude
+!  grid, in latlon projection, and at 1 hourly intervals. The derived
+!  data type {\tt geositbias\_struc} includes the variables that
+!  specify the runtime options, and the weights and neighbor
+!  information to be used for spatial interpolation. They are
+!  described below:
 !  \begin{description}
 !  \item[ncold]
 !    Number of columns (along the east west dimension) for the input data
@@ -109,8 +121,7 @@ module geositbias_forcingMod
      real*8             :: ringtime
      integer            :: nIter,st_iterid,en_iterid
 
-     real, allocatable :: metdata1(:,:,:)
-     real, allocatable :: metdata2(:,:,:)
+     real, allocatable :: metdata(:,:,:)
 
      integer                 :: use2mwind
      character(len=LIS_CONST_PATH_LEN) :: scaleffile
@@ -136,6 +147,8 @@ contains
 ! !REVISION HISTORY:
 ! 18 Mar 2015: James Geiger, initial code (based on merra-land)
 ! 20 Apr 2023: David Mocko,  initial code (based on merra2)
+! 17 Jun 2026: Kristen Whitney, clarified GEOS-ITbias dataset
+!              description and simplified metadata storage.
 !
 ! !INTERFACE:
   subroutine init_geositbias(findex)
@@ -286,13 +299,10 @@ contains
        geositbias_struc(n)%en_iterId = 1
        geositbias_struc(n)%nIter = 1
 
-       allocate(geositbias_struc(n)%metdata1(1,LIS_rc%met_nf(findex),    &
-            LIS_rc%ngrid(n)))
-       allocate(geositbias_struc(n)%metdata2(1,LIS_rc%met_nf(findex),    &
+       allocate(geositbias_struc(n)%metdata(1,LIS_rc%met_nf(findex),    &
             LIS_rc%ngrid(n)))
 
-       geositbias_struc(n)%metdata1 = 0
-       geositbias_struc(n)%metdata2 = 0
+       geositbias_struc(n)%metdata = 0
 
        geositbias_struc(n)%geositbiasforc1 = LIS_rc%udef
        geositbias_struc(n)%geositbiasforc2 = LIS_rc%udef

--- a/lis/metforcing/geos_itbias/get_geositbias.F90
+++ b/lis/metforcing/geos_itbias/get_geositbias.F90
@@ -1,9 +1,9 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 ! NASA Goddard Space Flight Center
 ! Land Information System Framework (LISF)
-! Version 7.4
+! Version 7.5
 !
-! Copyright (c) 2022 United States Government as represented by the
+! Copyright (c) 2024 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------

--- a/lis/metforcing/geos_itbias/get_geositbias.F90
+++ b/lis/metforcing/geos_itbias/get_geositbias.F90
@@ -1,0 +1,309 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.4
+!
+! Copyright (c) 2022 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+!
+! !ROUTINE: get_geositbias
+! \label{get_geositbias}
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it) 
+! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
+!
+! !INTERFACE:
+      subroutine get_geositbias(n,findex)
+! !USES:
+      use LIS_coreMod
+      use LIS_timeMgrMod
+      use LIS_logMod
+      use LIS_metforcingMod
+      use geositbias_forcingMod
+      use LIS_constantsMod, only : LIS_CONST_PATH_LEN, LIS_CONST_LAPSE_RATE
+
+      implicit none
+
+! !ARGUMENTS:
+      integer, intent(in) :: n
+      integer, intent(in) :: findex
+!
+! !DESCRIPTION:
+!  Opens, reads, and interpolates 1-hourly GEOS-ITbias forcing.
+!
+!  The GEOS-ITbias forcing data are organized into hourly files.
+!  The data are considered valid at the mid-point of the hourly interval.
+!
+!  In general, metforcing readers read the forcing data before the
+!  current time, referred to as bookend1, and after the current time,
+!  referred to as bookend2.  Then the readers temporally interpolate
+!  between bookend1 and bookend2.
+!
+!  Below are some examples to illustrate the timing logic of the
+!  GEOS-ITbias reader.
+!
+!  \begin{verbatim}
+!          ---*---|---*---|---*---|---*---|---*---|---*---|---*---|---*---
+!  hour          21      22      23       0       1       2       3
+!  hr_int         <---22--X--23---X--24---X---1---X---2---X---3--->
+!
+!  where:
+!  hour is the hour UTC
+!  hr_int is the hour-interval
+!  * marks the valid point for the interval <--- hr_int --->
+!
+!  The arguments are:
+!  \begin{description}
+!  \item[n]
+!    index of the nest
+!  \item[findex]
+!    forcing dataset index
+!  \end{description}
+!
+!  The routines invoked are:
+!  \begin{description}
+!  \item[LIS\_tick](\ref{LIS_tick}) \newline
+!    call to advance or retract time
+!  \item[geositbiasfiles](\ref{geositbiasfiles}) \newline
+!    Puts together appropriate file name for 1 hour intervals
+!  \item[read\_geositbias](\ref{read_geositbias}) \newline
+!    call to read the GEOS-ITbias data and perform spatial interpolation
+!  \end{description}
+!EOP
+      integer           :: order
+      integer           :: ferror
+      character(len=LIS_CONST_PATH_LEN) :: geosname
+      integer           :: c,f,r,kk
+      integer           :: yr1,mo1,da1,hr1,mn1,ss1,doy1
+      integer           :: yr2,mo2,da2,hr2,mn2,ss2,doy2
+      real*8            :: time1,time2,timenow
+      real              :: gmt1,gmt2
+      real              :: ts1,ts2
+      integer           :: gid
+      integer           :: hr_int1,hr_int2
+      integer           :: movetime ! Flag to move bookend2 files to bookend1
+      character(len=LIS_CONST_PATH_LEN) :: lapseratefname
+      character*20                      :: fdate
+! _________________________________________________________
+!
+
+      if (LIS_rc%nts(n).gt.3600) then ! > 1-hr timestep
+         write(LIS_logunit,*) '[ERR] When running LIS with GEOS-ITbias,'
+         write(LIS_logunit,*) '[ERR] the clock should run with a time'
+         write(LIS_logunit,*) '[ERR] step less than or equal to 1 hr.'
+         call LIS_endrun()
+      endif
+
+      geositbias_struc(n)%findtime1 = 0
+      geositbias_struc(n)%findtime2 = 0
+      movetime = 0
+
+!----------------------------------------------------------
+! Determine current time
+!----------------------------------------------------------
+      yr1 = LIS_rc%yr
+      mo1 = LIS_rc%mo
+      da1 = LIS_rc%da
+      hr1 = LIS_rc%hr
+      mn1 = LIS_rc%mn
+      ss1 = 0
+      ts1 = 0
+      call LIS_tick(timenow,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+
+      if (LIS_rc%ts.gt.3600.0) then 
+         write(LIS_logunit,*)                                          &
+                   '[ERR] The model timestep is > forcing data timestep'
+         write(LIS_logunit,*)                                          &
+                   '[ERR] LIS does not support this mode currently'
+         write(LIS_logunit,*) '[ERR] Program stopping ...'
+         call LIS_endrun()
+      endif
+
+      if (mod(nint(LIS_rc%ts),3600).eq.0) then 
+         if (timenow.ge.geositbias_struc(n)%geositbiastime2) then 
+            yr1 = LIS_rc%yr
+            mo1 = LIS_rc%mo
+            da1 = LIS_rc%da
+            hr1 = LIS_rc%hr
+            mn1 = 0
+            ss1 = 0
+            ts1 = -60*60
+            call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+
+            yr2 = LIS_rc%yr     !next hour
+            mo2 = LIS_rc%mo
+            da2 = LIS_rc%da
+            hr2 = LIS_rc%hr
+            mn2 = 0
+            ss2 = 0
+            ts2 = 0
+            call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+         endif
+      else
+         if (timenow.ge.geositbias_struc(n)%geositbiastime2) then 
+            yr1 = LIS_rc%yr
+            mo1 = LIS_rc%mo
+            da1 = LIS_rc%da
+            hr1 = LIS_rc%hr
+            mn1 = 0
+            ss1 = 0
+            ts1 = 0
+            call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+            geositbias_struc(n)%findtime1 = 1
+
+            yr2 = LIS_rc%yr     !next hour
+            mo2 = LIS_rc%mo
+            da2 = LIS_rc%da
+            hr2 = LIS_rc%hr
+            mn2 = 0
+            ss2 = 0
+            ts2 = 60*60
+            call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+            geositbias_struc(n)%geositbiastime2 = time2
+         endif
+      endif
+
+! Beginning of the run
+      if ((LIS_rc%tscount(n).eq.1).or.(LIS_rc%rstflag(n).eq.1)) then
+         geositbias_struc(n)%findtime1 = 1
+         geositbias_struc(n)%geositbiastime2 = time2
+         LIS_rc%rstflag(n) = 0
+      endif
+
+! Read GEOS-ITbias - Bookend 1 files:
+      if (geositbias_struc(n)%findtime1.eq.1) then
+         order = 1
+         do kk = geositbias_struc(n)%st_iterid,geositbias_struc(n)%en_iterid
+            call geositbiasfiles(n,kk,findex,geositbias_struc(n)%geositbiasdir,    &
+                           doy1,yr1,mo1,da1,hr1,                       &
+                           geosname)
+            
+                   ! Get lapse rate filename
+            write(fdate, fmt='(i4.4,"-",i2.2,"-",i2.2,"-",i2.2)') yr1,mo1,da1,hr1
+            lapseratefname = trim(geositbias_struc(n)%dynlapseratedir)//&
+                    trim(geositbias_struc(n)%dynlapseratepfx)//&
+                    trim(fdate)//trim(geositbias_struc(n)%dynlapseratesfx)
+            call read_geositbias(n,order,mo1,findex,                       &
+                           geosname, lapseratefname,           &
+                           geositbias_struc(n)%geositbiasforc1(kk,:,:),ferror)
+         enddo
+         geositbias_struc(n)%geositbiastime1 = time1
+      endif
+
+! Assign GEOS-ITbias forcing fields to two LIS time-interp placeholders:
+      do r = 1,LIS_rc%lnr(n)
+         do c = 1,LIS_rc%lnc(n)
+            if (LIS_domain(n)%gindex(c,r).ne.-1) then
+               geositbias_struc(n)%metdata1(:,:,LIS_domain(n)%gindex(c,r)) = &
+                  geositbias_struc(n)%geositbiasforc1(:,:,(c+(r-1)*LIS_rc%lnc(n)))
+               geositbias_struc(n)%metdata2(:,:,LIS_domain(n)%gindex(c,r)) = &
+                  geositbias_struc(n)%geositbiasforc2(:,:,(c+(r-1)*LIS_rc%lnc(n)))
+            endif
+         enddo
+      enddo
+
+      ! Assign lapse rate values
+      LIS_forc(n,findex)%lapseRate(:) = LIS_CONST_LAPSE_RATE
+
+      if ((geositbias_struc(n)%usedynlapserate.eq.1).and.                      &
+         ((LIS_rc%met_ecor(findex).eq."lapse-rate").or.                    &
+          (LIS_rc%met_ecor(findex).eq."lapse-rate and slope-aspect").or.   &
+          (LIS_rc%met_ecor(findex).eq."micromet"))) then
+          do r=1,LIS_rc%lnr(n)
+             do c=1,LIS_rc%lnc(n)
+                if(LIS_domain(n)%gindex(c,r).ne.-1) then
+                   gid = LIS_domain(n)%gindex(c,r)
+                   LIS_forc(n,findex)%lapseRate(gid) = &
+                      geositbias_struc(n)%lapserate1(gid)
+                   
+                   if(geositbias_struc(n)%applydynlapseratecutoff.eq.1) then
+                      if(LIS_forc(n,findex)%lapseRate(gid).gt.geositbias_struc(n)%dynlapseratemaxcutoff) then
+                         LIS_forc(n,findex)%lapseRate(gid) = geositbias_struc(n)%dynlapseratemaxcutoff
+                      elseif(LIS_forc(n,findex)%lapseRate(gid).lt.geositbias_struc(n)%dynlapseratemincutoff) then
+                         LIS_forc(n,findex)%lapseRate(gid) = geositbias_struc(n)%dynlapseratemincutoff
+                      endif
+                   endif
+                endif
+             enddo
+          enddo
+      endif
+      end subroutine get_geositbias
+
+!BOP
+! !ROUTINE: geositbiasfiles
+! \label{geositbiasfiles}
+!
+! !INTERFACE:
+      subroutine geositbiasfiles(n,kk,findex,geositbiasdir,doy,yr,mo,da,hr,    &
+                             geosname)
+
+! !USES:
+      use LIS_coreMod
+      use LIS_logMod
+      use LIS_timeMgrMod
+
+      implicit none
+! !ARGUMENTS:
+      integer                       :: n
+      integer                       :: kk
+      integer                       :: findex
+      character(len=*), intent(in)  :: geositbiasdir
+      integer, intent(in)           :: doy,yr,mo,da,hr
+      character(len=*), intent(out) :: geosname
+
+! !DESCRIPTION:
+!   This subroutine puts together GEOS-ITbias file names for
+!   hourly netCDF files.
+!
+!  The arguments are:
+!  \begin{description}
+!  \item[geositbiasdir]
+!    Name of the GEOS-ITbias directory
+!  \item[doy]
+!    day of year
+!  \item[yr]
+!    year
+!  \item[mo]
+!   month
+!  \item[da]
+!   day of month
+!  \item[hr]
+!   hour
+!  \item[slvname]
+!   name of the timestamped single level file
+!  \item[flxname]
+!   name of the timestamped flux file
+!  \item[lfoname]
+!   name of the timestamped land surface forcings file
+!  \item[radname]
+!   name of the timestamped radiation forcings file
+!  \end{description}
+!
+!EOP
+
+      character*4  :: cyear
+      character*2  :: cmo,cdy,chr
+      character*9 :: prefix
+
+      write(unit=cyear,fmt='(i4.4)') yr
+      write(unit=cmo,  fmt='(i2.2)') mo
+      write(unit=cdy,  fmt='(i2.2)') da
+      write(unit=chr,  fmt='(i2.2)') hr
+
+      prefix = 'geosbias_'
+      if (yr.lt.1998) then
+         write(LIS_logunit,*) '[ERR] GEOS-ITbias data starts 1 Jan 1998.'
+         call LIS_endrun()
+      endif
+
+
+! Single level fields:
+      geosname = trim(geositbiasdir)//'/'//cyear//   &
+                '/'//prefix//cyear//'-'//       &
+                cmo//'-'//cdy//'-'//chr//'.nc'
+      end subroutine geositbiasfiles
+

--- a/lis/metforcing/geos_itbias/get_geositbias.F90
+++ b/lis/metforcing/geos_itbias/get_geositbias.F90
@@ -77,17 +77,19 @@
       integer           :: order
       integer           :: ferror
       character(len=LIS_CONST_PATH_LEN) :: geosname
-      integer           :: c,f,r,kk
+      integer           :: c,r,kk
       integer           :: yr1,mo1,da1,hr1,mn1,ss1,doy1
       integer           :: yr2,mo2,da2,hr2,mn2,ss2,doy2
       real*8            :: time1,time2,timenow
       real              :: gmt1,gmt2
       real              :: ts1,ts2
       integer           :: gid
-      integer           :: hr_int1,hr_int2
       integer           :: movetime ! Flag to move bookend2 files to bookend1
       character(len=LIS_CONST_PATH_LEN) :: lapseratefname
       character*20                      :: fdate
+
+      external :: geositbiasfiles
+      external :: read_geositbias
 ! _________________________________________________________
 !
 

--- a/lis/metforcing/geos_itbias/get_geositbias.F90
+++ b/lis/metforcing/geos_itbias/get_geositbias.F90
@@ -13,24 +13,24 @@
 ! \label{get_geositbias}
 !
 ! !REVISION HISTORY:
-! 02 Oct 2025: Fadji Maina, initial code (based on geos-it) 
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
 ! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
 !
 ! !INTERFACE:
-      subroutine get_geositbias(n,findex)
+subroutine get_geositbias(n,findex)
 ! !USES:
-      use LIS_coreMod
-      use LIS_timeMgrMod
-      use LIS_logMod
-      use LIS_metforcingMod
-      use geositbias_forcingMod
-      use LIS_constantsMod, only : LIS_CONST_PATH_LEN, LIS_CONST_LAPSE_RATE
+  use LIS_coreMod
+  use LIS_timeMgrMod
+  use LIS_logMod
+  use LIS_metforcingMod
+  use geositbias_forcingMod
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN, LIS_CONST_LAPSE_RATE
 
-      implicit none
+  implicit none
 
 ! !ARGUMENTS:
-      integer, intent(in) :: n
-      integer, intent(in) :: findex
+  integer, intent(in) :: n
+  integer, intent(in) :: findex
 !
 ! !DESCRIPTION:
 !  Opens, reads, and interpolates 1-hourly GEOS-ITbias forcing.
@@ -74,188 +74,195 @@
 !    call to read the GEOS-ITbias data and perform spatial interpolation
 !  \end{description}
 !EOP
-      integer           :: order
-      integer           :: ferror
-      character(len=LIS_CONST_PATH_LEN) :: geosname
-      integer           :: c,r,kk
-      integer           :: yr1,mo1,da1,hr1,mn1,ss1,doy1
-      integer           :: yr2,mo2,da2,hr2,mn2,ss2,doy2
-      real*8            :: time1,time2,timenow
-      real              :: gmt1,gmt2
-      real              :: ts1,ts2
-      integer           :: gid
-      integer           :: movetime ! Flag to move bookend2 files to bookend1
-      character(len=LIS_CONST_PATH_LEN) :: lapseratefname
-      character*20                      :: fdate
+  integer           :: order
+  integer           :: ferror
+  character(len=LIS_CONST_PATH_LEN) :: geosname
+  integer           :: c,r,kk
+  integer           :: yr1,mo1,da1,hr1,mn1,ss1,doy1
+  integer           :: yr2,mo2,da2,hr2,mn2,ss2,doy2
+  real*8            :: time1,time2,timenow
+  real              :: gmt1,gmt2
+  real              :: ts1,ts2
+  integer           :: gid
+  integer           :: movetime ! Flag to move bookend2 files to bookend1
+  character(len=LIS_CONST_PATH_LEN) :: lapseratefname
+  character*20                      :: fdate
 
-      external :: geositbiasfiles
-      external :: read_geositbias
+  external :: geositbiasfiles
+  external :: read_geositbias
 ! _________________________________________________________
 !
 
-      if (LIS_rc%nts(n).gt.3600) then ! > 1-hr timestep
-         write(LIS_logunit,*) '[ERR] When running LIS with GEOS-ITbias,'
-         write(LIS_logunit,*) '[ERR] the clock should run with a time'
-         write(LIS_logunit,*) '[ERR] step less than or equal to 1 hr.'
-         call LIS_endrun()
-      endif
+  if (LIS_rc%nts(n).gt.3600) then ! > 1-hr timestep
+     write(LIS_logunit,*) '[ERR] When running LIS with GEOS-ITbias,'
+     write(LIS_logunit,*) '[ERR] the clock should run with a time'
+     write(LIS_logunit,*) '[ERR] step less than or equal to 1 hr.'
+     call LIS_endrun()
+  endif
 
-      geositbias_struc(n)%findtime1 = 0
-      geositbias_struc(n)%findtime2 = 0
-      movetime = 0
+  geositbias_struc(n)%findtime1 = 0
+  geositbias_struc(n)%findtime2 = 0
+  movetime = 0
 
 !----------------------------------------------------------
 ! Determine current time
 !----------------------------------------------------------
-      yr1 = LIS_rc%yr
-      mo1 = LIS_rc%mo
-      da1 = LIS_rc%da
-      hr1 = LIS_rc%hr
-      mn1 = LIS_rc%mn
-      ss1 = 0
-      ts1 = 0
-      call LIS_tick(timenow,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+  yr1 = LIS_rc%yr
+  mo1 = LIS_rc%mo
+  da1 = LIS_rc%da
+  hr1 = LIS_rc%hr
+  mn1 = LIS_rc%mn
+  ss1 = 0
+  ts1 = 0
+  call LIS_tick(timenow,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
 
-      if (LIS_rc%ts.gt.3600.0) then 
-         write(LIS_logunit,*)                                          &
-                   '[ERR] The model timestep is > forcing data timestep'
-         write(LIS_logunit,*)                                          &
-                   '[ERR] LIS does not support this mode currently'
-         write(LIS_logunit,*) '[ERR] Program stopping ...'
-         call LIS_endrun()
-      endif
+  if (LIS_rc%ts.gt.3600.0) then
+     write(LIS_logunit,*)                                          &
+          '[ERR] The model timestep is > forcing data timestep'
+     write(LIS_logunit,*)                                          &
+          '[ERR] LIS does not support this mode currently'
+     write(LIS_logunit,*) '[ERR] Program stopping ...'
+     call LIS_endrun()
+  endif
 
-      if (mod(nint(LIS_rc%ts),3600).eq.0) then 
-         if (timenow.ge.geositbias_struc(n)%geositbiastime2) then 
-            yr1 = LIS_rc%yr
-            mo1 = LIS_rc%mo
-            da1 = LIS_rc%da
-            hr1 = LIS_rc%hr
-            mn1 = 0
-            ss1 = 0
-            ts1 = -60*60
-            call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+  if (mod(nint(LIS_rc%ts),3600).eq.0) then
+     if (timenow.ge.geositbias_struc(n)%geositbiastime2) then
+        yr1 = LIS_rc%yr
+        mo1 = LIS_rc%mo
+        da1 = LIS_rc%da
+        hr1 = LIS_rc%hr
+        mn1 = 0
+        ss1 = 0
+        ts1 = -60*60
+        call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
 
-            yr2 = LIS_rc%yr     !next hour
-            mo2 = LIS_rc%mo
-            da2 = LIS_rc%da
-            hr2 = LIS_rc%hr
-            mn2 = 0
-            ss2 = 0
-            ts2 = 0
-            call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
-         endif
-      else
-         if (timenow.ge.geositbias_struc(n)%geositbiastime2) then 
-            yr1 = LIS_rc%yr
-            mo1 = LIS_rc%mo
-            da1 = LIS_rc%da
-            hr1 = LIS_rc%hr
-            mn1 = 0
-            ss1 = 0
-            ts1 = 0
-            call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
-            geositbias_struc(n)%findtime1 = 1
+        yr2 = LIS_rc%yr     !next hour
+        mo2 = LIS_rc%mo
+        da2 = LIS_rc%da
+        hr2 = LIS_rc%hr
+        mn2 = 0
+        ss2 = 0
+        ts2 = 0
+        call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+     endif
+  else
+     if (timenow.ge.geositbias_struc(n)%geositbiastime2) then
+        yr1 = LIS_rc%yr
+        mo1 = LIS_rc%mo
+        da1 = LIS_rc%da
+        hr1 = LIS_rc%hr
+        mn1 = 0
+        ss1 = 0
+        ts1 = 0
+        call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+        geositbias_struc(n)%findtime1 = 1
 
-            yr2 = LIS_rc%yr     !next hour
-            mo2 = LIS_rc%mo
-            da2 = LIS_rc%da
-            hr2 = LIS_rc%hr
-            mn2 = 0
-            ss2 = 0
-            ts2 = 60*60
-            call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
-            geositbias_struc(n)%geositbiastime2 = time2
-         endif
-      endif
+        yr2 = LIS_rc%yr     !next hour
+        mo2 = LIS_rc%mo
+        da2 = LIS_rc%da
+        hr2 = LIS_rc%hr
+        mn2 = 0
+        ss2 = 0
+        ts2 = 60*60
+        call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+        geositbias_struc(n)%geositbiastime2 = time2
+     endif
+  endif
 
 ! Beginning of the run
-      if ((LIS_rc%tscount(n).eq.1).or.(LIS_rc%rstflag(n).eq.1)) then
-         geositbias_struc(n)%findtime1 = 1
-         geositbias_struc(n)%geositbiastime2 = time2
-         LIS_rc%rstflag(n) = 0
-      endif
+  if ((LIS_rc%tscount(n).eq.1).or.(LIS_rc%rstflag(n).eq.1)) then
+     geositbias_struc(n)%findtime1 = 1
+     geositbias_struc(n)%geositbiastime2 = time2
+     LIS_rc%rstflag(n) = 0
+  endif
 
 ! Read GEOS-ITbias - Bookend 1 files:
-      if (geositbias_struc(n)%findtime1.eq.1) then
-         order = 1
-         do kk = geositbias_struc(n)%st_iterid,geositbias_struc(n)%en_iterid
-            call geositbiasfiles(n,kk,findex,geositbias_struc(n)%geositbiasdir,    &
-                           doy1,yr1,mo1,da1,hr1,                       &
-                           geosname)
-            
-                   ! Get lapse rate filename
-            write(fdate, fmt='(i4.4,"-",i2.2,"-",i2.2,"-",i2.2)') yr1,mo1,da1,hr1
-            lapseratefname = trim(geositbias_struc(n)%dynlapseratedir)//&
-                    trim(geositbias_struc(n)%dynlapseratepfx)//&
-                    trim(fdate)//trim(geositbias_struc(n)%dynlapseratesfx)
-            call read_geositbias(n,order,mo1,findex,                       &
-                           geosname, lapseratefname,           &
-                           geositbias_struc(n)%geositbiasforc1(kk,:,:),ferror)
-         enddo
-         geositbias_struc(n)%geositbiastime1 = time1
-      endif
+  if (geositbias_struc(n)%findtime1.eq.1) then
+     order = 1
+     do kk = geositbias_struc(n)%st_iterid,geositbias_struc(n)%en_iterid
+        call geositbiasfiles(n,kk,findex,          &
+             geositbias_struc(n)%geositbiasdir,    &
+             doy1,yr1,mo1,da1,hr1,                 &
+             geosname)
+
+        ! Get lapse rate filename
+        write(fdate, fmt='(i4.4,"-",i2.2,"-",i2.2,"-",i2.2)') &
+             yr1,mo1,da1,hr1
+        lapseratefname = trim(geositbias_struc(n)%dynlapseratedir)//   &
+             trim(geositbias_struc(n)%dynlapseratepfx)//               &
+             trim(fdate)//trim(geositbias_struc(n)%dynlapseratesfx)
+        call read_geositbias(n,order,mo1,findex,                       &
+             geosname, lapseratefname,                                 &
+             geositbias_struc(n)%geositbiasforc1(kk,:,:),ferror)
+     enddo
+     geositbias_struc(n)%geositbiastime1 = time1
+  endif
 
 ! Assign GEOS-ITbias forcing fields to two LIS time-interp placeholders:
-      do r = 1,LIS_rc%lnr(n)
-         do c = 1,LIS_rc%lnc(n)
-            if (LIS_domain(n)%gindex(c,r).ne.-1) then
-               geositbias_struc(n)%metdata1(:,:,LIS_domain(n)%gindex(c,r)) = &
-                  geositbias_struc(n)%geositbiasforc1(:,:,(c+(r-1)*LIS_rc%lnc(n)))
-               geositbias_struc(n)%metdata2(:,:,LIS_domain(n)%gindex(c,r)) = &
-                  geositbias_struc(n)%geositbiasforc2(:,:,(c+(r-1)*LIS_rc%lnc(n)))
-            endif
-         enddo
-      enddo
+  do r = 1,LIS_rc%lnr(n)
+     do c = 1,LIS_rc%lnc(n)
+        if (LIS_domain(n)%gindex(c,r).ne.-1) then
+           geositbias_struc(n)%metdata1(:,:,LIS_domain(n)%gindex(c,r)) = &
+                geositbias_struc(n)%geositbiasforc1(:,:,(c+(r-1)*LIS_rc%lnc(n)))
+           geositbias_struc(n)%metdata2(:,:,LIS_domain(n)%gindex(c,r)) = &
+                geositbias_struc(n)%geositbiasforc2(:,:,(c+(r-1)*LIS_rc%lnc(n)))
+        endif
+     enddo
+  enddo
 
-      ! Assign lapse rate values
-      LIS_forc(n,findex)%lapseRate(:) = LIS_CONST_LAPSE_RATE
+  ! Assign lapse rate values
+  LIS_forc(n,findex)%lapseRate(:) = LIS_CONST_LAPSE_RATE
 
-      if ((geositbias_struc(n)%usedynlapserate.eq.1).and.                      &
-         ((LIS_rc%met_ecor(findex).eq."lapse-rate").or.                    &
-          (LIS_rc%met_ecor(findex).eq."lapse-rate and slope-aspect").or.   &
-          (LIS_rc%met_ecor(findex).eq."micromet"))) then
-          do r=1,LIS_rc%lnr(n)
-             do c=1,LIS_rc%lnc(n)
-                if(LIS_domain(n)%gindex(c,r).ne.-1) then
-                   gid = LIS_domain(n)%gindex(c,r)
-                   LIS_forc(n,findex)%lapseRate(gid) = &
-                      geositbias_struc(n)%lapserate1(gid)
-                   
-                   if(geositbias_struc(n)%applydynlapseratecutoff.eq.1) then
-                      if(LIS_forc(n,findex)%lapseRate(gid).gt.geositbias_struc(n)%dynlapseratemaxcutoff) then
-                         LIS_forc(n,findex)%lapseRate(gid) = geositbias_struc(n)%dynlapseratemaxcutoff
-                      elseif(LIS_forc(n,findex)%lapseRate(gid).lt.geositbias_struc(n)%dynlapseratemincutoff) then
-                         LIS_forc(n,findex)%lapseRate(gid) = geositbias_struc(n)%dynlapseratemincutoff
-                      endif
-                   endif
-                endif
-             enddo
-          enddo
-      endif
-      end subroutine get_geositbias
+  if ((geositbias_struc(n)%usedynlapserate.eq.1).and.                  &
+       ((LIS_rc%met_ecor(findex).eq."lapse-rate").or.                  &
+       (LIS_rc%met_ecor(findex).eq.                                    &
+       "lapse-rate and slope-aspect").or.                              &
+       (LIS_rc%met_ecor(findex).eq."micromet"))) then
+     do r=1,LIS_rc%lnr(n)
+        do c=1,LIS_rc%lnc(n)
+           if(LIS_domain(n)%gindex(c,r).ne.-1) then
+              gid = LIS_domain(n)%gindex(c,r)
+              LIS_forc(n,findex)%lapseRate(gid) = &
+                   geositbias_struc(n)%lapserate1(gid)
+
+              if(geositbias_struc(n)%applydynlapseratecutoff.eq.1) then
+                 if(LIS_forc(n,findex)%lapseRate(gid).gt. &
+                      geositbias_struc(n)%dynlapseratemaxcutoff) then
+                    LIS_forc(n,findex)%lapseRate(gid) = &
+                         geositbias_struc(n)%dynlapseratemaxcutoff
+                 elseif(LIS_forc(n,findex)%lapseRate(gid).lt. &
+                      geositbias_struc(n)%dynlapseratemincutoff) then
+                    LIS_forc(n,findex)%lapseRate(gid) = &
+                         geositbias_struc(n)%dynlapseratemincutoff
+                 endif
+              endif
+           endif
+        enddo
+     enddo
+  endif
+end subroutine get_geositbias
 
 !BOP
 ! !ROUTINE: geositbiasfiles
 ! \label{geositbiasfiles}
 !
 ! !INTERFACE:
-      subroutine geositbiasfiles(n,kk,findex,geositbiasdir,doy,yr,mo,da,hr,    &
-                             geosname)
+subroutine geositbiasfiles(n,kk,findex,geositbiasdir,doy,yr,mo,da,hr,    &
+     geosname)
 
 ! !USES:
-      use LIS_coreMod
-      use LIS_logMod
-      use LIS_timeMgrMod
+  use LIS_coreMod
+  use LIS_logMod
+  use LIS_timeMgrMod
 
-      implicit none
+  implicit none
 ! !ARGUMENTS:
-      integer                       :: n
-      integer                       :: kk
-      integer                       :: findex
-      character(len=*), intent(in)  :: geositbiasdir
-      integer, intent(in)           :: doy,yr,mo,da,hr
-      character(len=*), intent(out) :: geosname
+  integer                       :: n
+  integer                       :: kk
+  integer                       :: findex
+  character(len=*), intent(in)  :: geositbiasdir
+  integer, intent(in)           :: doy,yr,mo,da,hr
+  character(len=*), intent(out) :: geosname
 
 ! !DESCRIPTION:
 !   This subroutine puts together GEOS-ITbias file names for
@@ -287,25 +294,24 @@
 !
 !EOP
 
-      character*4  :: cyear
-      character*2  :: cmo,cdy,chr
-      character*9 :: prefix
+  character*4  :: cyear
+  character*2  :: cmo,cdy,chr
+  character*9 :: prefix
 
-      write(unit=cyear,fmt='(i4.4)') yr
-      write(unit=cmo,  fmt='(i2.2)') mo
-      write(unit=cdy,  fmt='(i2.2)') da
-      write(unit=chr,  fmt='(i2.2)') hr
+  write(unit=cyear,fmt='(i4.4)') yr
+  write(unit=cmo,  fmt='(i2.2)') mo
+  write(unit=cdy,  fmt='(i2.2)') da
+  write(unit=chr,  fmt='(i2.2)') hr
 
-      prefix = 'geosbias_'
-      if (yr.lt.1998) then
-         write(LIS_logunit,*) '[ERR] GEOS-ITbias data starts 1 Jan 1998.'
-         call LIS_endrun()
-      endif
-
+  prefix = 'geosbias_'
+  if (yr.lt.1998) then
+     write(LIS_logunit,*) '[ERR] GEOS-ITbias data starts 1 Jan 1998.'
+     call LIS_endrun()
+  endif
 
 ! Single level fields:
-      geosname = trim(geositbiasdir)//'/'//cyear//   &
-                '/'//prefix//cyear//'-'//       &
-                cmo//'-'//cdy//'-'//chr//'.nc'
-      end subroutine geositbiasfiles
+  geosname = trim(geositbiasdir)//'/'//cyear//   &
+       '/'//prefix//cyear//'-'//                 &
+       cmo//'-'//cdy//'-'//chr//'.nc'
+end subroutine geositbiasfiles
 

--- a/lis/metforcing/geos_itbias/get_geositbias.F90
+++ b/lis/metforcing/geos_itbias/get_geositbias.F90
@@ -15,6 +15,8 @@
 ! !REVISION HISTORY:
 ! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
 ! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
+! 17 Jun 2026: Kristen Whitney, simplified metadata handling
+!              and updated dynamic lapse-rate filename construction.
 !
 ! !INTERFACE:
 subroutine get_geositbias(n,findex)
@@ -86,7 +88,7 @@ subroutine get_geositbias(n,findex)
   integer           :: gid
   integer           :: movetime ! Flag to move bookend2 files to bookend1
   character(len=LIS_CONST_PATH_LEN) :: lapseratefname
-  character*20                      :: fdate
+  character(len=13) :: fdate
 
   external :: geositbiasfiles
   external :: read_geositbias
@@ -188,9 +190,9 @@ subroutine get_geositbias(n,findex)
         ! Get lapse rate filename
         write(fdate, fmt='(i4.4,"-",i2.2,"-",i2.2,"-",i2.2)') &
              yr1,mo1,da1,hr1
-        lapseratefname = trim(geositbias_struc(n)%dynlapseratedir)//   &
-             trim(geositbias_struc(n)%dynlapseratepfx)//               &
-             trim(fdate)//trim(geositbias_struc(n)%dynlapseratesfx)
+        lapseratefname = trim(geositbias_struc(n)%dynlapseratedir)// &
+             trim(geositbias_struc(n)%dynlapseratepfx)// &
+             fdate//trim(geositbias_struc(n)%dynlapseratesfx) 
         call read_geositbias(n,order,mo1,findex,                       &
              geosname, lapseratefname,                                 &
              geositbias_struc(n)%geositbiasforc1(kk,:,:),ferror)
@@ -202,10 +204,8 @@ subroutine get_geositbias(n,findex)
   do r = 1,LIS_rc%lnr(n)
      do c = 1,LIS_rc%lnc(n)
         if (LIS_domain(n)%gindex(c,r).ne.-1) then
-           geositbias_struc(n)%metdata1(:,:,LIS_domain(n)%gindex(c,r)) = &
+           geositbias_struc(n)%metdata(:,:,LIS_domain(n)%gindex(c,r)) = &
                 geositbias_struc(n)%geositbiasforc1(:,:,(c+(r-1)*LIS_rc%lnc(n)))
-           geositbias_struc(n)%metdata2(:,:,LIS_domain(n)%gindex(c,r)) = &
-                geositbias_struc(n)%geositbiasforc2(:,:,(c+(r-1)*LIS_rc%lnc(n)))
         endif
      enddo
   enddo

--- a/lis/metforcing/geos_itbias/get_geositbias.F90
+++ b/lis/metforcing/geos_itbias/get_geositbias.F90
@@ -192,7 +192,7 @@ subroutine get_geositbias(n,findex)
              yr1,mo1,da1,hr1
         lapseratefname = trim(geositbias_struc(n)%dynlapseratedir)// &
              trim(geositbias_struc(n)%dynlapseratepfx)// &
-             fdate//trim(geositbias_struc(n)%dynlapseratesfx) 
+             fdate//trim(geositbias_struc(n)%dynlapseratesfx)
         call read_geositbias(n,order,mo1,findex,                       &
              geosname, lapseratefname,                                 &
              geositbias_struc(n)%geositbiasforc1(kk,:,:),ferror)

--- a/lis/metforcing/geos_itbias/get_geositbias.F90
+++ b/lis/metforcing/geos_itbias/get_geositbias.F90
@@ -17,6 +17,8 @@
 ! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
 ! 17 Jun 2026: Kristen Whitney, simplified metadata handling
 !              and updated dynamic lapse-rate filename construction.
+! 08 Jul 2026: Kristen Whitney, fixed hourly GEOS-ITbias time
+!              progression to correctly advance forcing input files.
 !
 ! !INTERFACE:
 subroutine get_geositbias(n,findex)
@@ -146,6 +148,9 @@ subroutine get_geositbias(n,findex)
         ss2 = 0
         ts2 = 0
         call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+
+        geositbias_struc(n)%findtime1 = 1
+        geositbias_struc(n)%geositbiastime2 = time2
      endif
   else
      if (timenow.ge.geositbias_struc(n)%geositbiastime2) then

--- a/lis/metforcing/geos_itbias/read_geositbias.F90
+++ b/lis/metforcing/geos_itbias/read_geositbias.F90
@@ -1,9 +1,9 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 ! NASA Goddard Space Flight Center
 ! Land Information System Framework (LISF)
-! Version 7.4
+! Version 7.5
 !
-! Copyright (c) 2022 United States Government as represented by the
+! Copyright (c) 2024 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------

--- a/lis/metforcing/geos_itbias/read_geositbias.F90
+++ b/lis/metforcing/geos_itbias/read_geositbias.F90
@@ -16,34 +16,36 @@
 ! !REVISION HISTORY:
 ! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
 ! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
+! 09 Jan 2026: Eric Kemp, reformatted.
 !
 ! !INTERFACE:
-      subroutine read_geositbias(n,order,month,findex,                     &
-                           geosname,            &
-                           lapseratefname,                             &
-                           geositbiasforc,ferror)
+subroutine read_geositbias(n,order,month,findex,                     &
+     geosname,                                                       &
+     lapseratefname,                                                 &
+     geositbiasforc,ferror)
 ! !USES:
-      use LIS_coreMod,       only : LIS_rc
-      use LIS_logMod
-      use LIS_FORC_AttributesMod
-      use LIS_metforcingMod, only : LIS_forc
-      use geositbias_forcingMod, only : geositbias_struc
-      use LIS_constantsMod, only : LIS_CONST_LAPSE_RATE
+  use LIS_coreMod,       only : LIS_rc
+  use LIS_logMod
+  use LIS_FORC_AttributesMod
+  use LIS_metforcingMod, only : LIS_forc
+  use geositbias_forcingMod, only : geositbias_struc
+  use LIS_constantsMod, only : LIS_CONST_LAPSE_RATE
 #if (defined USE_NETCDF3 || defined USE_NETCDF4)
-      use netcdf
+  use netcdf
 #endif
 
-      implicit none
+  implicit none
 ! !ARGUMENTS:
-      integer, intent(in)          :: n
-      integer, intent(in)          :: order
-      integer, intent(in)          :: month
-      integer, intent(in)          :: findex
-      character(len=*), intent(in) :: geosname
-      character(len=*), intent(in) :: lapseratefname
-      real, intent(inout)          :: geositbiasforc(geositbias_struc(n)%nvars,&
-                                            LIS_rc%lnc(n)*LIS_rc%lnr(n))
-      integer, intent(out)         :: ferror
+  integer, intent(in)          :: n
+  integer, intent(in)          :: order
+  integer, intent(in)          :: month
+  integer, intent(in)          :: findex
+  character(len=*), intent(in) :: geosname
+  character(len=*), intent(in) :: lapseratefname
+  real, intent(inout)          :: &
+       geositbiasforc(geositbias_struc(n)%nvars,&
+       LIS_rc%lnc(n)*LIS_rc%lnr(n))
+  integer, intent(out)         :: ferror
 
 ! !DESCRIPTION:
 !  For the given time, reads parameters from GEOS-ITbias data, transforms
@@ -89,33 +91,33 @@
 !  \end{description}
 !EOP
 
-      integer   :: ftn_geos
-      integer   :: tmpId,qId,psId
-      integer   :: lwgabId
-      integer   :: nr_index,nc_index
-      logical   :: file_exists
-      integer   :: mo
-      real      :: tair(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
-      real      :: qair(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
-      real      :: ps(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
-      real      :: lwgab(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
-      integer                           :: ftn_drate
-      integer                           :: lapserateid
-      real, allocatable                 :: lapse_rate_in(:,:)
-      integer :: nc_sub, nr_sub
-      real, allocatable :: lapse_rate_sub(:,:)
-      real, allocatable :: lat_sub(:), lon_sub(:)
-      real, allocatable :: lat_full(:), lon_full(:)
-      integer :: i0, j0
-      integer :: latid, lonid
+  integer   :: ftn_geos
+  integer   :: tmpId,qId,psId
+  integer   :: lwgabId
+  integer   :: nr_index,nc_index
+  logical   :: file_exists
+  integer   :: mo
+  real      :: tair(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
+  real      :: qair(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
+  real      :: ps(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
+  real      :: lwgab(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
+  integer                           :: ftn_drate
+  integer                           :: lapserateid
+  real, allocatable                 :: lapse_rate_in(:,:)
+  integer :: nc_sub, nr_sub
+  real, allocatable :: lapse_rate_sub(:,:)
+  real, allocatable :: lat_sub(:), lon_sub(:)
+  real, allocatable :: lat_full(:), lon_full(:)
+  integer :: i0, j0
+  integer :: latid, lonid
 
-      external :: interp_geositbias_var
-      external :: interp_lapserate_geositbias
+  external :: interp_geositbias_var
+  external :: interp_lapserate_geositbias
 ! __________________________________________________________________________
 
 #if (defined USE_NETCDF3)
-      write(LIS_logunit,*) "[ERR] GEOS-ITbias reader requires NetCDF4"
-      call LIS_endrun()
+  write(LIS_logunit,*) "[ERR] GEOS-ITbias reader requires NetCDF4"
+  call LIS_endrun()
 #endif
 
 #if (defined USE_NETCDF4)
@@ -127,135 +129,165 @@
 ! Read single layer file (*slv) fields:
   inquire(file=geosname,exist=file_exists)
   if(file_exists) then
-    write(LIS_logunit,*)                                          &
-         '[INFO] Reading GEOS-ITbias file: ',trim(geosname)
-    call LIS_verify(nf90_open(path=trim(geosname),                 &
-         mode=NF90_NOWRITE,ncid=ftn_geos),              &
-         'nf90_open failed for geosfile in read_geositbias')
+     write(LIS_logunit,*)                                           &
+          '[INFO] Reading GEOS-ITbias file: ',trim(geosname)
+     call LIS_verify(nf90_open(path=trim(geosname),                 &
+          mode=NF90_NOWRITE,ncid=ftn_geos),                         &
+          'nf90_open failed for geosfile in read_geositbias')
 
-    call LIS_verify(nf90_inq_varid(ftn_geos,'PS',psId),            &
-         'nf90_inq_varid failed for ps in read_geositbias')
-    call LIS_verify(nf90_get_var(ftn_geos,psId,ps),                &
-         'nf90_get_var failed for ps in read_geositbias')
+     call LIS_verify(nf90_inq_varid(ftn_geos,'PS',psId),            &
+          'nf90_inq_varid failed for ps in read_geositbias')
+     call LIS_verify(nf90_get_var(ftn_geos,psId,ps),                &
+          'nf90_get_var failed for ps in read_geositbias')
 
-    call LIS_verify(nf90_inq_varid(ftn_geos,'LWGAB',lwgabId),            &
-         'nf90_inq_varid failed for LWGAB in read_geositbias')
-    call LIS_verify(nf90_get_var(ftn_geos,lwgabId,lwgab),                &
-         'nf90_get_var failed for LWGAB in read_geositbias')
+     call LIS_verify(nf90_inq_varid(ftn_geos,'LWGAB',lwgabId),      &
+          'nf90_inq_varid failed for LWGAB in read_geositbias')
+     call LIS_verify(nf90_get_var(ftn_geos,lwgabId,lwgab),          &
+          'nf90_get_var failed for LWGAB in read_geositbias')
 
-    call LIS_verify(nf90_inq_varid(ftn_geos,'QV2M',qId),            &
-         'nf90_inq_varid failed for QV2M in read_geositbias')
-    call LIS_verify(nf90_get_var(ftn_geos,qId,qair),                &
-         'nf90_get_var failed for QV2M in read_geositbias')
+     call LIS_verify(nf90_inq_varid(ftn_geos,'QV2M',qId),           &
+          'nf90_inq_varid failed for QV2M in read_geositbias')
+     call LIS_verify(nf90_get_var(ftn_geos,qId,qair),               &
+          'nf90_get_var failed for QV2M in read_geositbias')
 
-    call LIS_verify(nf90_inq_varid(ftn_geos,'T2M',tmpId),            &
-         'nf90_inq_varid failed for T2M in read_geositbias')
-    call LIS_verify(nf90_get_var(ftn_geos,tmpId,Tair),                &
-         'nf90_get_var failed for T2M in read_geositbias')
+     call LIS_verify(nf90_inq_varid(ftn_geos,'T2M',tmpId),          &
+          'nf90_inq_varid failed for T2M in read_geositbias')
+     call LIS_verify(nf90_get_var(ftn_geos,tmpId,Tair),             &
+          'nf90_get_var failed for T2M in read_geositbias')
 
-    call LIS_verify(nf90_close(ftn_geos),                          &
-         '[WARN] Failed to close slvfile in read_geositbias.')
+     call LIS_verify(nf90_close(ftn_geos),                          &
+          '[WARN] Failed to close slvfile in read_geositbias.')
 
-    call interp_geositbias_var(n,findex,month,tair,  1,.false.,geositbiasforc)
-    call interp_geositbias_var(n,findex,month,qair,  2,.false.,geositbiasforc)
-    call interp_geositbias_var(n,findex,month,ps,    7,.false.,geositbiasforc)
-    call interp_geositbias_var(n,findex,month,lwgab,4,.false.,geositbiasforc)
-         
+     call interp_geositbias_var(n,findex,month,tair,  1,.false.,    &
+          geositbiasforc)
+     call interp_geositbias_var(n,findex,month,qair,  2,.false.,    &
+          geositbiasforc)
+     call interp_geositbias_var(n,findex,month,ps,    7,.false.,    &
+          geositbiasforc)
+     call interp_geositbias_var(n,findex,month,lwgab,4,.false.,     &
+          geositbiasforc)
+
     ! Obtain lapse rates
-    if ((geositbias_struc(n)%usedynlapserate.eq.1).and.                   &
-       ((LIS_rc%met_ecor(findex).eq."lapse-rate").or.                 &
-         (LIS_rc%met_ecor(findex).eq."lapse-rate and slope-aspect").or.&
-         (LIS_rc%met_ecor(findex).eq."micromet"))) then
-         inquire(file=trim(lapseratefname),exist=file_exists)
-         if (file_exists) then
-            write(LIS_logunit,*) 'Reading lapse rate file: ',trim(lapseratefname)
+     if ((geositbias_struc(n)%usedynlapserate.eq.1).and.            &
+          ((LIS_rc%met_ecor(findex).eq."lapse-rate").or.               &
+          (LIS_rc%met_ecor(findex).eq."lapse-rate and slope-aspect").or.&
+          (LIS_rc%met_ecor(findex).eq."micromet"))) then
+        inquire(file=trim(lapseratefname),exist=file_exists)
+        if (file_exists) then
+           write(LIS_logunit,*) 'Reading lapse rate file: ', &
+                trim(lapseratefname)
 
-            ! open file and get ID for lapse rate
-            call LIS_verify(nf90_open(path=trim(lapseratefname),        &
-               mode=NF90_NOWRITE,ncid=ftn_drate),                 &
-               'nf90_open failed for '//trim(lapseratefname))
-            call LIS_verify(nf90_inq_varid(ftn_drate,'lapse_rate',lapserateid), & 
-               'nf90_inq_varid failed for lapse_rate')
+           ! open file and get ID for lapse rate
+           call LIS_verify(nf90_open(path=trim(lapseratefname),     &
+                mode=NF90_NOWRITE,ncid=ftn_drate),                  &
+                'nf90_open failed for '//trim(lapseratefname))
+           call LIS_verify(nf90_inq_varid(ftn_drate,'lapse_rate',   &
+                lapserateid),                                       &
+                'nf90_inq_varid failed for lapse_rate')
 
-            ! Get subdomain dimensions directly from dimids 1=lat, 2=lon
-            call LIS_verify(nf90_inquire_dimension(ftn_drate,1,len=nr_sub), 'inq lat dim failed (sub)')
-            call LIS_verify(nf90_inquire_dimension(ftn_drate,2,len=nc_sub), 'inq lon dim failed (sub)')
+           ! Get subdomain dimensions directly from dimids 1=lat, 2=lon
+           call LIS_verify(nf90_inquire_dimension(ftn_drate,1, &
+                len=nr_sub), 'inq lat dim failed (sub)')
+           call LIS_verify(nf90_inquire_dimension(ftn_drate,2, &
+                len=nc_sub), 'inq lon dim failed (sub)')
 
-            ! allocate full-size lapse rate
-            allocate(lapse_rate_in(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold))
-            lapse_rate_in = 1.e+15
-            ! Case 1: full global lapse-rate file
-            if (nc_sub == geositbias_struc(n)%ncold .and. nr_sub == geositbias_struc(n)%nrold) then
-               call LIS_verify(nf90_get_var(ftn_drate,lapserateid,lapse_rate_in), 'get lapse_rate failed')
+           ! allocate full-size lapse rate
+           allocate(lapse_rate_in(geositbias_struc(n)%ncold,   &
+                geositbias_struc(n)%nrold))
+           lapse_rate_in = 1.e+15
+           ! Case 1: full global lapse-rate file
+           if (nc_sub == geositbias_struc(n)%ncold .and.       &
+                nr_sub == geositbias_struc(n)%nrold) then
+              call LIS_verify(nf90_get_var(ftn_drate,lapserateid, &
+                   lapse_rate_in), 'get lapse_rate failed')
 
-            ! Case 2: subdomain lapse-rate file
-            else if (nc_sub <= geositbias_struc(n)%ncold .and. nr_sub <= geositbias_struc(n)%nrold) then
-               allocate(lapse_rate_sub(nc_sub,nr_sub))
-               allocate(lat_sub(nr_sub), lon_sub(nc_sub))
-               allocate(lat_full(geositbias_struc(n)%nrold), lon_full(geositbias_struc(n)%ncold))
-               
-               ! Read subdomain values
-               call LIS_verify(nf90_get_var(ftn_drate,lapserateid,lapse_rate_sub), 'get lapse_rate_sub failed')
-               call LIS_verify(nf90_inq_varid(ftn_drate,'lat',latid),'inq lat varid failed')
-               call LIS_verify(nf90_inq_varid(ftn_drate,'lon',lonid),'inq lon varid failed')
-               call LIS_verify(nf90_get_var(ftn_drate,latid,lat_sub),'get lat_sub failed')
-               call LIS_verify(nf90_get_var(ftn_drate,lonid,lon_sub),'get lon_sub failed')
+              ! Case 2: subdomain lapse-rate file
+           else if (nc_sub <= geositbias_struc(n)%ncold .and.  &
+                nr_sub <= geositbias_struc(n)%nrold) then
+              allocate(lapse_rate_sub(nc_sub,nr_sub))
+              allocate(lat_sub(nr_sub), lon_sub(nc_sub))
+              allocate(lat_full(geositbias_struc(n)%nrold), &
+                   lon_full(geositbias_struc(n)%ncold))
 
-               ! Read full-domain coordinates from slv file
-               call LIS_verify(nf90_open(path=trim(geosname), mode=NF90_NOWRITE,ncid=ftn_geos),'nf90_open failed for geosfile in read_geositbias') 
-               call LIS_verify(nf90_inq_varid(ftn_geos,'lat',latid),'inq lat varid failed (full)')
-               call LIS_verify(nf90_inq_varid(ftn_geos,'lon',lonid),'inq lon varid failed (full)')
-               call LIS_verify(nf90_get_var(ftn_geos,latid,lat_full),'get lat_full failed')
-               call LIS_verify(nf90_get_var(ftn_geos,lonid,lon_full),'get lon_full failed')
-               call LIS_verify(nf90_close(ftn_geos),'[WARN] Failed to close slvfile in read_geositbias.')
+              ! Read subdomain values
+              call LIS_verify(nf90_get_var(ftn_drate,lapserateid,    &
+                   lapse_rate_sub), 'get lapse_rate_sub failed')
+              call LIS_verify(nf90_inq_varid(ftn_drate,'lat',latid), &
+                   'inq lat varid failed')
+              call LIS_verify(nf90_inq_varid(ftn_drate,'lon',lonid), &
+                   'inq lon varid failed')
+              call LIS_verify(nf90_get_var(ftn_drate,latid,lat_sub), &
+                   'get lat_sub failed')
+              call LIS_verify(nf90_get_var(ftn_drate,lonid,lon_sub), &
+                   'get lon_sub failed')
 
-               ! Find paste offsets
-               call find_index(lon_full, lon_sub(1), i0)
-               call find_index(lat_full, lat_sub(1), j0)
+              ! Read full-domain coordinates from slv file
+              call LIS_verify(nf90_open(path=trim(geosname),         &
+                   mode=NF90_NOWRITE,ncid=ftn_geos),                 &
+                   'nf90_open failed for geosfile in read_geositbias')
+              call LIS_verify(nf90_inq_varid(ftn_geos,'lat',latid),  &
+                   'inq lat varid failed (full)')
+              call LIS_verify(nf90_inq_varid(ftn_geos,'lon',lonid),  &
+                   'inq lon varid failed (full)')
+              call LIS_verify(nf90_get_var(ftn_geos,latid,lat_full), &
+                   'get lat_full failed')
+              call LIS_verify(nf90_get_var(ftn_geos,lonid,lon_full), &
+                   'get lon_full failed')
+              call LIS_verify(nf90_close(ftn_geos), &
+                   '[WARN] Failed to close slvfile in read_geositbias.')
 
-               ! Paste subdomain into full-domain buffer
-               lapse_rate_in(i0:i0+nc_sub-1, j0:j0+nr_sub-1) = lapse_rate_sub(:,:)
+              ! Find paste offsets
+              call find_index(lon_full, lon_sub(1), i0)
+              call find_index(lat_full, lat_sub(1), j0)
 
-               ! Cleanup
-               deallocate(lapse_rate_sub, lat_sub, lon_sub, lat_full, lon_full)
+              ! Paste subdomain into full-domain buffer
+              lapse_rate_in(i0:i0+nc_sub-1, j0:j0+nr_sub-1) = &
+                   lapse_rate_sub(:,:)
 
-            ! Case 3: unexpected
-            else
-               write(LIS_logunit,*) '[ERR] Unexpected lapse-rate dims: ', nc_sub, ' x ', nr_sub
-               call LIS_endrun()
-            end if
+              ! Cleanup
+              deallocate(lapse_rate_sub, lat_sub, lon_sub, lat_full, &
+                   lon_full)
 
-            call LIS_verify(nf90_close(ftn_drate),'close lapse-rate file failed')
-            call interp_lapserate_geositbias(n,order,lapse_rate_in)
-            
-            deallocate(lapse_rate_in)
+              ! Case 3: unexpected
+           else
+              write(LIS_logunit,*) '[ERR] Unexpected lapse-rate dims: ', &
+                   nc_sub, ' x ', nr_sub
+              call LIS_endrun()
+           end if
 
-         else
-            write(LIS_logunit,*) '[WARN] Could not find ',trim(lapseratefname)
-            write(LIS_logunit,*) '[WARN] Using static lapse rate.'
-            geositbias_struc(n)%lapserate1 = LIS_CONST_LAPSE_RATE
-            geositbias_struc(n)%lapserate2 = LIS_CONST_LAPSE_RATE
-         endif
-      endif
+           call LIS_verify(nf90_close(ftn_drate), &
+                'close lapse-rate file failed')
+           call interp_lapserate_geositbias(n,order,lapse_rate_in)
+
+           deallocate(lapse_rate_in)
+
+        else
+           write(LIS_logunit,*) '[WARN] Could not find ', &
+                trim(lapseratefname)
+           write(LIS_logunit,*) '[WARN] Using static lapse rate.'
+           geositbias_struc(n)%lapserate1 = LIS_CONST_LAPSE_RATE
+           geositbias_struc(n)%lapserate2 = LIS_CONST_LAPSE_RATE
+        endif
+     endif
   else
-      call LIS_endrun()
+     call LIS_endrun()
   endif
-     
+
 #endif
 contains
-subroutine find_index(x,val,idx)
-  real, intent(in) :: x(:), val
-  integer, intent(out) :: idx
-  real :: dmin
-  integer :: k
-  dmin = huge(1.0); idx = -1
-  do k=1,size(x)
-     if (abs(x(k)-val) < dmin) then
-        dmin = abs(x(k)-val)
-        idx = k
-     end if
-  enddo
-end subroutine find_index
+  subroutine find_index(x,val,idx)
+    real, intent(in) :: x(:), val
+    integer, intent(out) :: idx
+    real :: dmin
+    integer :: k
+    dmin = huge(1.0); idx = -1
+    do k=1,size(x)
+       if (abs(x(k)-val) < dmin) then
+          dmin = abs(x(k)-val)
+          idx = k
+       end if
+    enddo
+  end subroutine find_index
 end subroutine read_geositbias
 
 !BOP
@@ -265,7 +297,7 @@ end subroutine read_geositbias
 !
 ! !INTERFACE:
 subroutine interp_geositbias_var(n,findex,month,input_var,var_index, &
-    pcp_flag,geositbiasforc)
+     pcp_flag,geositbiasforc)
 
 ! !USES:
   use LIS_coreMod
@@ -285,7 +317,7 @@ subroutine interp_geositbias_var(n,findex,month,input_var,var_index, &
        geositbias_struc(n)%nrold)
   integer, intent(in)    :: var_index
   logical, intent(in)    :: pcp_flag
-  real,    intent(inout) :: geositbiasforc(geositbias_struc(n)%nvars,      &
+  real,    intent(inout) :: geositbiasforc(geositbias_struc(n)%nvars,  &
        LIS_rc%lnc(n)*LIS_rc%lnr(n))
 
 ! !DESCRIPTION:
@@ -293,102 +325,102 @@ subroutine interp_geositbias_var(n,findex,month,input_var,var_index, &
 !  to the LIS running domain
 !
 !EOP
-   integer   :: c,r,k,iret
-   real      :: f (geositbias_struc(n)%ncold*geositbias_struc(n)%nrold)
-   logical*1 :: lb(geositbias_struc(n)%ncold*geositbias_struc(n)%nrold)
-   logical*1 :: lo(LIS_rc%lnc(n)*LIS_rc%lnr(n))
-   integer   :: input_size
+  integer   :: c,r,k,iret
+  real      :: f (geositbias_struc(n)%ncold*geositbias_struc(n)%nrold)
+  logical*1 :: lb(geositbias_struc(n)%ncold*geositbias_struc(n)%nrold)
+  logical*1 :: lo(LIS_rc%lnc(n)*LIS_rc%lnr(n))
+  integer   :: input_size
 
-   external :: conserv_interp
-   external :: bilinear_interp
-   external :: neighbor_interp
+  external :: conserv_interp
+  external :: bilinear_interp
+  external :: neighbor_interp
 
 ! _____________________________________________________________
 
-   input_size = geositbias_struc(n)%ncold*geositbias_struc(n)%nrold
+  input_size = geositbias_struc(n)%ncold*geositbias_struc(n)%nrold
 
 !-----------------------------------------------------------------------
 ! Apply downscaling
 !-----------------------------------------------------------------------
-   lb = .true.
-   do r = 1,geositbias_struc(n)%nrold
-      do c = 1,geositbias_struc(n)%ncold
-         k = c+(r-1)*geositbias_struc(n)%ncold
-         f(k) = input_var(c,r)
-         if (f(k).eq.1.e+15) then 
-            f(k)  = LIS_rc%udef
-            lb(k) = .false. 
-         endif
-      enddo
-   enddo
+  lb = .true.
+  do r = 1,geositbias_struc(n)%nrold
+     do c = 1,geositbias_struc(n)%ncold
+        k = c+(r-1)*geositbias_struc(n)%ncold
+        f(k) = input_var(c,r)
+        if (f(k).eq.1.e+15) then
+           f(k)  = LIS_rc%udef
+           lb(k) = .false.
+        endif
+     enddo
+  enddo
 
-   if (pcp_flag.and.(LIS_rc%pcp_downscale(findex).ne.0)) then
-! input_data becomes the ratio field.
-      call LIS_generatePcpClimoRatioField(n,findex,"GEOS-ITbias",       &
-                                          month,input_size,f,lb)
-   endif
+  if (pcp_flag.and.(LIS_rc%pcp_downscale(findex).ne.0)) then
+     ! input_data becomes the ratio field.
+     call LIS_generatePcpClimoRatioField(n,findex,"GEOS-ITbias",       &
+          month,input_size,f,lb)
+  endif
 
-   if (pcp_flag.and.                                                &
+  if (pcp_flag.and.                                                    &
        (trim(LIS_rc%met_interp(findex)).eq."budget-bilinear")) then
 
-      call conserv_interp(LIS_rc%gridDesc(n,:),lb,f,lo,             &
-                  geositbiasforc(var_index,:),                          &
-                  geositbias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),   &
-                  LIS_domain(n)%lat,LIS_domain(n)%lon,              &
-                  geositbias_struc(n)%w112,geositbias_struc(n)%w122,        &
-                  geositbias_struc(n)%w212,geositbias_struc(n)%w222,        &
-                  geositbias_struc(n)%n112,geositbias_struc(n)%n122,        &
-                  geositbias_struc(n)%n212,geositbias_struc(n)%n222,        &
-                  LIS_rc%udef,iret)
+     call conserv_interp(LIS_rc%gridDesc(n,:),lb,f,lo,                 &
+          geositbiasforc(var_index,:),                                 &
+          geositbias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),          &
+          LIS_domain(n)%lat,LIS_domain(n)%lon,                         &
+          geositbias_struc(n)%w112,geositbias_struc(n)%w122,           &
+          geositbias_struc(n)%w212,geositbias_struc(n)%w222,           &
+          geositbias_struc(n)%n112,geositbias_struc(n)%n122,           &
+          geositbias_struc(n)%n212,geositbias_struc(n)%n222,           &
+          LIS_rc%udef,iret)
 
-   elseif ((trim(LIS_rc%met_interp(findex)).eq."bilinear").or.      &
-           (trim(LIS_rc%met_interp(findex)).eq."budget-bilinear")) then
-      call bilinear_interp(LIS_rc%gridDesc(n,:),lb,f,lo,            &
-                   geositbiasforc(var_index,:),                         &
-                   geositbias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),  &
-                   LIS_domain(n)%lat,LIS_domain(n)%lon,             &
-                   geositbias_struc(n)%w111,geositbias_struc(n)%w121,       &
-                   geositbias_struc(n)%w211,geositbias_struc(n)%w221,       &
-                   geositbias_struc(n)%n111,geositbias_struc(n)%n121,       &
-                   geositbias_struc(n)%n211,geositbias_struc(n)%n221,       &
-                   LIS_rc%udef,iret)
+  elseif ((trim(LIS_rc%met_interp(findex)).eq."bilinear").or.          &
+       (trim(LIS_rc%met_interp(findex)).eq."budget-bilinear")) then
+     call bilinear_interp(LIS_rc%gridDesc(n,:),lb,f,lo,                &
+          geositbiasforc(var_index,:),                                 &
+          geositbias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),          &
+          LIS_domain(n)%lat,LIS_domain(n)%lon,                         &
+          geositbias_struc(n)%w111,geositbias_struc(n)%w121,           &
+          geositbias_struc(n)%w211,geositbias_struc(n)%w221,           &
+          geositbias_struc(n)%n111,geositbias_struc(n)%n121,           &
+          geositbias_struc(n)%n211,geositbias_struc(n)%n221,           &
+          LIS_rc%udef,iret)
 
-   elseif (trim(LIS_rc%met_interp(findex)).eq."neighbor") then
-      call neighbor_interp(LIS_rc%gridDesc(n,:),lb,f,lo,            &
-                   geositbiasforc(var_index,:),                         &
-                   geositbias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),  &
-                   LIS_domain(n)%lat,LIS_domain(n)%lon,             &
-                   geositbias_struc(n)%n113,LIS_rc%udef,iret)
+  elseif (trim(LIS_rc%met_interp(findex)).eq."neighbor") then
+     call neighbor_interp(LIS_rc%gridDesc(n,:),lb,f,lo,                &
+          geositbiasforc(var_index,:),                                 &
+          geositbias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),          &
+          LIS_domain(n)%lat,LIS_domain(n)%lon,                         &
+          geositbias_struc(n)%n113,LIS_rc%udef,iret)
 
-   else
-      write(LIS_logunit,*) '[ERR] Spatial interpolation option '//  &
-                            trim(LIS_rc%met_interp(findex))//       &
-                           ' not supported for GEOS-ITbias.'
-      call LIS_endrun()
-   endif
+  else
+     write(LIS_logunit,*) '[ERR] Spatial interpolation option '//      &
+          trim(LIS_rc%met_interp(findex))//                            &
+          ' not supported for GEOS-ITbias.'
+     call LIS_endrun()
+  endif
 
-   if (pcp_flag.and.(LIS_rc%pcp_downscale(findex).ne.0)) then
-      call LIS_pcpClimoDownscaling(n,findex,month,                  &
-              LIS_rc%lnc(n)*LIS_rc%lnr(n),geositbiasforc(var_index,:),lo)
-   endif
+  if (pcp_flag.and.(LIS_rc%pcp_downscale(findex).ne.0)) then
+     call LIS_pcpClimoDownscaling(n,findex,month,                      &
+          LIS_rc%lnc(n)*LIS_rc%lnr(n),geositbiasforc(var_index,:),lo)
+  endif
 
 end subroutine interp_geositbias_var
 
 !BOP
-! 
+!
 ! !ROUTINE: interp_lapserate_geositbias
 ! \label{interp_lapserate_geositbias}
-! 
-! !INTERFACE: 
+!
+! !INTERFACE:
 subroutine interp_lapserate_geositbias(n,order,input_var)
 
-! !USES:  
+! !USES:
   use LIS_coreMod
   use LIS_logMod
   use LIS_spatialDownscalingMod
   use geositbias_forcingMod, only : geositbias_struc
   use LIS_constantsMod, only : LIS_CONST_LAPSE_RATE
-#if(defined USE_NETCDF3 || defined USE_NETCDF4)      
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
 #endif
   implicit none
@@ -398,11 +430,11 @@ subroutine interp_lapserate_geositbias(n,order,input_var)
   real,    intent(in)    :: input_var(geositbias_struc(n)%ncold, &
        geositbias_struc(n)%nrold)
 
-  !
-! !DESCRIPTION: 
-!  This subroutine spatially interpolates a GEOS-IT Bias-corrected field 
+!
+! !DESCRIPTION:
+!  This subroutine spatially interpolates a GEOS-IT Bias-corrected field
 !  to the LIS running domain
-! 
+!
 !EOP
 
   integer   :: c,r,k,iret
@@ -418,58 +450,59 @@ subroutine interp_lapserate_geositbias(n,order,input_var)
 
   input_size = geositbias_struc(n)%ncold*geositbias_struc(n)%nrold
 
-  
   lb = .true.
   do r=1,geositbias_struc(n)%nrold
-    do c=1,geositbias_struc(n)%ncold
-       k= c+(r-1)*geositbias_struc(n)%ncold
-       f(k) = input_var(c,r)
-       if ( f(k) == 1.e+15 ) then
-          f(k)  = LIS_rc%udef
-          lb(k) = .false.
-       endif
-    enddo
+     do c=1,geositbias_struc(n)%ncold
+        k= c+(r-1)*geositbias_struc(n)%ncold
+        f(k) = input_var(c,r)
+        if ( f(k) == 1.e+15 ) then
+           f(k)  = LIS_rc%udef
+           lb(k) = .false.
+        endif
+     enddo
   enddo
 
-  call bilinear_interp(LIS_rc%gridDesc(n,:),lb,f,lo,&
-      output_var(:), &
-      geositbias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n), &
-      LIS_domain(n)%lat, LIS_domain(n)%lon,&
-      geositbias_struc(n)%w111,geositbias_struc(n)%w121,&
-      geositbias_struc(n)%w211,geositbias_struc(n)%w221,&
-      geositbias_struc(n)%n111,geositbias_struc(n)%n121,&
-      geositbias_struc(n)%n211,geositbias_struc(n)%n221,&
-      LIS_rc%udef, iret)
-     
+  call bilinear_interp(LIS_rc%gridDesc(n,:),lb,f,lo,             &
+       output_var(:),                                            &
+       geositbias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),       &
+       LIS_domain(n)%lat, LIS_domain(n)%lon,                     &
+       geositbias_struc(n)%w111,geositbias_struc(n)%w121,        &
+       geositbias_struc(n)%w211,geositbias_struc(n)%w221,        &
+       geositbias_struc(n)%n111,geositbias_struc(n)%n121,        &
+       geositbias_struc(n)%n211,geositbias_struc(n)%n221,        &
+       LIS_rc%udef, iret)
+
   if (order.eq.1) then
-    do r=1,LIS_rc%lnr(n)
-       do c=1,LIS_rc%lnc(n)
-          if(LIS_domain(n)%gindex(c,r).ne.-1) then
-             gid = LIS_domain(n)%gindex(c,r)
-             if(.not.isNaN(output_var(c+(r-1)*LIS_rc%lnc(n)))) then
+     do r=1,LIS_rc%lnr(n)
+        do c=1,LIS_rc%lnc(n)
+           if(LIS_domain(n)%gindex(c,r).ne.-1) then
+              gid = LIS_domain(n)%gindex(c,r)
+              if(.not.isNaN(output_var(c+(r-1)*LIS_rc%lnc(n)))) then
                  geositbias_struc(n)%lapserate1(gid) = &
-                         output_var(c+(r-1)*LIS_rc%lnc(n))/1000.0
-             else
-                 geositbias_struc(n)%lapserate1(gid) = LIS_CONST_LAPSE_RATE
-             endif
-          endif
-       enddo
-    enddo
+                      output_var(c+(r-1)*LIS_rc%lnc(n))/1000.0
+              else
+                 geositbias_struc(n)%lapserate1(gid) = &
+                      LIS_CONST_LAPSE_RATE
+              endif
+           endif
+        enddo
+     enddo
   endif
   if (order.eq.2) then
-    do r=1,LIS_rc%lnr(n)
-       do c=1,LIS_rc%lnc(n)
-          if(LIS_domain(n)%gindex(c,r).ne.-1) then
-             gid = LIS_domain(n)%gindex(c,r)
-             if(.not.isNaN(output_var(c+(r-1)*LIS_rc%lnc(n)))) then
-                geositbias_struc(n)%lapserate2(gid) = &
-                     output_var(c+(r-1)*LIS_rc%lnc(n))/1000.0
-             else
-                geositbias_struc(n)%lapserate2(gid) = LIS_CONST_LAPSE_RATE
-             endif
-          endif
-       enddo
-    enddo
+     do r=1,LIS_rc%lnr(n)
+        do c=1,LIS_rc%lnc(n)
+           if(LIS_domain(n)%gindex(c,r).ne.-1) then
+              gid = LIS_domain(n)%gindex(c,r)
+              if(.not.isNaN(output_var(c+(r-1)*LIS_rc%lnc(n)))) then
+                 geositbias_struc(n)%lapserate2(gid) = &
+                      output_var(c+(r-1)*LIS_rc%lnc(n))/1000.0
+              else
+                 geositbias_struc(n)%lapserate2(gid) = &
+                      LIS_CONST_LAPSE_RATE
+              endif
+           endif
+        enddo
+     enddo
   endif
 
 end subroutine interp_lapserate_geositbias

--- a/lis/metforcing/geos_itbias/read_geositbias.F90
+++ b/lis/metforcing/geos_itbias/read_geositbias.F90
@@ -1,0 +1,474 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.4
+!
+! Copyright (c) 2022 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
+!BOP
+!
+! !ROUTINE: read_geositbias
+! \label{read_geositbias}
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
+!
+! !INTERFACE:
+      subroutine read_geositbias(n,order,month,findex,                     &
+                           geosname,            &
+                           lapseratefname,                             &
+                           geositbiasforc,ferror)
+! !USES:
+      use LIS_coreMod,       only : LIS_rc, LIS_domain, LIS_masterproc
+      use LIS_logMod
+      use LIS_FORC_AttributesMod
+      use LIS_metforcingMod, only : LIS_forc
+      use geositbias_forcingMod, only : geositbias_struc
+      use LIS_constantsMod, only : LIS_CONST_LAPSE_RATE
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+      use netcdf
+#endif
+
+      implicit none
+! !ARGUMENTS:
+      integer, intent(in)          :: n
+      integer, intent(in)          :: order
+      integer, intent(in)          :: month
+      integer, intent(in)          :: findex
+      character(len=*), intent(in) :: geosname
+      character(len=*), intent(in) :: lapseratefname
+      real, intent(inout)          :: geositbiasforc(geositbias_struc(n)%nvars,&
+                                            LIS_rc%lnc(n)*LIS_rc%lnr(n))
+      integer, intent(out)         :: ferror
+
+! !DESCRIPTION:
+!  For the given time, reads parameters from GEOS-ITbias data, transforms
+!  into 9 LIS forcing parameters and interpolates to the LIS domain. \newline
+!
+! GEOS-ITbias FORCING VARIABLES: \newline
+!  1. tair    Temperature of air at 2-m, 10-m, or LML [$K$] \newline
+!  2. qair    Specific humidity of air at 2-m, 10-m, or LML [$kg/kg$] \newline
+!  3. swgdn   Downward shortwave radiation at the ground [$W/m^2$] \newline
+!  4. lwgab   Downward longwave radiation at the ground [$W/m^2$] \newline
+!  5. uwind   Zonal wind at 2-m, 10-m, or LML [$m/s$] \newline
+!  6. vwind   Meridional wind at 2-m, 10-m, or LML [$m/s$] \newline
+!  7. ps      Instantaneous Surface Pressure [$Pa$] \newline
+!  8. pretot  Total precipitation [$mm/s$] \newline
+!  9. precon  Convective precipitation [$mm/s$] \newline
+! 10. presno  Precipitation falling as snow [$mm/s$] \newline
+! 11. swland  Net shortwave radiation at the ground [$W/m^2$] \newline
+! 12. pardr   Surface downward PAR beam flux [$W/m^2$] \newline
+! 13. pardf   Surface downward PAR diffuse flux [$W/m^2$] \newline
+! 14. hlml    Height of center of lowest model layer (LML) [$m$] \newline
+!
+!  The arguments are:
+!  \begin{description}
+!  \item[order]
+!    flag indicating which data to be read (order=1, read the previous
+!    1 hourly instance, order=2, read the next 1 hourly instance)
+!  \item[n]
+!    index of the nest
+!  \item[name]
+!    name of the 1 hour GEOS-ITbias analysis file
+!  \item[tscount]
+!    time step count
+!  \item[ferror]
+!    return error code (0 indicates success)
+!  \end{description}
+!
+!  The routines invoked are:
+!  \begin{description}
+!  \item[bilinear\_interp](\ref{bilinear_interp}) \newline
+!    spatially interpolate the forcing data using bilinear interpolation
+!  \item[conserv\_interp](\ref{conserv_interp}) \newline
+!    spatially interpolate the forcing data using conservative interpolation
+!  \end{description}
+!EOP
+
+      integer   :: ftn_geos
+      integer   :: tmpId,qId,psId
+      integer   :: lwgabId
+      integer   :: nr_index,nc_index
+      logical   :: file_exists,file_exists1
+      integer   :: c,r,t,k,iret
+      integer   :: mo
+      logical   :: read_lnd
+
+      real      :: tair(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
+      real      :: qair(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
+      real      :: ps(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
+      real      :: lwgab(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
+      integer                           :: ftn_drate
+      integer                           :: lapserateid
+      real, allocatable                 :: lapse_rate_in(:,:)
+      integer :: nc_sub, nr_sub
+      real, allocatable :: lapse_rate_sub(:,:)
+      real, allocatable :: lat_sub(:), lon_sub(:)
+      real, allocatable :: lat_full(:), lon_full(:)
+      integer :: i0, j0
+      integer :: latid, lonid
+! __________________________________________________________________________
+
+#if (defined USE_NETCDF3)
+      write(LIS_logunit,*) "[ERR] GEOS-ITbias reader requires NetCDF4"
+      call LIS_endrun()
+#endif
+
+#if (defined USE_NETCDF4)
+  ferror = 0
+  nr_index = geositbias_struc(n)%nrold
+  nc_index = geositbias_struc(n)%ncold
+  mo = LIS_rc%lnc(n)*LIS_rc%lnr(n)
+
+! Read single layer file (*slv) fields:
+  inquire(file=geosname,exist=file_exists)
+  if(file_exists) then
+    write(LIS_logunit,*)                                          &
+         '[INFO] Reading GEOS-ITbias file: ',trim(geosname)
+    call LIS_verify(nf90_open(path=trim(geosname),                 &
+         mode=NF90_NOWRITE,ncid=ftn_geos),              &
+         'nf90_open failed for geosfile in read_geositbias')
+
+    call LIS_verify(nf90_inq_varid(ftn_geos,'PS',psId),            &
+         'nf90_inq_varid failed for ps in read_geositbias')
+    call LIS_verify(nf90_get_var(ftn_geos,psId,ps),                &
+         'nf90_get_var failed for ps in read_geositbias')
+
+    call LIS_verify(nf90_inq_varid(ftn_geos,'LWGAB',lwgabId),            &
+         'nf90_inq_varid failed for LWGAB in read_geositbias')
+    call LIS_verify(nf90_get_var(ftn_geos,lwgabId,lwgab),                &
+         'nf90_get_var failed for LWGAB in read_geositbias')
+
+    call LIS_verify(nf90_inq_varid(ftn_geos,'QV2M',qId),            &
+         'nf90_inq_varid failed for QV2M in read_geositbias')
+    call LIS_verify(nf90_get_var(ftn_geos,qId,qair),                &
+         'nf90_get_var failed for QV2M in read_geositbias')
+
+    call LIS_verify(nf90_inq_varid(ftn_geos,'T2M',tmpId),            &
+         'nf90_inq_varid failed for T2M in read_geositbias')
+    call LIS_verify(nf90_get_var(ftn_geos,tmpId,Tair),                &
+         'nf90_get_var failed for T2M in read_geositbias')
+
+    call LIS_verify(nf90_close(ftn_geos),                          &
+         '[WARN] Failed to close slvfile in read_geositbias.')
+
+    call interp_geositbias_var(n,findex,month,tair,  1,.false.,geositbiasforc)
+    call interp_geositbias_var(n,findex,month,qair,  2,.false.,geositbiasforc)
+    call interp_geositbias_var(n,findex,month,ps,    7,.false.,geositbiasforc)
+    call interp_geositbias_var(n,findex,month,lwgab,4,.false.,geositbiasforc)
+         
+    ! Obtain lapse rates
+    if ((geositbias_struc(n)%usedynlapserate.eq.1).and.                   &
+       ((LIS_rc%met_ecor(findex).eq."lapse-rate").or.                 &
+         (LIS_rc%met_ecor(findex).eq."lapse-rate and slope-aspect").or.&
+         (LIS_rc%met_ecor(findex).eq."micromet"))) then
+         inquire(file=trim(lapseratefname),exist=file_exists)
+         if (file_exists) then
+            write(LIS_logunit,*) 'Reading lapse rate file: ',trim(lapseratefname)
+
+            ! open file and get ID for lapse rate
+            call LIS_verify(nf90_open(path=trim(lapseratefname),        &
+               mode=NF90_NOWRITE,ncid=ftn_drate),                 &
+               'nf90_open failed for '//trim(lapseratefname))
+            call LIS_verify(nf90_inq_varid(ftn_drate,'lapse_rate',lapserateid), & 
+               'nf90_inq_varid failed for lapse_rate')
+
+            ! Get subdomain dimensions directly from dimids 1=lat, 2=lon
+            call LIS_verify(nf90_inquire_dimension(ftn_drate,1,len=nr_sub), 'inq lat dim failed (sub)')
+            call LIS_verify(nf90_inquire_dimension(ftn_drate,2,len=nc_sub), 'inq lon dim failed (sub)')
+
+            ! allocate full-size lapse rate
+            allocate(lapse_rate_in(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold))
+            lapse_rate_in = 1.e+15
+            ! Case 1: full global lapse-rate file
+            if (nc_sub == geositbias_struc(n)%ncold .and. nr_sub == geositbias_struc(n)%nrold) then
+               call LIS_verify(nf90_get_var(ftn_drate,lapserateid,lapse_rate_in), 'get lapse_rate failed')
+
+            ! Case 2: subdomain lapse-rate file
+            else if (nc_sub <= geositbias_struc(n)%ncold .and. nr_sub <= geositbias_struc(n)%nrold) then
+               allocate(lapse_rate_sub(nc_sub,nr_sub))
+               allocate(lat_sub(nr_sub), lon_sub(nc_sub))
+               allocate(lat_full(geositbias_struc(n)%nrold), lon_full(geositbias_struc(n)%ncold))
+               
+               ! Read subdomain values
+               call LIS_verify(nf90_get_var(ftn_drate,lapserateid,lapse_rate_sub), 'get lapse_rate_sub failed')
+               call LIS_verify(nf90_inq_varid(ftn_drate,'lat',latid),'inq lat varid failed')
+               call LIS_verify(nf90_inq_varid(ftn_drate,'lon',lonid),'inq lon varid failed')
+               call LIS_verify(nf90_get_var(ftn_drate,latid,lat_sub),'get lat_sub failed')
+               call LIS_verify(nf90_get_var(ftn_drate,lonid,lon_sub),'get lon_sub failed')
+
+               ! Read full-domain coordinates from slv file
+               call LIS_verify(nf90_open(path=trim(geosname), mode=NF90_NOWRITE,ncid=ftn_geos),'nf90_open failed for geosfile in read_geositbias') 
+               call LIS_verify(nf90_inq_varid(ftn_geos,'lat',latid),'inq lat varid failed (full)')
+               call LIS_verify(nf90_inq_varid(ftn_geos,'lon',lonid),'inq lon varid failed (full)')
+               call LIS_verify(nf90_get_var(ftn_geos,latid,lat_full),'get lat_full failed')
+               call LIS_verify(nf90_get_var(ftn_geos,lonid,lon_full),'get lon_full failed')
+               call LIS_verify(nf90_close(ftn_geos),'[WARN] Failed to close slvfile in read_geositbias.')
+
+               ! Find paste offsets
+               call find_index(lon_full, lon_sub(1), i0)
+               call find_index(lat_full, lat_sub(1), j0)
+
+               ! Paste subdomain into full-domain buffer
+               lapse_rate_in(i0:i0+nc_sub-1, j0:j0+nr_sub-1) = lapse_rate_sub(:,:)
+
+               ! Cleanup
+               deallocate(lapse_rate_sub, lat_sub, lon_sub, lat_full, lon_full)
+
+            ! Case 3: unexpected
+            else
+               write(LIS_logunit,*) '[ERR] Unexpected lapse-rate dims: ', nc_sub, ' x ', nr_sub
+               call LIS_endrun()
+            end if
+
+            call LIS_verify(nf90_close(ftn_drate),'close lapse-rate file failed')
+            call interp_lapserate_geositbias(n,order,lapse_rate_in)
+            
+            deallocate(lapse_rate_in)
+
+         else
+            write(LIS_logunit,*) '[WARN] Could not find ',trim(lapseratefname)
+            write(LIS_logunit,*) '[WARN] Using static lapse rate.'
+            geositbias_struc(n)%lapserate1 = LIS_CONST_LAPSE_RATE
+            geositbias_struc(n)%lapserate2 = LIS_CONST_LAPSE_RATE
+         endif
+      endif
+  else
+      call LIS_endrun()
+  endif
+     
+#endif
+contains
+subroutine find_index(x,val,idx)
+  real, intent(in) :: x(:), val
+  integer, intent(out) :: idx
+  real :: dmin
+  integer :: k
+  dmin = huge(1.0); idx = -1
+  do k=1,size(x)
+     if (abs(x(k)-val) < dmin) then
+        dmin = abs(x(k)-val)
+        idx = k
+     end if
+  enddo
+end subroutine find_index
+end subroutine read_geositbias
+
+!BOP
+!
+! !ROUTINE: interp_geositbias_var
+! \label{interp_geositbias_var}
+!
+! !INTERFACE:
+subroutine interp_geositbias_var(n,findex,month,input_var,var_index, &
+    pcp_flag,geositbiasforc)
+
+! !USES:
+  use LIS_coreMod
+  use LIS_logMod
+  use LIS_spatialDownscalingMod
+  use geositbias_forcingMod, only : geositbias_struc
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)
+  use netcdf
+#endif
+
+  implicit none
+! !ARGUMENTS:
+  integer, intent(in)    :: n
+  integer, intent(in)    :: findex
+  integer, intent(in)    :: month
+  real,    intent(in)    :: input_var(geositbias_struc(n)%ncold,       &
+       geositbias_struc(n)%nrold)
+  integer, intent(in)    :: var_index
+  logical, intent(in)    :: pcp_flag
+  real,    intent(inout) :: geositbiasforc(geositbias_struc(n)%nvars,      &
+       LIS_rc%lnc(n)*LIS_rc%lnr(n))
+
+! !DESCRIPTION:
+!  This subroutine spatially interpolates a GEOS-ITbias field
+!  to the LIS running domain
+!
+!EOP
+   integer   :: t,c,r,k,iret
+   integer   :: doy
+   integer   :: ftn
+   integer   :: pcp1Id,pcp2Id,pcp3Id,pcp4Id,pcp5Id,pcp6Id
+   real      :: f (geositbias_struc(n)%ncold*geositbias_struc(n)%nrold)
+   logical*1 :: lb(geositbias_struc(n)%ncold*geositbias_struc(n)%nrold)
+   logical*1 :: lo(LIS_rc%lnc(n)*LIS_rc%lnr(n))
+   integer   :: input_size
+   logical   :: scal_read_flag
+! _____________________________________________________________
+
+   input_size = geositbias_struc(n)%ncold*geositbias_struc(n)%nrold
+
+!-----------------------------------------------------------------------
+! Apply downscaling
+!-----------------------------------------------------------------------
+   lb = .true.
+   do r = 1,geositbias_struc(n)%nrold
+      do c = 1,geositbias_struc(n)%ncold
+         k = c+(r-1)*geositbias_struc(n)%ncold
+         f(k) = input_var(c,r)
+         if (f(k).eq.1.e+15) then 
+            f(k)  = LIS_rc%udef
+            lb(k) = .false. 
+         endif
+      enddo
+   enddo
+
+   if (pcp_flag.and.(LIS_rc%pcp_downscale(findex).ne.0)) then
+! input_data becomes the ratio field.
+      call LIS_generatePcpClimoRatioField(n,findex,"GEOS-ITbias",       &
+                                          month,input_size,f,lb)
+   endif
+
+   if (pcp_flag.and.                                                &
+       (trim(LIS_rc%met_interp(findex)).eq."budget-bilinear")) then
+
+      call conserv_interp(LIS_rc%gridDesc(n,:),lb,f,lo,             &
+                  geositbiasforc(var_index,:),                          &
+                  geositbias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),   &
+                  LIS_domain(n)%lat,LIS_domain(n)%lon,              &
+                  geositbias_struc(n)%w112,geositbias_struc(n)%w122,        &
+                  geositbias_struc(n)%w212,geositbias_struc(n)%w222,        &
+                  geositbias_struc(n)%n112,geositbias_struc(n)%n122,        &
+                  geositbias_struc(n)%n212,geositbias_struc(n)%n222,        &
+                  LIS_rc%udef,iret)
+
+   elseif ((trim(LIS_rc%met_interp(findex)).eq."bilinear").or.      &
+           (trim(LIS_rc%met_interp(findex)).eq."budget-bilinear")) then
+      call bilinear_interp(LIS_rc%gridDesc(n,:),lb,f,lo,            &
+                   geositbiasforc(var_index,:),                         &
+                   geositbias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),  &
+                   LIS_domain(n)%lat,LIS_domain(n)%lon,             &
+                   geositbias_struc(n)%w111,geositbias_struc(n)%w121,       &
+                   geositbias_struc(n)%w211,geositbias_struc(n)%w221,       &
+                   geositbias_struc(n)%n111,geositbias_struc(n)%n121,       &
+                   geositbias_struc(n)%n211,geositbias_struc(n)%n221,       &
+                   LIS_rc%udef,iret)
+
+   elseif (trim(LIS_rc%met_interp(findex)).eq."neighbor") then
+      call neighbor_interp(LIS_rc%gridDesc(n,:),lb,f,lo,            &
+                   geositbiasforc(var_index,:),                         &
+                   geositbias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),  &
+                   LIS_domain(n)%lat,LIS_domain(n)%lon,             &
+                   geositbias_struc(n)%n113,LIS_rc%udef,iret)
+
+   else
+      write(LIS_logunit,*) '[ERR] Spatial interpolation option '//  &
+                            trim(LIS_rc%met_interp(findex))//       &
+                           ' not supported for GEOS-ITbias.'
+      call LIS_endrun()
+   endif
+
+   if (pcp_flag.and.(LIS_rc%pcp_downscale(findex).ne.0)) then
+      call LIS_pcpClimoDownscaling(n,findex,month,                  &
+              LIS_rc%lnc(n)*LIS_rc%lnr(n),geositbiasforc(var_index,:),lo)
+   endif
+
+end subroutine interp_geositbias_var
+
+!BOP
+! 
+! !ROUTINE: interp_lapserate_geositbias
+! \label{interp_lapserate_geositbias}
+! 
+! !INTERFACE: 
+subroutine interp_lapserate_geositbias(n,order,input_var)
+
+! !USES:  
+  use LIS_coreMod
+  use LIS_logMod
+  use LIS_spatialDownscalingMod
+  use geositbias_forcingMod, only : geositbias_struc
+  use LIS_constantsMod, only : LIS_CONST_LAPSE_RATE
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)      
+  use netcdf
+#endif
+  implicit none
+
+! !ARGUMENTS:
+  integer, intent(in)    :: n, order
+  real,    intent(in)    :: input_var(geositbias_struc(n)%ncold, &
+       geositbias_struc(n)%nrold)
+
+  !
+! !DESCRIPTION: 
+!  This subroutine spatially interpolates a GEOS-IT Bias-corrected field 
+!  to the LIS running domain
+! 
+!EOP
+
+  integer   :: c,r,k,iret
+  integer   :: doy
+  integer   :: ftn,gid
+  real      :: f (geositbias_struc(n)%ncold*geositbias_struc(n)%nrold)
+  logical*1 :: lb(geositbias_struc(n)%ncold*geositbias_struc(n)%nrold)
+  logical*1 :: lo(LIS_rc%lnc(n)*LIS_rc%lnr(n))
+  integer   :: input_size
+  real      :: output_var(LIS_rc%lnc(n)*LIS_rc%lnr(n))
+
+! _____________________________________________________________
+
+  input_size = geositbias_struc(n)%ncold*geositbias_struc(n)%nrold
+
+  
+  lb = .true.
+  do r=1,geositbias_struc(n)%nrold
+    do c=1,geositbias_struc(n)%ncold
+       k= c+(r-1)*geositbias_struc(n)%ncold
+       f(k) = input_var(c,r)
+       if ( f(k) == 1.e+15 ) then
+          f(k)  = LIS_rc%udef
+          lb(k) = .false.
+       endif
+    enddo
+  enddo
+
+  call bilinear_interp(LIS_rc%gridDesc(n,:),lb,f,lo,&
+      output_var(:), &
+      geositbias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n), &
+      LIS_domain(n)%lat, LIS_domain(n)%lon,&
+      geositbias_struc(n)%w111,geositbias_struc(n)%w121,&
+      geositbias_struc(n)%w211,geositbias_struc(n)%w221,&
+      geositbias_struc(n)%n111,geositbias_struc(n)%n121,&
+      geositbias_struc(n)%n211,geositbias_struc(n)%n221,&
+      LIS_rc%udef, iret)
+     
+  if (order.eq.1) then
+    do r=1,LIS_rc%lnr(n)
+       do c=1,LIS_rc%lnc(n)
+          if(LIS_domain(n)%gindex(c,r).ne.-1) then
+             gid = LIS_domain(n)%gindex(c,r)
+             if(.not.isNaN(output_var(c+(r-1)*LIS_rc%lnc(n)))) then
+                 geositbias_struc(n)%lapserate1(gid) = &
+                         output_var(c+(r-1)*LIS_rc%lnc(n))/1000.0
+             else
+                 geositbias_struc(n)%lapserate1(gid) = LIS_CONST_LAPSE_RATE
+             endif
+          endif
+       enddo
+    enddo
+  endif
+  if (order.eq.2) then
+    do r=1,LIS_rc%lnr(n)
+       do c=1,LIS_rc%lnc(n)
+          if(LIS_domain(n)%gindex(c,r).ne.-1) then
+             gid = LIS_domain(n)%gindex(c,r)
+             if(.not.isNaN(output_var(c+(r-1)*LIS_rc%lnc(n)))) then
+                geositbias_struc(n)%lapserate2(gid) = &
+                     output_var(c+(r-1)*LIS_rc%lnc(n))/1000.0
+             else
+                geositbias_struc(n)%lapserate2(gid) = LIS_CONST_LAPSE_RATE
+             endif
+          endif
+       enddo
+    enddo
+  endif
+
+end subroutine interp_lapserate_geositbias

--- a/lis/metforcing/geos_itbias/read_geositbias.F90
+++ b/lis/metforcing/geos_itbias/read_geositbias.F90
@@ -23,7 +23,7 @@
                            lapseratefname,                             &
                            geositbiasforc,ferror)
 ! !USES:
-      use LIS_coreMod,       only : LIS_rc, LIS_domain, LIS_masterproc
+      use LIS_coreMod,       only : LIS_rc
       use LIS_logMod
       use LIS_FORC_AttributesMod
       use LIS_metforcingMod, only : LIS_forc
@@ -93,11 +93,8 @@
       integer   :: tmpId,qId,psId
       integer   :: lwgabId
       integer   :: nr_index,nc_index
-      logical   :: file_exists,file_exists1
-      integer   :: c,r,t,k,iret
+      logical   :: file_exists
       integer   :: mo
-      logical   :: read_lnd
-
       real      :: tair(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
       real      :: qair(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
       real      :: ps(geositbias_struc(n)%ncold,geositbias_struc(n)%nrold)
@@ -111,6 +108,9 @@
       real, allocatable :: lat_full(:), lon_full(:)
       integer :: i0, j0
       integer :: latid, lonid
+
+      external :: interp_geositbias_var
+      external :: interp_lapserate_geositbias
 ! __________________________________________________________________________
 
 #if (defined USE_NETCDF3)
@@ -293,15 +293,16 @@ subroutine interp_geositbias_var(n,findex,month,input_var,var_index, &
 !  to the LIS running domain
 !
 !EOP
-   integer   :: t,c,r,k,iret
-   integer   :: doy
-   integer   :: ftn
-   integer   :: pcp1Id,pcp2Id,pcp3Id,pcp4Id,pcp5Id,pcp6Id
+   integer   :: c,r,k,iret
    real      :: f (geositbias_struc(n)%ncold*geositbias_struc(n)%nrold)
    logical*1 :: lb(geositbias_struc(n)%ncold*geositbias_struc(n)%nrold)
    logical*1 :: lo(LIS_rc%lnc(n)*LIS_rc%lnr(n))
    integer   :: input_size
-   logical   :: scal_read_flag
+
+   external :: conserv_interp
+   external :: bilinear_interp
+   external :: neighbor_interp
+
 ! _____________________________________________________________
 
    input_size = geositbias_struc(n)%ncold*geositbias_struc(n)%nrold
@@ -405,14 +406,14 @@ subroutine interp_lapserate_geositbias(n,order,input_var)
 !EOP
 
   integer   :: c,r,k,iret
-  integer   :: doy
-  integer   :: ftn,gid
+  integer   :: gid
   real      :: f (geositbias_struc(n)%ncold*geositbias_struc(n)%nrold)
   logical*1 :: lb(geositbias_struc(n)%ncold*geositbias_struc(n)%nrold)
   logical*1 :: lo(LIS_rc%lnc(n)*LIS_rc%lnr(n))
   integer   :: input_size
   real      :: output_var(LIS_rc%lnc(n)*LIS_rc%lnr(n))
 
+  external :: bilinear_interp
 ! _____________________________________________________________
 
   input_size = geositbias_struc(n)%ncold*geositbias_struc(n)%nrold

--- a/lis/metforcing/geos_itbias/read_geositbias.F90
+++ b/lis/metforcing/geos_itbias/read_geositbias.F90
@@ -17,6 +17,8 @@
 ! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
 ! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
 ! 09 Jan 2026: Eric Kemp, reformatted.
+! 17 Jun 2026: Kristen Whitney, corrected GEOS-ITbias forcing
+!              variable documentation and indexing.
 !
 ! !INTERFACE:
 subroutine read_geositbias(n,order,month,findex,                     &
@@ -49,23 +51,13 @@ subroutine read_geositbias(n,order,month,findex,                     &
 
 ! !DESCRIPTION:
 !  For the given time, reads parameters from GEOS-ITbias data, transforms
-!  into 9 LIS forcing parameters and interpolates to the LIS domain. \newline
+!  into 4 LIS forcing parameters and interpolates to the LIS domain. \newline
 !
 ! GEOS-ITbias FORCING VARIABLES: \newline
 !  1. tair    Temperature of air at 2-m, 10-m, or LML [$K$] \newline
 !  2. qair    Specific humidity of air at 2-m, 10-m, or LML [$kg/kg$] \newline
-!  3. swgdn   Downward shortwave radiation at the ground [$W/m^2$] \newline
-!  4. lwgab   Downward longwave radiation at the ground [$W/m^2$] \newline
-!  5. uwind   Zonal wind at 2-m, 10-m, or LML [$m/s$] \newline
-!  6. vwind   Meridional wind at 2-m, 10-m, or LML [$m/s$] \newline
-!  7. ps      Instantaneous Surface Pressure [$Pa$] \newline
-!  8. pretot  Total precipitation [$mm/s$] \newline
-!  9. precon  Convective precipitation [$mm/s$] \newline
-! 10. presno  Precipitation falling as snow [$mm/s$] \newline
-! 11. swland  Net shortwave radiation at the ground [$W/m^2$] \newline
-! 12. pardr   Surface downward PAR beam flux [$W/m^2$] \newline
-! 13. pardf   Surface downward PAR diffuse flux [$W/m^2$] \newline
-! 14. hlml    Height of center of lowest model layer (LML) [$m$] \newline
+!  3. ps      Instantaneous Surface Pressure [$Pa$] \newline
+!  4. lwgab   Downward longwave radiation at the ground [$W/m^2$] \newline 
 !
 !  The arguments are:
 !  \begin{description}
@@ -126,7 +118,7 @@ subroutine read_geositbias(n,order,month,findex,                     &
   nc_index = geositbias_struc(n)%ncold
   mo = LIS_rc%lnc(n)*LIS_rc%lnr(n)
 
-! Read single layer file (*slv) fields:
+! Read required fields from GEOS-ITbias input file:
   inquire(file=geosname,exist=file_exists)
   if(file_exists) then
      write(LIS_logunit,*)                                           &
@@ -162,9 +154,9 @@ subroutine read_geositbias(n,order,month,findex,                     &
           geositbiasforc)
      call interp_geositbias_var(n,findex,month,qair,  2,.false.,    &
           geositbiasforc)
-     call interp_geositbias_var(n,findex,month,ps,    7,.false.,    &
+     call interp_geositbias_var(n,findex,month,ps,    3,.false.,    &
           geositbiasforc)
-     call interp_geositbias_var(n,findex,month,lwgab,4,.false.,     &
+     call interp_geositbias_var(n,findex,month,lwgab, 4,.false.,     &
           geositbiasforc)
 
     ! Obtain lapse rates

--- a/lis/metforcing/geos_itbias/read_geositbias.F90
+++ b/lis/metforcing/geos_itbias/read_geositbias.F90
@@ -57,7 +57,7 @@ subroutine read_geositbias(n,order,month,findex,                     &
 !  1. tair    Temperature of air at 2-m, 10-m, or LML [$K$] \newline
 !  2. qair    Specific humidity of air at 2-m, 10-m, or LML [$kg/kg$] \newline
 !  3. ps      Instantaneous Surface Pressure [$Pa$] \newline
-!  4. lwgab   Downward longwave radiation at the ground [$W/m^2$] \newline 
+!  4. lwgab   Downward longwave radiation at the ground [$W/m^2$] \newline
 !
 !  The arguments are:
 !  \begin{description}

--- a/lis/metforcing/geos_itbias/read_geositbias_elev.F90
+++ b/lis/metforcing/geos_itbias/read_geositbias_elev.F90
@@ -1,9 +1,9 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 ! NASA Goddard Space Flight Center
 ! Land Information System Framework (LISF)
-! Version 7.4
+! Version 7.5
 !
-! Copyright (c) 2022 United States Government as represented by the
+! Copyright (c) 2024 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------

--- a/lis/metforcing/geos_itbias/read_geositbias_elev.F90
+++ b/lis/metforcing/geos_itbias/read_geositbias_elev.F90
@@ -1,0 +1,77 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.4
+!
+! Copyright (c) 2022 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: read_geositbias_elev
+! \label{read_geositbias_elev}
+!
+! !REVISION HISTORY:
+!
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+!
+! !INTERFACE:
+      subroutine read_geositbias_elev(n,findex)
+! !USES:
+      use LIS_coreMod,       only : LIS_rc, LIS_domain
+      use LIS_metforcingMod, only : LIS_forc
+      use LIS_fileIOMod,     only : LIS_read_param
+      use LIS_logMod,        only : LIS_logunit
+
+      implicit none
+
+! !ARGUMENTS:
+      integer, intent(in) :: n
+      integer, intent(in) :: findex
+
+! !DESCRIPTION:
+!
+!  Opens and reads MERRA-2 model elevation to the LIS grid.
+!  The MERRA-2 elevation is the same as the GEOS-ITbias elevation.
+!  The data will be used to perform any topographical adjustments
+!  to the forcing.
+!
+!  The elevation file needs to be preprocessed to fit the running
+!  resolution and domain.
+!
+!  The arguments are:
+!  \begin{description}
+!  \item[n]
+!   index of the nest
+!  \item[findex]
+!   index of the forcing source
+!  \end{description}
+!
+!  The routines invoked are:
+!  \begin{description}
+!   \item[LIS\_readData](\ref{LIS_readData}) \newline
+!    Abstract method to read the elevation of the forcing
+!    data in the same map projection used in LIS.
+!  \end{description}
+!EOP
+
+      integer :: c,r
+      real    :: go(LIS_rc%lnc(n),LIS_rc%lnr(n))
+
+      if (trim(LIS_rc%met_ecor(findex)).ne."none") then
+         write(LIS_logunit,*)                                          &
+                      'Reading the GEOS-ITbias/MERRA-2 elevation map ...'
+
+         call LIS_read_param(n,"ELEV_MERRA2",go)
+
+         do r = 1,LIS_rc%lnr(n)
+            do c = 1,LIS_rc%lnc(n)
+               if (LIS_domain(n)%gindex(c,r).ne.-1) then
+                  LIS_forc(n,findex)%modelelev(LIS_domain(n)%gindex(c,r)) = go(c,r)
+               endif
+            enddo
+         enddo
+      endif
+
+      end subroutine read_geositbias_elev
+

--- a/lis/metforcing/geos_itbias/read_geositbias_elev.F90
+++ b/lis/metforcing/geos_itbias/read_geositbias_elev.F90
@@ -14,20 +14,21 @@
 ! !REVISION HISTORY:
 !
 ! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+! 09 Jan 2026: Eric Kemp, reformatted.
 !
 ! !INTERFACE:
-      subroutine read_geositbias_elev(n,findex)
+subroutine read_geositbias_elev(n,findex)
 ! !USES:
-      use LIS_coreMod,       only : LIS_rc, LIS_domain
-      use LIS_metforcingMod, only : LIS_forc
-      use LIS_fileIOMod,     only : LIS_read_param
-      use LIS_logMod,        only : LIS_logunit
+  use LIS_coreMod,       only : LIS_rc, LIS_domain
+  use LIS_metforcingMod, only : LIS_forc
+  use LIS_fileIOMod,     only : LIS_read_param
+  use LIS_logMod,        only : LIS_logunit
 
-      implicit none
+  implicit none
 
 ! !ARGUMENTS:
-      integer, intent(in) :: n
-      integer, intent(in) :: findex
+  integer, intent(in) :: n
+  integer, intent(in) :: findex
 
 ! !DESCRIPTION:
 !
@@ -55,23 +56,24 @@
 !  \end{description}
 !EOP
 
-      integer :: c,r
-      real    :: go(LIS_rc%lnc(n),LIS_rc%lnr(n))
+  integer :: c,r
+  real    :: go(LIS_rc%lnc(n),LIS_rc%lnr(n))
 
-      if (trim(LIS_rc%met_ecor(findex)).ne."none") then
-         write(LIS_logunit,*)                                          &
-                      'Reading the GEOS-ITbias/MERRA-2 elevation map ...'
+  if (trim(LIS_rc%met_ecor(findex)).ne."none") then
+     write(LIS_logunit,*)                                          &
+          'Reading the GEOS-ITbias/MERRA-2 elevation map ...'
 
-         call LIS_read_param(n,"ELEV_MERRA2",go)
+     call LIS_read_param(n,"ELEV_MERRA2",go)
 
-         do r = 1,LIS_rc%lnr(n)
-            do c = 1,LIS_rc%lnc(n)
-               if (LIS_domain(n)%gindex(c,r).ne.-1) then
-                  LIS_forc(n,findex)%modelelev(LIS_domain(n)%gindex(c,r)) = go(c,r)
-               endif
-            enddo
-         enddo
-      endif
+     do r = 1,LIS_rc%lnr(n)
+        do c = 1,LIS_rc%lnc(n)
+           if (LIS_domain(n)%gindex(c,r).ne.-1) then
+              LIS_forc(n,findex)%modelelev(LIS_domain(n)%gindex(c,r)) = &
+                   go(c,r)
+           endif
+        enddo
+     enddo
+  endif
 
-      end subroutine read_geositbias_elev
+end subroutine read_geositbias_elev
 

--- a/lis/metforcing/geos_itbias/readcrd_geositbias.F90
+++ b/lis/metforcing/geos_itbias/readcrd_geositbias.F90
@@ -1,9 +1,9 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 ! NASA Goddard Space Flight Center
 ! Land Information System Framework (LISF)
-! Version 7.4
+! Version 7.5
 !
-! Copyright (c) 2022 United States Government as represented by the
+! Copyright (c) 2024 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------

--- a/lis/metforcing/geos_itbias/readcrd_geositbias.F90
+++ b/lis/metforcing/geos_itbias/readcrd_geositbias.F90
@@ -1,0 +1,132 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.4
+!
+! Copyright (c) 2022 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+!
+! !ROUTINE: readcrd_geositbias
+! \label{readcrd_geositbias}
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
+!
+! !INTERFACE:
+  subroutine readcrd_geositbias()
+! !USES:
+  use ESMF
+  use LIS_logMod
+  use LIS_coreMod, only       : LIS_rc,LIS_config
+  use geositbias_forcingMod, only : geositbias_struc
+!
+! !DESCRIPTION:
+!
+!  This routine reads the options specific to GEOS-ITbias forcing
+!  from the LIS configuration file.
+!
+!EOP
+  implicit none
+
+  integer :: n,t,rc,m
+  logical :: usedynlapserate
+  
+  call ESMF_ConfigFindLabel(LIS_config,                            &
+                                 "GEOS-ITbias forcing directory:",rc=rc)
+  do n = 1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,                      &
+                                  geositbias_struc(n)%geositbiasdir,rc=rc)
+     call LIS_verify(rc,'GEOS-ITbias forcing directory: not defined')
+  enddo
+ 
+  call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias apply dynamic lapse rates:",rc=rc)
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%usedynlapserate,&
+          default=0, rc=rc)
+     call LIS_verify(rc,&
+          'GEOS-ITbias apply dynamic lapse rates: not defined')
+  enddo
+
+  usedynlapserate = .true.
+
+  do n=1,LIS_rc%nnest
+     if(geositbias_struc(n)%usedynlapserate.eq.0) then
+        usedynlapserate = .false.
+     endif
+  enddo
+  
+  if(usedynlapserate) then
+     call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias dynamic lapse rate data directory:",rc=rc)
+     do n=1,LIS_rc%nnest
+        call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%dynlapseratedir,&
+             rc=rc)
+        call LIS_verify(rc,&
+             'GEOS-ITbias dynamic lapse rate data directory: not defined')
+     enddo
+
+     call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias dynamic lapse rate filename prefix:",rc=rc)
+     do n=1,LIS_rc%nnest
+        call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%dynlapseratepfx,&
+                      default='/GEOS-ITbias.lapse_rate.hourly.', rc=rc)
+        write(LIS_logunit,*) '[INFO] GEOS-ITbias dynamic lapse rate filename prefix:', trim(geositbias_struc(n)%dynlapseratepfx)
+     enddo
+
+     call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias dynamic lapse rate filename suffix: ",rc=rc)
+     do n=1,LIS_rc%nnest
+        call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%dynlapseratesfx,&
+                      default='.global.nc', rc=rc)
+        write(LIS_logunit,*) '[INFO] GEOS-ITbias dynamic lapse rate filename suffix: ', trim(geositbias_struc(n)%dynlapseratesfx)
+     enddo
+
+     call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias apply double-sided dynamic lapse rate cutoff:",rc=rc)
+     do n=1,LIS_rc%nnest
+        call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%applydynlapseratecutoff,&
+                default=0, rc=rc)
+        call LIS_verify(rc,&
+                'GEOS-ITbias apply double-sided dynamic lapse rate cutoff: not defined')
+     enddo
+
+     do n=1,LIS_rc%nnest
+        if(geositbias_struc(n)%applydynlapseratecutoff.eq.1) then
+           call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias minimum lapse rate cutoff (K/m):",rc=rc)
+           call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%dynlapseratemincutoff,&
+                   default=-0.01, rc=rc)
+           call LIS_verify(rc,&
+                   'GEOS-ITbias minimum lapse rate cutoff (K/m): not defined')
+           call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias maximum lapse rate cutoff (K/m):",rc=rc)
+           call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%dynlapseratemaxcutoff,&
+                   default=0.01, rc=rc)
+           call LIS_verify(rc,&
+                   'GEOS-ITbias maximum lapse rate cutoff (K/m): not defined')
+
+           ! Sanity check
+           if(geositbias_struc(n)%dynlapseratemincutoff.gt.geositbias_struc(n)%dynlapseratemaxcutoff) then
+              write(LIS_logunit,*) '[ERR] GEOS-ITbias minimum lapse rate cutoff value should be'
+              write(LIS_logunit,*) '[ERR] less than the GEOS-ITbias maximum lapse rate cutoff value.'
+              write(LIS_logunit,*) '[ERR] Note the default value is -0.01 K/m for the minimum cutoff,'
+              write(LIS_logunit,*) '[ERR] and 0.01 K/m for the maximum cutoff.'
+              write(LIS_logunit,*) '[ERR] Please ensure if specifying just the minimum (maximum)'
+              write(LIS_logunit,*) '[ERR] cutoff value, that it is less (greater) than the'
+              write(LIS_logunit,*) '[ERR] maximum (minimum) default value.'
+              write(LIS_logunit,*) '[ERR] STOPPING ....'
+              call LIS_endrun()
+           endif
+        endif
+     enddo
+  endif
+
+  do n = 1,LIS_rc%nnest
+     write(LIS_logunit,*) '[INFO] Using GEOS-ITbias forcing'
+     write(LIS_logunit,*) '[INFO] GEOS-ITbias forcing directory: ',    &
+                           trim(geositbias_struc(n)%geositbiasdir)
+
+     geositbias_struc(n)%geositbiastime1 = 3000.0
+     geositbias_struc(n)%geositbiastime2 = 0.0
+  enddo
+
+ end subroutine readcrd_geositbias
+

--- a/lis/metforcing/geos_itbias/readcrd_geositbias.F90
+++ b/lis/metforcing/geos_itbias/readcrd_geositbias.F90
@@ -32,7 +32,7 @@
 !EOP
   implicit none
 
-  integer :: n,t,rc,m
+  integer :: n,rc
   logical :: usedynlapserate
   
   call ESMF_ConfigFindLabel(LIS_config,                            &

--- a/lis/metforcing/geos_itbias/readcrd_geositbias.F90
+++ b/lis/metforcing/geos_itbias/readcrd_geositbias.F90
@@ -15,9 +15,10 @@
 ! !REVISION HISTORY:
 ! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
 ! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
+! 09 Jan 2026: Eric Kemp, reformatting.
 !
 ! !INTERFACE:
-  subroutine readcrd_geositbias()
+subroutine readcrd_geositbias()
 ! !USES:
   use ESMF
   use LIS_logMod
@@ -34,18 +35,20 @@
 
   integer :: n,rc
   logical :: usedynlapserate
-  
+
   call ESMF_ConfigFindLabel(LIS_config,                            &
-                                 "GEOS-ITbias forcing directory:",rc=rc)
+       "GEOS-ITbias forcing directory:",rc=rc)
   do n = 1,LIS_rc%nnest
      call ESMF_ConfigGetAttribute(LIS_config,                      &
-                                  geositbias_struc(n)%geositbiasdir,rc=rc)
+          geositbias_struc(n)%geositbiasdir,rc=rc)
      call LIS_verify(rc,'GEOS-ITbias forcing directory: not defined')
   enddo
- 
-  call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias apply dynamic lapse rates:",rc=rc)
+
+  call ESMF_ConfigFindLabel(LIS_config, &
+       "GEOS-ITbias apply dynamic lapse rates:",rc=rc)
   do n=1,LIS_rc%nnest
-     call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%usedynlapserate,&
+     call ESMF_ConfigGetAttribute(LIS_config, &
+          geositbias_struc(n)%usedynlapserate,&
           default=0, rc=rc)
      call LIS_verify(rc,&
           'GEOS-ITbias apply dynamic lapse rates: not defined')
@@ -58,60 +61,85 @@
         usedynlapserate = .false.
      endif
   enddo
-  
+
   if(usedynlapserate) then
-     call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias dynamic lapse rate data directory:",rc=rc)
+     call ESMF_ConfigFindLabel(LIS_config, &
+          "GEOS-ITbias dynamic lapse rate data directory:",rc=rc)
      do n=1,LIS_rc%nnest
-        call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%dynlapseratedir,&
+        call ESMF_ConfigGetAttribute(LIS_config, &
+             geositbias_struc(n)%dynlapseratedir,&
              rc=rc)
         call LIS_verify(rc,&
              'GEOS-ITbias dynamic lapse rate data directory: not defined')
      enddo
 
-     call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias dynamic lapse rate filename prefix:",rc=rc)
+     call ESMF_ConfigFindLabel(LIS_config, &
+          "GEOS-ITbias dynamic lapse rate filename prefix:",rc=rc)
      do n=1,LIS_rc%nnest
-        call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%dynlapseratepfx,&
-                      default='/GEOS-ITbias.lapse_rate.hourly.', rc=rc)
-        write(LIS_logunit,*) '[INFO] GEOS-ITbias dynamic lapse rate filename prefix:', trim(geositbias_struc(n)%dynlapseratepfx)
+        call ESMF_ConfigGetAttribute(LIS_config, &
+             geositbias_struc(n)%dynlapseratepfx,&
+             default='/GEOS-ITbias.lapse_rate.hourly.', rc=rc)
+        write(LIS_logunit,*) &
+             '[INFO] GEOS-ITbias dynamic lapse rate filename prefix:', &
+             trim(geositbias_struc(n)%dynlapseratepfx)
      enddo
 
-     call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias dynamic lapse rate filename suffix: ",rc=rc)
+     call ESMF_ConfigFindLabel(LIS_config, &
+          "GEOS-ITbias dynamic lapse rate filename suffix: ",rc=rc)
      do n=1,LIS_rc%nnest
-        call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%dynlapseratesfx,&
-                      default='.global.nc', rc=rc)
-        write(LIS_logunit,*) '[INFO] GEOS-ITbias dynamic lapse rate filename suffix: ', trim(geositbias_struc(n)%dynlapseratesfx)
+        call ESMF_ConfigGetAttribute(LIS_config, &
+             geositbias_struc(n)%dynlapseratesfx,&
+             default='.global.nc', rc=rc)
+        write(LIS_logunit,*) &
+             '[INFO] GEOS-ITbias dynamic lapse rate filename suffix: ', &
+             trim(geositbias_struc(n)%dynlapseratesfx)
      enddo
 
-     call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias apply double-sided dynamic lapse rate cutoff:",rc=rc)
+     call ESMF_ConfigFindLabel(LIS_config, &
+          "GEOS-ITbias apply double-sided dynamic lapse rate cutoff:", &
+          rc=rc)
      do n=1,LIS_rc%nnest
-        call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%applydynlapseratecutoff,&
-                default=0, rc=rc)
+        call ESMF_ConfigGetAttribute(LIS_config, &
+             geositbias_struc(n)%applydynlapseratecutoff,&
+             default=0, rc=rc)
         call LIS_verify(rc,&
-                'GEOS-ITbias apply double-sided dynamic lapse rate cutoff: not defined')
+             'GEOS-ITbias apply double-sided dynamic lapse rate cutoff: not defined')
      enddo
 
      do n=1,LIS_rc%nnest
         if(geositbias_struc(n)%applydynlapseratecutoff.eq.1) then
-           call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias minimum lapse rate cutoff (K/m):",rc=rc)
-           call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%dynlapseratemincutoff,&
-                   default=-0.01, rc=rc)
+           call ESMF_ConfigFindLabel(LIS_config, &
+                "GEOS-ITbias minimum lapse rate cutoff (K/m):",rc=rc)
+           call ESMF_ConfigGetAttribute(LIS_config, &
+                geositbias_struc(n)%dynlapseratemincutoff,&
+                default=-0.01, rc=rc)
            call LIS_verify(rc,&
-                   'GEOS-ITbias minimum lapse rate cutoff (K/m): not defined')
-           call ESMF_ConfigFindLabel(LIS_config,"GEOS-ITbias maximum lapse rate cutoff (K/m):",rc=rc)
-           call ESMF_ConfigGetAttribute(LIS_config,geositbias_struc(n)%dynlapseratemaxcutoff,&
+                'GEOS-ITbias minimum lapse rate cutoff (K/m): not defined')
+           call ESMF_ConfigFindLabel(LIS_config, &
+                "GEOS-ITbias maximum lapse rate cutoff (K/m):",rc=rc)
+           call ESMF_ConfigGetAttribute(LIS_config, &
+                geositbias_struc(n)%dynlapseratemaxcutoff,&
                    default=0.01, rc=rc)
            call LIS_verify(rc,&
-                   'GEOS-ITbias maximum lapse rate cutoff (K/m): not defined')
+                'GEOS-ITbias maximum lapse rate cutoff (K/m): not defined')
 
            ! Sanity check
-           if(geositbias_struc(n)%dynlapseratemincutoff.gt.geositbias_struc(n)%dynlapseratemaxcutoff) then
-              write(LIS_logunit,*) '[ERR] GEOS-ITbias minimum lapse rate cutoff value should be'
-              write(LIS_logunit,*) '[ERR] less than the GEOS-ITbias maximum lapse rate cutoff value.'
-              write(LIS_logunit,*) '[ERR] Note the default value is -0.01 K/m for the minimum cutoff,'
-              write(LIS_logunit,*) '[ERR] and 0.01 K/m for the maximum cutoff.'
-              write(LIS_logunit,*) '[ERR] Please ensure if specifying just the minimum (maximum)'
-              write(LIS_logunit,*) '[ERR] cutoff value, that it is less (greater) than the'
-              write(LIS_logunit,*) '[ERR] maximum (minimum) default value.'
+           if(geositbias_struc(n)%dynlapseratemincutoff.gt. &
+                geositbias_struc(n)%dynlapseratemaxcutoff) then
+              write(LIS_logunit,*) &
+                   '[ERR] GEOS-ITbias minimum lapse rate cutoff value should be'
+              write(LIS_logunit,*) &
+                   '[ERR] less than the GEOS-ITbias maximum lapse rate cutoff value.'
+              write(LIS_logunit,*) &
+                   '[ERR] Note the default value is -0.01 K/m for the minimum cutoff,'
+              write(LIS_logunit,*) &
+                   '[ERR] and 0.01 K/m for the maximum cutoff.'
+              write(LIS_logunit,*) &
+                   '[ERR] Please ensure if specifying just the minimum (maximum)'
+              write(LIS_logunit,*) &
+                   '[ERR] cutoff value, that it is less (greater) than the'
+              write(LIS_logunit,*) &
+                   '[ERR] maximum (minimum) default value.'
               write(LIS_logunit,*) '[ERR] STOPPING ....'
               call LIS_endrun()
            endif
@@ -122,11 +150,11 @@
   do n = 1,LIS_rc%nnest
      write(LIS_logunit,*) '[INFO] Using GEOS-ITbias forcing'
      write(LIS_logunit,*) '[INFO] GEOS-ITbias forcing directory: ',    &
-                           trim(geositbias_struc(n)%geositbiasdir)
+          trim(geositbias_struc(n)%geositbiasdir)
 
      geositbias_struc(n)%geositbiastime1 = 3000.0
      geositbias_struc(n)%geositbiastime2 = 0.0
   enddo
 
- end subroutine readcrd_geositbias
+end subroutine readcrd_geositbias
 

--- a/lis/metforcing/geos_itbias/reset_geositbias.F90
+++ b/lis/metforcing/geos_itbias/reset_geositbias.F90
@@ -1,9 +1,9 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 ! NASA Goddard Space Flight Center
 ! Land Information System Framework (LISF)
-! Version 7.4
+! Version 7.5
 !
-! Copyright (c) 2022 United States Government as represented by the
+! Copyright (c) 2024 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------

--- a/lis/metforcing/geos_itbias/reset_geositbias.F90
+++ b/lis/metforcing/geos_itbias/reset_geositbias.F90
@@ -1,0 +1,42 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.4
+!
+! Copyright (c) 2022 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !MODULE: reset_geositbias
+! \label{reset_geositbias}
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+!
+! !INTERFACE:
+      subroutine reset_geositbias
+! !USES:
+      use LIS_coreMod,  only   : LIS_rc
+      use LIS_timeMgrMod, only : LIS_date2time
+      use geositbias_forcingMod
+!
+! !DESCRIPTION:
+!  Routine to cleanup allocated structures for GEOS-ITbias forcing.
+!
+!EOP
+      implicit none
+
+      integer :: n
+
+      do n = 1,LIS_rc%nnest
+         geositbias_struc(n)%startFlag = .true.
+         geositbias_struc(n)%dayFlag = .true.
+         geositbias_struc(n)%geositbiastime1 = 3000.0
+         geositbias_struc(n)%geositbiastime2 = 0.0
+         geositbias_struc(n)%ringtime = 0.0
+         geositbias_struc(n)%reset_flag = .true.
+      enddo
+
+      end subroutine reset_geositbias
+

--- a/lis/metforcing/geos_itbias/reset_geositbias.F90
+++ b/lis/metforcing/geos_itbias/reset_geositbias.F90
@@ -13,30 +13,31 @@
 !
 ! !REVISION HISTORY:
 ! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+! 09 Jan 2026: Eric Kemp, reformatting.
 !
 ! !INTERFACE:
-      subroutine reset_geositbias
+subroutine reset_geositbias()
 ! !USES:
-      use LIS_coreMod,  only   : LIS_rc
-      use LIS_timeMgrMod, only : LIS_date2time
-      use geositbias_forcingMod
+  use LIS_coreMod,  only   : LIS_rc
+  use LIS_timeMgrMod, only : LIS_date2time
+  use geositbias_forcingMod
 !
 ! !DESCRIPTION:
 !  Routine to cleanup allocated structures for GEOS-ITbias forcing.
 !
 !EOP
-      implicit none
+  implicit none
 
-      integer :: n
+  integer :: n
 
-      do n = 1,LIS_rc%nnest
-         geositbias_struc(n)%startFlag = .true.
-         geositbias_struc(n)%dayFlag = .true.
-         geositbias_struc(n)%geositbiastime1 = 3000.0
-         geositbias_struc(n)%geositbiastime2 = 0.0
-         geositbias_struc(n)%ringtime = 0.0
-         geositbias_struc(n)%reset_flag = .true.
-      enddo
+  do n = 1,LIS_rc%nnest
+     geositbias_struc(n)%startFlag = .true.
+     geositbias_struc(n)%dayFlag = .true.
+     geositbias_struc(n)%geositbiastime1 = 3000.0
+     geositbias_struc(n)%geositbiastime2 = 0.0
+     geositbias_struc(n)%ringtime = 0.0
+     geositbias_struc(n)%reset_flag = .true.
+  enddo
 
-      end subroutine reset_geositbias
+end subroutine reset_geositbias
 

--- a/lis/metforcing/geos_itbias/timeinterp_geositbias.F90
+++ b/lis/metforcing/geos_itbias/timeinterp_geositbias.F90
@@ -15,25 +15,25 @@
 ! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
 !
 ! !INTERFACE:
-      subroutine timeinterp_geositbias(n,findex)
+subroutine timeinterp_geositbias(n,findex)
 
 ! !USES:
-      use ESMF
-      use LIS_FORC_AttributesMod
-      use LIS_coreMod,       only : LIS_rc,LIS_domain,LIS_localPet
-      use LIS_metforcingMod, only : LIS_forc,LIS_FORC_Base_State
-      use LIS_constantsMod,  only : LIS_CONST_SOLAR
-      use LIS_timeMgrMod,    only : LIS_tick
-      use LIS_logMod,        only : LIS_verify,LIS_endrun
-      use geositbias_forcingMod,   only : geositbias_struc
-      use LIS_forecastMod,   only : LIS_get_iteration_index
-      use LIS_ran2_gasdev
+  use ESMF
+  use LIS_FORC_AttributesMod
+  use LIS_coreMod,       only : LIS_rc,LIS_domain,LIS_localPet
+  use LIS_metforcingMod, only : LIS_forc,LIS_FORC_Base_State
+  use LIS_constantsMod,  only : LIS_CONST_SOLAR
+  use LIS_timeMgrMod,    only : LIS_tick
+  use LIS_logMod,        only : LIS_verify,LIS_endrun
+  use geositbias_forcingMod,   only : geositbias_struc
+  use LIS_forecastMod,   only : LIS_get_iteration_index
+  use LIS_ran2_gasdev
 
-      implicit none
+  implicit none
 
 ! !ARGUMENTS:
-      integer, intent(in):: n
-      integer, intent(in):: findex
+  integer, intent(in):: n
+  integer, intent(in):: findex
 !
 ! !DESCRIPTION:
 !  Temporally interpolates the forcing data to the current model
@@ -49,98 +49,97 @@
 !    zenith-angle based interpolation
 !  \end{description}
 !EOP
-      integer :: t,k,kk
-      integer :: index1
-      integer :: bdoy,byr,bmo
-      integer :: bda,bhr,bmn
-      integer :: bss
-      real*8  :: btime
-      real    :: gmt1,gmt2
-      real    :: bts
-      integer          :: status
-      integer          :: mfactor,m
-      type(ESMF_Field) :: tairField,qairField,psField,lwgabField
-      real,pointer     :: tair(:),qair(:),ps(:),lwgab(:)
-      
-      btime = geositbias_struc(n)%geositbiastime1
-      byr = LIS_rc%yr
-      bmo = LIS_rc%mo
-      bda = LIS_rc%da
-      bhr = LIS_rc%hr
-      bmn = 30
-      bss = 0
-      if (LIS_rc%mn.lt.30) then
-         bts = -(60*60)
-      else
-         bts = 0
-      endif
-      call LIS_tick(btime,bdoy,gmt1,byr,bmo,bda,bhr,bmn,bss,bts)
+  integer :: t,k,kk
+  integer :: index1
+  integer :: bdoy,byr,bmo
+  integer :: bda,bhr,bmn
+  integer :: bss
+  real*8  :: btime
+  real    :: gmt1,gmt2
+  real    :: bts
+  integer          :: status
+  integer          :: mfactor,m
+  type(ESMF_Field) :: tairField,qairField,psField,lwgabField
+  real,pointer     :: tair(:),qair(:),ps(:),lwgab(:)
 
-      btime = geositbias_struc(n)%geositbiastime2
-      byr = LIS_rc%yr             !next hour
-      bmo = LIS_rc%mo
-      bda = LIS_rc%da
-      bhr = LIS_rc%hr
-      bmn = 30
-      bss = 0
-      if (LIS_rc%mn.lt.30) then
-         bts = 0
-      else
-         bts = 60*60
-      endif
-      call LIS_tick(btime,bdoy,gmt2,byr,bmo,bda,bhr,bmn,bss,bts)
+  btime = geositbias_struc(n)%geositbiastime1
+  byr = LIS_rc%yr
+  bmo = LIS_rc%mo
+  bda = LIS_rc%da
+  bhr = LIS_rc%hr
+  bmn = 30
+  bss = 0
+  if (LIS_rc%mn.lt.30) then
+     bts = -(60*60)
+  else
+     bts = 0
+  endif
+  call LIS_tick(btime,bdoy,gmt1,byr,bmo,bda,bhr,bmn,bss,bts)
 
-      call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
-                         LIS_FORC_Tair%varname(1),tairField,           &
-                         rc=status)
-      call LIS_verify(status,                                          &
-              'Error: Enable Tair in the forcing variables list')
+  btime = geositbias_struc(n)%geositbiastime2
+  byr = LIS_rc%yr             !next hour
+  bmo = LIS_rc%mo
+  bda = LIS_rc%da
+  bhr = LIS_rc%hr
+  bmn = 30
+  bss = 0
+  if (LIS_rc%mn.lt.30) then
+     bts = 0
+  else
+     bts = 60*60
+  endif
+  call LIS_tick(btime,bdoy,gmt2,byr,bmo,bda,bhr,bmn,bss,bts)
 
-      call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
-                         LIS_FORC_Qair%varname(1),QairField,           &
-                         rc=status)
-      call LIS_verify(status,                                          &
-              'Error: Enable Qair in the forcing variables list')
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
+       LIS_FORC_Tair%varname(1),tairField,                         &
+       rc=status)
+  call LIS_verify(status,                                          &
+       'Error: Enable Tair in the forcing variables list')
 
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
+       LIS_FORC_Qair%varname(1),QairField,                         &
+       rc=status)
+  call LIS_verify(status,                                          &
+       'Error: Enable Qair in the forcing variables list')
 
-      call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
-                         LIS_FORC_LWdown%varname(1),lwgabField,        &
-                         rc=status)
-      call LIS_verify(status,                                          &
-              'Error: Enable LWdown in the forcing variables list')
-
-
-      call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
-                         LIS_FORC_Psurf%varname(1),psField,            &
-                         rc=status)
-      call LIS_verify(status,                                          &
-              'Error: Enable Psurf in the forcing variables list')
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
+       LIS_FORC_LWdown%varname(1),lwgabField,                      &
+       rc=status)
+  call LIS_verify(status,                                          &
+       'Error: Enable LWdown in the forcing variables list')
 
 
-      call ESMF_FieldGet(tairField,localDE=0,farrayPtr=tair,rc=status)
-      call LIS_verify(status)
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
+       LIS_FORC_Psurf%varname(1),psField,                          &
+       rc=status)
+  call LIS_verify(status,                                          &
+       'Error: Enable Psurf in the forcing variables list')
 
-      call ESMF_FieldGet(qairField,localDE=0,farrayPtr=qair,rc=status)
-      call LIS_verify(status)
 
-      call ESMF_FieldGet(lwgabField,localDE=0,farrayPtr=lwgab,rc=status)
-      call LIS_verify(status)
+  call ESMF_FieldGet(tairField,localDE=0,farrayPtr=tair,rc=status)
+  call LIS_verify(status)
 
-      call ESMF_FieldGet(psField,localDE=0,farrayPtr=ps,rc=status)
-      call LIS_verify(status)
+  call ESMF_FieldGet(qairField,localDE=0,farrayPtr=qair,rc=status)
+  call LIS_verify(status)
 
-      mfactor = LIS_rc%nensem(n)/geositbias_struc(n)%nIter
+  call ESMF_FieldGet(lwgabField,localDE=0,farrayPtr=lwgab,rc=status)
+  call LIS_verify(status)
 
-      do k = 1,LIS_rc%ntiles(n)/mfactor
-         do m = 1,mfactor
-            t = m + (k-1)*mfactor
-            index1 = LIS_domain(n)%tile(t)%index
-            kk = LIS_get_iteration_index(n,k,index1,mfactor)
-            tair(t) = geositbias_struc(n)%metdata1(kk,1,index1)
-            qair(t) = geositbias_struc(n)%metdata1(kk,2,index1)
-            lwgab(t) = geositbias_struc(n)%metdata1(kk,4,index1)
-            ps(t) = geositbias_struc(n)%metdata1(kk,7,index1)
-         enddo
-      enddo
-      end subroutine timeinterp_geositbias
+  call ESMF_FieldGet(psField,localDE=0,farrayPtr=ps,rc=status)
+  call LIS_verify(status)
+
+  mfactor = LIS_rc%nensem(n)/geositbias_struc(n)%nIter
+
+  do k = 1,LIS_rc%ntiles(n)/mfactor
+     do m = 1,mfactor
+        t = m + (k-1)*mfactor
+        index1 = LIS_domain(n)%tile(t)%index
+        kk = LIS_get_iteration_index(n,k,index1,mfactor)
+        tair(t) = geositbias_struc(n)%metdata1(kk,1,index1)
+        qair(t) = geositbias_struc(n)%metdata1(kk,2,index1)
+        lwgab(t) = geositbias_struc(n)%metdata1(kk,4,index1)
+        ps(t) = geositbias_struc(n)%metdata1(kk,7,index1)
+     enddo
+  enddo
+end subroutine timeinterp_geositbias
 

--- a/lis/metforcing/geos_itbias/timeinterp_geositbias.F90
+++ b/lis/metforcing/geos_itbias/timeinterp_geositbias.F90
@@ -24,7 +24,7 @@
       use LIS_metforcingMod, only : LIS_forc,LIS_FORC_Base_State
       use LIS_constantsMod,  only : LIS_CONST_SOLAR
       use LIS_timeMgrMod,    only : LIS_tick
-      use LIS_logMod,        only : LIS_logunit,LIS_verify,LIS_endrun
+      use LIS_logMod,        only : LIS_verify,LIS_endrun
       use geositbias_forcingMod,   only : geositbias_struc
       use LIS_forecastMod,   only : LIS_get_iteration_index
       use LIS_ran2_gasdev
@@ -49,14 +49,14 @@
 !    zenith-angle based interpolation
 !  \end{description}
 !EOP
-      integer :: t,zdoy,k,kk
+      integer :: t,k,kk
       integer :: index1
       integer :: bdoy,byr,bmo
       integer :: bda,bhr,bmn
       integer :: bss
       real*8  :: btime
-      real    :: wt1,wt2,czb,cze,czm,gmt1,gmt2
-      real    :: zw1,zw2,bts
+      real    :: gmt1,gmt2
+      real    :: bts
       integer          :: status
       integer          :: mfactor,m
       type(ESMF_Field) :: tairField,qairField,psField,lwgabField

--- a/lis/metforcing/geos_itbias/timeinterp_geositbias.F90
+++ b/lis/metforcing/geos_itbias/timeinterp_geositbias.F90
@@ -1,9 +1,9 @@
 !-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 ! NASA Goddard Space Flight Center
 ! Land Information System Framework (LISF)
-! Version 7.4
+! Version 7.5
 !
-! Copyright (c) 2022 United States Government as represented by the
+! Copyright (c) 2024 United States Government as represented by the
 ! Administrator of the National Aeronautics and Space Administration.
 ! All Rights Reserved.
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
@@ -13,6 +13,7 @@
 !
 ! !REVISION HISTORY:
 ! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+! 09 Jan 2026: Eric Kemp, reformatting.
 !
 ! !INTERFACE:
 subroutine timeinterp_geositbias(n,findex)

--- a/lis/metforcing/geos_itbias/timeinterp_geositbias.F90
+++ b/lis/metforcing/geos_itbias/timeinterp_geositbias.F90
@@ -1,0 +1,146 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.4
+!
+! Copyright (c) 2022 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: timeinterp_geositbias
+! \label{timeinterp_geositbias}
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+!
+! !INTERFACE:
+      subroutine timeinterp_geositbias(n,findex)
+
+! !USES:
+      use ESMF
+      use LIS_FORC_AttributesMod
+      use LIS_coreMod,       only : LIS_rc,LIS_domain,LIS_localPet
+      use LIS_metforcingMod, only : LIS_forc,LIS_FORC_Base_State
+      use LIS_constantsMod,  only : LIS_CONST_SOLAR
+      use LIS_timeMgrMod,    only : LIS_tick
+      use LIS_logMod,        only : LIS_logunit,LIS_verify,LIS_endrun
+      use geositbias_forcingMod,   only : geositbias_struc
+      use LIS_forecastMod,   only : LIS_get_iteration_index
+      use LIS_ran2_gasdev
+
+      implicit none
+
+! !ARGUMENTS:
+      integer, intent(in):: n
+      integer, intent(in):: findex
+!
+! !DESCRIPTION:
+!  Temporally interpolates the forcing data to the current model
+!  timestep.  Because all variables are a 1-hourly time average,
+!  no interpolation in time is actually performed.  The identical
+!  data is used for all timesteps within the hourly input file.
+!
+!  The routines invoked are:
+!  \begin{description}
+!   \item[LIS\_time2date](\ref{LIS_time2date}) \newline
+!    converts the time to a date format
+!   \item[zterp](\ref{zterp}) \newline
+!    zenith-angle based interpolation
+!  \end{description}
+!EOP
+      integer :: t,zdoy,k,kk
+      integer :: index1
+      integer :: bdoy,byr,bmo
+      integer :: bda,bhr,bmn
+      integer :: bss
+      real*8  :: btime
+      real    :: wt1,wt2,czb,cze,czm,gmt1,gmt2
+      real    :: zw1,zw2,bts
+      integer          :: status
+      integer          :: mfactor,m
+      type(ESMF_Field) :: tairField,qairField,psField,lwgabField
+      real,pointer     :: tair(:),qair(:),ps(:),lwgab(:)
+      
+      btime = geositbias_struc(n)%geositbiastime1
+      byr = LIS_rc%yr
+      bmo = LIS_rc%mo
+      bda = LIS_rc%da
+      bhr = LIS_rc%hr
+      bmn = 30
+      bss = 0
+      if (LIS_rc%mn.lt.30) then
+         bts = -(60*60)
+      else
+         bts = 0
+      endif
+      call LIS_tick(btime,bdoy,gmt1,byr,bmo,bda,bhr,bmn,bss,bts)
+
+      btime = geositbias_struc(n)%geositbiastime2
+      byr = LIS_rc%yr             !next hour
+      bmo = LIS_rc%mo
+      bda = LIS_rc%da
+      bhr = LIS_rc%hr
+      bmn = 30
+      bss = 0
+      if (LIS_rc%mn.lt.30) then
+         bts = 0
+      else
+         bts = 60*60
+      endif
+      call LIS_tick(btime,bdoy,gmt2,byr,bmo,bda,bhr,bmn,bss,bts)
+
+      call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
+                         LIS_FORC_Tair%varname(1),tairField,           &
+                         rc=status)
+      call LIS_verify(status,                                          &
+              'Error: Enable Tair in the forcing variables list')
+
+      call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
+                         LIS_FORC_Qair%varname(1),QairField,           &
+                         rc=status)
+      call LIS_verify(status,                                          &
+              'Error: Enable Qair in the forcing variables list')
+
+
+      call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
+                         LIS_FORC_LWdown%varname(1),lwgabField,        &
+                         rc=status)
+      call LIS_verify(status,                                          &
+              'Error: Enable LWdown in the forcing variables list')
+
+
+      call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
+                         LIS_FORC_Psurf%varname(1),psField,            &
+                         rc=status)
+      call LIS_verify(status,                                          &
+              'Error: Enable Psurf in the forcing variables list')
+
+
+      call ESMF_FieldGet(tairField,localDE=0,farrayPtr=tair,rc=status)
+      call LIS_verify(status)
+
+      call ESMF_FieldGet(qairField,localDE=0,farrayPtr=qair,rc=status)
+      call LIS_verify(status)
+
+      call ESMF_FieldGet(lwgabField,localDE=0,farrayPtr=lwgab,rc=status)
+      call LIS_verify(status)
+
+      call ESMF_FieldGet(psField,localDE=0,farrayPtr=ps,rc=status)
+      call LIS_verify(status)
+
+      mfactor = LIS_rc%nensem(n)/geositbias_struc(n)%nIter
+
+      do k = 1,LIS_rc%ntiles(n)/mfactor
+         do m = 1,mfactor
+            t = m + (k-1)*mfactor
+            index1 = LIS_domain(n)%tile(t)%index
+            kk = LIS_get_iteration_index(n,k,index1,mfactor)
+            tair(t) = geositbias_struc(n)%metdata1(kk,1,index1)
+            qair(t) = geositbias_struc(n)%metdata1(kk,2,index1)
+            lwgab(t) = geositbias_struc(n)%metdata1(kk,4,index1)
+            ps(t) = geositbias_struc(n)%metdata1(kk,7,index1)
+         enddo
+      enddo
+      end subroutine timeinterp_geositbias
+

--- a/lis/metforcing/geos_itbias/timeinterp_geositbias.F90
+++ b/lis/metforcing/geos_itbias/timeinterp_geositbias.F90
@@ -14,6 +14,8 @@
 ! !REVISION HISTORY:
 ! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
 ! 09 Jan 2026: Eric Kemp, reformatting.
+! 17 Jun 2026: Kristen Whitney, updated metadata storage references
+!              and corrected GEOS-ITbias forcing indexing.
 !
 ! !INTERFACE:
 subroutine timeinterp_geositbias(n,findex)
@@ -136,10 +138,10 @@ subroutine timeinterp_geositbias(n,findex)
         t = m + (k-1)*mfactor
         index1 = LIS_domain(n)%tile(t)%index
         kk = LIS_get_iteration_index(n,k,index1,mfactor)
-        tair(t) = geositbias_struc(n)%metdata1(kk,1,index1)
-        qair(t) = geositbias_struc(n)%metdata1(kk,2,index1)
-        lwgab(t) = geositbias_struc(n)%metdata1(kk,4,index1)
-        ps(t) = geositbias_struc(n)%metdata1(kk,7,index1)
+        tair(t) = geositbias_struc(n)%metdata(kk,1,index1)
+        qair(t) = geositbias_struc(n)%metdata(kk,2,index1)
+        ps(t) = geositbias_struc(n)%metdata(kk,3,index1)
+        lwgab(t) = geositbias_struc(n)%metdata(kk,4,index1)
      enddo
   enddo
 end subroutine timeinterp_geositbias

--- a/lis/metforcing/merra2/get_merra2.F90
+++ b/lis/metforcing/merra2/get_merra2.F90
@@ -181,7 +181,9 @@ subroutine get_merra2(n, findex)
 
   character(len=LIS_CONST_PATH_LEN) :: lapseratefname
   character*8                       :: fdate
-  
+
+  external :: merra2files
+  external :: read_merra2
 ! _________________________________________________________
 
 ! Please note that the timing logic has been tested only for
@@ -554,12 +556,7 @@ subroutine merra2files(n, kk, findex, merra2dir, yr, mo, da, slvname, flxname, l
   character*10 :: prefix
   character*17 :: slv_spec, flx_spec, lfo_spec, rad_spec
   character*20 :: dir
-  integer      :: seed
-  real         :: rand
   integer      :: hr, mn, ss
-  real*8       :: time
-  integer      :: doy
-  real         :: gmt
 
   hr = 0 
   mn = 0 

--- a/lis/metforcing/merra2/get_merra2.F90
+++ b/lis/metforcing/merra2/get_merra2.F90
@@ -19,6 +19,7 @@
 ! 13 Sep 2024: Sujay Kumar, Initial code for using dynamic lapse rate
 ! 31 Oct 2024: David Mocko, Final code for using dynamic lapse rate
 ! 18 Dec 2024: Kristen Whitney, code for using double-sided dynamic lapse rate cutoff
+! 07 Jan 2026: Kristen Whitney, added use of dynamic lapse rate input filename prefix and suffix variables
 !
 ! !INTERFACE:
 subroutine get_merra2(n, findex)
@@ -317,8 +318,8 @@ subroutine get_merra2(n, findex)
 
         write(unit=fdate, fmt='(i4.4,i2.2,i2.2)') yr1,mo1,da1
         lapseratefname = trim(merra2_struc(n)%dynlapseratedir)//&
-             '/MERRA2.lapse_rate.hourly.'//&
-             trim(fdate)//'.global.nc'
+             trim(merra2_struc(n)%dynlapseratepfx)//&
+             trim(fdate)//trim(merra2_struc(n)%dynlapseratesfx)
 
         call read_merra2(n, order, mo1, &
              findex, slvname, flxname, lfoname, radname, lapseratefname, &
@@ -344,8 +345,8 @@ subroutine get_merra2(n, findex)
 
         write(unit=fdate, fmt='(i4.4,i2.2,i2.2)') yr2,mo2,da2
         lapseratefname = trim(merra2_struc(n)%dynlapseratedir)//&
-             '/MERRA2.lapse_rate.hourly.'//&
-             trim(fdate)//'.global.nc'
+             trim(merra2_struc(n)%dynlapseratepfx)//&
+             trim(fdate)//trim(merra2_struc(n)%dynlapseratesfx)
 
         call read_merra2(n, order, mo2,&
              findex, slvname, flxname, lfoname, radname, lapseratefname, &

--- a/lis/metforcing/merra2/merra2_forcingMod.F90
+++ b/lis/metforcing/merra2/merra2_forcingMod.F90
@@ -16,6 +16,7 @@ module merra2_forcingMod
 ! 13 Sep 2024: Sujay Kumar, Initial code for using dynamic lapse rate
 ! 31 Oct 2024: David Mocko, Final code for using dynamic lapse rate
 ! 18 Dec 2024: Kristen Whitney, code for using double-sided dynamic lapse rate cutoff
+! 07 Jan 2026: Kristen Whitney, added use of dynamic lapse rate input filename prefix and suffix variables
 !
 ! !DESCRIPTION:
 !  This module contains variables and data structures that are used
@@ -134,6 +135,8 @@ module merra2_forcingMod
      integer, allocatable    :: rseed(:,:)
      integer                 :: usedynlapserate
      character(len=LIS_CONST_PATH_LEN) :: dynlapseratedir
+     character(len=LIS_CONST_PATH_LEN) :: dynlapseratepfx
+     character(len=LIS_CONST_PATH_LEN) :: dynlapseratesfx
      integer                 :: applydynlapseratecutoff
      real                    :: dynlapseratemincutoff
      real                    :: dynlapseratemaxcutoff

--- a/lis/metforcing/merra2/merra2_forcingMod.F90
+++ b/lis/metforcing/merra2/merra2_forcingMod.F90
@@ -186,9 +186,13 @@ contains
 !  \end{description}
 !EOP
     real :: gridDesci(LIS_rc%nnest,50)
-    integer :: updoy, yr1,mo1,da1,hr1,mn1,ss1
-    real :: upgmt
     integer :: n
+
+    external :: readcrd_merra2
+    external :: bilinear_interp_input
+    external :: conserv_interp_input
+    external :: neighbor_interp_input
+    external :: read_merra2_elev
 
     allocate(merra2_struc(LIS_rc%nnest))
 

--- a/lis/metforcing/merra2/read_merra2.F90
+++ b/lis/metforcing/merra2/read_merra2.F90
@@ -17,6 +17,7 @@
 ! 18 Mar 2015: James Geiger, initial code (based on merra-land)
 ! 13 Sep 2024: Sujay Kumar, Initial code for using dynamic lapse rate
 ! 31 Oct 2024: David Mocko, Final code for using dynamic lapse rate
+! 07 Jan 2026: Kristen Whitney, Update dynamic lapse rate code to accept lapse rate inputs over a smaller domain than the forcings
 !
 ! !INTERFACE:
 subroutine read_merra2(n, order, month, findex,  &
@@ -123,6 +124,13 @@ subroutine read_merra2(n, order, month, findex,  &
   integer                           :: ftn_drate
   integer                           :: lapserateid
   real, allocatable                 :: lapse_rate_in(:,:,:)
+  
+  integer :: nc_sub, nr_sub
+  real, allocatable :: lapse_rate_sub(:,:,:)
+  real, allocatable :: lat_sub(:), lon_sub(:)
+  real, allocatable :: lat_full(:), lon_full(:)
+  integer :: i0, j0
+  integer :: latid, lonid
 
 !_______________________________________________________________________
 
@@ -224,7 +232,8 @@ subroutine read_merra2(n, order, month, findex,  &
      call interp_merra2_var(n,findex,month,uwind, 5, .false., merraforc)
      call interp_merra2_var(n,findex,month,vwind, 6, .false., merraforc)
      call interp_merra2_var(n,findex,month,ps,    7, .false., merraforc)
-
+     
+     ! Obtain lapse rates
      if ((merra2_struc(n)%usedynlapserate.eq.1).and.                   &
         ((LIS_rc%met_ecor(findex).eq."lapse-rate").or.                 &
          (LIS_rc%met_ecor(findex).eq."lapse-rate and slope-aspect").or.&
@@ -232,23 +241,75 @@ subroutine read_merra2(n, order, month, findex,  &
         inquire(file=trim(lapseratefname),exist=file_exists)
         if (file_exists) then
            write(LIS_logunit,*) 'Reading ',trim(lapseratefname)
-
-           allocate(lapse_rate_in(merra2_struc(n)%ncold,merra2_struc(n)%nrold,24))
-
+           
+           ! open file and get ID for lapse rate
            call LIS_verify(nf90_open(path=trim(lapseratefname),        &
-                    mode=NF90_NOWRITE,ncid=ftn_drate),                 &
-                    'nf90_open failed for '//trim(lapseratefname))
-           call LIS_verify(nf90_inq_varid(ftn_drate,                   &
-                    'lapse_rate',lapserateid),                         &
-                    'nf90_inq_varid failed for lapse_rate')
-           call LIS_verify(nf90_get_var(ftn_drate,                     &
-                    lapserateid,lapse_rate_in),                        &
-                    'nf90_get_var failed for lapse_rate')
-           call LIS_verify(nf90_close(ftn_drate),'nf90_close failed')
+              mode=NF90_NOWRITE,ncid=ftn_drate),                 &
+              'nf90_open failed for '//trim(lapseratefname))
+           call LIS_verify(nf90_inq_varid(ftn_drate,'lapse_rate',lapserateid), &
+              'nf90_inq_varid failed for lapse_rate')
 
-           call interp_lapserate_var(n,order,lapse_rate_in)
+           ! Get subdomain dimensions directly from dimids 2=lat, 3=lon
+           call LIS_verify(nf90_inquire_dimension(ftn_drate,2,len=nr_sub), 'inq lat dim failed (sub)')
+           call LIS_verify(nf90_inquire_dimension(ftn_drate,3,len=nc_sub), 'inq lon dim failed (sub)')
 
+           ! allocate full-size lapse rate
+           allocate(lapse_rate_in(merra2_struc(n)%ncold,merra2_struc(n)%nrold,24))
+           lapse_rate_in = 1.e+15
+           
+           ! Case 1: full global lapse-rate file
+           if (nc_sub == merra2_struc(n)%ncold .and. nr_sub == merra2_struc(n)%nrold) then
+              call LIS_verify(nf90_get_var(ftn_drate,lapserateid,lapse_rate_in), 'get lapse_rate failed')
+           
+           ! Case 2: subdomain lapse-rate file
+           else if (nc_sub <= merra2_struc(n)%ncold .and. nr_sub <= merra2_struc(n)%nrold) then
+              allocate(lapse_rate_sub(nc_sub,nr_sub,24))
+              allocate(lat_sub(nr_sub), lon_sub(nc_sub))
+              allocate(lat_full(merra2_struc(n)%nrold), lon_full(merra2_struc(n)%ncold))
+
+              ! Read subdomain values
+              call LIS_verify(nf90_get_var(ftn_drate,lapserateid,lapse_rate_sub), 'get lapse_rate_sub failed')
+              call LIS_verify(nf90_inq_varid(ftn_drate,'lat',latid),'inq lat varid failed')
+              call LIS_verify(nf90_inq_varid(ftn_drate,'lon',lonid),'inq lon varid failed')
+              call LIS_verify(nf90_get_var(ftn_drate,latid,lat_sub),'get lat_sub failed')
+              call LIS_verify(nf90_get_var(ftn_drate,lonid,lon_sub),'get lon_sub failed')
+
+              ! Read full-domain coordinates from slv file
+              call LIS_verify(nf90_open(path=trim(slvname), mode=NF90_NOWRITE, ncid=ftn_slv), &
+                              'nf90_open failed for slvfile in read_merra2')
+              call LIS_verify(nf90_inq_varid(ftn_slv,'lat',latid),'inq lat varid failed (full)')
+              call LIS_verify(nf90_inq_varid(ftn_slv,'lon',lonid),'inq lon varid failed (full)')
+              call LIS_verify(nf90_get_var(ftn_slv,latid,lat_full),'get lat_full failed')
+              call LIS_verify(nf90_get_var(ftn_slv,lonid,lon_full),'get lon_full failed')
+              call LIS_verify(nf90_close(ftn_slv),'failed to close slvfile in read_merra2')
+
+              ! Find paste offsets
+              call find_index(lon_full, lon_sub(1), i0)
+              call find_index(lat_full, lat_sub(1), j0)
+
+              ! Time consistency check
+              if (size(lapse_rate_sub,3) /= size(lapse_rate_in,3)) then
+                 write(LIS_logunit,*) '[ERR] Time dimension mismatch between sub and full lapse_rate'
+                 call LIS_endrun()
+              end if
+
+              ! Paste subdomain into full-domain buffer
+              lapse_rate_in(i0:i0+nc_sub-1, j0:j0+nr_sub-1, :) = lapse_rate_sub(:,:,:)
+
+              ! Cleanup
+              deallocate(lapse_rate_sub, lat_sub, lon_sub, lat_full, lon_full)
+
+           !  Case 3: unexpected
+           else
+              write(LIS_logunit,*) '[ERR] Unexpected lapse-rate dims: ', nc_sub, ' x ', nr_sub
+              call LIS_endrun()
+           end if
+           
+           call LIS_verify(nf90_close(ftn_drate),'close lapse-rate file failed')
+           call interp_lapserate_merra2(n,order,lapse_rate_in)
+           
            deallocate(lapse_rate_in)
+           
         else
            write(LIS_logunit,*) '[WARN] Could not find ',trim(lapseratefname)
            write(LIS_logunit,*) '[WARN] Using static lapse rate.'
@@ -449,6 +510,20 @@ subroutine read_merra2(n, order, month, findex,  &
   endif
   
 #endif
+contains
+subroutine find_index(x,val,idx)
+  real, intent(in) :: x(:), val
+  integer, intent(out) :: idx
+  real :: dmin
+  integer :: k
+  dmin = huge(1.0); idx = -1
+  do k=1,size(x)
+     if (abs(x(k)-val) < dmin) then
+        dmin = abs(x(k)-val)
+        idx = k
+     end if
+  enddo
+end subroutine find_index
 end subroutine read_merra2
 
 !BOP
@@ -647,7 +722,7 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
         call LIS_endrun()
      endif
 
-!Interpolate the refmean fields
+     !Interpolate the refmean fields
      if( pcp_flag .and. scal_read_flag.and. &
           merra2_struc(n)%usescalef==1.and. &
           merra2_struc(n)%usepcpsampling.eq.1) then 
@@ -698,7 +773,7 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
         endif
      endif
 
-!Interpolate the refstdev fields
+     !Interpolate the refstdev fields
      if( pcp_flag .and. scal_read_flag.and. &
           merra2_struc(n)%usescalef==1.and. &
           merra2_struc(n)%usepcpsampling.eq.1) then 
@@ -762,11 +837,11 @@ end subroutine interp_merra2_var
 
 !BOP
 ! 
-! !ROUTINE: interp_lapserate_var
-! \label{interp_lapserate_var}
+! !ROUTINE: interp_lapserate_merra2
+! \label{interp_lapserate_merra2}
 ! 
 ! !INTERFACE: 
-subroutine interp_lapserate_var(n,order,input_var)
+subroutine interp_lapserate_merra2(n,order,input_var)
 
 ! !USES: 
   use LIS_coreMod
@@ -859,7 +934,7 @@ subroutine interp_lapserate_var(n,order,input_var)
      endif
   enddo
 
-end subroutine interp_lapserate_var
+end subroutine interp_lapserate_merra2
 
 #if 0 
 !BOP

--- a/lis/metforcing/merra2/read_merra2.F90
+++ b/lis/metforcing/merra2/read_merra2.F90
@@ -12,7 +12,7 @@
 !
 ! !ROUTINE: read_merra2
 ! \label{read_merra2}
-! 
+!
 ! !REVISION HISTORY:
 ! 18 Mar 2015: James Geiger, initial code (based on merra-land)
 ! 13 Sep 2024: Sujay Kumar, Initial code for using dynamic lapse rate
@@ -31,12 +31,12 @@ subroutine read_merra2(n, order, month, findex,  &
   use LIS_metforcingMod, only : LIS_forc
   use merra2_forcingMod, only : merra2_struc
   use LIS_constantsMod, only : LIS_CONST_LAPSE_RATE
-#if (defined USE_NETCDF3 || defined USE_NETCDF4) 
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
 #endif
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in)          :: n
   integer, intent(in)          :: order
   integer, intent(in)          :: month
@@ -48,12 +48,12 @@ subroutine read_merra2(n, order, month, findex,  &
   character(len=*), intent(in) :: lapseratefname
   real, intent(inout)          :: merraforc(merra2_struc(n)%nvars, 24, &
        LIS_rc%lnc(n)*LIS_rc%lnr(n))
-  integer, intent(out)         :: ferror          
+  integer, intent(out)         :: ferror
 
 !
 ! !DESCRIPTION:
 !  For the given time, reads parameters from
-!  MERRA2 data, transforms into 9 LIS forcing 
+!  MERRA2 data, transforms into 9 LIS forcing
 !  parameters and interpolates to the LIS domain. \newline
 !
 ! merra2 FORCING VARIABLES (unless noted, fields are 1-hr upstream averaged): \newline
@@ -68,10 +68,10 @@ subroutine read_merra2(n, order, month, findex,  &
 !  9. precon  Convective precipitation [$mm/s$] \newline
 ! 10. albedo  Surface albedo (0-1) \newline
 !
-!  The arguments are: 
+!  The arguments are:
 !  \begin{description}
 !  \item[order]
-!    flag indicating which data to be read (order=1, read the previous 
+!    flag indicating which data to be read (order=1, read the previous
 !    1 hourly instance, order=2, read the next 1 hourly instance)
 !  \item[n]
 !    index of the nest
@@ -82,8 +82,8 @@ subroutine read_merra2(n, order, month, findex,  &
 !  \item[ferror]
 !    return error code (0 indicates success)
 !  \end{description}
-! 
-!  The routines invoked are: 
+!
+!  The routines invoked are:
 !  \begin{description}
 !  \item[bilinear\_interp](\ref{bilinear_interp}) \newline
 !    spatially interpolate the forcing data using bilinear interpolation
@@ -91,7 +91,7 @@ subroutine read_merra2(n, order, month, findex,  &
 !    spatially interpolate the forcing data using conservative interpolation
 !  \end{description}
 !EOP
-  
+
   integer   :: ftn_slv, ftn_flx, ftn_lfo,ftn_rad
   integer   :: tmpId, qId, uId, vId, psId
   integer   :: prectotId, precconId, swgdnId, lwgabId
@@ -120,7 +120,7 @@ subroutine read_merra2(n, order, month, findex,  &
   integer                           :: ftn_drate
   integer                           :: lapserateid
   real, allocatable                 :: lapse_rate_in(:,:,:)
-  
+
   integer :: nc_sub, nr_sub
   real, allocatable :: lapse_rate_sub(:,:,:)
   real, allocatable :: lat_sub(:), lon_sub(:)
@@ -132,20 +132,20 @@ subroutine read_merra2(n, order, month, findex,  &
   external :: interp_lapserate_merra2
 !_______________________________________________________________________
 
-#if (defined USE_NETCDF3) 
+#if (defined USE_NETCDF3)
   write(LIS_logunit,*) "[ERR] MERRA2 reader requires NetCDF4"
   call LIS_endrun()
 #endif
 
-#if (defined USE_NETCDF4) 
-  ferror = 0 
+#if (defined USE_NETCDF4)
+  ferror = 0
   nr_index = merra2_struc(n)%nrold
   nc_index = merra2_struc(n)%ncold
   mo = LIS_rc%lnc(n)*LIS_rc%lnr(n)
 
 ! Read single layer file (*slv) fields:
-  inquire(file=slvname,exist=file_exists) 
-  if(file_exists) then 
+  inquire(file=slvname,exist=file_exists)
+  if(file_exists) then
      write(LIS_logunit,*)'[INFO] Reading MERRA-2 file (bookend,', order,' ... ',trim(slvname)
      call LIS_verify(nf90_open(path=trim(slvname), mode=NF90_NOWRITE, &
           ncid=ftn_slv), 'nf90_open failed for slvfile in read_merra2')
@@ -153,12 +153,12 @@ subroutine read_merra2(n, order, month, findex,  &
           'nf90_inq_varid failed for ps in read_merra2')
 
      call LIS_verify(nf90_get_var(ftn_slv,psId, ps), &
-          'nf90_get_var failed for ps in read_merra2') 
-     
-   ! If using the MERRA2 lowest model level forcing (*flx): 
-     if(merra2_struc(n)%uselml.eq.1) then 
+          'nf90_get_var failed for ps in read_merra2')
+
+   ! If using the MERRA2 lowest model level forcing (*flx):
+     if(merra2_struc(n)%uselml.eq.1) then
         inquire(file=flxname,exist=file_exists1)
-        if(.not.file_exists1) then 
+        if(.not.file_exists1) then
            write(LIS_logunit,*) '[ERR] ',trim(flxname)//' does not exist'
            call LIS_endrun()
         endif
@@ -210,7 +210,7 @@ subroutine read_merra2(n, order, month, findex,  &
             call LIS_verify(nf90_get_var(ftn_slv,vId, vwind), &
                  'nf90_get_var failed for v2m in read_merra2')
         else
-            call LIS_verify(nf90_inq_varid(ftn_slv,'U10M',uId), & 
+            call LIS_verify(nf90_inq_varid(ftn_slv,'U10M',uId), &
                  'nf90_inq_varid failed for u10m in read_merra2')
             call LIS_verify(nf90_inq_varid(ftn_slv,'V10M',vId), &
                  'nf90_inq_varid failed for v10m in read_merra2')
@@ -219,7 +219,7 @@ subroutine read_merra2(n, order, month, findex,  &
             call LIS_verify(nf90_get_var(ftn_slv,vId, vwind), &
                  'nf90_get_var failed for v10m in read_merra2')
         endif
-           
+
      endif
 
      call LIS_verify(nf90_close(ftn_slv), &
@@ -230,7 +230,7 @@ subroutine read_merra2(n, order, month, findex,  &
      call interp_merra2_var(n,findex,month,uwind, 5, .false., merraforc)
      call interp_merra2_var(n,findex,month,vwind, 6, .false., merraforc)
      call interp_merra2_var(n,findex,month,ps,    7, .false., merraforc)
-     
+
      ! Obtain lapse rates
      if ((merra2_struc(n)%usedynlapserate.eq.1).and.                   &
         ((LIS_rc%met_ecor(findex).eq."lapse-rate").or.                 &
@@ -239,7 +239,7 @@ subroutine read_merra2(n, order, month, findex,  &
         inquire(file=trim(lapseratefname),exist=file_exists)
         if (file_exists) then
            write(LIS_logunit,*) 'Reading ',trim(lapseratefname)
-           
+
            ! open file and get ID for lapse rate
            call LIS_verify(nf90_open(path=trim(lapseratefname),        &
               mode=NF90_NOWRITE,ncid=ftn_drate),                 &
@@ -254,11 +254,11 @@ subroutine read_merra2(n, order, month, findex,  &
            ! allocate full-size lapse rate
            allocate(lapse_rate_in(merra2_struc(n)%ncold,merra2_struc(n)%nrold,24))
            lapse_rate_in = 1.e+15
-           
+
            ! Case 1: full global lapse-rate file
            if (nc_sub == merra2_struc(n)%ncold .and. nr_sub == merra2_struc(n)%nrold) then
               call LIS_verify(nf90_get_var(ftn_drate,lapserateid,lapse_rate_in), 'get lapse_rate failed')
-           
+
            ! Case 2: subdomain lapse-rate file
            else if (nc_sub <= merra2_struc(n)%ncold .and. nr_sub <= merra2_struc(n)%nrold) then
               allocate(lapse_rate_sub(nc_sub,nr_sub,24))
@@ -302,12 +302,12 @@ subroutine read_merra2(n, order, month, findex,  &
               write(LIS_logunit,*) '[ERR] Unexpected lapse-rate dims: ', nc_sub, ' x ', nr_sub
               call LIS_endrun()
            end if
-           
+
            call LIS_verify(nf90_close(ftn_drate),'close lapse-rate file failed')
            call interp_lapserate_merra2(n,order,lapse_rate_in)
-           
+
            deallocate(lapse_rate_in)
-           
+
         else
            write(LIS_logunit,*) '[WARN] Could not find ',trim(lapseratefname)
            write(LIS_logunit,*) '[WARN] Using static lapse rate.'
@@ -315,23 +315,23 @@ subroutine read_merra2(n, order, month, findex,  &
            merra2_struc(n)%lapserate2 = LIS_CONST_LAPSE_RATE
         endif
      endif
-     
+
   else
      write(LIS_logunit,*) '[ERR] ',trim(slvname)//' does not exist'
      call LIS_endrun()
   endif
 
 ! Read in the flux file fields (*flx):
-  inquire(file=flxname,exist=file_exists) 
-  if(file_exists) then 
+  inquire(file=flxname,exist=file_exists)
+  if(file_exists) then
 
      write(LIS_logunit,*) '[INFO] Reading MERRA-2 file (bookend,',order,' ... '
      write(LIS_logunit,*) trim(flxname),' (for corrected precipitation fields)'
      call LIS_verify(nf90_open(path=trim(flxname), mode=NF90_NOWRITE, &
           ncid=ftn_flx),'nf90_open failed for flxfile in read_merra2')
-     
+
    ! Read in the *corrected* total precipitation field:
-     if(merra2_struc(n)%usecorr.eq.1) then 
+     if(merra2_struc(n)%usecorr.eq.1) then
         call LIS_verify(nf90_inq_varid(ftn_flx,'PRECTOTCORR',prectotId), &
              'nf90_inq_varid failed for prectotcorr (flx) in read_merra2')
 
@@ -364,7 +364,7 @@ subroutine read_merra2(n, order, month, findex,  &
      if( LIS_FORC_Snowf%selectOpt.eq.1 .and. &
           merra2_struc(n)%usecorr.eq.0 ) then
         call LIS_verify(nf90_inq_varid(ftn_flx,'PRECSNO',precsnoId), &
-             'nf90_inq_varid failed for precsno (flx) in read_merra2')  
+             'nf90_inq_varid failed for precsno (flx) in read_merra2')
 
         call LIS_verify(nf90_get_var(ftn_flx,precsnoId, precsno), &
             'nf90_get_var failed for precsno (flx) in read_merra2')
@@ -385,15 +385,15 @@ subroutine read_merra2(n, order, month, findex,  &
 
      call LIS_verify(nf90_close(ftn_flx), &
           'failed to close flxfile in read_merra2')
-     
+
   else
      write(LIS_logunit,*) '[ERR] ',trim(flxname)//' does not exist'
      call LIS_endrun()
   endif
-  
+
 ! Read in the radiation file fields (*rad):
-  inquire(file=radname,exist=file_exists) 
-  if(file_exists) then 
+  inquire(file=radname,exist=file_exists)
+  if(file_exists) then
      write(LIS_logunit,*) '[INFO] Reading MERRA-2 file (bookend,',order,' ... ',trim(radname)
      call LIS_verify(nf90_open(path=trim(radname), mode=NF90_NOWRITE, &
           ncid=ftn_rad), 'nf90_open failed in read_merra2')
@@ -403,7 +403,7 @@ subroutine read_merra2(n, order, month, findex,  &
           'nf90_inq_varid failed for lwgab in read_merra2')
 !     call LIS_verify(nf90_inq_varid(ftn_rad,'emis',emisId), &
 !          'nf90_inq_varid failed for emis in read_merra2')
-    
+
      call LIS_verify(nf90_get_var(ftn_rad,swgdnId,swgdn), &
           'nf90_get_var failed for swgdn in read_merra2')
      call LIS_verify(nf90_get_var(ftn_rad,lwgabId,lwgab), &
@@ -422,7 +422,7 @@ subroutine read_merra2(n, order, month, findex,  &
   endif
 
 ! Checks: For reading in the surface layer file fields (*lfo):
-  read_lnd = .false. 
+  read_lnd = .false.
   if ( LIS_FORC_Pardr%selectOpt.eq.1.or.&
        LIS_FORC_Pardf%selectOpt.eq.1.or.&
        LIS_FORC_SWnet%selectOpt.eq.1 ) then
@@ -436,15 +436,15 @@ subroutine read_merra2(n, order, month, findex,  &
   endif
 
 ! Read in the surface layer fields (*lfo):
-  if(read_lnd) then 
-     inquire(file=lfoname,exist=file_exists) 
-     if(file_exists) then 
+  if(read_lnd) then
+     inquire(file=lfoname,exist=file_exists)
+     if(file_exists) then
        write(LIS_logunit,*) '[INFO] Reading MERRA-2 file (bookend,',order,&
              ' ... ',trim(lfoname)
        call LIS_verify(nf90_open(path=trim(lfoname), mode=NF90_NOWRITE, &
             ncid=ftn_lfo), 'nf90_open failed in read_merra2')
 
-       ! Read *corrected* convective precipitation, if selected: 
+       ! Read *corrected* convective precipitation, if selected:
        if( LIS_FORC_CRainf%selectOpt.eq.1 .and. &
           merra2_struc(n)%usecorr.eq.1 ) then
          call LIS_verify(nf90_inq_varid(ftn_lfo,'PRECCUCORR',precconId), &
@@ -456,7 +456,7 @@ subroutine read_merra2(n, order, month, findex,  &
          call interp_merra2_var(n,findex,month,preccon, 9,.true.,merraforc)
        endif
 
-       ! Read *corrected* snowfall field, if selected: 
+       ! Read *corrected* snowfall field, if selected:
        if( LIS_FORC_Snowf%selectOpt.eq.1 .and. &
           merra2_struc(n)%usecorr.eq.1 ) then
          call LIS_verify(nf90_inq_varid(ftn_flx,'PRECSNOCORR',precsnoId), &
@@ -468,34 +468,34 @@ subroutine read_merra2(n, order, month, findex,  &
          call interp_merra2_var(n,findex,month,precsno, 10,.true.,merraforc)
        endif
 
-       if(LIS_FORC_SWnet%selectOpt.eq.1) then 
+       if(LIS_FORC_SWnet%selectOpt.eq.1) then
           call LIS_verify(nf90_inq_varid(ftn_lfo,'SWLAND',swlandId), &
                'nf90_inq_varid failed for swland in read_merra2')
 
           call LIS_verify(nf90_get_var(ftn_lfo,swlandId,swland), &
                'nf90_get_var failed for swland in read_merra2')
-          
+
           call interp_merra2_var(n,findex,month,swland,11,.false.,merraforc)
        endif
-        
-        if(LIS_FORC_Pardr%selectOpt.eq.1) then 
+
+        if(LIS_FORC_Pardr%selectOpt.eq.1) then
            call LIS_verify(nf90_inq_varid(ftn_lfo,'PARDR',pardrId), &
                 'nf90_inq_varid failed for pardr in read_merra2')
 
            call LIS_verify(nf90_get_var(ftn_lfo,pardrId,pardr), &
                 'nf90_get_var failed for pardr in read_merra2')
-           
+
            call interp_merra2_var(n,findex,month,pardr,12,.false.,merraforc)
         endif
 
-        if(LIS_FORC_Pardf%selectOpt.eq.1) then 
+        if(LIS_FORC_Pardf%selectOpt.eq.1) then
            call LIS_verify(nf90_inq_varid(ftn_lfo,'PARDF',pardfId), &
                 'nf90_inq_varid failed for pardf in read_merra2')
 
            call LIS_verify(nf90_get_var(ftn_lfo,pardfId,pardf), &
                 'nf90_get_var failed for pardf in read_merra2')
            call interp_merra2_var(n,findex,month,pardf,13,.false.,merraforc)
-           
+
         endif
 
         call LIS_verify(nf90_close(ftn_lfo),&
@@ -506,7 +506,7 @@ subroutine read_merra2(n, order, month, findex,  &
      endif
 
   endif
-  
+
 #endif
 contains
 subroutine find_index(x,val,idx)
@@ -525,20 +525,20 @@ end subroutine find_index
 end subroutine read_merra2
 
 !BOP
-! 
+!
 ! !ROUTINE: interp_merra2_var
 ! \label{interp_merra2_var}
-! 
-! !INTERFACE: 
+!
+! !INTERFACE:
 subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
      pcp_flag, merraforc)
 
-! !USES: 
+! !USES:
   use LIS_coreMod
   use LIS_logMod
   use LIS_spatialDownscalingMod
   use merra2_forcingMod, only : merra2_struc
-#if(defined USE_NETCDF3 || defined USE_NETCDF4)      
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
 #endif
   implicit none
@@ -554,10 +554,10 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
   real,    intent(inout) :: merraforc(merra2_struc(n)%nvars, &
        24, LIS_rc%lnc(n)*LIS_rc%lnr(n))
   !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This subroutine spatially interpolates a MERRA2 field
 !  to the LIS running domain
-! 
+!
 !EOP
 
   integer   :: t,c,r,k,iret
@@ -578,26 +578,26 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
 
   input_size = merra2_struc(n)%ncold*merra2_struc(n)%nrold
 
-!-----------------------------------------------------------------------    
+!-----------------------------------------------------------------------
 ! Apply corrections
-!-----------------------------------------------------------------------  
-  
-  scal_read_flag = .false. 
+!-----------------------------------------------------------------------
 
-  if(merra2_struc(n)%pcpscal_cmo.ne.LIS_rc%mo) then 
-     scal_read_flag = .true. 
+  scal_read_flag = .false.
+
+  if(merra2_struc(n)%pcpscal_cmo.ne.LIS_rc%mo) then
+     scal_read_flag = .true.
   endif
-     
+
   if ( pcp_flag .and. merra2_struc(n)%usescalef==1.and.&
-       scal_read_flag ) then 
-     
+       scal_read_flag ) then
+
 !     call finddoy(doy, LIS_rc%yr, LIS_rc%mo, LIS_rc%da)
-     
-#if(defined USE_NETCDF3 || defined USE_NETCDF4)      
+
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)
      call LIS_verify(nf90_open(path=merra2_struc(n)%scaleffile,&
           mode=nf90_nowrite,ncid=ftn),&
           'failed to open MERRA2 precip scaling factor input file')
-     
+
      call LIS_verify(nf90_inq_varid(ftn,"REF_XRANGE",pcp1id),&
           'nf90_inq_varid failed for REF_XRANGE')
      call LIS_verify(nf90_get_var(ftn,pcp1id,merra2_struc(n)%refxrange,&
@@ -605,7 +605,7 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
           count=(/merra2_struc(n)%ncold,merra2_struc(n)%nrold,1,&
           merra2_struc(n)%nbins/)),&
           'nf90_get_var failed for REF_XRANGE')
-     
+
      call LIS_verify(nf90_inq_varid(ftn,"REF_CDF",pcp2id),&
           'nf90_inq_varid failed for REF_CDF')
      call LIS_verify(nf90_get_var(ftn,pcp2id,merra2_struc(n)%refcdf,&
@@ -613,7 +613,7 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
           count=(/merra2_struc(n)%ncold,merra2_struc(n)%nrold,1,&
           merra2_struc(n)%nbins/)),&
           'nf90_get_var failed for REF_CDF')
-     
+
      call LIS_verify(nf90_inq_varid(ftn,"MERRA2_XRANGE",pcp3id),&
           'nf90_inq_varid failed for MERRA2_XRANGE')
      call LIS_verify(nf90_get_var(ftn,pcp3id,merra2_struc(n)%merraxrange,&
@@ -621,7 +621,7 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
           count=(/merra2_struc(n)%ncold,merra2_struc(n)%nrold,1,&
           merra2_struc(n)%nbins/)),&
           'nf90_get_var failed for MERRA2_XRANGE')
-     
+
      call LIS_verify(nf90_inq_varid(ftn,"MERRA2_CDF",pcp4id),&
           'nf90_inq_varid failed for MERRA2_CDF')
      call LIS_verify(nf90_get_var(ftn,pcp4id,merra2_struc(n)%merracdf,&
@@ -630,7 +630,7 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
           merra2_struc(n)%nbins/)),&
           'nf90_get_var failed for MERRA2_CDF')
 
-     if(merra2_struc(n)%usepcpsampling.gt.0) then 
+     if(merra2_struc(n)%usepcpsampling.gt.0) then
         !REF MEAN, STDEV
         call LIS_verify(nf90_inq_varid(ftn,"REF_MEAN",pcp5id),&
              'nf90_inq_varid failed for REF_MEAN')
@@ -655,13 +655,13 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
         do c=1,merra2_struc(n)%ncold
            k= c+(r-1)*merra2_struc(n)%ncold
            f(k) = input_var(c,r,t)
-           if ( f(k) == 1.e+15 ) then 
+           if ( f(k) == 1.e+15 ) then
               f(k)  = LIS_rc%udef
-              lb(k) = .false. 
+              lb(k) = .false.
            endif
         enddo
      enddo
-     if ( pcp_flag .and. merra2_struc(n)%usescalef==1 ) then 
+     if ( pcp_flag .and. merra2_struc(n)%usescalef==1 ) then
 
         call rescaleWithCDFmatching(&
              merra2_struc(n)%ncold,&
@@ -674,25 +674,25 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
              f)
 
      endif
-!-----------------------------------------------------------------------    
+!-----------------------------------------------------------------------
 ! Apply downscaling
-!-----------------------------------------------------------------------    
-     
-     if(pcp_flag.and.LIS_rc%pcp_downscale(findex).ne.0) then 
-        !input_data becomes the ratio field. 
+!-----------------------------------------------------------------------
+
+     if(pcp_flag.and.LIS_rc%pcp_downscale(findex).ne.0) then
+        !input_data becomes the ratio field.
         call LIS_generatePcpClimoRatioField(n,findex,"MERRA2",&
-             month, & 
+             month, &
              input_size, &
              f, &
-             lb)     
+             lb)
      endif
-          
+
      if(pcp_flag.and.&
-         trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then 
+         trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then
 
         call conserv_interp(LIS_rc%gridDesc(n,:),lb,f,lo,&
              merraforc(var_index,t,:), &
-             merra2_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),& 
+             merra2_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),&
              LIS_domain(n)%lat, LIS_domain(n)%lon,&
              merra2_struc(n)%w112,merra2_struc(n)%w122,&
              merra2_struc(n)%w212,merra2_struc(n)%w222,&
@@ -701,10 +701,10 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
              LIS_rc%udef, iret)
 
      elseif(trim(LIS_rc%met_interp(findex)).eq."bilinear".or.&
-             trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then 
+             trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then
         call bilinear_interp(LIS_rc%gridDesc(n,:),lb,f,lo,&
              merraforc(var_index,t,:), &
-             merra2_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n), & 
+             merra2_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n), &
              LIS_domain(n)%lat, LIS_domain(n)%lon,&
              merra2_struc(n)%w111,merra2_struc(n)%w121,&
              merra2_struc(n)%w211,merra2_struc(n)%w221,&
@@ -712,7 +712,7 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
              merra2_struc(n)%n211,merra2_struc(n)%n221,&
              LIS_rc%udef, iret)
 
-     elseif(trim(LIS_rc%met_interp(findex)).eq."neighbor") then 
+     elseif(trim(LIS_rc%met_interp(findex)).eq."neighbor") then
         call neighbor_interp(LIS_rc%gridDesc(n,:),lb,f,lo,&
              merraforc(var_index,t,:),merra2_struc(n)%mi,&
              LIS_rc%lnc(n)*LIS_rc%lnr(n),&
@@ -728,38 +728,38 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
      !Interpolate the refmean fields
      if( pcp_flag .and. scal_read_flag.and. &
           merra2_struc(n)%usescalef==1.and. &
-          merra2_struc(n)%usepcpsampling.eq.1) then 
+          merra2_struc(n)%usepcpsampling.eq.1) then
 
-        lb = .false. 
+        lb = .false.
         f = -9999.0
         do r=1,merra2_struc(n)%nrold
            do c=1,merra2_struc(n)%ncold
               k= c+(r-1)*merra2_struc(n)%ncold
               f(k) = merra2_struc(n)%refmean(c,r,1)
-              if(f(k).ne.-9999.0) then 
+              if(f(k).ne.-9999.0) then
                  lb(k) = .true.
               endif
            enddo
         enddo
-        
-        if(trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then 
+
+        if(trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then
 
            call conserv_interp(LIS_rc%gridDesc(n,:),lb,f,lo,&
                 merra2_struc(n)%refmean_ip, &
-                merra2_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),& 
+                merra2_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),&
                 LIS_domain(n)%lat, LIS_domain(n)%lon,&
                 merra2_struc(n)%w112,merra2_struc(n)%w122,&
                 merra2_struc(n)%w212,merra2_struc(n)%w222,&
                 merra2_struc(n)%n112,merra2_struc(n)%n122,&
                 merra2_struc(n)%n212,merra2_struc(n)%n222,&
                 LIS_rc%udef, iret)
-           
+
         elseif(trim(LIS_rc%met_interp(findex)).eq."bilinear".or.&
              trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then
 
            call bilinear_interp(LIS_rc%gridDesc(n,:),lb,f,lo,&
                 merra2_struc(n)%refmean_ip, &
-                merra2_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n), & 
+                merra2_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n), &
                 LIS_domain(n)%lat, LIS_domain(n)%lon,&
                 merra2_struc(n)%w111,merra2_struc(n)%w121,&
                 merra2_struc(n)%w211,merra2_struc(n)%w221,&
@@ -767,7 +767,7 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
                 merra2_struc(n)%n211,merra2_struc(n)%n221,&
                 LIS_rc%udef, iret)
 
-        elseif(trim(LIS_rc%met_interp(findex)).eq."neighbor") then 
+        elseif(trim(LIS_rc%met_interp(findex)).eq."neighbor") then
            call neighbor_interp(LIS_rc%gridDesc(n,:),lb,f,lo,&
                 merra2_struc(n)%refmean_ip,merra2_struc(n)%mi,&
                 LIS_rc%lnc(n)*LIS_rc%lnr(n),&
@@ -779,38 +779,38 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
      !Interpolate the refstdev fields
      if( pcp_flag .and. scal_read_flag.and. &
           merra2_struc(n)%usescalef==1.and. &
-          merra2_struc(n)%usepcpsampling.eq.1) then 
+          merra2_struc(n)%usepcpsampling.eq.1) then
 
-        lb = .false. 
+        lb = .false.
         f = -9999.0
         do r=1,merra2_struc(n)%nrold
            do c=1,merra2_struc(n)%ncold
               k= c+(r-1)*merra2_struc(n)%ncold
               f(k) = merra2_struc(n)%refstdev(c,r,1)
-              if(f(k).ne.-9999.0) then 
+              if(f(k).ne.-9999.0) then
                  lb(k) = .true.
               endif
            enddo
         enddo
-        
-        if(trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then 
+
+        if(trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then
 
            call conserv_interp(LIS_rc%gridDesc(n,:),lb,f,lo,&
                 merra2_struc(n)%refstdev_ip, &
-                merra2_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),& 
+                merra2_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),&
                 LIS_domain(n)%lat, LIS_domain(n)%lon,&
                 merra2_struc(n)%w112,merra2_struc(n)%w122,&
                 merra2_struc(n)%w212,merra2_struc(n)%w222,&
                 merra2_struc(n)%n112,merra2_struc(n)%n122,&
                 merra2_struc(n)%n212,merra2_struc(n)%n222,&
                 LIS_rc%udef, iret)
-           
+
         elseif(trim(LIS_rc%met_interp(findex)).eq."bilinear".or.&
              trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then
 
            call bilinear_interp(LIS_rc%gridDesc(n,:),lb,f,lo,&
                 merra2_struc(n)%refstdev_ip, &
-                merra2_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n), & 
+                merra2_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n), &
                 LIS_domain(n)%lat, LIS_domain(n)%lon,&
                 merra2_struc(n)%w111,merra2_struc(n)%w121,&
                 merra2_struc(n)%w211,merra2_struc(n)%w221,&
@@ -818,7 +818,7 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
                 merra2_struc(n)%n211,merra2_struc(n)%n221,&
                 LIS_rc%udef, iret)
 
-        elseif(trim(LIS_rc%met_interp(findex)).eq."neighbor") then 
+        elseif(trim(LIS_rc%met_interp(findex)).eq."neighbor") then
            call neighbor_interp(LIS_rc%gridDesc(n,:),lb,f,lo,&
                 merra2_struc(n)%refstdev_ip,merra2_struc(n)%mi,&
                 LIS_rc%lnc(n)*LIS_rc%lnr(n),&
@@ -827,32 +827,32 @@ subroutine interp_merra2_var(n,findex,month, input_var,  var_index, &
         endif
      endif
 
-     if( pcp_flag.and.LIS_rc%pcp_downscale(findex).ne.0 ) then 
+     if( pcp_flag.and.LIS_rc%pcp_downscale(findex).ne.0 ) then
 
         call LIS_pcpClimoDownscaling(n, findex, month,&
              LIS_rc%lnc(n)*LIS_rc%lnr(n), merraforc(var_index,t,:), lo)
-        
+
      endif
-     
+
   enddo
-  
+
 end subroutine interp_merra2_var
 
 !BOP
-! 
+!
 ! !ROUTINE: interp_lapserate_merra2
 ! \label{interp_lapserate_merra2}
-! 
-! !INTERFACE: 
+!
+! !INTERFACE:
 subroutine interp_lapserate_merra2(n,order,input_var)
 
-! !USES: 
+! !USES:
   use LIS_coreMod
   use LIS_logMod
   use LIS_spatialDownscalingMod
   use merra2_forcingMod, only : merra2_struc
   use LIS_constantsMod, only : LIS_CONST_LAPSE_RATE
-#if(defined USE_NETCDF3 || defined USE_NETCDF4)      
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
 #endif
   implicit none
@@ -863,10 +863,10 @@ subroutine interp_lapserate_merra2(n,order,input_var)
        merra2_struc(n)%nrold,24)
 
   !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This subroutine spatially interpolates a MERRA2 field
 !  to the LIS running domain
-! 
+!
 !EOP
 
   integer   :: t,c,r,k,iret
@@ -878,7 +878,7 @@ subroutine interp_lapserate_merra2(n,order,input_var)
   real      :: output_var(LIS_rc%lnc(n)*LIS_rc%lnr(n),24)
 
   external :: bilinear_interp
-  
+
 ! _____________________________________________________________
 
   input_size = merra2_struc(n)%ncold*merra2_struc(n)%nrold
@@ -940,12 +940,12 @@ subroutine interp_lapserate_merra2(n,order,input_var)
 
 end subroutine interp_lapserate_merra2
 
-#if 0 
+#if 0
 !BOP
 !
 ! !ROUTINE: finddoy
-! \label{finddoy} 
-! 
+! \label{finddoy}
+!
 ! !INTERFACE:
   subroutine finddoy(doy,yr,mo,da)
 
@@ -955,17 +955,17 @@ end subroutine interp_lapserate_merra2
     integer,intent(out)  :: doy
 !
 ! !DESCRIPTION:
-! 
+!
 !  Determines the time, time in GMT, and the day of the year
-!  based on the value of year, month, day of month, hour of 
-!  the day, minute and second. This method is the inverse of 
+!  based on the value of year, month, day of month, hour of
+!  the day, minute and second. This method is the inverse of
 !  time2date.
 !
 !   NOTE: This routine has been known to give round off error
 !   problems when attempting to retrieving minutes and seconds
 !   from the given number. Use at your own risk!
-! 
-!  The arguments are: 
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[yr]
 !    year
@@ -993,44 +993,44 @@ end subroutine interp_lapserate_merra2
 
     if((mod(yr,4).eq.0.and.mod(yr,100).ne.0) &     !correct for leap year
          .or.(mod(yr,400).eq.0))then             !correct for y2k
-       yrdays=366                  
+       yrdays=366
     else
        yrdays=365
     endif
-    
+
     doy=0
     do k=1,(mo-1)
        doy=doy+days(k)
     enddo
     doy=doy+da
-    
+
 !    if(yrdays.eq.366.and.mo.gt.2)doy=doy+1
-    
+
     return
   end subroutine finddoy
 #endif
 
 !BOP
-! 
+!
 ! !ROUTINE: rescaleWithCDFmatching
 ! \label{rescaleWithCDFmatching}
 !
 ! !INTERFACE:
   subroutine rescaleWithCDFmatching(&
-       nc,            & 
-       nr,            & 
-       nbins,         & 
-       ref_xrange,    & 
-       merra_xrange,  &       
+       nc,            &
+       nr,            &
+       nbins,         &
+       ref_xrange,    &
+       merra_xrange,  &
        ref_cdf,       &
        merra_cdf,     &
        out_value)
 
     use LIS_logMod
-       
+
     implicit none
-! 
-! !ARGUMENTS: 
+!
+! !ARGUMENTS:
     integer             :: nc
     integer             :: nr
     integer             :: nbins
@@ -1040,17 +1040,17 @@ end subroutine interp_lapserate_merra2
     real                :: merra_cdf(nc,nr,1,nbins)
     real                :: out_value(nc*nr)
 !
-! !DESCRIPTION: 
-! 
+! !DESCRIPTION:
+!
 !   This routine rescales the input merraervation data to the ref's
 !   climatology so that the cumulative distribution functions (CDFs)
-!   of the merraervations and the ref match (for each grid point). 
-! 
-!   Ref: Reichle and Koster, 2004, Bias reduction in short records of 
-!   satellite soil moisture, Geophys. Res. Lett. 31, L19501, 
-!   doi:10.1029/2004GL020938. 
-! 
-!  The arguments are: 
+!   of the merraervations and the ref match (for each grid point).
+!
+!   Ref: Reichle and Koster, 2004, Bias reduction in short records of
+!   satellite soil moisture, Geophys. Res. Lett. 31, L19501,
+!   doi:10.1029/2004GL020938.
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[n]               index of the nest
 !  \item[nbins]           number of bins used to compute the ref and merra CDFs
@@ -1060,7 +1060,7 @@ end subroutine interp_lapserate_merra2
 !  \item[merra\_xrange]     x-axis values corresponding to the merra CDF
 !  \item[ref\_cdf]      y-axis (CDF) values corresponding to the ref CDF
 !  \item[merra\_cdf]        y-axis (CDF) values corresponding to the merra CDF
-!  \item[merra\_value]      merraervation value to be rescaled. 
+!  \item[merra\_value]      merraervation value to be rescaled.
 ! \end{description}
 !EOP
 
@@ -1077,15 +1077,15 @@ end subroutine interp_lapserate_merra2
     integer,dimension(1) :: index_25 , index_75
     real                 :: Lb_xrange, Ub_xrange, iqr_merra, iqr_ref
 
-    ref_delta   = 0 
+    ref_delta   = 0
     merra_delta = 0
-   
+
     do r=1,nr
        do c=1,nc
           if(ref_xrange(c,r,1,2).ne.-9999.0.and.&
                ref_xrange(c,r,1,1).ne.-9999.0.and.&
                merra_xrange(c,r,1,2).ne.-9999.0.and.&
-               merra_xrange(c,r,1,1).ne.-9999.0) then 
+               merra_xrange(c,r,1,1).ne.-9999.0) then
              ref_delta(c,r) = ref_xrange(c,r,1,2)-ref_xrange(c,r,1,1)
              merra_delta(c,r)   = merra_xrange(c,r,1,2)-merra_xrange(c,r,1,1)
           endif
@@ -1093,7 +1093,7 @@ end subroutine interp_lapserate_merra2
     enddo
     do r=1,nr
        do c=1,nc
-          if(ref_delta(c,r).gt.1E-14.and.merra_delta(c,r).gt.1E-14) then 
+          if(ref_delta(c,r).gt.1E-14.and.merra_delta(c,r).gt.1E-14) then
              min_merra_value = ref_xrange(c,r,1,1)
              max_merra_value = ref_xrange(c,r,1,nbins)
              index_25 = minloc(abs(merra_cdf(c,r,1,:) - 0.25))
@@ -1101,37 +1101,37 @@ end subroutine interp_lapserate_merra2
              Lb_xrange = merra_xrange(c,r,1,index_25(1))
              Ub_xrange = merra_xrange(c,r,1,index_75(1))
              iqr_merra = Ub_xrange - Lb_xrange
-             
+
              index_25 = minloc(abs(ref_cdf(c,r,1,:) - 0.25))
              index_75 = minloc(abs(ref_cdf(c,r,1,:) - 0.75))
              Lb_xrange = ref_xrange(c,r,1,index_25(1))
              Ub_xrange = ref_xrange(c,r,1,index_75(1))
              iqr_ref = Ub_xrange - Lb_xrange
-             
+
 ! In a normal distribution 50% of data will fall between +/- 0.67448 sigma (1.134896 sigma)
 ! and 99.7% of data are between the +/-3 sigma (6 sigma) By dividing these two values we
-! get 1.134896 / 6 = 0.189. That means IQR is about the 0.19 of the 
+! get 1.134896 / 6 = 0.189. That means IQR is about the 0.19 of the
 ! x-range (~ dynamic range of the variable).
-! We can say if IQR is less than 0.05 of the x-range then CDF is too 
-! steep and it is better to ignore that for CDF matching.  
+! We can say if IQR is less than 0.05 of the x-range then CDF is too
+! steep and it is better to ignore that for CDF matching.
 ! NOTE: more tests are needed to determine the best threshold
 
 !             if( iqr_merra .lt. 0.05 * (merra_xrange(c,r,1,nbins)-merra_xrange(c,r,1,1)) .or. &
-!                  iqr_ref .lt. 0.05 * (ref_xrange(c,r,1,nbins)-ref_xrange(c,r,1,1)) ) then 
+!                  iqr_ref .lt. 0.05 * (ref_xrange(c,r,1,nbins)-ref_xrange(c,r,1,1)) ) then
 !                merra_delta(c,r) = 0
 !             endif
-             if(out_value(c+(r-1)*nc).lt.merra_xrange(c,r,1,nbins)) then 
-             
-                if(out_value(c+(r-1)*nc).ne.-9999.0) then 
+             if(out_value(c+(r-1)*nc).lt.merra_xrange(c,r,1,nbins)) then
+
+                if(out_value(c+(r-1)*nc).ne.-9999.0) then
                    merra_in = out_value(c+(r-1)*nc)
 !                print*,c,r,merra_in,merra_delta(c,r)
-                   if(merra_in.gt.1E-14) then 
+                   if(merra_in.gt.1E-14) then
 !                      print*, c,r,out_value(c+(r-1)*nc),merra_xrange(c,r,1,1),&
 !                           merra_xrange(c,r,1,nbins),&
-!                           merra_delta(c,r)                   
+!                           merra_delta(c,r)
                       binval = nint((out_value(c+(r-1)*nc)-merra_xrange(c,r,1,1))/&
                            merra_delta(c,r))+1
-                      
+
                       if(binval.gt.nbins) binval = nbins
                       if(binval.le.0) binval = 1
                       cdf_merraval = merra_cdf(c,r,1,binval)
@@ -1144,26 +1144,26 @@ end subroutine interp_lapserate_merra2
                       enddo
                       if(i.gt.nbins) i = i-1
                       merra_tmp = ref_xrange(c,r,1,i)
-                      
-                      if(merra_tmp.gt.max_merra_value) then 
+
+                      if(merra_tmp.gt.max_merra_value) then
                          !                      print*, 'max const',merra_tmp
                          merra_tmp = -9999.0
                       endif
-                      
-                      if(merra_tmp.lt.min_merra_value) then 
+
+                      if(merra_tmp.lt.min_merra_value) then
                          merra_tmp = -9999.0
                       endif
                       out_value(c+(r-1)*nc) = merra_tmp
                    endif
                    if(out_value(c+(r-1)*nc).lt.min_merra_value.and.&
-                        out_value(c+(r-1)*nc).ne.-9999.0) then 
+                        out_value(c+(r-1)*nc).ne.-9999.0) then
                       write(LIS_logunit,*) '[ERR] Problem in CDF scaling '
                       call LIS_endrun()
                    endif
                 else
                    out_value(c+(r-1)*nc) = -9999.0
                 endif
-                if(merra_in.ne.-9999.0.and.out_value(c+(r-1)*nc).eq.-9999.0) then 
+                if(merra_in.ne.-9999.0.and.out_value(c+(r-1)*nc).eq.-9999.0) then
                    print*,'mismatch', c,r,merra_in, out_value(c+(r-1)*nc)
                    stop
                 endif

--- a/lis/metforcing/merra2/readcrd_merra2.F90
+++ b/lis/metforcing/merra2/readcrd_merra2.F90
@@ -17,6 +17,7 @@
 ! 13 Sep 2024: Sujay Kumar, Initial code for using dynamic lapse rate
 ! 31 Oct 2024: David Mocko, Final code for using dynamic lapse rate
 ! 18 Dec 2024: Kristen Whitney, code for using double-sided dynamic lapse rate cutoff
+! 07 Jan 2026: Kristen Whitney, added use of optional config arguments for the dynamic lapse rate input filename prefix and suffix
 !
 ! !INTERFACE:    
 subroutine readcrd_merra2()
@@ -88,12 +89,26 @@ subroutine readcrd_merra2()
              'MERRA2 dynamic lapse rate data directory: not defined')
      enddo
 
+     call ESMF_ConfigFindLabel(LIS_config,"MERRA2 dynamic lapse rate filename prefix:",rc=rc)
+     do n=1,LIS_rc%nnest
+        call ESMF_ConfigGetAttribute(LIS_config,merra2_struc(n)%dynlapseratepfx,&
+                      default='/MERRA2.lapse_rate.hourly.', rc=rc)
+        write(LIS_logunit,*) '[INFO] MERRA2 dynamic lapse rate filename prefix:', trim(merra2_struc(n)%dynlapseratepfx)
+     enddo
+
+     call ESMF_ConfigFindLabel(LIS_config,"MERRA2 dynamic lapse rate filename suffix: ",rc=rc)
+     do n=1,LIS_rc%nnest
+        call ESMF_ConfigGetAttribute(LIS_config,merra2_struc(n)%dynlapseratesfx,&
+                      default='.global.nc', rc=rc)
+        write(LIS_logunit,*) '[INFO] MERRA2 dynamic lapse rate filename suffix: ', trim(merra2_struc(n)%dynlapseratesfx)
+     enddo
+
      call ESMF_ConfigFindLabel(LIS_config,"MERRA2 apply double-sided dynamic lapse rate cutoff:",rc=rc)
      do n=1,LIS_rc%nnest
         call ESMF_ConfigGetAttribute(LIS_config,merra2_struc(n)%applydynlapseratecutoff,&
                 default=0, rc=rc)
         call LIS_verify(rc,&
-                'MERRA2 apply double-sided dynamic lapse rate cutoff: no defined')
+                'MERRA2 apply double-sided dynamic lapse rate cutoff: not defined')
      enddo
 
      do n=1,LIS_rc%nnest 

--- a/lis/plugins/LIS_metforcing_pluginMod.F90
+++ b/lis/plugins/LIS_metforcing_pluginMod.F90
@@ -22,6 +22,7 @@ module LIS_metforcing_pluginMod
 ! !REVISION HISTORY: 
 !  11 Dec 2003   Sujay Kumar:  Initial Specification
 !  11 Oct 2014   K. Arsenault: Reorganzed for syncing with LDT
+!  02 Oct 2025   Fadji Maina: Added support for GEOS-ITbias
 ! 
 !EOP  
   implicit none
@@ -138,6 +139,10 @@ subroutine LIS_metforcing_plugin
 
 #if ( defined MF_GEOS_IT )
    use geosit_forcingMod
+#endif
+
+#if ( defined MF_GEOS_ITbias )
+   use geositbias_forcingMod
 #endif
 
 #if ( defined MF_ERA5 )
@@ -393,6 +398,13 @@ subroutine LIS_metforcing_plugin
    external timeinterp_geosit
    external finalize_geosit
    external reset_geosit
+#endif
+
+#if ( defined MF_GEOS_ITbias )
+   external get_geositbias
+   external timeinterp_geositbias
+   external finalize_geositbias
+   external reset_geositbias
 #endif
 
 #if ( defined MF_ERA5 )
@@ -808,6 +820,16 @@ subroutine LIS_metforcing_plugin
                                   timeinterp_geosit)
    call registerresetmetforc(trim(LIS_geositId)//char(0),reset_geosit)
    call registerfinalmetforc(trim(LIS_geositId)//char(0),finalize_geosit)
+#endif
+
+#if ( defined MF_GEOS_ITbias )
+! - GEOS-ITbias Forcing:
+   call registerinitmetforc(trim(LIS_geositbiasId)//char(0),init_geositbias)
+   call registerretrievemetforc(trim(LIS_geositbiasId)//char(0),get_geositbias)
+   call registertimeinterpmetforc(trim(LIS_geositbiasId)//char(0), &
+                                  timeinterp_geositbias)
+   call registerresetmetforc(trim(LIS_geositbiasId)//char(0),reset_geositbias)
+   call registerfinalmetforc(trim(LIS_geositbiasId)//char(0),finalize_geositbias)
 #endif
 
 #if ( defined MF_ERA5)

--- a/lis/plugins/LIS_pluginIndices.F90
+++ b/lis/plugins/LIS_pluginIndices.F90
@@ -30,6 +30,7 @@ module LIS_pluginIndices
 !  27 Jan 2014: Shugong Wang, added HRAP projection
 !   4 Nov 2014: Jonathan Case, added support for daily NESDIS/VIIRS GVF for Noah
 !  16 Aug 2016: Mahdi Navari, added PILDAS  
+!  02 Oct 2025  Fadji Maina, added support for GEOS-ITbias
 !
 !EOP
   PRIVATE
@@ -137,7 +138,7 @@ module LIS_pluginIndices
    character*50, public,  parameter :: LIS_gfsId             = "GFS"
    character*50, public,  parameter :: LIS_merra2Id          = "MERRA2"
    character*50, public,  parameter :: LIS_geositId          = "GEOS-IT"
-
+   character*50, public,  parameter :: LIS_geositbiasId      = "GEOS-ITbias"
    character*50, public,  parameter :: LIS_cmapId            = "CMAP"
    character*50, public,  parameter :: LIS_chirps2Id         = "CHIRPS2"
 

--- a/lis/surfacemodels/land/template/template_f2t.F90
+++ b/lis/surfacemodels/land/template/template_f2t.F90
@@ -16,6 +16,7 @@
 ! !REVISION HISTORY: 
 ! 21 Jul 2004: Sujay Kumar   Initial Specification
 ! 23 Oct 2007: Kristi Arsenault, Implemented code for LISv5.0
+! 15 Oct 2025: Fadji Maina, Made precipitation handling optional; only assign rainf when LIS_FORC_CRainf is selected
 ! 
 ! !INTERFACE:
 subroutine template_f2t(n)
@@ -164,10 +165,12 @@ subroutine template_f2t(n)
      if(LIS_FORC_Psurf%selectOpt.eq.1) then
        template_struc(n)%template(t)%psurf=psurf(tid)
      endif
-     if(pcp(tid).ne.LIS_rc%udef) then
-        template_struc(n)%template(t)%rainf=pcp(tid)
-     else
-        template_struc(n)%template(t)%rainf=0.0
+     if(LIS_FORC_CRainf%selectOpt.eq.1) then
+       if(pcp(tid).ne.LIS_rc%udef) then
+          template_struc(n)%template(t)%rainf=pcp(tid)
+       else
+          template_struc(n)%template(t)%rainf=0.0
+       endif
      endif
      if(LIS_FORC_CRainf%selectOpt.eq.1) then 
         if(cpcp(tid).ne.LIS_rc%udef) then 

--- a/lis/testcases/metforcing/geositbias/MODEL_OUTPUT_LIST.TBL
+++ b/lis/testcases/metforcing/geositbias/MODEL_OUTPUT_LIST.TBL
@@ -1,0 +1,143 @@
+#short_name select? units signconv timeavg? min/max? std? vert.levels grib_id grib_scalefactor longname
+
+#Energy balance components
+Swnet:        0  W/m2    DN   1 0 0 1 111 10      # Net Shortwave Radiation (W/m2)
+Lwnet:        0  W/m2    DN   1 0 0 1 112 10      # Net Longwave Radiation (W/m2)
+Qle:          0  W/m2    UP   1 0 0 1 121 10      # Latent Heat Flux (W/m2)
+Qh:           0  W/m2    UP   1 0 0 1 122 10      # Sensible Heat Flux (W/m2)
+Qg:           0  W/m2    DN   1 0 0 1 155 10      # Ground Heat Flux (W/m2)
+Qf:           0  W/m2    S2L  1 0 0 1 229 10      # Energy of fusion (W/m2)
+Qv:           0  W/m2    S2V  1 0 0 1 134 10      # Energy of sublimation (W/m2)
+Qa:           0  W/m2    DN   1 0 0 1 136 10      # Advective Energy (W/m2)
+Qtau:         0  N/m2    DN   1 0 0 1 135 10      # Momentum flux (N/m2)
+DelSurfHeat:  0  J/m2    INC  1 0 0 1 137 10      # Change in surface heat storage (J/m2)
+DelColdCont:  0  J/m2    INC  1 0 0 1 138 10      # Change in snow cold content (J/m2)
+BR:           0  -       -    1 0 1 1 256 10      # Bowen ratio
+EF:           0  -       -    1 0 1 1 256 10      # Evaporative fraction
+
+#Water balance components
+Snowf:        0  kg/m2s  DN   1 0 0 1 161 10000   # Snowfall rate (kg/m2s)
+Rainf:        0  kg/m2s  DN   1 0 0 1 162 10000   # Rainfall rate (kg/m2s)
+RainfConv:    0  kg/m2s  DN   1 0 0 1 163 10000   # Convective Rainfall rate (kg/m2s)
+TotalPrecip:  0  kg/m2s  DN   1 0 0 1 164 10000   # Total Precipitation rate (kg/m2s)
+Evap:         0  kg/m2s  UP   1 0 0 1  57 10000   # Total Evapotranspiration (kg/m2s)
+Qs:           0  kg/m2s  OUT  1 0 0 1 235 10000   # Surface runoff (kg/m2s)
+Qrec:         0  kg/m2s  IN   1 0 0 1 143 10000   # Recharge (kg/m2s)
+Qsb:          0  kg/m2s  OUT  1 0 0 1 254 10000   # Subsurface runoff (kg/m2s)
+Qsm:          0  kg/m2s  S2L  1 0 0 1  99 10000   # Snowmelt (kg/m2s)
+Qfz:          0  kg/m2s  L2S  1 0 0 1 146 10000   # Refreezing of water in the snowpack (kg/m2s)
+Qst:          0  kg/m2s  -    1 0 0 1 147 10000   # Snow throughfall (kg/m2s)
+DelSoilMoist: 0  kg/m2   INC  0 0 0 1 148 10000   # Change in soil moisture (kg/m2)
+DelSWE:       0  kg/m2   INC  0 0 0 1 149 1000    # Change in snow water equivalent (kg/m2)
+DelSurfStor:  0  kg/m2   INC  1 0 0 1 150 1000    # Change in surface water storage (kg/m2)
+DelIntercept: 0  kg/m2   INC  1 0 0 1 151 1000    # Change in interception storage (kg/m2)
+RHMin:        0   -      -    1 0 0 1  51 10      # Minimum 2 meter relative humidity (-)
+
+#Surface state variables
+SnowT:        0  K       -    1 0 0 1 152 10      # Snow surface temperature (K)
+VegT:         0  K       -    1 0 0 1 153 10      # Vegetation canopy temperature (K)
+BareSoilT:    0  K       -    1 0 0 1 154 10      # Temperature of bare soil (K)
+AvgSurfT:     0  K       -    1 0 0 1 148 10      # Average surface temperature (K)
+RadT:         0  K       -    1 1 0 1 156 10      # Surface Radiative Temperature (K)
+Albedo:       0  -       -    1 0 0 1  84 100     # Surface Albedo (-)
+SWE:          0  kg/m2   -    1 0 0 1  65 1000    # Snow Water Equivalent (kg/m2)
+SWEVeg:       0  kg/m2   -    1 0 0 1 159 1000    # SWE intercepted by vegetation (kg/m2)
+SurfStor:     0  kg/m2   -    1 0 0 1 160 1000    # Surface water storage (kg/m2)
+TWS:          0  mm      -    1 0 0 1 160 1000    # Terrestrial water storage (mm)
+GWS:          0  mm      -    1 0 0 1 176 100     # Ground water storage (mm)
+WaterTableD:  0  m       -    1 0 0 1 174 1       # Water table depth (m)
+SWS:          0  mm      -    1 0 0 1 333 10      # Surface water storage
+
+#Subsurface state variables
+SoilMoist:    0  m3/m3   -    1 0 0 4  86 1000    # Average layer soil moisture (kg/m2)
+SoilTemp:     0  K       -    1 0 0 4  85 1000    # Average layer soil temperature (K)
+SmLiqFrac:    0  -       -    1 0 0 4  85 100     # Average layer fraction of liquid moisture (-)
+SmFrozFrac:   0  -       -    1 0 0 4  85 100     # Average layer fraction of frozen moisture (-)
+SoilWet:      0  -       -    0 0 0 1  85 100     # Total soil wetness (-)
+RelSMC:       0  m3/m3   -    0 0 0 1  86 1000    # Relative soil moisture
+RootTemp:     0  K       -    0 0 0 1  85 1000    # Rootzone temperature (K)
+
+#Evaporation components
+PotEvap:      0  kg/m2s  UP   1 0 0 1 166 1       # Potential Evapotranspiration (kg/m2s)
+ECanop:       0  kg/m2s  UP   1 0 0 1 200 1       # Interception evaporation (kg/m2s)
+TVeg:         0  kg/m2s  UP   1 0 0 1 210 1       # Vegetation transpiration (kg/m2s)
+ESoil:        0  kg/m2s  UP   1 0 0 1 199 1       # Bare soil evaporation (kg/m2s)
+EWater:       0  kg/m2s  UP   1 0 0 1 170 1       # Open water evaporation (kg/m2s)
+RootMoist:    0  kg/m2   -    0 0 0 1 171 1       # Root zone soil moisture (kg/m2)
+CanopInt:     0  kg/m2   -    1 0 0 1 223 1000    # Total canopy water storage (kg/m2)
+EvapSnow:     0  kg/m2s  -    1 0 0 1 173 1000    # Snow evaporation (kg/m2s)
+SubSnow:      0  kg/m2s  -    1 0 0 1 198 1000    # Snow sublimation (kg/m2s)
+SubSurf:      0  kg/m2s  -    1 0 0 1 175 1000    # Sublimation of the snow free area (kg/m2s)
+ACond:        0  m/s     -    1 0 0 1 179 100000  # Aerodynamic conductance
+CCond:        0  m/s     -    1 0 0 1 179 1000000 # Canopy conductance
+
+#Cold season processes
+Snowcover:    0  -       -    1 0 0 1  66 100     # Snow Cover (-)
+SnowDepth:    0  m       -    1 0 0 1  66 1000    # Snow Depth (m)
+SLiqFrac:     0  -       -    0 0 0 1  65 1000    # Fraction of SWE in the liquid phase
+
+#Forcings
+Wind_f:       0  m/s     -    1 0 0 1 177 10      # Near Surface Wind (m/s)
+Rainf_f:      0  kg/m2s  DN   1 0 0 1 162 1000    # Average rainfall rate
+Snowf_f:      0  kg/m2s  DN   1 0 0 1 161 1000    # Average snowfall rate
+Tair_f:       1  K       -    1 0 0 1  11 10      # Near surface air temperature
+Qair_f:       1  kg/kg   -    1 0 0 1  51 1000    # Near surface specific humidity
+Psurf_f:      1  Pa      -    1 0 0 1   1 10      # Surface pressure
+SWdown_f:     0  W/m2    DN   1 0 0 1 204 10      # Surface incident shortwave radiation
+LWdown_f:     1  W/m2    DN   1 0 0 1 205 10      # Surface incident longwave radiation
+
+#Additional forcings
+DirectSW_f:   0  W/m2    -    0 0 0 1 256 10      # Surface direct incident shortwave radiation
+DiffuseSW_f:  0  W/m2    -    0 0 0 1 256 10      # Surface diffuse incident shortwave radiation
+NWind_f:      0  m/s     N    0 0 0 1 256 10      # Northward wind
+EWind_f:      0  m/s     E    0 0 0 1 256 10      # Eastward wind
+FHeight_f:    0  m       -    0 0 0 1 256 10      # Height of forcing variables
+CH_f:         0  -       -    0 0 0 1 256 10      # Surface exchange coefficient for heat
+CM_f:         0  -       -    0 0 0 1 256 10      # Surface Exchange Coefficient for momentum
+Emiss_f:      0  -       -    0 0 0 1 256 10      # Surface emissivity
+MixRatio_f:   0  kg/kg   -    0 0 0 1 256 10      # Surface mixing ration
+CosZenith_f:  0  -       -    0 0 0 1 256 10      # Cosine of zenith angle
+Albedo_f:     0  -       -    0 0 0 1 256 10      # Surface albedo
+
+#Parameters
+Landmask:     0  -       -    0 0 0 1  81 1       # Land Mask (0 - Water, 1- Land)
+Landcover:    0  -       -    0 0 0 1 186 1       # Land cover
+Soiltype:     0  -       -    0 0 0 1 187 1       # Soil type
+SandFrac:     0  -       -    0 0 0 1 999 1       # Sand fraction
+ClayFrac:     0  -       -    0 0 0 1 999 1       # Clay fraction
+SiltFrac:     0  -       -    0 0 0 1 999 1       # Silt fraction
+Porosity:     0  -       -    3 0 0 1 999 1       # Porosity
+Soilcolor:    0  -       -    0 0 0 1 188 1       # Soil color
+Elevation:    0  m       -    0 0 0 1 189 10      # Elevation
+Slope:        0  -       -    0 0 0 1 999 10      # Slope
+LAI:          0  -       -    1 0 0 1 190 100     # LAI
+SAI:          0  -       -    0 0 0 1 191 100     # SAI
+Snfralbedo:   0  -       -    0 0 0 1 192 100     # Snow fraction albedo
+Mxsnalbedo:   0  -       -    0 0 0 1 192 100     # Maximum snow albedo
+Greenness:    0  -       -    0 0 0 1  87 100     # Greenness
+Tempbot:      0  -       -    0 0 0 1 194 10      # Bottom soil temperature
+
+#RoutingStreamflow:      1 m3/s    -     1 0 0 1 333 10      #Streamflow
+Streamflow:      0 m3/s    -     1 0 0 1 333 10      #Streamflow
+RiverDepth:      0 m       -     1 0 0 1 333 10      #RiverDepth
+RiverVelocity:   0 m/s     -     1 0 0 1 333 10      #RiverVelocity
+FloodQ:          0 m3/s    -     1 0 0 1 333 10      #FloodDischarge
+FloodEvap:       0 m3      -     1 0 0 1 333 10      #FloodEvap
+FloodStor:       0 m3      -     1 0 0 1 333 10      #FloodStorage
+FloodDepth:      0 m       -     1 0 0 1 333 10      #FloodDepth
+FloodVelocity:   0 m/s     -     1 0 0 1 333 10      #FloodVelocity
+FloodedFrac:     0 -       -     1 0 0 1 333 10      #FloodedFrac
+FloodedArea:     0 m2      -     1 0 0 1 333 10      #FloodedArea
+SurfElev:        0 m       -     1 0 0 1 333 10      #SurfElev
+RunoffStor:      0 m3      -     1 0 0 1 333 10      #RunoffStor
+BaseflowStor:    0 m3      -     1 0 0 1 333 10      #BaseflowStor
+
+#
+GPP:          0  g/m2s   IN   1 0 0 1 256 1       # Gross Primary Production
+NEE:          0  g/m2s   OUT  1 0 0 1 256 1       # Net Ecosystem Exchange
+
+#Irrigation
+Irrigated water:   0 kg/m2s    -     1 0 0 1 333 10      #Irrigation amount
+
+#Lapse rate
+Lapserate:    1  K/km    UP   1 0 0 1 255 10      # Lapse rate

--- a/lis/testcases/metforcing/geositbias/README
+++ b/lis/testcases/metforcing/geositbias/README
@@ -1,0 +1,90 @@
+GEOS-ITbias Dynamic Lapse-Rate Forcing Test Case
+
+This test case performs a 1-km simulation over central California using
+the TEMPLATE LSM option from 2023-12-31 01:00 UTC through 2023-12-31
+06:00 UTC to test the processing of GEOS-ITbias forcing data and
+dynamic lapse-rate downscaling within the NASA Land Information System
+(LIS).
+
+The test case uses:
+
+(a) GEOS-ITbias forcing data containing near-surface air temperature,
+    near-surface specific humidity, surface pressure, and downward
+    longwave radiation.
+
+(b) Dynamic lapse-rate downscaling within LIS.
+
+(c) The TEMPLATE LSM option, which serves as a placeholder land surface
+    model and outputs the processed forcing fields.
+
+(d) A 1-km domain over central California.
+
+(e) Dynamic lapse-rate fields generated from GEOS-ITbias air-temperature
+    inputs using the methodology of Whitney et al. (2025).
+
+GEOS-ITbias forcings are generated upstream of LIS by bias-adjusting
+native GEOS-IT fields using climatological reference datasets. For the
+NLDAS-3 near-real-time forcing workflow, the temperature, humidity,
+and pressure fields are adjusted using MERRA-2 monthly climatologies
+spanning 2001–2024. The resulting GEOS-ITbias forcing fields are
+provided as input to LIS through the input/GEOSITBIAS directory.
+
+The dynamic lapse-rate fields used by this test case are provided
+through the input/dynlapserates_geositbias directory. These lapse rates
+are generated from GEOS-ITbias air-temperature fields using the
+methodology described by Whitney et al. (2025) and are used by LIS to
+perform elevation-based downscaling of air temperature.
+
+This directory contains:
+
+* this README file.
+* the ldt.config file used to generate the LIS parameter file.
+* the lis.config file used for this test case.
+* the MODEL_OUTPUT_LIST.TBL file used to specify output variables.
+* a sample GrADS control file that can be used to visualize the LIS
+  parameter file (input.ctl).
+* a sample GrADS control file that can be used to visualize the model
+  output (output.ctl).
+* a sample GrADS control file that can be used to visualize the target
+  output (testcase.ctl).
+
+To run this test case:
+
+* Generate the LIS executable.
+* Run the LIS executable using the supplied lis.config file and the
+  testcase input data.
+* Compare the generated output against the supplied target output.
+* View the output using the provided GrADS control files.
+
+Notes
+
+Additional information regarding the dynamic lapse-rate generation
+workflow used for NLDAS-3 forcing production can be found in:
+
+  lis/utils/nldas-3_forcing/dynamic_lapse_rates
+
+The dynamic lapse-rate methodology follows the framework of Rouf et al.
+(2020) with modifications described by Whitney et al. (2025). The
+associated workflow documentation and implementation are maintained in
+the dynamic_lapse_rates directory.
+
+References
+
+Whitney, K. M., Kumar, S. V., Mocko, D., Pflug, J., Bolten, J. D.,
+Maina, F. Z., Wrzesien, M. L., and Hain, C. R., 2025:
+Quantifying the Impacts of Dynamic Lapse Regimes on Snow Simulations.
+Journal of Hydrometeorology, 26(10), 1525–1560.
+https://doi.org/10.1175/JHM-D-25-0021.1
+
+Rouf, T., Mei, Y., Maggioni, V., Houser, P., and Noonan, M., 2020:
+A Physically Based Atmospheric Variables Downscaling Technique.
+Journal of Hydrometeorology, 21(1), 93–108.
+https://doi.org/10.1175/JHM-D-19-0109.1
+
+Maina, F., Kumar, S. V., Hain, C., Mocko, D., Locke, K., Wade, R.,
+Getirana, A., Case, J., Whitney, K. M., Ahmad, S., Lahmers, T.,
+Bolten, J., Pflug, J., Junod, R., Dodson, M., Wrzesien, M., Mishra, V.,
+Nie, W., and Hashemi, M. G. Z.:
+Retrospective and Near–Real-Time Surface Meteorology in the North
+American Land Data Assimilation System Phase 3 (NLDAS-3).
+Journal of Hydrometeorology, in review.

--- a/lis/testcases/metforcing/geositbias/README
+++ b/lis/testcases/metforcing/geositbias/README
@@ -24,10 +24,13 @@ The test case uses:
 
 GEOS-ITbias forcings are generated upstream of LIS by bias-adjusting
 native GEOS-IT fields using climatological reference datasets. For the
-NLDAS-3 near-real-time forcing workflow, the temperature, humidity,
-and pressure fields are adjusted using MERRA-2 monthly climatologies
-spanning 2001–2024. The resulting GEOS-ITbias forcing fields are
-provided as input to LIS through the input/GEOSITBIAS directory.
+NLDAS-3 near-real-time forcing workflow, the temperature, humidity, and
+surface pressure fields are bias-adjusted using MERRA-2 monthly
+climatologies spanning 2001–2024. Downward longwave radiation is
+bias-adjusted using the NLDAS-3 retrospective downward longwave
+radiation climatology spanning the 2001–2024 period. The resulting
+GEOS-ITbias forcing fields are provided as input to LIS through the
+input/GEOSITBIAS directory.
 
 The dynamic lapse-rate fields used by this test case are provided
 through the input/dynlapserates_geositbias directory. These lapse rates

--- a/lis/testcases/metforcing/geositbias/input.ctl
+++ b/lis/testcases/metforcing/geositbias/input.ctl
@@ -1,0 +1,94 @@
+dset ^lis_input_testcase.d01.nc
+dtype netcdf
+options template
+undef -9999
+xdef 101 linear -122.5 0.01
+ydef 101 linear 36.0 0.01
+zdef 1 linear 1 1
+* dummy tdef
+tdef 1 linear 00z01jan2026 1hr
+vars 83
+DOMAINMASK=>DOMAINMASK 1 y,x description
+LANDMASK=>LANDMASK 1 y,x description
+SURFACETYPE=>SURFACETYPE1 0 0,y,x description
+SURFACETYPE=>SURFACETYPE2 0 1,y,x description
+SURFACETYPE=>SURFACETYPE3 0 2,y,x description
+SURFACETYPE=>SURFACETYPE4 0 3,y,x description
+SURFACETYPE=>SURFACETYPE5 0 4,y,x description
+SURFACETYPE=>SURFACETYPE6 0 5,y,x description
+SURFACETYPE=>SURFACETYPE7 0 6,y,x description
+SURFACETYPE=>SURFACETYPE8 0 7,y,x description
+SURFACETYPE=>SURFACETYPE9 0 8,y,x description
+SURFACETYPE=>SURFACETYPE10 0 9,y,x description
+SURFACETYPE=>SURFACETYPE11 0 10,y,x description
+SURFACETYPE=>SURFACETYPE12 0 11,y,x description
+SURFACETYPE=>SURFACETYPE13 0 12,y,x description
+SURFACETYPE=>SURFACETYPE14 0 13,y,x description
+SURFACETYPE=>SURFACETYPE15 0 14,y,x description
+SURFACETYPE=>SURFACETYPE16 0 15,y,x description
+SURFACETYPE=>SURFACETYPE17 0 16,y,x description
+SURFACETYPE=>SURFACETYPE18 0 17,y,x description
+SURFACETYPE=>SURFACETYPE19 0 18,y,x description
+SURFACETYPE=>SURFACETYPE20 0 19,y,x description
+LANDCOVER=>LANDCOVER1 0 0,y,x description
+LANDCOVER=>LANDCOVER2 0 1,y,x description
+LANDCOVER=>LANDCOVER3 0 2,y,x description
+LANDCOVER=>LANDCOVER4 0 3,y,x description
+LANDCOVER=>LANDCOVER5 0 4,y,x description
+LANDCOVER=>LANDCOVER6 0 5,y,x description
+LANDCOVER=>LANDCOVER7 0 6,y,x description
+LANDCOVER=>LANDCOVER8 0 7,y,x description
+LANDCOVER=>LANDCOVER9 0 8,y,x description
+LANDCOVER=>LANDCOVER10 0 9,y,x description
+LANDCOVER=>LANDCOVER11 0 10,y,x description
+LANDCOVER=>LANDCOVER12 0 11,y,x description
+LANDCOVER=>LANDCOVER13 0 12,y,x description
+LANDCOVER=>LANDCOVER14 0 13,y,x description
+LANDCOVER=>LANDCOVER15 0 14,y,x description
+LANDCOVER=>LANDCOVER16 0 15,y,x description
+LANDCOVER=>LANDCOVER17 0 16,y,x description
+LANDCOVER=>LANDCOVER18 0 17,y,x description
+LANDCOVER=>LANDCOVER19 0 18,y,x description
+LANDCOVER=>LANDCOVER20 0 19,y,x description
+TEXTURE=>TEXTURE1 0 0,y,x description
+TEXTURE=>TEXTURE2 0 1,y,x description
+TEXTURE=>TEXTURE3 0 2,y,x description
+TEXTURE=>TEXTURE4 0 3,y,x description
+TEXTURE=>TEXTURE5 0 4,y,x description
+TEXTURE=>TEXTURE6 0 5,y,x description
+TEXTURE=>TEXTURE7 0 6,y,x description
+TEXTURE=>TEXTURE8 0 7,y,x description
+TEXTURE=>TEXTURE9 0 8,y,x description
+TEXTURE=>TEXTURE10 0 9,y,x description
+TEXTURE=>TEXTURE11 0 10,y,x description
+TEXTURE=>TEXTURE12 0 11,y,x description
+TEXTURE=>TEXTURE13 0 12,y,x description
+TEXTURE=>TEXTURE14 0 13,y,x description
+TEXTURE=>TEXTURE15 0 14,y,x description
+TEXTURE=>TEXTURE16 0 15,y,x description
+ELEVFGRD=>ELEVFGRD 1 y,x description
+ELEVATION=>ELEVATION 1 y,x description
+SLOPEFGRD=>SLOPEFGRD 1 y,x description
+SLOPE=>SLOPE 1 y,x description
+ASPECTFGRD=>ASPECTFGRD 1 y,x description
+ASPECT=>ASPECT 1 y,x description
+GREENNESS=>GREENNESS1 0 0,y,x description
+GREENNESS=>GREENNESS2 0 1,y,x description
+GREENNESS=>GREENNESS3 0 2,y,x description
+GREENNESS=>GREENNESS4 0 3,y,x description
+GREENNESS=>GREENNESS5 0 4,y,x description
+GREENNESS=>GREENNESS6 0 5,y,x description
+GREENNESS=>GREENNESS7 0 6,y,x description
+GREENNESS=>GREENNESS8 0 7,y,x description
+GREENNESS=>GREENNESS9 0 8,y,x description
+GREENNESS=>GREENNESS10 0 9,y,x description
+GREENNESS=>GREENNESS11 0 10,y,x description
+GREENNESS=>GREENNESS12 0 11,y,x description
+SHDMIN=>SHDMIN 1 y,x description
+SHDMAX=>SHDMAX 1 y,x description
+TBOT=>TBOT 1 y,x description
+NOAHMP36_PBLH=>NOAHMP36_PBLH 1 y,x description
+ELEV_MERRA2=>ELEV_MERRA2 1 y,x description
+lat=>lat 1 y,x description
+lon=>lon 1 y,x description
+endvars

--- a/lis/testcases/metforcing/geositbias/input_testcase.ctl
+++ b/lis/testcases/metforcing/geositbias/input_testcase.ctl
@@ -1,4 +1,4 @@
-dset ^lis_input.d01.nc
+dset ^lis_input_testcase.d01.nc
 dtype netcdf
 options template
 undef -9999

--- a/lis/testcases/metforcing/geositbias/ldt.config
+++ b/lis/testcases/metforcing/geositbias/ldt.config
@@ -1,0 +1,131 @@
+#Overall driver options
+LDT running mode:                       "LSM parameter processing"
+Processed LSM parameter filename:       ./lis_input_testcase.d01.nc
+LIS number of nests:                    1
+Number of surface model types:          1
+Surface model types:                    "LSM"
+Land surface model:                     "Noah-MP.4.0.1"
+Routing model:                          none
+Lake model:                             none
+Water fraction cutoff value:            0.5
+Incorporate crop information:           .false.
+Number of met forcing sources:          1
+Met forcing sources:                    "MERRA2"
+Met spatial transform methods:          bilinear
+Topographic correction method (met forcing):  "lapse-rate"
+Temporal interpolation method (met forcing):  none
+LDT diagnostic file:                    ldtlog_testcase
+Mask-parameter fill diagnostic file:    MaskParamFill.lis_input_testcase.d01.log
+LDT output directory:                   OUTPUT
+Undefined value:                        -9999.0
+
+#LIS domain
+Map projection of the LIS domain:       latlon
+LL run domain lower left lat: 36.000
+LL run domain lower left lon: -122.500
+LL run domain upper right lat: 37.000
+LL run domain upper right lon: -121.500
+LL run domain resolution (dx): 0.01
+LL run domain resolution (dy): 0.01
+
+Number of processors along x:           4
+Number of processors along y:           4
+
+#Landcover parameter inputs
+Landcover data source:                  "MODIS_Native"
+Landcover classification:               "IGBPNCEP"
+Landcover file:                         ./input/LS_PARAMETERS/noah_2dparms/igbp.bin
+Landcover spatial transform:            neighbor
+Landcover map projection:               latlon
+Landcover fill option:                  neighbor
+Landcover fill radius:                  5
+Landcover fill value:                   6
+
+#Landmask parameter inputs
+Create or readin landmask:              "create"
+Landmask data source:                   "MODIS_Native"
+
+#Soil parameter inputs
+Soil fraction data source:              none
+Soils spatial transform:                none
+Soils map projection:                   latlon
+Soils fill option:                      none
+Porosity data source:                   none
+Porosity map:                           none
+
+#Soil texture inputs
+Soil texture data source:               "ISRIC"
+Soil texture map:                       ./input/LS_PARAMETERS/soil_parms/ISRIC/v2017/TEXMHT_M_sl1_250m.tif
+Soil texture spatial transform:         mode
+Soil texture map projection:            latlon
+Soil texture fill option:               neighbor
+Soil texture fill radius:               5
+Soil texture fill value:                6
+Soil texture force exclusion of water points during fill:  .true.
+
+#Topography parameter inputs
+Elevation data source:                  "MERIT_1K"
+Elevation number of bands:              1
+Elevation map:                          ./input/LS_PARAMETERS/topo_parms/MERIT
+Elevation fill option:                  neighbor
+Elevation fill radius:                  5
+Elevation fill value:                   0.0
+
+Slope data source:                      "MERIT_1K"
+Slope number of bands:                  1
+Slope map:                              ./input/LS_PARAMETERS/topo_parms/MERIT
+Slope fill option:                      neighbor
+Slope fill radius:                      5
+Slope fill value:                       0.0
+
+Aspect data source:                     "MERIT_1K"
+Aspect number of bands:                 1
+Aspect map:                             ./input/LS_PARAMETERS/topo_parms/MERIT
+Aspect fill option:                     neighbor
+Aspect fill radius:                     5
+Aspect fill value:                      3.14159
+
+Topography spatial transform:           average
+Topography map projection:              latlon
+
+#Albedo inputs
+Albedo data source:                     none
+
+#Maximum snow albedo inputs
+Max snow albedo data source:            none
+
+#Greenness inputs
+Greenness data source:                  "NCEP_Native"
+Greenness fraction map:                 ./input/LS_PARAMETERS/noah_2dparms/gfrac
+Greenness climatology interval:         monthly
+Calculate min-max greenness fraction:   .true.
+Greenness spatial transform:            "budget-bilinear"
+Greenness map projection:               latlon
+Greenness fill option:                  neighbor
+Greenness fill radius:                  5
+Greenness fill value:                   0.3
+Greenness maximum fill value:           1.0
+Greenness minimum fill value:           0.0
+
+#Slope type inputs
+Slope type data source:                 none
+
+#Bottom temperature inputs
+Bottom temperature data source:         "ISLSCP1"
+Bottom temperature map:                 ./input/LS_PARAMETERS/noah_2dparms/SOILTEMP.60
+Bottom temperature spatial transform:   "budget-bilinear"
+Bottom temperature map projection:      latlon
+Bottom temperature fill option:         average
+Bottom temperature fill radius:         5
+Bottom temperature fill value:          287.0
+Bottom temperature topographic downscaling:  "lapse-rate"
+
+#Noah-MP LSM inputs
+Noah-MP PBL Height Value:               900.
+
+#Forcing-based parameter inputs
+MERRA2 forcing directory:                  ./input/MET_FORCING/MERRA2
+MERRA2 use lowest model level forcing:     1
+MERRA2 use corrected total precipitation:  1
+MERRA2 geopotential terrain height file:   ./input/MET_FORCING/MERRA2/MERRA2_all/MERRA2.const_2d_asm_Nx.00000000.nc4
+

--- a/lis/testcases/metforcing/geositbias/ldt.config
+++ b/lis/testcases/metforcing/geositbias/ldt.config
@@ -1,6 +1,6 @@
 #Overall driver options
 LDT running mode:                       "LSM parameter processing"
-Processed LSM parameter filename:       ./lis_input_testcase.d01.nc
+Processed LSM parameter filename:       ./lis_input.d01.nc
 LIS number of nests:                    1
 Number of surface model types:          1
 Surface model types:                    "LSM"
@@ -14,8 +14,8 @@ Met forcing sources:                    "MERRA2"
 Met spatial transform methods:          bilinear
 Topographic correction method (met forcing):  "lapse-rate"
 Temporal interpolation method (met forcing):  none
-LDT diagnostic file:                    ldtlog_testcase
-Mask-parameter fill diagnostic file:    MaskParamFill.lis_input_testcase.d01.log
+LDT diagnostic file:                    ldtlog
+Mask-parameter fill diagnostic file:    MaskParamFill.lis_input.d01.log
 LDT output directory:                   OUTPUT
 Undefined value:                        -9999.0
 

--- a/lis/testcases/metforcing/geositbias/lis.config
+++ b/lis/testcases/metforcing/geositbias/lis.config
@@ -1,0 +1,161 @@
+#Overall driver options
+Running mode:                           retrospective
+Map projection of the LIS domain:       latlon
+Number of nests:                        1
+Number of surface model types:          1
+Surface model types:                    LSM
+Surface model output interval:          1hr
+Land surface model:                     none
+Open water model:                       none
+Number of met forcing sources:          1
+Blending method for forcings:           overlay
+Met forcing sources:                    "GEOS-ITbias"
+Met forcing chosen ensemble member:     1
+Topographic correction method (met forcing):  "lapse-rate"
+Enable spatial downscaling of precipitation:  0
+Spatial upscaling method (met forcing):       none
+Spatial interpolation method (met forcing):   bilinear 
+Temporal interpolation method (met forcing):  "linear"
+
+#Runtime options
+Forcing variables list file:            ./input/forcing_variables.txt
+Output methodology:                     "2d gridspace" # "none" for spinup, "2d gridspace" for model runs
+Output model restart files:             0
+Output data format:                     netcdf #netcdf #binary
+Output naming style:                    "3 level hierarchy"
+Enable output statistics:               .false.
+Start mode:                             coldstart
+Starting year:                          2023
+Starting month:                         12
+Starting day:                           31
+Starting hour:                          00 
+Starting minute:                        00 
+Starting second:                        00
+Ending year:                            2023 
+Ending month:                           12 
+Ending day:                             31
+Ending hour:                            06
+Ending minute:                          00
+Ending second:                          00
+Undefined value:                       -9999
+Output directory:                       'OUTPUT'
+Diagnostic output file:                 lislog
+Number of ensembles per tile:           1
+
+#The following options are used for subgrid tiling based on vegetation
+Maximum number of surface type tiles per grid:    1
+Minimum cutoff percentage (surface type tiles):   0.05
+Maximum number of soil texture tiles per grid:    1
+Minimum cutoff percentage (soil texture tiles):   0.05
+Maximum number of soil fraction tiles per grid:   1
+Minimum cutoff percentage (soil fraction tiles):  0.05
+Maximum number of elevation bands per grid:       1
+Minimum cutoff percentage (elevation bands):      0.05
+Maximum number of slope bands per grid:           1
+Minimum cutoff percentage (slope bands):          0.05
+Maximum number of aspect bands per grid:          1
+Minimum cutoff percentage (aspect bands):         0.05
+
+#Processor layout
+#Should match the total number of processors used
+Number of processors along x:        1
+Number of processors along y:        1
+Halo size along x:                      0
+Halo size along y:                      0
+
+#Sub-models
+Radiative transfer model:               none
+Number of application models:           0
+
+#HYMAP router
+Routing model:                           "none"
+
+#---------------------DATA ASSIMILATION ----------------------------------
+#Data assimilation options
+
+Number of data assimilation instances:               0
+Data assimilation algorithm:                         none
+Data assimilation set:                               none
+
+Apply perturbation bias correction:        0
+Bias estimation algorithm:                "none"  "none"
+Bias estimation attributes file:          "none"  "none"
+Data assimilation number of observation types:       1
+Data assimilation output ensemble spread:            0
+Data assimilation scaling strategy:                  "none"
+Data assimilation output processed observations:     1
+Data assimilation output innovations:                0
+Data assimilation use a trained forward model: 0
+Data assimilation trained forward model output file: none
+
+#Perturbation options
+Perturbations start mode:                  coldstart
+Perturbations restart output interval:     1mo
+Perturbations restart filename:            none
+Forcing perturbation algorithm:            none
+Forcing perturbation frequency:            1hr
+Forcing attributes file:                   none
+Forcing perturbation attributes file:      none
+State perturbation algorithm:              none
+State perturbation frequency:              3hr
+State attributes file:                     none
+State perturbation attributes file:        none
+Observation perturbation algorithm:        none
+Observation perturbation frequency:        6hr
+Observation attributes file:               none
+Observation perturbation attributes file:  none
+
+#------------------------DOMAIN SPECIFICATION--------------------------
+#The following options list the choice of parameter maps to be used
+LIS domain and parameter data file:     ./lis_input_testcase.d01.nc
+Landmask data source:                   LDT
+Landcover data source:                  LDT
+Soil texture data source:               LDT
+Soil fraction data source:              none
+Soil color data source:                 none
+Elevation data source:                  LDT
+Slope data source:                      LDT
+Aspect data source:                     LDT
+Curvature data source:                  none
+LAI data source:                        none
+SAI data source:                        none
+Albedo data source:                     none
+Max snow albedo data source:            none
+Greenness data source:                  LDT
+Roughness data source:                  none
+Porosity data source:                   none
+Ksat data source:                       none
+B parameter data source:                none
+Quartz data source:                     none
+Emissivity data source:                 none
+
+TBOT lag skin temperature update option:  0
+TBOT skin temperature lag days:           
+
+#--------------------------------FORCINGS----------------------------------
+GEOS-ITbias forcing directory:       ./input/GEOSITBIAS/
+GEOS-ITbias dynamic lapse rate filename prefix: /GEOS-ITbias.lapse_rate.hourly.
+GEOS-ITbias dynamic lapse rate filename suffix: .nldas3.nc
+GEOS-ITbias apply dynamic lapse rates:          1
+GEOS-ITbias dynamic lapse rate data directory:  ./input/dynlapserates_geositbias/
+GEOS-ITbias apply double-sided dynamic lapse rate cutoff:  1
+
+#------------------------------IRRIGATION-------------------------
+Irrigation scheme:            "none"
+
+#-----------------------LAND SURFACE MODELS--------------------------
+Template open water timestep:                1hr
+TEMPLATE model timestep:                     1hr
+
+#---------------------------MODEL OUTPUT CONFIGURATION-----------------------
+#Specify the list of ALMA variables that need to be featured in the
+#LSM model output
+Output start year:
+Output start month:
+Output start day:
+Output start hour:
+Output start minutes:
+Output start seconds:
+Time Average option:  1
+Number of dimensions in the lat/lon output fields:  "1D"
+Model output attributes file:           ./MODEL_OUTPUT_LIST.TBL

--- a/lis/testcases/metforcing/geositbias/lis.config
+++ b/lis/testcases/metforcing/geositbias/lis.config
@@ -58,8 +58,8 @@ Minimum cutoff percentage (aspect bands):         0.05
 
 #Processor layout
 #Should match the total number of processors used
-Number of processors along x:        1
-Number of processors along y:        1
+Number of processors along x:        2
+Number of processors along y:        2
 Halo size along x:                      0
 Halo size along y:                      0
 
@@ -107,7 +107,7 @@ Observation perturbation attributes file:  none
 
 #------------------------DOMAIN SPECIFICATION--------------------------
 #The following options list the choice of parameter maps to be used
-LIS domain and parameter data file:     ./lis_input_testcase.d01.nc
+LIS domain and parameter data file:     ./lis_input.d01.nc
 Landmask data source:                   LDT
 Landcover data source:                  LDT
 Soil texture data source:               LDT

--- a/lis/testcases/metforcing/geositbias/output.ctl
+++ b/lis/testcases/metforcing/geositbias/output.ctl
@@ -1,0 +1,16 @@
+DSET ^OUTPUT/SURFACEMODEL/202312/LIS_HIST_%y4%m2%d2%h2%n2.d01.nc
+DTYPE netcdf
+OPTIONS template
+TITLE LIS output
+UNDEF -9999.0
+XDEF 101 LINEAR -122.5 0.01
+YDEF 101 LINEAR 36.0 0.01
+ZDEF 1 LINEAR 1 1
+TDEF 6 LINEAR 01:00Z31dec2023 1hr
+VARS 5
+Tair_f_tavg       1 99 ** air temperature K
+Qair_f_tavg       1 99 ** specific humidity kg/kg
+Psurf_f_tavg      1 99 ** surface pressure Pa
+LWdown_f_tavg     1 99 ** downward longwave radiation W/m2
+Lapserate_tavg    1 99 ** lapse rate K/km
+ENDVARS

--- a/lis/testcases/metforcing/geositbias/output.ctl
+++ b/lis/testcases/metforcing/geositbias/output.ctl
@@ -1,16 +1,16 @@
 DSET ^OUTPUT/SURFACEMODEL/202312/LIS_HIST_%y4%m2%d2%h2%n2.d01.nc
-DTYPE netcdf
-OPTIONS template
-TITLE LIS output
-UNDEF -9999.0
-XDEF 101 LINEAR -122.5 0.01
-YDEF 101 LINEAR 36.0 0.01
-ZDEF 1 LINEAR 1 1
-TDEF 6 LINEAR 01:00Z31dec2023 1hr
-VARS 5
-Tair_f_tavg       1 99 ** air temperature K
-Qair_f_tavg       1 99 ** specific humidity kg/kg
-Psurf_f_tavg      1 99 ** surface pressure Pa
-LWdown_f_tavg     1 99 ** downward longwave radiation W/m2
-Lapserate_tavg    1 99 ** lapse rate K/km
-ENDVARS
+dtype netcdf
+options template
+title LIS output
+undef -9999
+xdef 101 linear -122.5 0.01
+ydef 101 linear 36. 0.01
+zdef 1 linear 1 1
+tdef 6 LINEAR 01:00Z31dec2023 1hr
+vars 5
+Tair_f_tavg=>Tair_f_tavg 1 y,x description
+Qair_f_tavg=>Qair_f_tavg 1 y,x description
+Psurf_f_tavg=>Psurf_f_tavg 1 y,x description
+LWdown_f_tavg=>LWdown_f_tavg 1 y,x description
+Lapserate_tavg=>Lapserate_tavg 1 y,x description
+endvars

--- a/lis/testcases/metforcing/geositbias/testcase.ctl
+++ b/lis/testcases/metforcing/geositbias/testcase.ctl
@@ -1,0 +1,16 @@
+DSET ^TARGET_OUTPUT/SURFACEMODEL/202312/LIS_HIST_%y4%m2%d2%h2%n2.d01.nc
+DTYPE netcdf
+OPTIONS template
+TITLE LIS output
+UNDEF -9999.0
+XDEF 101 LINEAR -122.5 0.01
+YDEF 101 LINEAR 36.0 0.01
+ZDEF 1 LINEAR 1 1
+TDEF 6 LINEAR 01:00Z31dec2023 1hr
+VARS 5
+Tair_f_tavg       1 99 ** air temperature K
+Qair_f_tavg       1 99 ** specific humidity kg/kg
+Psurf_f_tavg      1 99 ** surface pressure Pa
+LWdown_f_tavg     1 99 ** downward longwave radiation W/m2
+Lapserate_tavg    1 99 ** lapse rate K/km
+ENDVARS

--- a/lis/testcases/metforcing/geositbias/testcase.ctl
+++ b/lis/testcases/metforcing/geositbias/testcase.ctl
@@ -1,16 +1,16 @@
 DSET ^TARGET_OUTPUT/SURFACEMODEL/202312/LIS_HIST_%y4%m2%d2%h2%n2.d01.nc
-DTYPE netcdf
-OPTIONS template
-TITLE LIS output
-UNDEF -9999.0
-XDEF 101 LINEAR -122.5 0.01
-YDEF 101 LINEAR 36.0 0.01
-ZDEF 1 LINEAR 1 1
-TDEF 6 LINEAR 01:00Z31dec2023 1hr
-VARS 5
-Tair_f_tavg       1 99 ** air temperature K
-Qair_f_tavg       1 99 ** specific humidity kg/kg
-Psurf_f_tavg      1 99 ** surface pressure Pa
-LWdown_f_tavg     1 99 ** downward longwave radiation W/m2
-Lapserate_tavg    1 99 ** lapse rate K/km
-ENDVARS
+dtype netcdf
+options template
+title LIS output
+undef -9999
+xdef 101 linear -122.5 0.01
+ydef 101 linear 36. 0.01
+zdef 1 linear 1 1
+tdef 6 LINEAR 01:00Z31dec2023 1hr
+vars 5
+Tair_f_tavg=>Tair_f_tavg 1 y,x description
+Qair_f_tavg=>Qair_f_tavg 1 y,x description
+Psurf_f_tavg=>Psurf_f_tavg 1 y,x description
+LWdown_f_tavg=>LWdown_f_tavg 1 y,x description
+Lapserate_tavg=>Lapserate_tavg 1 y,x description
+endvars


### PR DESCRIPTION
### Description

Fixes #1760

This PR adds a GEOS-IT bias meteorological forcing option (GEOS-IT forcings bias-corrected using MERRA-2 climatology) to support seamless transitions from MERRA-2 to GEOS-IT forcing in LIS simulations.

It also extends the MERRA-2 lapse rate reader with:
- new configuration options for lapse rate file prefix/suffix, and
- support for using lapse rate files defined over sub-global (regional) domains that are smaller than the global MERRA-2 forcing domain.

Summary of changes:
- Add GEOS-IT bias metforcing implementation: `lis/metforcing/geos_itbias/`
- Update plugin registration/build configuration/documentation as needed for the new forcing option
- Update MERRA-2 lapse rate reader to support prefix/suffix configuration and sub-global lapse rate domains
- Make template precipitation handling conditional on precipitation forcing selection

### Credits

- The GEOS-IT bias metforcing implementation is primarily based on the existing GEOS-IT code base and was developed by @fadjimaina with bias correction relative to MERRA-2 climatology.
- **Kristen Whitney** integrated the GEOS-IT bias forcing into LISF and implemented the updates to the MERRA-2 lapse rate reader, including new configuration options (prefix/suffix) and support for sub-global lapse rate domains.
- **Kristen Whitney** and @fadjimaina performed sanity checks and short LIS runs to verify correct forcing selection and lapse rate application.
- Feedback from @dmocko and @jvgeiger is requested.

### Testcase

Sanity checks were performed to verify correct reading and application of lapse rate files. Short LIS runs were performed using both MERRA-2 and GEOS-IT bias forcings, including cases with dynamic lapse rates enabled.



