### PR TITLE
Update to s2s_config file

### DIFF
--- a/lis/utils/usaf/S2S/ghis2s/s2s_app/s2s_config_global_fcast
+++ b/lis/utils/usaf/S2S/ghis2s/s2s_app/s2s_config_global_fcast
@@ -11,6 +11,7 @@ SETUP:
   METFORC: /discover/nobackup/projects/usaf_lis/USAF_FORCING/
   supplementarydir: /discover/nobackup/projects/usaf_lis/GHI_S2S/supplementary_files/
   ldtinputfile: lis_input.s2s_global.noahmp401_hymap2.25km.nc
+  user_cache_dir: /[path]/nwp601/scratch/[username]/
   SPCODE:  s1189
   CONSTRAINT: mil
   DATATYPE: forecast


### PR DESCRIPTION

Update to s2s_config file

 Added the "user_cache_dir:" parameter to the s2s_config file
  example, which helps write the Matplotlib config/fonts to a directory,
  if local/.cache or $HOME is unavailable during slurm job runtime.
  The user can specify a different directory location, e.g., scratch dir.

@jvgeiger 