### PR TITLE
Bug fix:  Update bookends for surface pressure in AGRMET code.

### DIFF
--- a/lis/metforcing/usaf/AGRMET_sfcalc.F90
+++ b/lis/metforcing/usaf/AGRMET_sfcalc.F90
@@ -270,6 +270,7 @@ subroutine AGRMET_sfcalc(n)
         agrmet_struc(n)%agr_hgt_sfc_p = agrmet_struc(n)%agr_hgt_sfc_c
         agrmet_struc(n)%agr_rh_sfc_p = agrmet_struc(n)%agr_rh_sfc_c
         agrmet_struc(n)%agr_wspd_p = agrmet_struc(n)%agr_wspd_c
+        agrmet_struc(n)%agr_pres_p = agrmet_struc(n)%agr_pres_c ! EMK Fix for sfc pressure
 
         order = 1
         call AGRMET_fldbld(n,order,julend)


### PR DESCRIPTION

### Description

This addresses a behavior noted by @karsenau.  When LIS-AGRMET advances in time, the two temporal bookends are periodically updated, with the old "later" bookend becoming the new "earlier" bookend.  The AGRMET code erroneously did not do this for surface pressure, causing differences in the pressure field for the same valid time between two LIS runs started at different times.  A single line of code fixes the problem.
