### PR TITLE
Remove multiple uses of ESMF within program files

### DIFF
--- a/lis/utils/usaf/retune_bratseth/src/procOBA_NWP.F90
+++ b/lis/utils/usaf/retune_bratseth/src/procOBA_NWP.F90
@@ -708,7 +708,6 @@ contains
         use_blacklist, nstns, blacklist_stns)
 
       ! Imports
-      use esmf
       use USAF_ReportsMod, only: Reports, newReports, getNobs, getReport, &
            destroyReports, appendToReports, bcast_reports
       use USAF_StationsMod, only: great_circle_distance

--- a/lis/utils/usaf/retune_bratseth/src/procOBA_Sat.F90
+++ b/lis/utils/usaf/retune_bratseth/src/procOBA_Sat.F90
@@ -878,7 +878,6 @@ contains
         use_blacklist, nstns, blacklist_stns)
 
       ! Imports
-      use esmf
       use USAF_GridHashMod, only: GridHash, newGridHash, destroyGridHash, &
            insertIntoGridHash, getObindexVectorFromGridHash, &
            createIJForGridHash


### PR DESCRIPTION
### Description

Do not `use ESMF` both at the top of a module and within its subroutines. That leads to this error:

```
      use esmf
          ^
ftn-487 ftn: ERROR READFILES, File = procOBA_NWP.F90, Line = 711, Column = 11
  The specific interfaces for "ESMF_INFOINQUIRE" and "ESMF_INFOGETI4" make the GENERIC interface "ESMF_INFOGET" ambiguous.
```

