### PR TITLE
Updated FOC files and MODEL_OUTPUT_LIST.TBL settings.

### DIFF
--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/tables/MODEL_OUTPUT_LIST.TBL.noah39
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/tables/MODEL_OUTPUT_LIST.TBL.noah39
@@ -1,0 +1,58 @@
+#short_name select? units signconv timeavg? min/max? std? vert.levels grib_id grib_scalefactor longname
+
+#Energy balance components
+Qle:          0  W/m2    UP   1 0 0 1 121 100      # Latent Heat Flux (W/m2)
+Qh:           0  W/m2    UP   1 0 0 1 122 100      # Sensible Heat Flux (W/m2)
+Qg:           0  W/m2    DN   1 0 0 1 155 100      # Ground Heat Flux (W/m2)
+
+#Water balance components
+TotalPrecip:  1  kg/m2   DN   3 0 0 1  61 10000    # Total Precipitation rate (kg/m2s)
+Evap:         0  kg/m2s  UP   1 0 0 1 204 10000    # Total Evapotranspiration (kg/m2s)
+Qs:           1  kg/m2s  OUT  1 0 0 1 235 10000    # Surface runoff (kg/m2s)
+Qsb:          1  kg/m2s  OUT  1 0 0 1 234 10000    # Subsurface runoff (kg/m2s)
+RHMin:        0  %       -    0 0 0 1 210 10       # Minimum 2-meter relative humidity (-)
+
+#Surface state variables
+AvgSurfT:     1  K       -    0 0 0 1  11 100      # Average surface temperature (K)
+Albedo:       0  %       -    1 0 0 1  84 1000     # Surface Albedo (-)
+SWE:          0  kg/m2   -    0 0 0 1  65 10000    # Snow Water Equivalent (kg/m2)
+
+#Subsurface state variables
+SoilMoist:    0  m3/m3   -    2 0 0 4 201 1000     # Average layer soil moisture (kg/m2)
+SoilTemp:     0  K       -    2 0 0 4  85 1000     # Average layer soil temperature (K)
+SmLiqFrac:    0  m3/m3   -    0 0 0 4  10 1000     # Average layer fraction of liquid moisture (-)
+RelSMC:       0  -       -    0 0 0 4 194 1000     # Relative soil moisture
+
+#Evaporation components
+PotEvap:      0  W/m2    UP   1 0 0 1 208 100      # Potential Evapotranspiration (kg/m2s)
+CanopInt:     0  kg/m2   -    0 0 0 1 207 1000     # Total canopy water storage (kg/m2)
+
+#Cold season processes
+Snowcover:    0  %       -    0 0 0 1 238 100      # Snow Cover (-) or percentage Snow Coverage
+SnowDepth:    0  m       -    0 0 0 1  66 1000     # Snow Depth (m)
+
+#Forcings
+Wind_f:       0  m/s     -    2 0 0 1 209 10000    # Near surface Wind (m/s)
+Tair_f:       0  K       -    2 1 0 1  11 10000    # Near surface air temperature
+Qair_f:       0  kg/kg   -    2 0 0 1  51 10000000 # Near surface specific humidity
+Psurf_f:      0  Pa      -    2 0 0 1   1 1000     # Surface pressure
+SWdown_f:     0  W/m2    DN   2 0 0 1 145 10000    # Surface incident shortwave radiation
+LWdown_f:     0  W/m2    DN   2 0 0 1 144 100000   # Surface incident longwave radiation
+
+#Parameters
+Landmask:     0  -       -    0 0 0 1  81 1        # Land Mask (0 - Water, 1 - Land)
+Landcover:    0  -       -    0 0 0 1 241 1        # Land cover
+Soiltype:     0  -       -    0 0 0 1 205 1        # Soil type
+Elevation:    0  m       -    0 0 0 1 233 100      # Elevation
+Greenness:    0  -       -    0 0 0 1 193 1000     # Greenness
+
+# HyMAP-2 Routing
+Streamflow:      1 m3/s    -     1 0 0 1 333 10    # Streamflow
+SWS:             1 mm      -     1 0 0 1 333 10    # Surface water storage
+SurfElev:        0 m       -     1 0 0 1 333 10    # SurfElev
+RiverStor:       0 m3      -     1 0 0 1 333 10    # RiverStorage
+RiverDepth:      0 m       -     1 0 0 1 333 10    # RiverDepth
+RiverVelocity:   0 m/s     -     1 0 0 1 333 10    # RiverVelocity
+FloodStor:       0 m3      -     1 0 0 1 333 10    # FloodStorage
+FloodedFrac:     1 -       -     1 0 0 1 333 10    # FloodedFrac
+FloodedArea:     0 m2      -     1 0 0 1 333 10    # FloodedArea

--- a/lis/configs/557WW-7.5-FOC/MRF_GHI/tables/MODEL_OUTPUT_LIST.TBL.noahmp401
+++ b/lis/configs/557WW-7.5-FOC/MRF_GHI/tables/MODEL_OUTPUT_LIST.TBL.noahmp401
@@ -1,0 +1,60 @@
+#short_name select? units signconv timeavg? min/max? std? vert.levels grib_id grib_scalefactor longname
+
+#Energy balance components
+Qle:          0  W/m2    UP   1 0 0 1 121 100      # Latent Heat Flux (W/m2)
+Qh:           0  W/m2    UP   1 0 0 1 122 100      # Sensible Heat Flux (W/m2)
+Qg:           0  W/m2    DN   1 0 0 1 155 100      # Ground Heat Flux (W/m2)
+
+#Water balance components
+TotalPrecip:  1  kg/m2   DN   3 0 0 1  61 10000    # Total Precipitation rate (kg/m2s)
+Evap:         0  kg/m2s  UP   1 0 0 1 204 10000    # Total Evapotranspiration (kg/m2s)
+Qs:           1  kg/m2s  OUT  1 0 0 1 235 10000    # Surface runoff (kg/m2s)
+Qsb:          1  kg/m2s  OUT  1 0 0 1 234 10000    # Subsurface runoff (kg/m2s)
+RHMin:        0  %       -    0 0 0 1 210 10       # Minimum 2-meter relative humidity (-)
+Snowf:        0  kg/m2s  DN   1 0 0 1 161 10000   # Snowfall rate (kg/m2s)
+
+#Surface state variables
+AvgSurfT:     1  K       -    0 0 0 1  11 100      # Average surface temperature (K)
+Albedo:       0  %       -    1 0 0 1  84 1000     # Surface Albedo (-)
+SWE:          0  kg/m2   -    0 0 0 1  65 10000    # Snow Water Equivalent (kg/m2)
+
+#Subsurface state variables
+SoilMoist:    0  m3/m3   -    2 0 0 4 201 1000     # Average layer soil moisture (kg/m2)
+SoilTemp:     0  K       -    2 0 0 4  85 1000     # Average layer soil temperature (K)
+SmLiqFrac:    0  m3/m3   -    0 0 0 4  10 1000     # Average layer fraction of liquid moisture (-)
+RelSMC:       0  -       -    0 0 0 4 194 1000     # Relative soil moisture
+
+#Evaporation components
+CanopInt:     0  kg/m2   -    0 0 0 1 207 1000     # Total canopy water storage (kg/m2)
+
+#Cold season processes
+Snowcover:    0  %       -    0 0 0 1 238 100      # Snow Cover (-) or percentage Snow Coverage
+SnowDepth:    0  m       -    0 0 0 1  66 1000     # Snow Depth (m)
+
+#Forcings
+Wind_f:       0  m/s     -    2 0 0 1 209 10000    # Near surface Wind (m/s)
+Tair_f:       0  K       -    2 1 0 1  11 10000    # Near surface air temperature
+Qair_f:       0  kg/kg   -    2 0 0 1  51 10000000 # Near surface specific humidity
+Psurf_f:      0  Pa      -    2 0 0 1   1 1000     # Surface pressure
+SWdown_f:     0  W/m2    DN   2 0 0 1 145 10000    # Surface incident shortwave radiation
+LWdown_f:     0  W/m2    DN   2 0 0 1 144 100000   # Surface incident longwave radiation
+
+#Parameters
+Landmask:     0  -       -    0 0 0 1  81 1        # Land Mask (0 - Water, 1 - Land)
+Landcover:    0  -       -    0 0 0 1 241 1        # Land cover
+Soiltype:     0  -       -    0 0 0 1 205 1        # Soil type
+Elevation:    0  m       -    0 0 0 1 233 100      # Elevation
+Greenness:    0  -       -    0 0 0 1 193 1000     # Greenness
+
+# HyMAP-2 Routing
+Streamflow:      1 m3/s    -     1 0 0 1 333 10    # Streamflow
+SWS:             1 mm      -     1 0 0 1 333 10    # Surface water storage
+SurfElev:        0 m       -     1 0 0 1 333 10    # SurfElev
+RiverStor:       0 m3      -     1 0 0 1 333 10    # RiverStorage
+RiverDepth:      0 m       -     1 0 0 1 333 10    # RiverDepth
+RiverVelocity:   0 m/s     -     1 0 0 1 333 10    # RiverVelocity
+FloodQ:          0 m3/s    -     1 0 0 1 256 10    # Flood discharge
+FloodStor:       0 m3      -     1 0 0 1 333 10    # FloodStorage
+FloodedFrac:     1 -       -     1 0 0 1 333 10    # FloodedFrac
+FloodedArea:     0 m2      -     1 0 0 1 333 10    # FloodedArea
+FloodDepth:      0 m       -     1 0 0 1 256 10    # Flood depth

--- a/lis/configs/557WW-7.5-FOC/NRT_GLOBAL/lis.config.global.noah39.galwem17
+++ b/lis/configs/557WW-7.5-FOC/NRT_GLOBAL/lis.config.global.noah39.galwem17
@@ -239,7 +239,7 @@ AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
 AGRMET IMERG data directory:               ./input/USAF_FORCING/IMERG
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V07B            # V07B released 1 Jun 2024
+AGRMET IMERG version:                      V07C            # V07C released 4 Mar 2026
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings

--- a/lis/configs/557WW-7.5-FOC/NRT_GLOBAL/lis.config.global.noahmp401.galwem17
+++ b/lis/configs/557WW-7.5-FOC/NRT_GLOBAL/lis.config.global.noahmp401.galwem17
@@ -239,7 +239,7 @@ AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
 AGRMET IMERG data directory:               ./input/USAF_FORCING/IMERG
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V07B            # V07B released 1 Jun 2024
+AGRMET IMERG version:                      V07C            # V07C released 4 Mar 2026
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings

--- a/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.noah39.rapid
+++ b/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.noah39.rapid
@@ -237,7 +237,7 @@ AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
 AGRMET IMERG data directory:               ./input/USAF_FORCING/IMERG/
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V07B            # V07B released 1 Jun 2024
+AGRMET IMERG version:                      V07C            # V07C released 4 Mar 2026
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings

--- a/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.noahmp401.rapid
+++ b/lis/configs/557WW-7.5-FOC/NRT_STREAMFLOW/lis.config.nrt_streamflow.noahmp401.rapid
@@ -236,7 +236,7 @@ AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
 AGRMET IMERG data directory:               ./input/USAF_FORCING/IMERG
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V07B            # V07B released 1 Jun 2024
+AGRMET IMERG version:                      V07C            # V07C released 4 Mar 2026
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings


### PR DESCRIPTION
### Description

Two necessary changes:

(1) IMERG will upgrade to V07C on 4 Mar 2026.  So, the FOC files for NRT and
    NRT-Streamflow must be updated accordingly.
(2) 16 WS is adding instantaneous skin temperature to the MR output in Prod.
    So, MODEL_OUTPUT_LIST.TBL files from the use cases are added to the FOC
    directory, and are modified to turn this additional variable on for
    output.

NOTE:  These changes are restricted to two LSMs (noah39 and noahmp401), and to one routing model (RAPID) if relevant.  Jules50 and HYMAP are not used in NRT, NRT-Streamflow, and MR configurations in Prod, so no changes are made to those files.