### PR TITLE
Correct ending date in lvt.config file

### DIFF
--- a/lis/testcases/dataassim/wus_ucla/lvt.config
+++ b/lis/testcases/dataassim/wus_ucla/lvt.config
@@ -14,8 +14,8 @@ Starting day:                              01
 Starting hour:                             0
 Starting minute:                           0
 Starting second:                           0
-Ending year:                               2018
-Ending month:                              04
+Ending year:                               2017 #2018
+Ending month:                              11 #04
 Ending day:                                01
 Ending hour:                               0  
 Ending minute:                             0


### PR DESCRIPTION
### Description

Correct ending date in lvt.config file for the WUS_UCLA testcase.
