### PR TITLE
Patch/s2s updates

### DIFF
--- a/lis/utils/usaf/S2S/docs/README_ghis2s-cylc.md
+++ b/lis/utils/usaf/S2S/docs/README_ghis2s-cylc.md
@@ -74,6 +74,8 @@ s2s_run.py -y YYYY -m M -c CONFIG_FILE -j
 - **"USER_EMAIL"**: (str, email_address)
 - **"S2S_STEP"**: (str, "E2E", )
 - **"ONE_STEP"**: (bool, False)
+- **"PF_SLURM"**: (str, "slurm-ghi") name of the slurm platform in global.cylc
+- **"PF_LHOST"**: (str, "localhost-ghi") name of the localhost platform in global.cylc 
 
 ### Acceptable keys for S2S_STEP:
 - `E2E`: end-to-end S2S forecast

--- a/lis/utils/usaf/S2S/ghis2s/cylc_script/ghis2s_program.py
+++ b/lis/utils/usaf/S2S/ghis2s/cylc_script/ghis2s_program.py
@@ -20,6 +20,8 @@ ENV_DEFINITION = {
     "SUBMIT_JOB": (bool, False),
     "E2ESDIR": (str, "/discover/nobackup/projects/ghilis/smahanam/ghi-coupling/"),
     "PYTHONPATH": (str, None),
+    "PF_SLURM": (str, "slurm-ghi"),
+    "PF_LHOST": (str, "localhost-ghi"),
 }
 
 # NOTE 1: Allowed S2S_STEP values are: LISDA, LDTICS, BCSD, FCST, POST, METRICS or PLOTS
@@ -286,6 +288,8 @@ class Ghis2sProgram():
         filedata = filedata.replace('--error ', '--error=')
         filedata = filedata.replace('--exclusive', '--exclusive=')
         filedata = filedata.replace('-N ', '--nodes=')
+        filedata = filedata.replace('PF_SLURM', self.env["PF_SLURM"])
+        filedata = filedata.replace('PF_LHOST', self.env["PF_LHOST"])
 
         with config_file.open('w', encoding="utf-8") as file:
             file.write(filedata)

--- a/lis/utils/usaf/S2S/ghis2s/lis_darun/template_files/lis.config_template.GLOBAL
+++ b/lis/utils/usaf/S2S/ghis2s/lis_darun/template_files/lis.config_template.GLOBAL
@@ -245,9 +245,9 @@ AGRMET CMORPH minimum temperature threshold:    273
 # Use IMERG rainfall data
 AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
-AGRMET IMERG data directory:               ./IMERG/Early_V07B
+AGRMET IMERG data directory:               ./IMERG/Early_V07C
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V07B            # V07B released Jun-1-2024
+AGRMET IMERG version:                      V07C            # V07C released early March-2026
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings

--- a/lis/utils/usaf/S2S/ghis2s/s2s_app/s2s_run.py
+++ b/lis/utils/usaf/S2S/ghis2s/s2s_app/s2s_run.py
@@ -1017,16 +1017,16 @@ class S2Srun(DownloadForecasts):
 
             file.write("    [[log_monitor]]\n")
             file.write(f"        script = {self.scrdir}ghis2s_log.sh\n")
-            file.write("        platform = PF_LHOST\n") 
+            file.write("        platform = PF_LHOST\n")
             file.write("  \n")
 
             file.write("    [[final_log_collect]]\n")
             file.write(f"        script = {self.scrdir}ghis2s_log.sh\n")
-            file.write("        platform = PF_LHOST\n") 
+            file.write("        platform = PF_LHOST\n")
             file.write("  \n")
 
             file.write("    [[stop_log_monitor]]\n")
-            file.write("        platform = PF_LHOST\n") 
+            file.write("        platform = PF_LHOST\n")
             file.write("        script = \"\"\"\n")
             file.write("            cylc stop $CYLC_WORKFLOW_ID --now\n")
             file.write("        \"\"\"\n")
@@ -1887,7 +1887,7 @@ class S2Srun(DownloadForecasts):
             utils.remove_sbatch_lines(jobname + f'{i+1:02d}_run.sh')
             #utils.cylc_job_scripts(jobname + 'run.sh', 4, cwd, command_list=slurm_commands)
 
-        # write tiff files
+        # write monthly tiff files
         jobname='s2smetric_tiff_'
         prev = [f"{key}" for key in self.schedule.keys() if 's2smetric_0' in key]
         par_info = {}
@@ -1903,7 +1903,7 @@ class S2Srun(DownloadForecasts):
         try:
             s2s_api.python_job_file(
                 self.e2esroot +'/' + self.config_file, 's2smetric_tiff_run.j',
-                's2smetric_tiff_', 1, str(1), cwd, tfile.name, parallel_run=par_info)
+                's2smetric_tiff_', 1, str(2), cwd, tfile.name, parallel_run=par_info)
             self.create_dict('s2smetric_tiff_run.j', 's2smetric', prev=prev)
         finally:
             tfile.close()
@@ -1913,7 +1913,7 @@ class S2Srun(DownloadForecasts):
         utils.remove_sbatch_lines(jobname + 'run.sh')
         #utils.cylc_job_scripts(jobname + 'run.sh', 3, cwd, command_list=command)
 
-        # write tiff files
+        # write weekly tiff files
         jobname='s2smetric_weekly_tiff_'
         prev = [f"{key}" for key in self.schedule.keys() if 's2smetric_weekly_0' in key]
         par_info = {}
@@ -1929,7 +1929,7 @@ class S2Srun(DownloadForecasts):
         try:
             s2s_api.python_job_file(self.e2esroot +'/' + self.config_file,
                                     's2smetric_weekly_tiff_run.j', 's2smetric_weekly_tiff_', 1,
-                                    str(1), cwd, tfile.name, parallel_run=par_info)
+                                    str(2), cwd, tfile.name, parallel_run=par_info)
             self.create_dict('s2smetric_weekly_tiff_run.j', 's2smetric', prev=prev)
         finally:
             tfile.close()

--- a/lis/utils/usaf/S2S/ghis2s/s2s_app/s2s_run.py
+++ b/lis/utils/usaf/S2S/ghis2s/s2s_app/s2s_run.py
@@ -993,7 +993,7 @@ class S2Srun(DownloadForecasts):
             # Write runtime section
             file.write("[runtime]\n")
             file.write("    [[root]]\n")
-            file.write("        platform = slurm-ghi\n")
+            file.write("        platform = PF_SLURM\n")
             file.write("        pre-script = \"\"\"\n")
             if 'discover' in platform.node() or 'borg' in platform.node():
                 file.write("            source /etc/profile.d/modules.sh\n")
@@ -1017,16 +1017,16 @@ class S2Srun(DownloadForecasts):
 
             file.write("    [[log_monitor]]\n")
             file.write(f"        script = {self.scrdir}ghis2s_log.sh\n")
-            file.write("        platform = localhost-ghi\n")
+            file.write("        platform = PF_LHOST\n") 
             file.write("  \n")
 
             file.write("    [[final_log_collect]]\n")
             file.write(f"        script = {self.scrdir}ghis2s_log.sh\n")
-            file.write("        platform = localhost-ghi\n")
+            file.write("        platform = PF_LHOST\n") 
             file.write("  \n")
 
             file.write("    [[stop_log_monitor]]\n")
-            file.write("        platform = localhost-ghi\n")
+            file.write("        platform = PF_LHOST\n") 
             file.write("        script = \"\"\"\n")
             file.write("            cylc stop $CYLC_WORKFLOW_ID --now\n")
             file.write("        \"\"\"\n")
@@ -1840,8 +1840,10 @@ class S2Srun(DownloadForecasts):
             try:
                 s2s_api.python_job_file(self.e2esroot +'/' + self.config_file, jobname + \
                                         f'{i+1:02d}_run.j',
-                                        jobname + f'{i+1:02d}_', 1, str(1), cwd, tfile.name,
+                                        jobname + f'{i+1:02d}_', 1, str(2), cwd, tfile.name,
                                         parallel_run=par_info)
+#                                        jobname + f'{i+1:02d}_', 1, str(1), cwd, tfile.name,
+#                                        parallel_run=par_info)
                 self.create_dict(jobname + f'{i+1:02d}_run.j', 's2smetric', prev=prev)
             finally:
                 tfile.close()
@@ -1872,8 +1874,10 @@ class S2Srun(DownloadForecasts):
             tfile = self.sublist_to_file(slurm_commands, cwd)
             try:
                 s2s_api.python_job_file(self.e2esroot +'/' + self.config_file, jobname + \
-                                        f'{i+1:02d}_run.j', jobname + f'{i+1:02d}_', 1, str(1),
+                                        f'{i+1:02d}_run.j', jobname + f'{i+1:02d}_', 1, str(2),
                                         cwd, tfile.name, parallel_run=par_info)
+#                                        f'{i+1:02d}_run.j', jobname + f'{i+1:02d}_', 1, str(1),
+#                                        cwd, tfile.name, parallel_run=par_info)
                 self.create_dict(jobname + f'{i+1:02d}_run.j', 's2smetric', prev=prev)
             finally:
                 tfile.close()

--- a/lis/utils/usaf/S2S/ghis2s/s2smetric/compute_weekly_anom.py
+++ b/lis/utils/usaf/S2S/ghis2s/s2smetric/compute_weekly_anom.py
@@ -273,8 +273,8 @@ def process_variable(var_name, anom):
         'units': '1'
     }
     anom_xr['time'].attrs = {
-        'long_name': 'Forecast month',
-        'units': 'months'
+        'long_name': 'Forecast week',
+        'units': 'week'
     }
     anom_xr[var_name + '_' + anom].attrs = {
         'long_name': long_names[var_name],

--- a/lis/utils/usaf/S2S/global_usaf_forc/input/lis.config.template
+++ b/lis/utils/usaf/S2S/global_usaf_forc/input/lis.config.template
@@ -244,9 +244,9 @@ AGRMET CMORPH minimum temperature threshold:      273
 # Use IMERG rainfall data
 AGRMET use IMERG data:                     1               # 1 = Use
 AGRMET IMERG temperature threshold:        278
-AGRMET IMERG data directory:               ./input/IMERG/Early_V07B
+AGRMET IMERG data directory:               ./input/IMERG/Early_V07C
 AGRMET IMERG product:                      3B-HHR-E        # Early Run
-AGRMET IMERG version:                      V07B            # V07B released in 2024
+AGRMET IMERG version:                      V07C            # V07C released early March-2026
 AGRMET IMERG Probability Liquid Precip Threshold: 100
 
 # Bratseth runtime settings


### PR DESCRIPTION
Latest S2S Updates for LISV7.7.1 patch

 Incorporated:
 - Updated any LIS config template files to reflect latest IMERG V07C naming convention
 - Fix to weekly s2smetric netcdf file time unit 
 - Allow for user configurable platform and slurm host (via env variable entries)
 - Updated a README file for the new configurable env variable options
 - Increase slurm job submission time to 2 hours for the s2smetric jobs (to allow for expansion of new vars and metrics)

