### PR TITLE
Clean-up of WSF-M code in LIS

### DIFF
--- a/lis/dataassim/obs/WSF_sm/WSFsm_Mod.F90
+++ b/lis/dataassim/obs/WSF_sm/WSFsm_Mod.F90
@@ -120,7 +120,7 @@ contains
 !   \end{description}
 !EOP
     real, parameter                   ::  minssdev =0.001
-    integer                           ::  n,i,t,kk,jj
+    integer                           ::  n,i,t,jj
     integer                           ::  ftn
     integer                           ::  status
     type(ESMF_Field)                  ::  obsField(LIS_rc%nnest)
@@ -136,11 +136,10 @@ contains
     type(pert_dec_type)               ::  obs_pert
     real, pointer                     ::  obs_temp(:,:)
     real, allocatable                 ::  ssdev(:)
-    real, allocatable                 ::  obserr(:,:)
-    real, allocatable                 ::  lobserr(:,:)
-    integer                           ::  c,r
-    real, allocatable                 ::  ssdev_grid(:,:)
     integer                           ::  ngrid
+
+    external :: bilinear_interp_input_withgrid
+    external :: upscaleByAveraging_input
 
     allocate(WSFsm_struc(LIS_rc%nnest))
 

--- a/lis/dataassim/obs/WSF_sm/read_WSFsm.F90
+++ b/lis/dataassim/obs/WSF_sm/read_WSFsm.F90
@@ -57,7 +57,7 @@ subroutine read_WSFsm(n, k, OBS_State, OBS_Pert_State)
    integer                :: grid_index
    character(len=LIS_CONST_PATH_LEN) :: smobsdir
    character(len=LIS_CONST_PATH_LEN) :: fname
-   logical                :: alarmCheck, file_exists
+   logical                :: alarmCheck
    integer                :: t, c, r, jj
    real,          pointer :: obsl(:)
    type(ESMF_Field)       :: smfield, pertField
@@ -68,21 +68,16 @@ subroutine read_WSFsm(n, k, OBS_State, OBS_Pert_State)
    logical                :: data_upd_flag(LIS_npes)
    logical                :: data_upd_flag_local
    logical                :: data_upd
-   real                   :: smobs(LIS_rc%obs_lnc(k)*LIS_rc%obs_lnr(k))
    real                   :: smobs_D(LIS_rc%obs_lnc(k)*LIS_rc%obs_lnr(k))
    real                   :: smobs_A(LIS_rc%obs_lnc(k)*LIS_rc%obs_lnr(k))
    real                   :: sm_current(LIS_rc%obs_lnc(k), LIS_rc%obs_lnr(k))
    real                   :: dt
-   real                   :: lon
-   real                   :: lhour
    real                   :: gmt
-   integer                :: zone
    integer                :: fnd
    real, allocatable      :: ssdev(:)
-   character*4            :: yyyy
    character*8            :: yyyymmdd
-   character*2            :: mm, dd, hh
-   integer                :: yr, mo, da, hr, mn, ss
+   character*2            :: hh
+   integer                :: mn, ss
    integer                :: cyr, cmo, cda, chr, cmn, css
    integer                :: nyr, nmo, nda, nhr, nmn, nss
    real*8                 :: timenow, time1,time2,time3
@@ -91,8 +86,10 @@ subroutine read_WSFsm(n, k, OBS_State, OBS_Pert_State)
    integer                :: mn_ind
    integer                :: ftn, ierr
    integer                :: rc
-   character(len=3)       :: CRID
    integer, external      :: create_filelist ! C function
+
+   external :: read_WSFsm_data
+   external :: lsmdaqcobsstate
 
    call ESMF_AttributeGet(OBS_State, "Data Directory", &
                           smobsdir, rc=status)
@@ -448,22 +445,22 @@ subroutine read_WSFsm_data(n, k,fname, smobs_inp, time)
   real*8                   :: time
 !EOP
   integer,  parameter     :: nc=2560, nr=1920
-  real*4                  :: sm_raw(WSFsm_struc(n)%nc,WSFsm_struc(n)%nr)
   real                    :: sm_in(WSFsm_struc(n)%nc*WSFsm_struc(n)%nr)
   real                    :: smobs_ip(LIS_rc%obs_lnc(k)*LIS_rc%obs_lnr(k))
   logical*1               :: sm_data_b(WSFsm_struc(n)%nc*WSFsm_struc(n)%nr)
   logical*1               :: smobs_b_ip(LIS_rc%obs_lnc(k)*LIS_rc%obs_lnr(k))
-  integer                 :: smid
-  integer                 :: ios, nid
+  integer                 :: ios
   integer                 :: c,r
   integer                 :: r_flip
-  integer                 :: ftn1
   logical :: file_exists
   character(255) :: map_projection
   integer :: ncid, dim_ids(3), var_id
   integer :: ntime, nlat, nlon
   real, allocatable :: tmp(:,:,:)
   integer :: rc
+
+  external :: bilinear_interp
+  external :: upscaleByAveraging
 
   sm_in = LIS_rc%udef
   sm_data_b = .false.

--- a/lis/dataassim/obs/WSF_sm/write_WSFsmobs.F90
+++ b/lis/dataassim/obs/WSF_sm/write_WSFsmobs.F90
@@ -48,6 +48,8 @@ subroutine write_WSFsmobs(n, k, OBS_State)
   integer                  :: ftn
   integer                  :: status
 
+  external :: WSFsm_obsname
+
   call ESMF_AttributeGet(OBS_State, "Data Update Status", &
        data_update, rc=status)
   call LIS_verify(status)


### PR DESCRIPTION

### Description

Removed unused variables, added external statements.  This is to appease the strict checks of ifort.
