### PR TITLE
Updates to Bratseth tuning software.

### DIFF
--- a/lis/utils/usaf/retune_bratseth/cfgs/autotune.cfg
+++ b/lis/utils/usaf/retune_bratseth/cfgs/autotune.cfg
@@ -3,15 +3,15 @@
 #
 
 [Input]
-workdir: /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf76_foc/NRT/lis/noah39_autotune
+workdir: /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf78_test_cases/nrt_lis_autotune_noahmp401
 
-scriptdir: /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf76_foc/NRT/lis/noah39_autotune/scripts
+scriptdir: /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf78_test_cases/nrt_lis_autotune_noahmp401/scripts
 
-cfgdir: /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf76_foc/NRT/lis/noah39_autotune/cfgs
+cfgdir: /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf78_test_cases/nrt_lis_autotune_noahmp401/cfgs
 
-bindir: /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf76_foc/NRT/lis/noah39_autotune/bin
+bindir: /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf78_test_cases/nrt_lis_autotune_noahmp401/src
 
-lis_cfg_template: /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf76_foc/NRT/lis/noah39_autotune/lis.config.new
+lis_cfg_template: /discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf78_test_cases/nrt_lis_autotune_noahmp401/input/lis.config.tmpl
 
 varlist: rh2m,spd10m,t2m,gage,imerg
 

--- a/lis/utils/usaf/retune_bratseth/cfgs/blacklist_gage.cfg
+++ b/lis/utils/usaf/retune_bratseth/cfgs/blacklist_gage.cfg
@@ -7,6 +7,6 @@ network_thresh: 1
 count_thresh: 0
 omb_thresh: 10
 
-data_directory: precip_OBA
+data_directory: ./input/precip_OBA
 data_frequency: 12
 data_hours: 00,06,12,18

--- a/lis/utils/usaf/retune_bratseth/cfgs/blacklist_rh2m.cfg
+++ b/lis/utils/usaf/retune_bratseth/cfgs/blacklist_rh2m.cfg
@@ -7,6 +7,6 @@ network_thresh: 1
 count_thresh: 28
 omb_thresh: 25
 
-data_directory: rh2m_OBA
+data_directory: ./input/rh2m_OBA
 data_frequency: 01
 data_hours: 00,06,12,18

--- a/lis/utils/usaf/retune_bratseth/cfgs/blacklist_spd10m.cfg
+++ b/lis/utils/usaf/retune_bratseth/cfgs/blacklist_spd10m.cfg
@@ -7,6 +7,6 @@ network_thresh: 1
 count_thresh: 28
 omb_thresh: 1.
 
-data_directory: spd10m_OBA
+data_directory: ./input/spd10m_OBA
 data_frequency: 01
 data_hours: 00,06,12,18

--- a/lis/utils/usaf/retune_bratseth/cfgs/blacklist_t2m.cfg
+++ b/lis/utils/usaf/retune_bratseth/cfgs/blacklist_t2m.cfg
@@ -7,6 +7,6 @@ network_thresh: 1
 count_thresh: 28
 omb_thresh: 2.
 
-data_directory: t2m_OBA
+data_directory: ./input/t2m_OBA
 data_frequency: 01
 data_hours: 00,06,12,18

--- a/lis/utils/usaf/retune_bratseth/cfgs/procOBA_NWP.gage.config
+++ b/lis/utils/usaf/retune_bratseth/cfgs/procOBA_NWP.gage.config
@@ -1,7 +1,7 @@
-max_stations:      6000
+max_stations:    20000
 max_vario_bins:     51
 vario_bin_dist:     10
-datadir: "./precip_OBA"
+datadir: "./input/precip_OBA"
 obtype: Gage
 use_blacklist: true
 blacklist_file: blacklist_precip.txt

--- a/lis/utils/usaf/retune_bratseth/cfgs/procOBA_NWP.rh2m.config
+++ b/lis/utils/usaf/retune_bratseth/cfgs/procOBA_NWP.rh2m.config
@@ -1,7 +1,7 @@
-max_stations:     10000
-max_vario_bins:     51
-vario_bin_dist:     10
-datadir: "./rh2m_OBA"
+max_stations:    20000
+max_vario_bins:     21
+vario_bin_dist:      5
+datadir: "./input/rh2m_OBA"
 obtype: RH2M
 use_blacklist: true
 blacklist_file: blacklist_rh2m.txt

--- a/lis/utils/usaf/retune_bratseth/cfgs/procOBA_NWP.spd10m.config
+++ b/lis/utils/usaf/retune_bratseth/cfgs/procOBA_NWP.spd10m.config
@@ -1,7 +1,7 @@
-max_stations:     10000
-max_vario_bins:     51
-vario_bin_dist:     10
-datadir: "./spd10m_OBA"
+max_stations:    20000
+max_vario_bins:     21
+vario_bin_dist:      5
+datadir: "./input/spd10m_OBA"
 obtype: SPD10M
 use_blacklist: true
 blacklist_file: blacklist_spd10m.txt

--- a/lis/utils/usaf/retune_bratseth/cfgs/procOBA_NWP.t2m.config
+++ b/lis/utils/usaf/retune_bratseth/cfgs/procOBA_NWP.t2m.config
@@ -1,7 +1,7 @@
-max_stations:     10000
-max_vario_bins:     51
-vario_bin_dist:     10
-datadir: "./t2m_OBA"
+max_stations:     20000
+max_vario_bins:     21
+vario_bin_dist:      5
+datadir: "./input/t2m_OBA"
 obtype: T2M
 use_blacklist: true
 blacklist_file: blacklist_t2m.txt

--- a/lis/utils/usaf/retune_bratseth/cfgs/procOBA_Sat.imerg.config
+++ b/lis/utils/usaf/retune_bratseth/cfgs/procOBA_Sat.imerg.config
@@ -1,8 +1,8 @@
-max_stations:        10000
+max_stations:        20000
 max_sat_reports:   1750000
 max_vario_bins:     51
 vario_bin_dist:     10
-datadir: "./precip_OBA"
+datadir: "./input/precip_OBA"
 sattype: IMERG
 use_blacklist: true
 blacklist_file: blacklist_gage.txt

--- a/lis/utils/usaf/retune_bratseth/cfgs/rh2m.cfg
+++ b/lis/utils/usaf/retune_bratseth/cfgs/rh2m.cfg
@@ -4,7 +4,7 @@
 
 [Input]
 vario_filename: ./semivariogram_rh2m_nwp.out
-max_distance: 500
+max_distance: 100
 
 [Fit]
 function_type: Gaussian

--- a/lis/utils/usaf/retune_bratseth/cfgs/spd10m.cfg
+++ b/lis/utils/usaf/retune_bratseth/cfgs/spd10m.cfg
@@ -4,7 +4,7 @@
 
 [Input]
 vario_filename: ./semivariogram_spd10m_nwp.out
-max_distance: 500
+max_distance: 100
 
 [Fit]
 function_type: Gaussian

--- a/lis/utils/usaf/retune_bratseth/cfgs/t2m.cfg
+++ b/lis/utils/usaf/retune_bratseth/cfgs/t2m.cfg
@@ -4,7 +4,7 @@
 
 [Input]
 vario_filename: ./semivariogram_t2m_nwp.out
-max_distance: 500
+max_distance: 100
 
 [Fit]
 function_type: Gaussian

--- a/lis/utils/usaf/retune_bratseth/scripts/run_autotune_discover.sh
+++ b/lis/utils/usaf/retune_bratseth/scripts/run_autotune_discover.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #SBATCH --job-name=autotune
-#SBATCH --time=0:30:00
+#SBATCH --time=1:00:00
 #SBATCH --account s1189
 #SBATCH --output autotune.slurm.out
 #SBATCH --ntasks=5 --ntasks-per-node=1 --constraint="[mil]"
@@ -47,9 +47,9 @@ NWPVARS=(gage rh2m spd10m t2m)
 SATVARS=(imerg)
 
 # Paths on local system
-SCRIPTDIR=/discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf76_foc/NRT/lis/noah39_autotune/scripts
-CFGDIR=/discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf76_foc/NRT/lis/noah39_autotune/cfgs
-BINDIR=/discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf76_foc/NRT/lis/noah39_autotune/bin
+SCRIPTDIR=/discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf78_test_cases/nrt_lis_autotune_noahmp401/scripts
+CFGDIR=/discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf78_test_cases/nrt_lis_autotune_noahmp401/cfgs
+BINDIR=/discover/nobackup/projects/usaf_lis/emkemp/AFWA/lisf78_test_cases/nrt_lis_autotune_noahmp401/src
 
 # Get the command line arguments to specify the training period.
 if [ -z "$1" ] ; then

--- a/lis/utils/usaf/retune_bratseth/scripts/run_lis_autotune_noah39_hpc11.sh
+++ b/lis/utils/usaf/retune_bratseth/scripts/run_lis_autotune_noah39_hpc11.sh
@@ -44,9 +44,9 @@ NWPVARS=(gage rh2m spd10m t2m)
 SATVARS=(imerg)
 
 # Paths on local system. Customize before running this script.
-SCRIPTDIR=/lustre/typhoon/nwp601/proj-shared/emkemp/lisf761_testing/nrt_lis_autotune_noah39/work/scripts
-CFGDIR=/lustre/typhoon/nwp601/proj-shared/emkemp/lisf761_testing/nrt_lis_autotune_noah39/work/cfgs
-BINDIR=/lustre/typhoon/nwp601/proj-shared/emkemp/lisf761_testing/LISF/lis/utils/usaf/retune_bratseth/src
+SCRIPTDIR=/lustre/typhoon/nwp601/proj-shared/emkemp/LISFV7.8/nrt_lis_autotune_noah39/scripts
+CFGDIR=/lustre/typhoon/nwp601/proj-shared/emkemp/LISFV7.8/nrt_lis_autotune_noah39/cfgs
+BINDIR=/lustre/typhoon/nwp601/proj-shared/emkemp/LISFV7.8/nrt_lis_autotune_noah39/src
 
 # Get the command line arguments to specify the training period.
 if [ -z "$1" ] ; then

--- a/lis/utils/usaf/retune_bratseth/scripts/run_lis_autotune_noahmp401_hpc11.sh
+++ b/lis/utils/usaf/retune_bratseth/scripts/run_lis_autotune_noahmp401_hpc11.sh
@@ -44,9 +44,9 @@ NWPVARS=(gage rh2m spd10m t2m)
 SATVARS=(imerg)
 
 # Paths on local system. Customize before running this script.
-SCRIPTDIR=/lustre/typhoon/nwp601/proj-shared/emkemp/lisf761_testing/nrt_lis_autotune_noahmp401/work/scripts
-CFGDIR=/lustre/typhoon/nwp601/proj-shared/emkemp/lisf761_testing/nrt_lis_autotune_noahmp401/work/cfgs
-BINDIR=/lustre/typhoon/nwp601/proj-shared/emkemp/lisf761_testing/LISF/lis/utils/usaf/retune_bratseth/src
+SCRIPTDIR=/lustre/typhoon/nwp601/proj-shared/emkemp/LISFV7.8/nrt_lis_autotune_noahmp401/scripts
+CFGDIR=/lustre/typhoon/nwp601/proj-shared/emkemp/LISFV7.8/nrt_lis_autotune_noahmp401/cfgs
+BINDIR=/lustre/typhoon/nwp601/proj-shared/emkemp/LISFV7.8/nrt_lis_autotune_noahmp401/src
 
 # Get the command line arguments to specify the training period.
 if [ -z "$1" ] ; then


### PR DESCRIPTION

### Description

Updates to Bratseth tuning software.

The biggest changes are for RH2M, SPD10M, and T2M.  The range of comparisons is limited to 100 km, and the bins are reduced to 5 km.  This is to address strange semivariogram shapes at larger distances. (Precip remains at 500 km and 10 km, respectively.)

Otherwise, minor tweaks based on latest use cases.



