### PR TITLE
Fix incompatible function pointer types gcc 15+

### DIFF
--- a/lis/core/LIS_optUEMod.F90
+++ b/lis/core/LIS_optUEMod.F90
@@ -275,10 +275,8 @@ contains
 !  \end{description}
 !EOP    
     implicit none 
-    
-    logical         :: rstflag
 
-    call optuereadrestart(trim(LIS_rc%optuealg)//char(0), rstflag)
+    call optuereadrestart(trim(LIS_rc%optuealg)//char(0))
 
   end subroutine LIS_optUEAlg_readrestart
 

--- a/lis/core/LIS_optUE_FTable.c
+++ b/lis/core/LIS_optUE_FTable.c
@@ -89,7 +89,7 @@ struct optuegetnpnode* optuegetnp_table = NULL;
 struct optuerstnode
 { 
   char *name;
-  void (*func)();
+  void (*func)(void*);
 
   struct optuerstnode* next;
 } ;
@@ -780,7 +780,7 @@ void FTN(registeroptuereadrestart)(char *j, void (*func)(void*),int len)
 // \label{optuereadrestart}
 // 
 // !INTERFACE:
-void FTN(optuereadrestart)(char *j,int len)
+void FTN(optuereadrestart)(char *j,void *rstflag,int len)
 //  
 // !DESCRIPTION: 
 // Invokes the routine from the registry to retrieve 
@@ -808,7 +808,7 @@ void FTN(optuereadrestart)(char *j,int len)
       printf("****************Error****************************\n"); 
     }
   }
-  current->func(); 
+  current->func(rstflag);
 }
 
 //BOP

--- a/lis/core/LIS_optUE_FTable.c
+++ b/lis/core/LIS_optUE_FTable.c
@@ -738,7 +738,7 @@ void FTN(getoptuealgnparam)(char *j, void *nparam,int len)
 //  
 // 
 // !INTERFACE:
-void FTN(registeroptuereadrestart)(char *j, void (*func)(void*),int len)
+void FTN(registeroptuereadrestart)(char *j, void (*func)(),int len)
 //
 // !DESCRIPTION: 
 //  Creates an entry in the registry for the routine that

--- a/lis/core/LIS_optUE_FTable.c
+++ b/lis/core/LIS_optUE_FTable.c
@@ -89,7 +89,7 @@ struct optuegetnpnode* optuegetnp_table = NULL;
 struct optuerstnode
 { 
   char *name;
-  void (*func)(void*);
+  void (*func)();
 
   struct optuerstnode* next;
 } ;
@@ -780,7 +780,7 @@ void FTN(registeroptuereadrestart)(char *j, void (*func)(void*),int len)
 // \label{optuereadrestart}
 // 
 // !INTERFACE:
-void FTN(optuereadrestart)(char *j,void *rstflag,int len)
+void FTN(optuereadrestart)(char *j,int len)
 //  
 // !DESCRIPTION: 
 // Invokes the routine from the registry to retrieve 
@@ -808,7 +808,7 @@ void FTN(optuereadrestart)(char *j,void *rstflag,int len)
       printf("****************Error****************************\n"); 
     }
   }
-  current->func(rstflag);
+  current->func(); 
 }
 
 //BOP


### PR DESCRIPTION
### Description

Resolves #1818 

- Update the restart registry callback type from void (*func)() to void (*func)(void*) so it matches the registered function signature.
- Change FTN(optuereadrestart) to accept a restart flag pointer (void *rstflag) and forward it to the callback.
- Replace the callback invocation from current->func(); to current->func(rstflag);.

### Testcase
Needs proper testing. Compiles fine with gcc-15


