### PR TITLE
Add pio option to configure

### DIFF
--- a/docs/LIS_users_guide/build.adoc
+++ b/docs/LIS_users_guide/build.adoc
@@ -48,6 +48,7 @@ Set the appropriate LIS environment variables.  These are used to control the co
 | `LIS_PETSC`     | path to PETSc library            | optional
 | `LIS_JPEG`      | path to JPEG library             | optional (use system libjpeg by default)
 | `LIS_RPC`       | path to RPC library              | optional (use system RPC library by default)
+| `LIS_PIO`       | path to PIO library              | optional (only for NASA Land Coupler (NLC) and NASA Water Insight projects)
 |====
 
 Set the `LIS_ARCH` environment variable based on the system you are using.  The following commands are written using Bash shell syntax.
@@ -141,6 +142,7 @@ Use LIS-CMEM? (1-yes, 0-no, default=0):
 Use LIS-LAPACK? (0-no, 1-mkl, 2-lapack/blas, 3-lapack/refblas, default=0):
 Use PETSc? (1-yes, 0-no, default=0):
 Enable USAF LIS75 SM DA codes? (1-yes, 0-no, default=0):
+Use PIO? (1-yes, 0-no, default=0):
 -----------------------------------------------------
  configure.lis file generated successfully
 -----------------------------------------------------
@@ -189,6 +191,8 @@ select the type of LAPACK library that you have installed.  This is used with `U
 |====
 +
 For example, on a Cray system using the Cray compilers, select 0 because the linker will find Cray's LAPACK libraries.
+
+* for `Use PIO? (1-yes, 0-no, default=0):`, if you wish to enable PIO support, then you must either set the `LIS_PIO` environment variable or the `LIS_PIO_IN_ESMF` environment variable.  If you are using the PIO library, then set `LIS_PIO` to the path of the PIO library.  If you are using PIO included in ESMF, then set `LIS_PIO_IN_ESMF=1`.
 
 Note that due to an issue involving multiple definitions within the NetCDF 3 and HDF 4 libraries, you cannot compile LIS with support for both NetCDF 3 and HDF 4 together.
 

--- a/lis/arch/Config.pl
+++ b/lis/arch/Config.pl
@@ -863,6 +863,38 @@ if($use_usaf_lis75_smda eq ""){
    $use_usaf_lis75_smda=0;
 }
 
+print "Use PIO? (1-yes, 0-no, default=0): ";
+$use_pio=<stdin>;
+$use_pio=~s/ *#.*$//;
+chomp($use_pio);
+if($use_pio eq ""){
+   $use_pio=0;
+}
+
+if($use_pio == 1) {
+   if(defined($ENV{LIS_PIO})){
+      $sys_pio_path = $ENV{LIS_PIO};
+      $inc = "/include/";
+      $lib = "/lib/";
+      $inc_pio=$sys_pio_path.$inc;
+      $lib_pio=$sys_pio_path.$lib;
+   }
+   elsif(defined($ENV{LIS_PIO_IN_ESMF}) && $ENV{LIS_PIO_IN_ESMF} eq "1"){
+      $inc_pio=$sys_esmfmod_path;
+      $lib_pio=$sys_esmflib_path;
+   }
+   else {
+      print "--------------ERROR---------------------\n";
+      print "Please specify the PIO path using\n";
+      print "the LIS_PIO variable or set the\n";
+      print "LIS_PIO_IN_ESMF variable if PIO is\n";
+      print "embedded in ESMF.\n";
+      print "Configuration exiting ....\n";
+      print "--------------ERROR---------------------\n";
+      exit 1;
+   }
+}
+
 if(defined($ENV{LIS_JPEG})){
    $libjpeg = "-L".$ENV{LIS_JPEG}."/lib"." -ljpeg";
 }
@@ -1073,6 +1105,14 @@ elsif($use_lapack == 3){
    $lib_paths= $lib_paths." -L\$(LIB_LAPACK)";
 }
 
+if($use_pio == 1) {
+   $fflags77 = $fflags77." -I\$(INC_PIO)";
+   $fflags = $fflags." -I\$(INC_PIO)";
+   $ldflags = $ldflags." -L\$(LIB_PIO) -lpioc";
+   $lib_flags= $lib_flags." -lpioc";
+   $lib_paths= $lib_paths." -L\$(LIB_PIO)";
+}
+
 if($use_esmf_trace == 1){
    $fflags77 = $fflags77." -DESMF_TRACE";
    $fflags = $fflags." -DESMF_TRACE";
@@ -1166,6 +1206,8 @@ printf conf_file "%s%s\n","LIB_CMEM        = $lib_cmem";
 printf conf_file "%s%s\n","LIB_LAPACK      = $lib_lapack";
 printf conf_file "%s%s\n","INC_PETSC       = $inc_petsc";
 printf conf_file "%s%s\n","LIB_PETSC       = $lib_petsc";
+printf conf_file "%s%s\n","INC_PIO         = $inc_pio";
+printf conf_file "%s%s\n","LIB_PIO         = $lib_pio";
 printf conf_file "%s%s\n","CFLAGS          = $cflags";
 printf conf_file "%s%s\n","FFLAGS77        = $fflags77";
 printf conf_file "%s%s\n","FFLAGS          = $fflags";


### PR DESCRIPTION
### Description
Resolves #1744

Add `Use PIO?` option to Config.pl. The default for this option is `0-no`. PIO location can be defined using `LIS_PIO` or setting `LIS_PIO_IN_ESMF = 1`. The latter will use the ESMF library location to set the PIO library and include locations. If neither environment variable is set than Config.pl throws an error.

### Testcase
Build LIS on Discover including the esmf/8.6.1_intel-2023.2.1_impi-2021.11 library
`/discover/nobackup/projects/lis/libs/sles-15.4/esmf/8.6.1_intel-2023.2.1_impi-2021.11/`


