### PR TITLE
Support compiling LISF without GRIB support

### DIFF
--- a/lis/metforcing/usaf/AGRMET_fldbld_gfs.F90
+++ b/lis/metforcing/usaf/AGRMET_fldbld_gfs.F90
@@ -419,8 +419,8 @@ subroutine AGRMET_fldbld_gfs(n,order,julhr,rc)
      found = .true.
      exit
 
-  end do
 #endif     
+  end do
 
   ! Give up if no acceptable GFS files were found
   if (.not. found) then

--- a/lis/routing/HYMAP3_router/runoffdata/GLDAS1data/readGLDAS1runoffdata.F90
+++ b/lis/routing/HYMAP3_router/runoffdata/GLDAS1data/readGLDAS1runoffdata.F90
@@ -269,6 +269,7 @@ subroutine retrieve_GLDAS1data(igrib, nc, nr, nvars, index, gldas_var)
   integer              :: c,r,ios
   real                 :: var(nvars,nc*nr)
 
+#if ( defined USE_GRIBAPI)
   call grib_get(igrib,"values",var(index,:),ios)
   call LIS_verify(ios,                                            &
        'grib_get failed for values in readGLDAS1data')
@@ -280,6 +281,7 @@ subroutine retrieve_GLDAS1data(igrib, nc, nr, nvars, index, gldas_var)
         endif
      enddo
   enddo
+#endif
 
 end subroutine retrieve_GLDAS1data
 

--- a/lis/routing/HYMAP3_router/runoffdata/NLDAS2data/readNLDAS2runoffdata.F90
+++ b/lis/routing/HYMAP3_router/runoffdata/NLDAS2data/readNLDAS2runoffdata.F90
@@ -261,6 +261,7 @@ subroutine retrieve_NLDAS2data(igrib, nc, nr, nvars, index, nldas_var)
   integer              :: c,r,ios
   real                 :: var(nvars,nc*nr)
 
+#if ( defined USE_GRIBAPI)
   call grib_get(igrib,"values",var(index,:),ios)
   call LIS_verify(ios,                                            &
        'grib_get failed for values in readNLDAS2data')
@@ -272,6 +273,7 @@ subroutine retrieve_NLDAS2data(igrib, nc, nr, nvars, index, nldas_var)
         endif
      enddo
   enddo
+#endif
 
 end subroutine retrieve_NLDAS2data
 


### PR DESCRIPTION
### Description

Several routines failed to compile when ecCodes was disabled at configure-time with:

`Use GRIBAPI/ECCODES? (0-neither, 1-gribapi, 2-eccodes, default=2): 0`