### PR TITLE
Add MERRA2bias meteorological forcing reader and testcase

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -351,6 +351,7 @@ Acceptable values for the sources are:
 |"`GLDAS`"                     | GLDAS
 |"`GFS`"                       | GFS
 |"`MERRA2`"                    | MERRA2
+|"`MERRA2bias`"                | MERRA2bias
 |"`GEOS-IT`"                   | GEOS-IT
 |"`CMAP`"                      | CMAP
 |"`TRMM 3B42RT`"               | TRMM 3B42RT
@@ -5780,6 +5781,79 @@ MERRA2 dynamic lapse rate data directory:             ./MERRA2_lapse_rates
 MERRA2 apply double-sided dynamic lapse rate cutoff:  1
 MERRA2 maximum lapse rate cutoff (K/m):               0.009
 MERRA2 minimum lapse rate cutoff (K/m):               -0.009
+....
+
+[[sssec_forcings_MERRA2bias,MERRA2bias]]
+==== MERRA2bias
+
+`MERRA2bias forcing directory:` specifies the location of
+the MERRA2 bias-corrected forcing files.
+
+`MERRA2bias apply dynamic lapse rates:` specifies whether to read
+in and apply the pre-computed MERRA2bias lapse rates.  This is an
+optional config entry; if not present, the default is 0.  Note
+that one of the two lapse-rate options for the topographic
+correction method for met forcing must be chosen for this
+config entry to be used.
+Acceptable values are:
+
+|====
+|Value | Description
+
+|0     | Do not apply MERRA2bias dynamic lapse rates (use static lapse rate).
+|1     | Apply MERRA2bias dynamic lapse rates
+|====
+
+`MERRA2bias dynamic lapse rate data directory:` specifies the
+directory of the pre-computed MERRA2bias lapse rate dataset.
+
+`MERRA2bias dynamic lapse rate filename prefix:` specifies the prefix
+of the pre-computed MERRA2bias lapse rate files. This is an optional
+config entry; if not present, the default is `/MERRA2bias.lapse_rate.hourly.`.
+
+`MERRA2bias dynamic lapse rate filename suffix:` specifies the suffix
+of the pre-computed MERRA2 lapse rate files. This is an optional
+config entry; if not present, the default is `.global.nc`.
+
+`MERRA2bias apply double-sided dynamic lapse rate cutoff:` specifies whether
+to apply a double-sided cutoff to the dynamic lapse rate values. This is
+an optional config entry; if not present, the default is 0. If set to 1,
+values above (below) the maximum (minimum) cutoff are replaced with the
+maximum (minimum) cutoff value. Maximum and minimum cutoff values can
+optionally be set using the MERRA2bias maximum and minimum lapse rate cutoff
+aguments, or otherwise are assumed the default cutoff values, as described
+below.
+
+|====
+|Value | Description
+
+|0     | Do not apply MERRA2bias double-sided dynamic lapse rate cutoff.
+|1     | Apply MERRA2bias double-sided dynamic lapse rate cutoff.
+|====
+
+`MERRA2bias maximum lapse rate cutoff (K/m):` specifies the maximum value
+for the MERRA2bias double-sided dynamic lapse rate cutoff range, in units
+of Kelvin per meter (K/m). This is an optional config entry; if
+not present, the default is set to 0.01 K/m. This is only applied if
+MERRA2bias apply double-sided dynamic lapse rate cutoff is turned on
+(i.e., set to a value of 1).
+
+`MERRA2bias minimum lapse rate cutoff (K/m):` specifies the minimum value
+for the MERRA2bias double-sided dynamic lapse rate cutoff range, in units
+of Kelvin per meter (K/m). This is an optional config entry; if
+not present, the default is set to -0.1 K/m. This is only applied if
+MERRA2bias apply double-sided dynamic lapse rate cutoff is turned on
+(i.e., set to a value of 1).
+
+.Example _lis.config_ entry
+
+....
+MERRA2bias forcing directory:                             ./MERRA2bias
+MERRA2bias apply dynamic lapse rates:                     1
+MERRA2bias dynamic lapse rate data directory:             ./MERRA2bias_lapse_rates
+MERRA2bias apply double-sided dynamic lapse rate cutoff:  1
+MERRA2bias maximum lapse rate cutoff (K/m):               0.009
+MERRA2bias minimum lapse rate cutoff (K/m):               -0.009
 ....
 
 [[sssec_forcings_GEOS-IT,GEOS-IT]]

--- a/lis/make/default.cfg
+++ b/lis/make/default.cfg
@@ -287,6 +287,11 @@ enabled: True
 macro: MF_MERRA2
 path: metforcing/merra2
 
+[MERRA2bias]
+enabled: True
+macro: MF_MERRA2bias
+path: metforcing/merra2bias
+
 [GEOS-IT]
 enabled: True
 macro: MF_GEOS_IT

--- a/lis/metforcing/merra2bias/0Intro_merra2bias.txt
+++ b/lis/metforcing/merra2bias/0Intro_merra2bias.txt
@@ -1,0 +1,14 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.4
+!
+! Copyright (c) 2022 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!
+!BOP
+!\section{MERRA2bias}
+!This section describes the implementation of the MERRA2bias forcing data.
+!EOP

--- a/lis/metforcing/merra2bias/finalize_merra2bias.F90
+++ b/lis/metforcing/merra2bias/finalize_merra2bias.F90
@@ -12,8 +12,6 @@
 ! \label{finalize_merra2bias}
 !
 ! !REVISION HISTORY:
-! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
-! 09 Jan 2026: Eric Kemp, reformatted.
 ! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
 !
 ! !INTERFACE:

--- a/lis/metforcing/merra2bias/finalize_merra2bias.F90
+++ b/lis/metforcing/merra2bias/finalize_merra2bias.F90
@@ -1,0 +1,73 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: finalize_merra2bias
+! \label{finalize_merra2bias}
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+! 09 Jan 2026: Eric Kemp, reformatted.
+! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
+!
+! !INTERFACE:
+subroutine finalize_merra2bias(findex)
+
+! !USES:
+  use LIS_coreMod,     only   : LIS_rc
+  use merra2bias_forcingMod, only : merra2bias_struc
+!
+! !DESCRIPTION:
+!  Routine to cleanup MERRA2bias forcing related memory allocations.
+!
+!EOP
+  implicit none
+
+  integer :: findex
+  integer :: n
+
+  do n = 1,LIS_rc%nnest
+     select case( LIS_rc%met_interp(findex) )
+
+     case( "bilinear" )
+        deallocate(merra2bias_struc(n)%n111)
+        deallocate(merra2bias_struc(n)%n121)
+        deallocate(merra2bias_struc(n)%n211)
+        deallocate(merra2bias_struc(n)%n221)
+        deallocate(merra2bias_struc(n)%w111)
+        deallocate(merra2bias_struc(n)%w121)
+        deallocate(merra2bias_struc(n)%w211)
+        deallocate(merra2bias_struc(n)%w221)
+
+     case( "budget-bilinear" )
+        deallocate(merra2bias_struc(n)%n111)
+        deallocate(merra2bias_struc(n)%n121)
+        deallocate(merra2bias_struc(n)%n211)
+        deallocate(merra2bias_struc(n)%n221)
+        deallocate(merra2bias_struc(n)%w111)
+        deallocate(merra2bias_struc(n)%w121)
+        deallocate(merra2bias_struc(n)%w211)
+        deallocate(merra2bias_struc(n)%w221)
+        deallocate(merra2bias_struc(n)%n112)
+        deallocate(merra2bias_struc(n)%n122)
+        deallocate(merra2bias_struc(n)%n212)
+        deallocate(merra2bias_struc(n)%n222)
+        deallocate(merra2bias_struc(n)%w112)
+        deallocate(merra2bias_struc(n)%w122)
+        deallocate(merra2bias_struc(n)%w212)
+        deallocate(merra2bias_struc(n)%w222)
+
+     case( "neighbor" )
+        deallocate(merra2bias_struc(n)%n113)
+     end select
+  enddo
+  deallocate(merra2bias_struc)
+
+end subroutine finalize_merra2bias
+

--- a/lis/metforcing/merra2bias/get_merra2bias.F90
+++ b/lis/metforcing/merra2bias/get_merra2bias.F90
@@ -1,0 +1,321 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+!
+! !ROUTINE: get_merra2bias
+! \label{get_merra2bias}
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
+! 17 Jun 2026: Kristen Whitney, simplified metadata handling
+!              and updated dynamic lapse-rate filename construction.
+! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
+!
+! !INTERFACE:
+subroutine get_merra2bias(n,findex)
+! !USES:
+  use LIS_coreMod
+  use LIS_timeMgrMod
+  use LIS_logMod
+  use LIS_metforcingMod
+  use merra2bias_forcingMod
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN, LIS_CONST_LAPSE_RATE
+
+  implicit none
+
+! !ARGUMENTS:
+  integer, intent(in) :: n
+  integer, intent(in) :: findex
+!
+! !DESCRIPTION:
+!  Opens, reads, and interpolates 1-hourly MERRA2bias forcing.
+!
+!  The MERRA2bias forcing data are organized into hourly files.
+!  The data are considered valid at the mid-point of the hourly interval.
+!
+!  In general, metforcing readers read the forcing data before the
+!  current time, referred to as bookend1, and after the current time,
+!  referred to as bookend2.  Then the readers temporally interpolate
+!  between bookend1 and bookend2.
+!
+!  Below are some examples to illustrate the timing logic of the
+!  MERRA2bias reader.
+!
+!  \begin{verbatim}
+!          ---*---|---*---|---*---|---*---|---*---|---*---|---*---|---*---
+!  hour          21      22      23       0       1       2       3
+!  hr_int         <---22--X--23---X--24---X---1---X---2---X---3--->
+!
+!  where:
+!  hour is the hour UTC
+!  hr_int is the hour-interval
+!  * marks the valid point for the interval <--- hr_int --->
+!
+!  The arguments are:
+!  \begin{description}
+!  \item[n]
+!    index of the nest
+!  \item[findex]
+!    forcing dataset index
+!  \end{description}
+!
+!  The routines invoked are:
+!  \begin{description}
+!  \item[LIS\_tick](\ref{LIS_tick}) \newline
+!    call to advance or retract time
+!  \item[merra2biasfiles](\ref{merra2biasfiles}) \newline
+!    Puts together appropriate file name for 1 hour intervals
+!  \item[read\_merra2bias](\ref{read_merra2bias}) \newline
+!    call to read the MERRA2bias data and perform spatial interpolation
+!  \end{description}
+!EOP
+  integer           :: order
+  integer           :: ferror
+  character(len=LIS_CONST_PATH_LEN) :: merra2name
+  integer           :: c,r,kk
+  integer           :: yr1,mo1,da1,hr1,mn1,ss1,doy1
+  integer           :: yr2,mo2,da2,hr2,mn2,ss2,doy2
+  real*8            :: time1,time2,timenow
+  real              :: gmt1,gmt2
+  real              :: ts1,ts2
+  integer           :: gid
+  integer           :: movetime ! Flag to move bookend2 files to bookend1
+  character(len=LIS_CONST_PATH_LEN) :: lapseratefname
+  character(len=13) :: fdate
+
+  external :: merra2biasfiles
+  external :: read_merra2bias
+! _________________________________________________________
+!
+
+  if (LIS_rc%nts(n).gt.3600) then ! > 1-hr timestep
+     write(LIS_logunit,*) '[ERR] When running LIS with MERRA2bias,'
+     write(LIS_logunit,*) '[ERR] the clock should run with a time'
+     write(LIS_logunit,*) '[ERR] step less than or equal to 1 hr.'
+     call LIS_endrun()
+  endif
+
+  merra2bias_struc(n)%findtime1 = 0
+  merra2bias_struc(n)%findtime2 = 0
+  movetime = 0
+
+!----------------------------------------------------------
+! Determine current time
+!----------------------------------------------------------
+  yr1 = LIS_rc%yr
+  mo1 = LIS_rc%mo
+  da1 = LIS_rc%da
+  hr1 = LIS_rc%hr
+  mn1 = LIS_rc%mn
+  ss1 = 0
+  ts1 = 0
+  call LIS_tick(timenow,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+
+  if (LIS_rc%ts.gt.3600.0) then
+     write(LIS_logunit,*)                                          &
+          '[ERR] The model timestep is > forcing data timestep'
+     write(LIS_logunit,*)                                          &
+          '[ERR] LIS does not support this mode currently'
+     write(LIS_logunit,*) '[ERR] Program stopping ...'
+     call LIS_endrun()
+  endif
+
+  if (mod(nint(LIS_rc%ts),3600).eq.0) then
+     if (timenow.ge.merra2bias_struc(n)%merra2biastime2) then
+        yr1 = LIS_rc%yr
+        mo1 = LIS_rc%mo
+        da1 = LIS_rc%da
+        hr1 = LIS_rc%hr
+        mn1 = 0
+        ss1 = 0
+        ts1 = -60*60
+        call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+
+        yr2 = LIS_rc%yr     !next hour
+        mo2 = LIS_rc%mo
+        da2 = LIS_rc%da
+        hr2 = LIS_rc%hr
+        mn2 = 0
+        ss2 = 0
+        ts2 = 0
+        call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+
+        merra2bias_struc(n)%findtime1 = 1
+        merra2bias_struc(n)%merra2biastime2 = time2
+     endif
+  else
+     if (timenow.ge.merra2bias_struc(n)%merra2biastime2) then
+        yr1 = LIS_rc%yr
+        mo1 = LIS_rc%mo
+        da1 = LIS_rc%da
+        hr1 = LIS_rc%hr
+        mn1 = 0
+        ss1 = 0
+        ts1 = 0
+        call LIS_tick(time1,doy1,gmt1,yr1,mo1,da1,hr1,mn1,ss1,ts1)
+        merra2bias_struc(n)%findtime1 = 1
+
+        yr2 = LIS_rc%yr     !next hour
+        mo2 = LIS_rc%mo
+        da2 = LIS_rc%da
+        hr2 = LIS_rc%hr
+        mn2 = 0
+        ss2 = 0
+        ts2 = 60*60
+        call LIS_tick(time2,doy2,gmt2,yr2,mo2,da2,hr2,mn2,ss2,ts2)
+        merra2bias_struc(n)%merra2biastime2 = time2
+     endif
+  endif
+
+! Beginning of the run
+  if ((LIS_rc%tscount(n).eq.1).or.(LIS_rc%rstflag(n).eq.1)) then
+     merra2bias_struc(n)%findtime1 = 1
+     merra2bias_struc(n)%merra2biastime2 = time2
+     LIS_rc%rstflag(n) = 0
+  endif
+
+! Read MERRA2bias - Bookend 1 files:
+  if (merra2bias_struc(n)%findtime1.eq.1) then
+     order = 1
+     do kk = merra2bias_struc(n)%st_iterid,merra2bias_struc(n)%en_iterid
+        call merra2biasfiles(n,kk,findex,          &
+             merra2bias_struc(n)%merra2biasdir,    &
+             doy1,yr1,mo1,da1,hr1,                 &
+             merra2name)
+
+        ! Get lapse rate filename
+        write(fdate, fmt='(i4.4,"-",i2.2,"-",i2.2,"-",i2.2)') &
+             yr1,mo1,da1,hr1
+        lapseratefname = trim(merra2bias_struc(n)%dynlapseratedir)// &
+             trim(merra2bias_struc(n)%dynlapseratepfx)// &
+             fdate//trim(merra2bias_struc(n)%dynlapseratesfx)
+        call read_merra2bias(n,order,mo1,findex,                       &
+             merra2name, lapseratefname,                                 &
+             merra2bias_struc(n)%merra2biasforc1(kk,:,:),ferror)
+     enddo
+     merra2bias_struc(n)%merra2biastime1 = time1
+  endif
+
+! Assign MERRA2bias forcing fields to two LIS time-interp placeholders:
+  do r = 1,LIS_rc%lnr(n)
+     do c = 1,LIS_rc%lnc(n)
+        if (LIS_domain(n)%gindex(c,r).ne.-1) then
+           merra2bias_struc(n)%metdata(:,:,LIS_domain(n)%gindex(c,r)) = &
+                merra2bias_struc(n)%merra2biasforc1(:,:,(c+(r-1)*LIS_rc%lnc(n)))
+        endif
+     enddo
+  enddo
+
+  ! Assign lapse rate values
+  LIS_forc(n,findex)%lapseRate(:) = LIS_CONST_LAPSE_RATE
+
+  if ((merra2bias_struc(n)%usedynlapserate.eq.1).and.                  &
+       ((LIS_rc%met_ecor(findex).eq."lapse-rate").or.                  &
+       (LIS_rc%met_ecor(findex).eq.                                    &
+       "lapse-rate and slope-aspect").or.                              &
+       (LIS_rc%met_ecor(findex).eq."micromet"))) then
+     do r=1,LIS_rc%lnr(n)
+        do c=1,LIS_rc%lnc(n)
+           if(LIS_domain(n)%gindex(c,r).ne.-1) then
+              gid = LIS_domain(n)%gindex(c,r)
+              LIS_forc(n,findex)%lapseRate(gid) = &
+                   merra2bias_struc(n)%lapserate1(gid)
+
+              if(merra2bias_struc(n)%applydynlapseratecutoff.eq.1) then
+                 if(LIS_forc(n,findex)%lapseRate(gid).gt. &
+                      merra2bias_struc(n)%dynlapseratemaxcutoff) then
+                    LIS_forc(n,findex)%lapseRate(gid) = &
+                         merra2bias_struc(n)%dynlapseratemaxcutoff
+                 elseif(LIS_forc(n,findex)%lapseRate(gid).lt. &
+                      merra2bias_struc(n)%dynlapseratemincutoff) then
+                    LIS_forc(n,findex)%lapseRate(gid) = &
+                         merra2bias_struc(n)%dynlapseratemincutoff
+                 endif
+              endif
+           endif
+        enddo
+     enddo
+  endif
+end subroutine get_merra2bias
+
+!BOP
+! !ROUTINE: merra2biasfiles
+! \label{merra2biasfiles}
+!
+! !INTERFACE:
+subroutine merra2biasfiles(n,kk,findex,merra2biasdir,doy,yr,mo,da,hr,    &
+     merra2name)
+
+! !USES:
+  use LIS_coreMod
+  use LIS_logMod
+  use LIS_timeMgrMod
+
+  implicit none
+! !ARGUMENTS:
+  integer                       :: n
+  integer                       :: kk
+  integer                       :: findex
+  character(len=*), intent(in)  :: merra2biasdir
+  integer, intent(in)           :: doy,yr,mo,da,hr
+  character(len=*), intent(out) :: merra2name
+
+! !DESCRIPTION:
+!   This subroutine puts together MERRA2bias file names for
+!   hourly netCDF files.
+!
+!  The arguments are:
+!  \begin{description}
+!  \item[merra2biasdir]
+!    Name of the MERRA2bias directory
+!  \item[doy]
+!    day of year
+!  \item[yr]
+!    year
+!  \item[mo]
+!   month
+!  \item[da]
+!   day of month
+!  \item[hr]
+!   hour
+!  \item[slvname]
+!   name of the timestamped single level file
+!  \item[flxname]
+!   name of the timestamped flux file
+!  \item[lfoname]
+!   name of the timestamped land surface forcings file
+!  \item[radname]
+!   name of the timestamped radiation forcings file
+!  \end{description}
+!
+!EOP
+
+  character*4  :: cyear
+  character*2  :: cmo,cdy,chr
+  character*9 :: prefix
+
+  write(unit=cyear,fmt='(i4.4)') yr
+  write(unit=cmo,  fmt='(i2.2)') mo
+  write(unit=cdy,  fmt='(i2.2)') da
+  write(unit=chr,  fmt='(i2.2)') hr
+
+  prefix = 'merra2bias_'
+  if (yr.lt.1998) then
+     write(LIS_logunit,*) '[ERR] MERRA2bias data starts 1 Jan 1998.'
+     call LIS_endrun()
+  endif
+
+! Single level fields:
+  merra2name = trim(merra2biasdir)//'/'//cyear//   &
+       '/'//prefix//cyear//'-'//                 &
+       cmo//'-'//cdy//'-'//chr//'.nc'
+end subroutine merra2biasfiles
+

--- a/lis/metforcing/merra2bias/get_merra2bias.F90
+++ b/lis/metforcing/merra2bias/get_merra2bias.F90
@@ -190,7 +190,6 @@ subroutine get_merra2bias(n,findex)
              merra2bias_struc(n)%merra2biasdir,    &
              doy1,yr1,mo1,da1,hr1,                 &
              merra2name)
-
         ! Get lapse rate filename
         write(fdate, fmt='(i4.4,"-",i2.2,"-",i2.2,"-",i2.2)') &
              yr1,mo1,da1,hr1
@@ -300,7 +299,7 @@ subroutine merra2biasfiles(n,kk,findex,merra2biasdir,doy,yr,mo,da,hr,    &
 
   character*4  :: cyear
   character*2  :: cmo,cdy,chr
-  character*9 :: prefix
+  character*11 :: prefix
 
   write(unit=cyear,fmt='(i4.4)') yr
   write(unit=cmo,  fmt='(i2.2)') mo

--- a/lis/metforcing/merra2bias/get_merra2bias.F90
+++ b/lis/metforcing/merra2bias/get_merra2bias.F90
@@ -13,10 +13,6 @@
 ! \label{get_merra2bias}
 !
 ! !REVISION HISTORY:
-! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
-! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
-! 17 Jun 2026: Kristen Whitney, simplified metadata handling
-!              and updated dynamic lapse-rate filename construction.
 ! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
 !
 ! !INTERFACE:

--- a/lis/metforcing/merra2bias/merra2bias_forcingMod.F90
+++ b/lis/metforcing/merra2bias/merra2bias_forcingMod.F90
@@ -12,9 +12,6 @@ module merra2bias_forcingMod
 ! !MODULE: merra2bias_forcingMod
 !
 ! !REVISION HISTORY:
-! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
-! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
-! 09 Jan 2026: Eric Kemp, reformatted.
 ! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
 !
 ! !DESCRIPTION:

--- a/lis/metforcing/merra2bias/merra2bias_forcingMod.F90
+++ b/lis/metforcing/merra2bias/merra2bias_forcingMod.F90
@@ -1,0 +1,327 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+module merra2bias_forcingMod
+!BOP
+! !MODULE: merra2bias_forcingMod
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
+! 09 Jan 2026: Eric Kemp, reformatted.
+! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
+!
+! !DESCRIPTION:
+!  This module contains variables and data structures that are used
+!  for the implementation of the MERRA2bias forcing data.
+!  MERRA2bias consists of bias-adjusted MERRA2 surface forcing
+!  fields that are generated upstream of LIS. LIS does not perform
+!  the MERRA2 to MERRA2bias adjustment; it reads the prepared
+!  MERRA2bias files and applies the requested LIS spatial
+!  interpolation and downscaling procedures.
+!
+!  The MERRA2bias files used by this reader contain four hourly
+!  surface forcing fields: 2-m air temperature, 2-m specific humidity,
+!  surface pressure, and downward longwave radiation. The fields are
+!  bias-adjusted using climatological reference datasets generated
+!  outside of LIS.
+!
+!  The data are on a 0.625-degree longitude by 0.5-degree latitude
+!  grid, in latlon projection, and at 1 hourly intervals. The derived
+!  data type {\tt merra2bias\_struc} includes the variables that
+!  specify the runtime options, and the weights and neighbor
+!  information to be used for spatial interpolation. They are
+!  described below:
+!  \begin{description}
+!  \item[ncold]
+!    Number of columns (along the east west dimension) for the input data
+!  \item[nrold]
+!    Number of rows (along the north south dimension) for the input data
+!  \item[nmif]
+!    Number of forcing variables in the data
+!  \item[merra2biastime1]
+!    The nearest, previous 1 hour instance of the incoming
+!    data (as a real time).
+!  \item[merra2biastime2]
+!    The nearest, next 1 hour instance of the incoming
+!    data (as a real time).
+!  \item[merra2biasdir]
+!    Directory containing the input data
+!  \item[mi]
+!    Number of points in the input grid
+!  \item[n111,n121,n211,n221]
+!    Arrays containing the neighbor information of the input grid
+!    for each grid point in LIS, for bilinear interpolation.
+!  \item[w111,w121,w211,w221]
+!    Arrays containing the weights of the input grid
+!    for each grid point in LIS, for bilinear interpolation.
+!  \item[n122,n122,n212,n222]
+!    Arrays containing the neighbor information of the input grid
+!    for each grid point in LIS, for conservative interpolation.
+!  \item[w112,w122,w212,w222]
+!    Arrays containing the weights of the input grid
+!    for each grid point in LIS, for conservative interpolation.
+!  \item[n113]
+!    Arrays containing the neighbor information of the input grid
+!    for each grid point in LIS, for n. neighbor interpolation.
+!  \item[findtime1, findtime2]
+!   boolean flags to indicate which time is to be read for
+!   temporal interpolation.
+!  \end{description}
+!
+! !USES:
+  use LIS_constantsMod, only : LIS_CONST_PATH_LEN
+
+  implicit none
+
+  PRIVATE
+!-----------------------------------------------------------------------------
+! !PUBLIC MEMBER FUNCTIONS:
+!-----------------------------------------------------------------------------
+  public :: init_merra2bias    ! defines the native resolution of the input data
+!-----------------------------------------------------------------------------
+! !PUBLIC TYPES:
+!-----------------------------------------------------------------------------
+  public :: merra2bias_struc
+
+!EOP
+  type, public :: merra2bias_type_dec
+     real         :: ts
+     integer      :: ncold, nrold
+     character(len=LIS_CONST_PATH_LEN) :: merra2biasdir   ! MERRA2bias Forcing Directory
+     real*8       :: merra2biastime1,merra2biastime2
+     logical      :: reset_flag
+
+     integer                :: mi
+     integer, allocatable   :: n111(:)
+     integer, allocatable   :: n121(:)
+     integer, allocatable   :: n211(:)
+     integer, allocatable   :: n221(:)
+     real, allocatable      :: w111(:),w121(:)
+     real, allocatable      :: w211(:),w221(:)
+
+     integer, allocatable   :: n112(:,:)
+     integer, allocatable   :: n122(:,:)
+     integer, allocatable   :: n212(:,:)
+     integer, allocatable   :: n222(:,:)
+     real, allocatable      :: w112(:,:),w122(:,:)
+     real, allocatable      :: w212(:,:),w222(:,:)
+     integer, allocatable   :: n113(:)
+     integer                :: findtime1,findtime2
+     logical                :: startFlag,dayFlag
+     real, allocatable      :: merra2biasforc1(:,:,:),merra2biasforc2(:,:,:)
+     real, allocatable      :: lapserate1(:), lapserate2(:)
+     integer            :: nvars
+     integer            :: uselml
+     real*8             :: ringtime
+     integer            :: nIter,st_iterid,en_iterid
+
+     real, allocatable :: metdata(:,:,:)
+
+     integer                 :: use2mwind
+     character(len=LIS_CONST_PATH_LEN) :: scaleffile
+     integer, allocatable    :: rseed(:,:)
+     integer                 :: usedynlapserate
+     character(len=LIS_CONST_PATH_LEN) :: dynlapseratedir
+     character(len=LIS_CONST_PATH_LEN) :: dynlapseratepfx
+     character(len=LIS_CONST_PATH_LEN) :: dynlapseratesfx
+     integer                 :: applydynlapseratecutoff
+     real                    :: dynlapseratemincutoff
+     real                    :: dynlapseratemaxcutoff
+  end type merra2bias_type_dec
+
+  type(merra2bias_type_dec), allocatable :: merra2bias_struc(:)
+
+contains
+
+!BOP
+!
+! !ROUTINE: init_merra2bias
+! \label{init_merra2bias}
+!
+! !REVISION HISTORY:
+! 18 Mar 2015: James Geiger, initial code (based on merra-land)
+! 20 Apr 2023: David Mocko,  initial code (based on merra2)
+! 17 Jun 2026: Kristen Whitney, clarified MERRA2bias dataset
+!              description and simplified metadata storage.
+!
+! !INTERFACE:
+  subroutine init_merra2bias(findex)
+
+! !USES:
+    use LIS_coreMod
+    use LIS_timeMgrMod
+    use LIS_logMod
+    use LIS_spatialDownscalingMod, only : LIS_init_pcpclimo_native
+
+    implicit none
+
+! !AGRUMENTS:
+    integer, intent(in) :: findex
+
+! !DESCRIPTION:
+!  Defines the native resolution of the input forcing for MERRA2bias
+!  data. The grid description arrays are based on the decoding
+!  schemes used by NCEP and followed in the LIS interpolation
+!  schemes (see Section~\ref{interp}).
+!
+!  The routines invoked are:
+!  \begin{description}
+!   \item[readcrd\_merra2bias](\ref{readcrd_merra2bias}) \newline
+!     reads the runtime options specified for MERRA2bias data
+!   \item[bilinear\_interp\_input](\ref{bilinear_interp_input}) \newline
+!    computes the neighbor, weights for bilinear interpolation
+!   \item[conserv\_interp\_input](\ref{conserv_interp_input}) \newline
+!    computes the neighbor, weights for conservative interpolation
+!  \end{description}
+!EOP
+    real :: gridDesci(LIS_rc%nnest,50)
+    integer :: n
+
+    external :: readcrd_merra2bias
+    external :: bilinear_interp_input
+    external :: conserv_interp_input
+    external :: neighbor_interp_input
+    external :: read_merra2bias_elev
+
+    allocate(merra2bias_struc(LIS_rc%nnest))
+
+    do n = 1,LIS_rc%nnest
+       merra2bias_struc(n)%ncold = 187
+       merra2bias_struc(n)%nrold = 131
+    enddo
+
+    call readcrd_merra2bias()
+    LIS_rc%met_nf(findex) = 4
+
+    merra2bias_struc%reset_flag = .false.
+
+    do n = 1, LIS_rc%nnest
+       merra2bias_struc(n)%ts = 3600 !check
+       call LIS_update_timestep(LIS_rc,n,merra2bias_struc(n)%ts)
+    enddo
+
+    gridDesci = 0
+    do n = 1,LIS_rc%nnest
+       gridDesci(n,1)  = 0
+       gridDesci(n,2)  = merra2bias_struc(n)%ncold
+       gridDesci(n,3)  = merra2bias_struc(n)%nrold
+       gridDesci(n,4)  = 7.0
+       gridDesci(n,5)  = -168.75
+       gridDesci(n,6)  = 128
+       gridDesci(n,7)  = 72.0
+       gridDesci(n,8)  = -52.5
+       gridDesci(n,9)  = 0.625
+       gridDesci(n,10) = 0.5
+       gridDesci(n,20) = 0
+
+       merra2bias_struc(n)%mi = merra2bias_struc(n)%ncold * &
+            merra2bias_struc(n)%nrold
+
+       ! Setting up weights for Interpolation
+       if (trim(LIS_rc%met_interp(findex)).eq."bilinear") then
+          allocate(merra2bias_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          call bilinear_interp_input(n,gridDesci(n,:),               &
+               merra2bias_struc(n)%n111,merra2bias_struc(n)%n121,    &
+               merra2bias_struc(n)%n211,merra2bias_struc(n)%n221,    &
+               merra2bias_struc(n)%w111,merra2bias_struc(n)%w121,    &
+               merra2bias_struc(n)%w211,merra2bias_struc(n)%w221)
+
+       elseif (trim(LIS_rc%met_interp(findex)).eq."budget-bilinear") then
+          allocate(merra2bias_struc(n)%n111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%n121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%n211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%n221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%w111(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%w121(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%w211(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          allocate(merra2bias_struc(n)%w221(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          call bilinear_interp_input(n,gridDesci(n,:),               &
+               merra2bias_struc(n)%n111,merra2bias_struc(n)%n121,    &
+               merra2bias_struc(n)%n211,merra2bias_struc(n)%n221,    &
+               merra2bias_struc(n)%w111,merra2bias_struc(n)%w121,    &
+               merra2bias_struc(n)%w211,merra2bias_struc(n)%w221)
+
+          allocate(merra2bias_struc(n)%n112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(merra2bias_struc(n)%n122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(merra2bias_struc(n)%n212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(merra2bias_struc(n)%n222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(merra2bias_struc(n)%w112(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(merra2bias_struc(n)%w122(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(merra2bias_struc(n)%w212(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          allocate(merra2bias_struc(n)%w222(LIS_rc%lnc(n)*LIS_rc%lnr(n),25))
+          call conserv_interp_input(n,gridDesci(n,:),                &
+               merra2bias_struc(n)%n112,merra2bias_struc(n)%n122,    &
+               merra2bias_struc(n)%n212,merra2bias_struc(n)%n222,    &
+               merra2bias_struc(n)%w112,merra2bias_struc(n)%w122,    &
+               merra2bias_struc(n)%w212,merra2bias_struc(n)%w222)
+
+       elseif (trim(LIS_rc%met_interp(findex)).eq."neighbor") then
+          allocate(merra2bias_struc(n)%n113(LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+          call neighbor_interp_input(n,gridDesci(n,:),               &
+               merra2bias_struc(n)%n113)
+
+       else
+          write(LIS_logunit,*) '[ERR] Interpolation option '//       &
+               trim(LIS_rc%met_interp(findex))//                     &
+               ' for MERRA2bias forcing is not supported'
+          call LIS_endrun()
+       endif
+
+       if (merra2bias_struc(n)%usedynlapserate.eq.1) then
+          allocate(merra2bias_struc(n)%lapserate1(LIS_rc%ngrid(n)))
+          allocate(merra2bias_struc(n)%lapserate2(LIS_rc%ngrid(n)))
+       endif
+
+       call LIS_registerAlarm("MERRA2bias forcing alarm",86400.0,86400.0)
+       merra2bias_struc(n)%startFlag = .true.
+       merra2bias_struc(n)%dayFlag = .true.
+
+       merra2bias_struc(n)%nvars = 4
+
+       allocate(merra2bias_struc(n)%merra2biasforc1(1,               &
+            merra2bias_struc(n)%nvars, LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+       allocate(merra2bias_struc(n)%merra2biasforc2(1,               &
+            merra2bias_struc(n)%nvars, LIS_rc%lnc(n)*LIS_rc%lnr(n)))
+       merra2bias_struc(n)%st_iterid = 1
+       merra2bias_struc(n)%en_iterId = 1
+       merra2bias_struc(n)%nIter = 1
+
+       allocate(merra2bias_struc(n)%metdata(1,LIS_rc%met_nf(findex),    &
+            LIS_rc%ngrid(n)))
+
+       merra2bias_struc(n)%metdata = 0
+
+       merra2bias_struc(n)%merra2biasforc1 = LIS_rc%udef
+       merra2bias_struc(n)%merra2biasforc2 = LIS_rc%udef
+
+       if (LIS_rc%met_ecor(findex).eq."lapse-rate" .or.             &
+            LIS_rc%met_ecor(findex).eq."lapse-rate and slope-aspect" .or. &
+            LIS_rc%met_ecor(findex) == "micromet" ) then
+          call read_merra2bias_elev(n,findex)
+       endif
+
+! Set up precipitation climate downscaling:
+       if (LIS_rc%pcp_downscale(findex).ne.0) then
+          call LIS_init_pcpclimo_native(n,findex,merra2bias_struc(n)%ncold,&
+               merra2bias_struc(n)%nrold)
+       endif
+
+    enddo                     ! End nest loop
+
+  end subroutine init_merra2bias
+end module merra2bias_forcingMod
+

--- a/lis/metforcing/merra2bias/read_merra2bias.F90
+++ b/lis/metforcing/merra2bias/read_merra2bias.F90
@@ -1,0 +1,499 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+#include "LIS_misc.h"
+!BOP
+!
+! !ROUTINE: read_merra2bias
+! \label{read_merra2bias}
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
+! 09 Jan 2026: Eric Kemp, reformatted.
+! 17 Jun 2026: Kristen Whitney, corrected GEOS-ITbias forcing
+!              variable documentation and indexing.
+! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
+!
+! !INTERFACE:
+subroutine read_merra2bias(n,order,month,findex,                     &
+     merra2name,                                                       &
+     lapseratefname,                                                 &
+     merra2biasforc,ferror)
+! !USES:
+  use LIS_coreMod,       only : LIS_rc
+  use LIS_logMod
+  use LIS_FORC_AttributesMod
+  use LIS_metforcingMod, only : LIS_forc
+  use merra2bias_forcingMod, only : merra2bias_struc
+  use LIS_constantsMod, only : LIS_CONST_LAPSE_RATE
+#if (defined USE_NETCDF3 || defined USE_NETCDF4)
+  use netcdf
+#endif
+
+  implicit none
+! !ARGUMENTS:
+  integer, intent(in)          :: n
+  integer, intent(in)          :: order
+  integer, intent(in)          :: month
+  integer, intent(in)          :: findex
+  character(len=*), intent(in) :: merra2name
+  character(len=*), intent(in) :: lapseratefname
+  real, intent(inout)          :: &
+       merra2biasforc(merra2bias_struc(n)%nvars,&
+       LIS_rc%lnc(n)*LIS_rc%lnr(n))
+  integer, intent(out)         :: ferror
+
+! !DESCRIPTION:
+!  For the given time, reads parameters from MERRA2bias data, transforms
+!  into 4 LIS forcing parameters and interpolates to the LIS domain. \newline
+!
+! MERRA2bias FORCING VARIABLES: \newline
+!  1. tair    Temperature of air at 2-m, 10-m, or LML [$K$] \newline
+!  2. qair    Specific humidity of air at 2-m, 10-m, or LML [$kg/kg$] \newline
+!  3. ps      Instantaneous Surface Pressure [$Pa$] \newline
+!  4. lwgab   Downward longwave radiation at the ground [$W/m^2$] \newline
+!
+!  The arguments are:
+!  \begin{description}
+!  \item[order]
+!    flag indicating which data to be read (order=1, read the previous
+!    1 hourly instance, order=2, read the next 1 hourly instance)
+!  \item[n]
+!    index of the nest
+!  \item[name]
+!    name of the 1 hour MERRA2bias analysis file
+!  \item[tscount]
+!    time step count
+!  \item[ferror]
+!    return error code (0 indicates success)
+!  \end{description}
+!
+!  The routines invoked are:
+!  \begin{description}
+!  \item[bilinear\_interp](\ref{bilinear_interp}) \newline
+!    spatially interpolate the forcing data using bilinear interpolation
+!  \item[conserv\_interp](\ref{conserv_interp}) \newline
+!    spatially interpolate the forcing data using conservative interpolation
+!  \end{description}
+!EOP
+  integer   :: ftn_merra2
+  integer   :: tmpId,qId,psId
+  integer   :: lwgabId
+  integer   :: nr_index,nc_index
+  logical   :: file_exists
+  integer   :: mo
+  real      :: tair(merra2bias_struc(n)%ncold,merra2bias_struc(n)%nrold)
+  real      :: qair(merra2bias_struc(n)%ncold,merra2bias_struc(n)%nrold)
+  real      :: ps(merra2bias_struc(n)%ncold,merra2bias_struc(n)%nrold)
+  real      :: lwgab(merra2bias_struc(n)%ncold,merra2bias_struc(n)%nrold)
+  integer                           :: ftn_drate
+  integer                           :: lapserateid
+  real, allocatable                 :: lapse_rate_in(:,:)
+  integer :: nc_sub, nr_sub
+  real, allocatable :: lapse_rate_sub(:,:)
+  real, allocatable :: lat_sub(:), lon_sub(:)
+  real, allocatable :: lat_full(:), lon_full(:)
+  integer :: i0, j0
+  integer :: latid, lonid
+
+  external :: interp_merra2bias_var
+  external :: interp_lapserate_merra2bias
+! __________________________________________________________________________
+
+#if (defined USE_NETCDF3)
+  write(LIS_logunit,*) "[ERR] MERRA2bias reader requires NetCDF4"
+  call LIS_endrun()
+#endif
+
+#if (defined USE_NETCDF4)
+  ferror = 0
+  nr_index = merra2bias_struc(n)%nrold
+  nc_index = merra2bias_struc(n)%ncold
+  mo = LIS_rc%lnc(n)*LIS_rc%lnr(n)
+
+! Read required fields from MERRA2bias input file:
+  inquire(file=merra2name,exist=file_exists)
+  if(file_exists) then
+     write(LIS_logunit,*)                                           &
+          '[INFO] Reading MERRA2bias file: ',trim(merra2name)
+     call LIS_verify(nf90_open(path=trim(merra2name),                 &
+          mode=NF90_NOWRITE,ncid=ftn_merra2),                         &
+          'nf90_open failed for merra2file in read_merra2bias')
+
+     call LIS_verify(nf90_inq_varid(ftn_merra2,'PS',psId),            &
+          'nf90_inq_varid failed for ps in read_merra2bias')
+     call LIS_verify(nf90_get_var(ftn_merra2,psId,ps),                &
+          'nf90_get_var failed for ps in read_merra2bias')
+
+     call LIS_verify(nf90_inq_varid(ftn_merra2,'LWGAB',lwgabId),      &
+          'nf90_inq_varid failed for LWGAB in read_merra2bias')
+     call LIS_verify(nf90_get_var(ftn_merra2,lwgabId,lwgab),          &
+          'nf90_get_var failed for LWGAB in read_merra2bias')
+
+     call LIS_verify(nf90_inq_varid(ftn_merra2,'QV2M',qId),           &
+          'nf90_inq_varid failed for QV2M in read_merra2bias')
+     call LIS_verify(nf90_get_var(ftn_merra2,qId,qair),               &
+          'nf90_get_var failed for QV2M in read_merra2bias')
+
+     call LIS_verify(nf90_inq_varid(ftn_merra2,'T2M',tmpId),          &
+          'nf90_inq_varid failed for T2M in read_merra2bias')
+     call LIS_verify(nf90_get_var(ftn_merra2,tmpId,Tair),             &
+          'nf90_get_var failed for T2M in read_merra2bias')
+
+     call LIS_verify(nf90_close(ftn_merra2),                          &
+          '[WARN] Failed to close slvfile in read_merra2bias.')
+
+     call interp_merra2bias_var(n,findex,month,tair,  1,.false.,    &
+          merra2biasforc)
+     call interp_merra2bias_var(n,findex,month,qair,  2,.false.,    &
+          merra2biasforc)
+     call interp_merra2bias_var(n,findex,month,ps,    3,.false.,    &
+          merra2biasforc)
+     call interp_merra2bias_var(n,findex,month,lwgab, 4,.false.,     &
+          merra2biasforc)
+
+    ! Obtain lapse rates
+     if ((merra2bias_struc(n)%usedynlapserate.eq.1).and.            &
+          ((LIS_rc%met_ecor(findex).eq."lapse-rate").or.               &
+          (LIS_rc%met_ecor(findex).eq."lapse-rate and slope-aspect").or.&
+          (LIS_rc%met_ecor(findex).eq."micromet"))) then
+        inquire(file=trim(lapseratefname),exist=file_exists)
+        if (file_exists) then
+           write(LIS_logunit,*) 'Reading lapse rate file: ', &
+                trim(lapseratefname)
+
+           ! open file and get ID for lapse rate
+           call LIS_verify(nf90_open(path=trim(lapseratefname),     &
+                mode=NF90_NOWRITE,ncid=ftn_drate),                  &
+                'nf90_open failed for '//trim(lapseratefname))
+           call LIS_verify(nf90_inq_varid(ftn_drate,'lapse_rate',   &
+                lapserateid),                                       &
+                'nf90_inq_varid failed for lapse_rate')
+
+           ! Get subdomain dimensions directly from dimids 1=lat, 2=lon
+           call LIS_verify(nf90_inquire_dimension(ftn_drate,1, &
+                len=nr_sub), 'inq lat dim failed (sub)')
+           call LIS_verify(nf90_inquire_dimension(ftn_drate,2, &
+                len=nc_sub), 'inq lon dim failed (sub)')
+
+           ! allocate full-size lapse rate
+           allocate(lapse_rate_in(merra2bias_struc(n)%ncold,   &
+                merra2bias_struc(n)%nrold))
+           lapse_rate_in = 1.e+15
+           ! Case 1: full global lapse-rate file
+           if (nc_sub == merra2bias_struc(n)%ncold .and.       &
+                nr_sub == merra2bias_struc(n)%nrold) then
+              call LIS_verify(nf90_get_var(ftn_drate,lapserateid, &
+                   lapse_rate_in), 'get lapse_rate failed')
+
+              ! Case 2: subdomain lapse-rate file
+           else if (nc_sub <= merra2bias_struc(n)%ncold .and.  &
+                nr_sub <= merra2bias_struc(n)%nrold) then
+              allocate(lapse_rate_sub(nc_sub,nr_sub))
+              allocate(lat_sub(nr_sub), lon_sub(nc_sub))
+              allocate(lat_full(merra2bias_struc(n)%nrold), &
+                   lon_full(merra2bias_struc(n)%ncold))
+
+              ! Read subdomain values
+              call LIS_verify(nf90_get_var(ftn_drate,lapserateid,    &
+                   lapse_rate_sub), 'get lapse_rate_sub failed')
+              call LIS_verify(nf90_inq_varid(ftn_drate,'lat',latid), &
+                   'inq lat varid failed')
+              call LIS_verify(nf90_inq_varid(ftn_drate,'lon',lonid), &
+                   'inq lon varid failed')
+              call LIS_verify(nf90_get_var(ftn_drate,latid,lat_sub), &
+                   'get lat_sub failed')
+              call LIS_verify(nf90_get_var(ftn_drate,lonid,lon_sub), &
+                   'get lon_sub failed')
+
+              ! Read full-domain coordinates from slv file
+              call LIS_verify(nf90_open(path=trim(merra2name),         &
+                   mode=NF90_NOWRITE,ncid=ftn_merra2),                 &
+                   'nf90_open failed for merra2file in read_merra2bias')
+              call LIS_verify(nf90_inq_varid(ftn_merra2,'lat',latid),  &
+                   'inq lat varid failed (full)')
+              call LIS_verify(nf90_inq_varid(ftn_merra2,'lon',lonid),  &
+                   'inq lon varid failed (full)')
+              call LIS_verify(nf90_get_var(ftn_merra2,latid,lat_full), &
+                   'get lat_full failed')
+              call LIS_verify(nf90_get_var(ftn_merra2,lonid,lon_full), &
+                   'get lon_full failed')
+              call LIS_verify(nf90_close(ftn_merra2), &
+                   '[WARN] Failed to close slvfile in read_merra2bias.')
+
+              ! Find paste offsets
+              call find_index(lon_full, lon_sub(1), i0)
+              call find_index(lat_full, lat_sub(1), j0)
+
+              ! Paste subdomain into full-domain buffer
+              lapse_rate_in(i0:i0+nc_sub-1, j0:j0+nr_sub-1) = &
+                   lapse_rate_sub(:,:)
+
+              ! Cleanup
+              deallocate(lapse_rate_sub, lat_sub, lon_sub, lat_full, &
+                   lon_full)
+
+              ! Case 3: unexpected
+           else
+              write(LIS_logunit,*) '[ERR] Unexpected lapse-rate dims: ', &
+                   nc_sub, ' x ', nr_sub
+              call LIS_endrun()
+           end if
+
+           call LIS_verify(nf90_close(ftn_drate), &
+                'close lapse-rate file failed')
+           call interp_lapserate_merra2bias(n,order,lapse_rate_in)
+
+           deallocate(lapse_rate_in)
+
+        else
+           write(LIS_logunit,*) '[WARN] Could not find ', &
+                trim(lapseratefname)
+           write(LIS_logunit,*) '[WARN] Using static lapse rate.'
+           merra2bias_struc(n)%lapserate1 = LIS_CONST_LAPSE_RATE
+           merra2bias_struc(n)%lapserate2 = LIS_CONST_LAPSE_RATE
+        endif
+     endif
+  else
+     call LIS_endrun()
+  endif
+
+#endif
+contains
+  subroutine find_index(x,val,idx)
+    real, intent(in) :: x(:), val
+    integer, intent(out) :: idx
+    real :: dmin
+    integer :: k
+    dmin = huge(1.0); idx = -1
+    do k=1,size(x)
+       if (abs(x(k)-val) < dmin) then
+          dmin = abs(x(k)-val)
+          idx = k
+       end if
+    enddo
+  end subroutine find_index
+end subroutine read_merra2bias
+
+!BOP
+!
+! !ROUTINE: interp_merra2bias_var
+! \label{interp_merra2bias_var}
+!
+! !INTERFACE:
+subroutine interp_merra2bias_var(n,findex,month,input_var,var_index, &
+     pcp_flag,merra2biasforc)
+
+! !USES:
+  use LIS_coreMod
+  use LIS_logMod
+  use LIS_spatialDownscalingMod
+  use merra2bias_forcingMod, only : merra2bias_struc
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)
+  use netcdf
+#endif
+
+  implicit none
+! !ARGUMENTS:
+  integer, intent(in)    :: n
+  integer, intent(in)    :: findex
+  integer, intent(in)    :: month
+  real,    intent(in)    :: input_var(merra2bias_struc(n)%ncold,       &
+       merra2bias_struc(n)%nrold)
+  integer, intent(in)    :: var_index
+  logical, intent(in)    :: pcp_flag
+  real,    intent(inout) :: merra2biasforc(merra2bias_struc(n)%nvars,  &
+       LIS_rc%lnc(n)*LIS_rc%lnr(n))
+
+! !DESCRIPTION:
+!  This subroutine spatially interpolates a MERRA2bias field
+!  to the LIS running domain
+!
+!EOP
+  integer   :: c,r,k,iret
+  real      :: f (merra2bias_struc(n)%ncold*merra2bias_struc(n)%nrold)
+  logical*1 :: lb(merra2bias_struc(n)%ncold*merra2bias_struc(n)%nrold)
+  logical*1 :: lo(LIS_rc%lnc(n)*LIS_rc%lnr(n))
+  integer   :: input_size
+
+  external :: conserv_interp
+  external :: bilinear_interp
+  external :: neighbor_interp
+
+! _____________________________________________________________
+
+  input_size = merra2bias_struc(n)%ncold*merra2bias_struc(n)%nrold
+
+!-----------------------------------------------------------------------
+! Apply downscaling
+!-----------------------------------------------------------------------
+  lb = .true.
+  do r = 1,merra2bias_struc(n)%nrold
+     do c = 1,merra2bias_struc(n)%ncold
+        k = c+(r-1)*merra2bias_struc(n)%ncold
+        f(k) = input_var(c,r)
+        if (f(k).eq.1.e+15) then
+           f(k)  = LIS_rc%udef
+           lb(k) = .false.
+        endif
+     enddo
+  enddo
+
+  if (pcp_flag.and.(LIS_rc%pcp_downscale(findex).ne.0)) then
+     ! input_data becomes the ratio field.
+     call LIS_generatePcpClimoRatioField(n,findex,"MERRA2bias",       &
+          month,input_size,f,lb)
+  endif
+
+  if (pcp_flag.and.                                                    &
+       (trim(LIS_rc%met_interp(findex)).eq."budget-bilinear")) then
+
+     call conserv_interp(LIS_rc%gridDesc(n,:),lb,f,lo,                 &
+          merra2biasforc(var_index,:),                                 &
+          merra2bias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),          &
+          LIS_domain(n)%lat,LIS_domain(n)%lon,                         &
+          merra2bias_struc(n)%w112,merra2bias_struc(n)%w122,           &
+          merra2bias_struc(n)%w212,merra2bias_struc(n)%w222,           &
+          merra2bias_struc(n)%n112,merra2bias_struc(n)%n122,           &
+          merra2bias_struc(n)%n212,merra2bias_struc(n)%n222,           &
+          LIS_rc%udef,iret)
+
+  elseif ((trim(LIS_rc%met_interp(findex)).eq."bilinear").or.          &
+       (trim(LIS_rc%met_interp(findex)).eq."budget-bilinear")) then
+     call bilinear_interp(LIS_rc%gridDesc(n,:),lb,f,lo,                &
+          merra2biasforc(var_index,:),                                 &
+          merra2bias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),          &
+          LIS_domain(n)%lat,LIS_domain(n)%lon,                         &
+          merra2bias_struc(n)%w111,merra2bias_struc(n)%w121,           &
+          merra2bias_struc(n)%w211,merra2bias_struc(n)%w221,           &
+          merra2bias_struc(n)%n111,merra2bias_struc(n)%n121,           &
+          merra2bias_struc(n)%n211,merra2bias_struc(n)%n221,           &
+          LIS_rc%udef,iret)
+
+  elseif (trim(LIS_rc%met_interp(findex)).eq."neighbor") then
+     call neighbor_interp(LIS_rc%gridDesc(n,:),lb,f,lo,                &
+          merra2biasforc(var_index,:),                                 &
+          merra2bias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),          &
+          LIS_domain(n)%lat,LIS_domain(n)%lon,                         &
+          merra2bias_struc(n)%n113,LIS_rc%udef,iret)
+
+  else
+     write(LIS_logunit,*) '[ERR] Spatial interpolation option '//      &
+          trim(LIS_rc%met_interp(findex))//                            &
+          ' not supported for MERRA2bias.'
+     call LIS_endrun()
+  endif
+
+  if (pcp_flag.and.(LIS_rc%pcp_downscale(findex).ne.0)) then
+     call LIS_pcpClimoDownscaling(n,findex,month,                      &
+          LIS_rc%lnc(n)*LIS_rc%lnr(n),merra2biasforc(var_index,:),lo)
+  endif
+
+end subroutine interp_merra2bias_var
+
+!BOP
+!
+! !ROUTINE: interp_lapserate_merra2bias
+! \label{interp_lapserate_merra2bias}
+!
+! !INTERFACE:
+subroutine interp_lapserate_merra2bias(n,order,input_var)
+
+! !USES:
+  use LIS_coreMod
+  use LIS_logMod
+  use LIS_spatialDownscalingMod
+  use merra2bias_forcingMod, only : merra2bias_struc
+  use LIS_constantsMod, only : LIS_CONST_LAPSE_RATE
+#if(defined USE_NETCDF3 || defined USE_NETCDF4)
+  use netcdf
+#endif
+  implicit none
+
+! !ARGUMENTS:
+  integer, intent(in)    :: n, order
+  real,    intent(in)    :: input_var(merra2bias_struc(n)%ncold, &
+       merra2bias_struc(n)%nrold)
+
+!
+! !DESCRIPTION:
+!  This subroutine spatially interpolates a MERRA2 Bias-corrected field
+!  to the LIS running domain
+!
+!EOP
+  integer   :: c,r,k,iret
+  integer   :: gid
+  real      :: f (merra2bias_struc(n)%ncold*merra2bias_struc(n)%nrold)
+  logical*1 :: lb(merra2bias_struc(n)%ncold*merra2bias_struc(n)%nrold)
+  logical*1 :: lo(LIS_rc%lnc(n)*LIS_rc%lnr(n))
+  integer   :: input_size
+  real      :: output_var(LIS_rc%lnc(n)*LIS_rc%lnr(n))
+
+  external :: bilinear_interp
+! _____________________________________________________________
+
+  input_size = merra2bias_struc(n)%ncold*merra2bias_struc(n)%nrold
+
+  lb = .true.
+  do r=1,merra2bias_struc(n)%nrold
+     do c=1,merra2bias_struc(n)%ncold
+        k= c+(r-1)*merra2bias_struc(n)%ncold
+        f(k) = input_var(c,r)
+        if ( f(k) == 1.e+15 ) then
+           f(k)  = LIS_rc%udef
+           lb(k) = .false.
+        endif
+     enddo
+  enddo
+
+  call bilinear_interp(LIS_rc%gridDesc(n,:),lb,f,lo,             &
+       output_var(:),                                            &
+       merra2bias_struc(n)%mi,LIS_rc%lnc(n)*LIS_rc%lnr(n),       &
+       LIS_domain(n)%lat, LIS_domain(n)%lon,                     &
+       merra2bias_struc(n)%w111,merra2bias_struc(n)%w121,        &
+       merra2bias_struc(n)%w211,merra2bias_struc(n)%w221,        &
+       merra2bias_struc(n)%n111,merra2bias_struc(n)%n121,        &
+       merra2bias_struc(n)%n211,merra2bias_struc(n)%n221,        &
+       LIS_rc%udef, iret)
+
+  if (order.eq.1) then
+     do r=1,LIS_rc%lnr(n)
+        do c=1,LIS_rc%lnc(n)
+           if(LIS_domain(n)%gindex(c,r).ne.-1) then
+              gid = LIS_domain(n)%gindex(c,r)
+              if(.not.isNaN(output_var(c+(r-1)*LIS_rc%lnc(n)))) then
+                 merra2bias_struc(n)%lapserate1(gid) = &
+                      output_var(c+(r-1)*LIS_rc%lnc(n))/1000.0
+              else
+                 merra2bias_struc(n)%lapserate1(gid) = &
+                      LIS_CONST_LAPSE_RATE
+              endif
+           endif
+        enddo
+     enddo
+  endif
+  if (order.eq.2) then
+     do r=1,LIS_rc%lnr(n)
+        do c=1,LIS_rc%lnc(n)
+           if(LIS_domain(n)%gindex(c,r).ne.-1) then
+              gid = LIS_domain(n)%gindex(c,r)
+              if(.not.isNaN(output_var(c+(r-1)*LIS_rc%lnc(n)))) then
+                 merra2bias_struc(n)%lapserate2(gid) = &
+                      output_var(c+(r-1)*LIS_rc%lnc(n))/1000.0
+              else
+                 merra2bias_struc(n)%lapserate2(gid) = &
+                      LIS_CONST_LAPSE_RATE
+              endif
+           endif
+        enddo
+     enddo
+  endif
+
+end subroutine interp_lapserate_merra2bias

--- a/lis/metforcing/merra2bias/read_merra2bias.F90
+++ b/lis/metforcing/merra2bias/read_merra2bias.F90
@@ -14,11 +14,6 @@
 ! \label{read_merra2bias}
 !
 ! !REVISION HISTORY:
-! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
-! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
-! 09 Jan 2026: Eric Kemp, reformatted.
-! 17 Jun 2026: Kristen Whitney, corrected GEOS-ITbias forcing
-!              variable documentation and indexing.
 ! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
 !
 ! !INTERFACE:

--- a/lis/metforcing/merra2bias/read_merra2bias_elev.F90
+++ b/lis/metforcing/merra2bias/read_merra2bias_elev.F90
@@ -13,8 +13,6 @@
 !
 ! !REVISION HISTORY:
 !
-! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
-! 09 Jan 2026: Eric Kemp, reformatted.
 ! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
 !
 ! !INTERFACE:

--- a/lis/metforcing/merra2bias/read_merra2bias_elev.F90
+++ b/lis/metforcing/merra2bias/read_merra2bias_elev.F90
@@ -1,0 +1,80 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: read_merra2bias_elev
+! \label{read_merra2bias_elev}
+!
+! !REVISION HISTORY:
+!
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+! 09 Jan 2026: Eric Kemp, reformatted.
+! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
+!
+! !INTERFACE:
+subroutine read_merra2bias_elev(n,findex)
+! !USES:
+  use LIS_coreMod,       only : LIS_rc, LIS_domain
+  use LIS_metforcingMod, only : LIS_forc
+  use LIS_fileIOMod,     only : LIS_read_param
+  use LIS_logMod,        only : LIS_logunit
+
+  implicit none
+
+! !ARGUMENTS:
+  integer, intent(in) :: n
+  integer, intent(in) :: findex
+
+! !DESCRIPTION:
+!
+!  Opens and reads MERRA-2 model elevation to the LIS grid.
+!  The MERRA-2 elevation is the same as the MERRA2bias elevation.
+!  The data will be used to perform any topographical adjustments
+!  to the forcing.
+!
+!  The elevation file needs to be preprocessed to fit the running
+!  resolution and domain.
+!
+!  The arguments are:
+!  \begin{description}
+!  \item[n]
+!   index of the nest
+!  \item[findex]
+!   index of the forcing source
+!  \end{description}
+!
+!  The routines invoked are:
+!  \begin{description}
+!   \item[LIS\_readData](\ref{LIS_readData}) \newline
+!    Abstract method to read the elevation of the forcing
+!    data in the same map projection used in LIS.
+!  \end{description}
+!EOP
+
+  integer :: c,r
+  real    :: go(LIS_rc%lnc(n),LIS_rc%lnr(n))
+
+  if (trim(LIS_rc%met_ecor(findex)).ne."none") then
+     write(LIS_logunit,*)                                          &
+          'Reading the MERRA2bias/MERRA-2 elevation map ...'
+
+     call LIS_read_param(n,"ELEV_MERRA2",go)
+
+     do r = 1,LIS_rc%lnr(n)
+        do c = 1,LIS_rc%lnc(n)
+           if (LIS_domain(n)%gindex(c,r).ne.-1) then
+              LIS_forc(n,findex)%modelelev(LIS_domain(n)%gindex(c,r)) = &
+                   go(c,r)
+           endif
+        enddo
+     enddo
+  endif
+
+end subroutine read_merra2bias_elev
+

--- a/lis/metforcing/merra2bias/readcrd_merra2bias.F90
+++ b/lis/metforcing/merra2bias/readcrd_merra2bias.F90
@@ -13,9 +13,6 @@
 ! \label{readcrd_merra2bias}
 !
 ! !REVISION HISTORY:
-! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
-! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
-! 09 Jan 2026: Eric Kemp, reformatting.
 ! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
 !
 ! !INTERFACE:

--- a/lis/metforcing/merra2bias/readcrd_merra2bias.F90
+++ b/lis/metforcing/merra2bias/readcrd_merra2bias.F90
@@ -1,0 +1,161 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+!
+! !ROUTINE: readcrd_merra2bias
+! \label{readcrd_merra2bias}
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+! 07 Jan 2026: Kristen Whitney, initial code for using dynamic lapse rate
+! 09 Jan 2026: Eric Kemp, reformatting.
+! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
+!
+! !INTERFACE:
+subroutine readcrd_merra2bias()
+! !USES:
+  use ESMF
+  use LIS_logMod
+  use LIS_coreMod, only       : LIS_rc,LIS_config
+  use merra2bias_forcingMod, only : merra2bias_struc
+!
+! !DESCRIPTION:
+!
+!  This routine reads the options specific to MERRA2bias forcing
+!  from the LIS configuration file.
+!
+!EOP
+  implicit none
+
+  integer :: n,rc
+  logical :: usedynlapserate
+
+  call ESMF_ConfigFindLabel(LIS_config,                            &
+       "MERRA2bias forcing directory:",rc=rc)
+  do n = 1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config,                      &
+          merra2bias_struc(n)%merra2biasdir,rc=rc)
+     call LIS_verify(rc,'MERRA2bias forcing directory: not defined')
+  enddo
+
+  call ESMF_ConfigFindLabel(LIS_config, &
+       "MERRA2bias apply dynamic lapse rates:",rc=rc)
+  do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config, &
+          merra2bias_struc(n)%usedynlapserate,&
+          default=0, rc=rc)
+     call LIS_verify(rc,&
+          'MERRA2bias apply dynamic lapse rates: not defined')
+  enddo
+
+  usedynlapserate = .true.
+
+  do n=1,LIS_rc%nnest
+     if(merra2bias_struc(n)%usedynlapserate.eq.0) then
+        usedynlapserate = .false.
+     endif
+  enddo
+
+  if(usedynlapserate) then
+     call ESMF_ConfigFindLabel(LIS_config, &
+          "MERRA2bias dynamic lapse rate data directory:",rc=rc)
+     do n=1,LIS_rc%nnest
+        call ESMF_ConfigGetAttribute(LIS_config, &
+             merra2bias_struc(n)%dynlapseratedir,&
+             rc=rc)
+        call LIS_verify(rc,&
+             'MERRA2bias dynamic lapse rate data directory: not defined')
+     enddo
+
+     call ESMF_ConfigFindLabel(LIS_config, &
+          "MERRA2bias dynamic lapse rate filename prefix:",rc=rc)
+     do n=1,LIS_rc%nnest
+        call ESMF_ConfigGetAttribute(LIS_config, &
+             merra2bias_struc(n)%dynlapseratepfx,&
+             default='/MERRA2bias.lapse_rate.hourly.', rc=rc)
+        write(LIS_logunit,*) &
+             '[INFO] MERRA2bias dynamic lapse rate filename prefix:', &
+             trim(merra2bias_struc(n)%dynlapseratepfx)
+     enddo
+
+     call ESMF_ConfigFindLabel(LIS_config, &
+          "MERRA2bias dynamic lapse rate filename suffix: ",rc=rc)
+     do n=1,LIS_rc%nnest
+        call ESMF_ConfigGetAttribute(LIS_config, &
+             merra2bias_struc(n)%dynlapseratesfx,&
+             default='.global.nc', rc=rc)
+        write(LIS_logunit,*) &
+             '[INFO] MERRA2bias dynamic lapse rate filename suffix: ', &
+             trim(merra2bias_struc(n)%dynlapseratesfx)
+     enddo
+
+     call ESMF_ConfigFindLabel(LIS_config, &
+          "MERRA2bias apply double-sided dynamic lapse rate cutoff:", &
+          rc=rc)
+     do n=1,LIS_rc%nnest
+        call ESMF_ConfigGetAttribute(LIS_config, &
+             merra2bias_struc(n)%applydynlapseratecutoff,&
+             default=0, rc=rc)
+        call LIS_verify(rc,&
+             'MERRA2bias apply double-sided dynamic lapse rate cutoff: not defined')
+     enddo
+
+     do n=1,LIS_rc%nnest
+        if(merra2bias_struc(n)%applydynlapseratecutoff.eq.1) then
+           call ESMF_ConfigFindLabel(LIS_config, &
+                "MERRA2bias minimum lapse rate cutoff (K/m):",rc=rc)
+           call ESMF_ConfigGetAttribute(LIS_config, &
+                merra2bias_struc(n)%dynlapseratemincutoff,&
+                default=-0.01, rc=rc)
+           call LIS_verify(rc,&
+                'MERRA2bias minimum lapse rate cutoff (K/m): not defined')
+           call ESMF_ConfigFindLabel(LIS_config, &
+                "MERRA2bias maximum lapse rate cutoff (K/m):",rc=rc)
+           call ESMF_ConfigGetAttribute(LIS_config, &
+                merra2bias_struc(n)%dynlapseratemaxcutoff,&
+                   default=0.01, rc=rc)
+           call LIS_verify(rc,&
+                'MERRA2bias maximum lapse rate cutoff (K/m): not defined')
+
+           ! Sanity check
+           if(merra2bias_struc(n)%dynlapseratemincutoff.gt. &
+                merra2bias_struc(n)%dynlapseratemaxcutoff) then
+              write(LIS_logunit,*) &
+                   '[ERR] MERRA2bias minimum lapse rate cutoff value should be'
+              write(LIS_logunit,*) &
+                   '[ERR] less than the MERRA2bias maximum lapse rate cutoff value.'
+              write(LIS_logunit,*) &
+                   '[ERR] Note the default value is -0.01 K/m for the minimum cutoff,'
+              write(LIS_logunit,*) &
+                   '[ERR] and 0.01 K/m for the maximum cutoff.'
+              write(LIS_logunit,*) &
+                   '[ERR] Please ensure if specifying just the minimum (maximum)'
+              write(LIS_logunit,*) &
+                   '[ERR] cutoff value, that it is less (greater) than the'
+              write(LIS_logunit,*) &
+                   '[ERR] maximum (minimum) default value.'
+              write(LIS_logunit,*) '[ERR] STOPPING ....'
+              call LIS_endrun()
+           endif
+        endif
+     enddo
+  endif
+
+  do n = 1,LIS_rc%nnest
+     write(LIS_logunit,*) '[INFO] Using MERRA2bias forcing'
+     write(LIS_logunit,*) '[INFO] MERRA2bias forcing directory: ',    &
+          trim(merra2bias_struc(n)%merra2biasdir)
+
+     merra2bias_struc(n)%merra2biastime1 = 3000.0
+     merra2bias_struc(n)%merra2biastime2 = 0.0
+  enddo
+
+end subroutine readcrd_merra2bias
+

--- a/lis/metforcing/merra2bias/reset_merra2bias.F90
+++ b/lis/metforcing/merra2bias/reset_merra2bias.F90
@@ -12,8 +12,6 @@
 ! \label{reset_merra2bias}
 !
 ! !REVISION HISTORY:
-! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
-! 09 Jan 2026: Eric Kemp, reformatting.
 ! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
 !
 ! !INTERFACE:

--- a/lis/metforcing/merra2bias/reset_merra2bias.F90
+++ b/lis/metforcing/merra2bias/reset_merra2bias.F90
@@ -1,0 +1,44 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !MODULE: reset_merra2bias
+! \label{reset_merra2bias}
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on geos-it)
+! 09 Jan 2026: Eric Kemp, reformatting.
+! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
+!
+! !INTERFACE:
+subroutine reset_merra2bias()
+! !USES:
+  use LIS_coreMod,  only   : LIS_rc
+  use LIS_timeMgrMod, only : LIS_date2time
+  use merra2bias_forcingMod
+!
+! !DESCRIPTION:
+!  Routine to cleanup allocated structures for MERRA2bias forcing.
+!
+!EOP
+  implicit none
+
+  integer :: n
+
+  do n = 1,LIS_rc%nnest
+     merra2bias_struc(n)%startFlag = .true.
+     merra2bias_struc(n)%dayFlag = .true.
+     merra2bias_struc(n)%merra2biastime1 = 3000.0
+     merra2bias_struc(n)%merra2biastime2 = 0.0
+     merra2bias_struc(n)%ringtime = 0.0
+     merra2bias_struc(n)%reset_flag = .true.
+  enddo
+
+end subroutine reset_merra2bias
+

--- a/lis/metforcing/merra2bias/timeinterp_merra2bias.F90
+++ b/lis/metforcing/merra2bias/timeinterp_merra2bias.F90
@@ -12,10 +12,6 @@
 ! \label{timeinterp_merra2bias}
 !
 ! !REVISION HISTORY:
-! 02 Oct 2025: Fadji Maina, initial code (based on -it)
-! 09 Jan 2026: Eric Kemp, reformatting.
-! 17 Jun 2026: Kristen Whitney, updated metadata storage references
-!              and corrected GEOS-ITbias forcing indexing.
 ! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
 !
 ! !INTERFACE:

--- a/lis/metforcing/merra2bias/timeinterp_merra2bias.F90
+++ b/lis/metforcing/merra2bias/timeinterp_merra2bias.F90
@@ -1,0 +1,149 @@
+!-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+! NASA Goddard Space Flight Center
+! Land Information System Framework (LISF)
+! Version 7.5
+!
+! Copyright (c) 2024 United States Government as represented by the
+! Administrator of the National Aeronautics and Space Administration.
+! All Rights Reserved.
+!-------------------------END NOTICE -- DO NOT EDIT-----------------------
+!BOP
+! !ROUTINE: timeinterp_merra2bias
+! \label{timeinterp_merra2bias}
+!
+! !REVISION HISTORY:
+! 02 Oct 2025: Fadji Maina, initial code (based on -it)
+! 09 Jan 2026: Eric Kemp, reformatting.
+! 17 Jun 2026: Kristen Whitney, updated metadata storage references
+!              and corrected GEOS-ITbias forcing indexing.
+! 29 Jun 2026: Kristen Whitney, initial code (based on geos-itbias)
+!
+! !INTERFACE:
+subroutine timeinterp_merra2bias(n,findex)
+
+! !USES:
+  use ESMF
+  use LIS_FORC_AttributesMod
+  use LIS_coreMod,       only : LIS_rc,LIS_domain,LIS_localPet
+  use LIS_metforcingMod, only : LIS_forc,LIS_FORC_Base_State
+  use LIS_constantsMod,  only : LIS_CONST_SOLAR
+  use LIS_timeMgrMod,    only : LIS_tick
+  use LIS_logMod,        only : LIS_verify,LIS_endrun
+  use merra2bias_forcingMod,   only : merra2bias_struc
+  use LIS_forecastMod,   only : LIS_get_iteration_index
+  use LIS_ran2_gasdev
+
+  implicit none
+
+! !ARGUMENTS:
+  integer, intent(in):: n
+  integer, intent(in):: findex
+!
+! !DESCRIPTION:
+!  Temporally interpolates the forcing data to the current model
+!  timestep.  Because all variables are a 1-hourly time average,
+!  no interpolation in time is actually performed.  The identical
+!  data is used for all timesteps within the hourly input file.
+!
+!  The routines invoked are:
+!  \begin{description}
+!   \item[LIS\_time2date](\ref{LIS_time2date}) \newline
+!    converts the time to a date format
+!   \item[zterp](\ref{zterp}) \newline
+!    zenith-angle based interpolation
+!  \end{description}
+!EOP
+  integer :: t,k,kk
+  integer :: index1
+  integer :: bdoy,byr,bmo
+  integer :: bda,bhr,bmn
+  integer :: bss
+  real*8  :: btime
+  real    :: gmt1,gmt2
+  real    :: bts
+  integer          :: status
+  integer          :: mfactor,m
+  type(ESMF_Field) :: tairField,qairField,psField,lwgabField
+  real,pointer     :: tair(:),qair(:),ps(:),lwgab(:)
+
+  btime = merra2bias_struc(n)%merra2biastime1
+  byr = LIS_rc%yr
+  bmo = LIS_rc%mo
+  bda = LIS_rc%da
+  bhr = LIS_rc%hr
+  bmn = 30
+  bss = 0
+  if (LIS_rc%mn.lt.30) then
+     bts = -(60*60)
+  else
+     bts = 0
+  endif
+  call LIS_tick(btime,bdoy,gmt1,byr,bmo,bda,bhr,bmn,bss,bts)
+
+  btime = merra2bias_struc(n)%merra2biastime2
+  byr = LIS_rc%yr             !next hour
+  bmo = LIS_rc%mo
+  bda = LIS_rc%da
+  bhr = LIS_rc%hr
+  bmn = 30
+  bss = 0
+  if (LIS_rc%mn.lt.30) then
+     bts = 0
+  else
+     bts = 60*60
+  endif
+  call LIS_tick(btime,bdoy,gmt2,byr,bmo,bda,bhr,bmn,bss,bts)
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
+       LIS_FORC_Tair%varname(1),tairField,                         &
+       rc=status)
+  call LIS_verify(status,                                          &
+       'Error: Enable Tair in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
+       LIS_FORC_Qair%varname(1),QairField,                         &
+       rc=status)
+  call LIS_verify(status,                                          &
+       'Error: Enable Qair in the forcing variables list')
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
+       LIS_FORC_LWdown%varname(1),lwgabField,                      &
+       rc=status)
+  call LIS_verify(status,                                          &
+       'Error: Enable LWdown in the forcing variables list')
+
+
+  call ESMF_StateGet(LIS_FORC_Base_State(n,findex),                &
+       LIS_FORC_Psurf%varname(1),psField,                          &
+       rc=status)
+  call LIS_verify(status,                                          &
+       'Error: Enable Psurf in the forcing variables list')
+
+
+  call ESMF_FieldGet(tairField,localDE=0,farrayPtr=tair,rc=status)
+  call LIS_verify(status)
+
+  call ESMF_FieldGet(qairField,localDE=0,farrayPtr=qair,rc=status)
+  call LIS_verify(status)
+
+  call ESMF_FieldGet(lwgabField,localDE=0,farrayPtr=lwgab,rc=status)
+  call LIS_verify(status)
+
+  call ESMF_FieldGet(psField,localDE=0,farrayPtr=ps,rc=status)
+  call LIS_verify(status)
+
+  mfactor = LIS_rc%nensem(n)/merra2bias_struc(n)%nIter
+
+  do k = 1,LIS_rc%ntiles(n)/mfactor
+     do m = 1,mfactor
+        t = m + (k-1)*mfactor
+        index1 = LIS_domain(n)%tile(t)%index
+        kk = LIS_get_iteration_index(n,k,index1,mfactor)
+        tair(t) = merra2bias_struc(n)%metdata(kk,1,index1)
+        qair(t) = merra2bias_struc(n)%metdata(kk,2,index1)
+        ps(t) = merra2bias_struc(n)%metdata(kk,3,index1)
+        lwgab(t) = merra2bias_struc(n)%metdata(kk,4,index1)
+     enddo
+  enddo
+end subroutine timeinterp_merra2bias
+

--- a/lis/plugins/LIS_metforcing_pluginMod.F90
+++ b/lis/plugins/LIS_metforcing_pluginMod.F90
@@ -22,6 +22,7 @@ module LIS_metforcing_pluginMod
 ! !REVISION HISTORY: 
 !  11 Dec 2003   Sujay Kumar:  Initial Specification
 !  11 Oct 2014   K. Arsenault: Reorganzed for syncing with LDT
+!  29 Jun 2026: Kristen whitney, added support for MERRA2bias
 ! 
 !EOP  
   implicit none
@@ -134,6 +135,10 @@ subroutine LIS_metforcing_plugin
 
 #if ( defined MF_MERRA2 )
    use merra2_forcingMod
+#endif
+
+#if ( defined MF_MERRA2bias )
+   use merra2bias_forcingMod
 #endif
 
 #if ( defined MF_GEOS_IT )
@@ -386,6 +391,13 @@ subroutine LIS_metforcing_plugin
    external timeinterp_merra2
    external finalize_merra2
    external reset_merra2
+#endif
+
+#if ( defined MF_MERRA2bias )
+   external get_merra2bias
+   external timeinterp_merra2bias
+   external finalize_merra2bias
+   external reset_merra2bias
 #endif
 
 #if ( defined MF_GEOS_IT )
@@ -798,6 +810,16 @@ subroutine LIS_metforcing_plugin
                                   timeinterp_merra2)
    call registerresetmetforc(trim(LIS_merra2Id)//char(0),reset_merra2)
    call registerfinalmetforc(trim(LIS_merra2Id)//char(0),finalize_merra2)
+#endif
+
+#if ( defined MF_MERRA2bias )
+! - MERRA2bias Reanalysis Forcing:
+   call registerinitmetforc(trim(LIS_merra2biasId)//char(0),init_merra2bias)
+   call registerretrievemetforc(trim(LIS_merra2biasId)//char(0),get_merra2bias)
+   call registertimeinterpmetforc(trim(LIS_merra2biasId)//char(0), &
+                                  timeinterp_merra2bias)
+   call registerresetmetforc(trim(LIS_merra2biasId)//char(0),reset_merra2bias)
+   call registerfinalmetforc(trim(LIS_merra2biasId)//char(0),finalize_merra2bias)
 #endif
 
 #if ( defined MF_GEOS_IT )

--- a/lis/plugins/LIS_pluginIndices.F90
+++ b/lis/plugins/LIS_pluginIndices.F90
@@ -30,6 +30,7 @@ module LIS_pluginIndices
 !  27 Jan 2014: Shugong Wang, added HRAP projection
 !   4 Nov 2014: Jonathan Case, added support for daily NESDIS/VIIRS GVF for Noah
 !  16 Aug 2016: Mahdi Navari, added PILDAS  
+!  29 Jun 2026: Kristen whitney, added support for MERRA2bias
 !
 !EOP
   PRIVATE
@@ -136,6 +137,7 @@ module LIS_pluginIndices
    character*50, public,  parameter :: LIS_gldasId           = "GLDAS"
    character*50, public,  parameter :: LIS_gfsId             = "GFS"
    character*50, public,  parameter :: LIS_merra2Id          = "MERRA2"
+   character*50, public,  parameter :: LIS_merra2biasId      = "MERRA2bias"
    character*50, public,  parameter :: LIS_geositId          = "GEOS-IT"
 
    character*50, public,  parameter :: LIS_cmapId            = "CMAP"

--- a/lis/surfacemodels/land/template/template_f2t.F90
+++ b/lis/surfacemodels/land/template/template_f2t.F90
@@ -16,6 +16,7 @@
 ! !REVISION HISTORY: 
 ! 21 Jul 2004: Sujay Kumar   Initial Specification
 ! 23 Oct 2007: Kristi Arsenault, Implemented code for LISv5.0
+! 29 Jun 2026: Kristen Whitney, Made precipitation handling optional; only assign rainf when LIS_FORC_CRainf is selected
 ! 
 ! !INTERFACE:
 subroutine template_f2t(n)
@@ -164,10 +165,12 @@ subroutine template_f2t(n)
      if(LIS_FORC_Psurf%selectOpt.eq.1) then
        template_struc(n)%template(t)%psurf=psurf(tid)
      endif
-     if(pcp(tid).ne.LIS_rc%udef) then
-        template_struc(n)%template(t)%rainf=pcp(tid)
-     else
-        template_struc(n)%template(t)%rainf=0.0
+     if(LIS_FORC_CRainf%selectOpt.eq.1) then
+       if(pcp(tid).ne.LIS_rc%udef) then
+          template_struc(n)%template(t)%rainf=pcp(tid)
+       else
+          template_struc(n)%template(t)%rainf=0.0
+       endif
      endif
      if(LIS_FORC_CRainf%selectOpt.eq.1) then 
         if(cpcp(tid).ne.LIS_rc%udef) then 

--- a/lis/testcases/metforcing/merra2bias/MODEL_OUTPUT_LIST.TBL
+++ b/lis/testcases/metforcing/merra2bias/MODEL_OUTPUT_LIST.TBL
@@ -1,0 +1,143 @@
+#short_name select? units signconv timeavg? min/max? std? vert.levels grib_id grib_scalefactor longname
+
+#Energy balance components
+Swnet:        0  W/m2    DN   1 0 0 1 111 10      # Net Shortwave Radiation (W/m2)
+Lwnet:        0  W/m2    DN   1 0 0 1 112 10      # Net Longwave Radiation (W/m2)
+Qle:          0  W/m2    UP   1 0 0 1 121 10      # Latent Heat Flux (W/m2)
+Qh:           0  W/m2    UP   1 0 0 1 122 10      # Sensible Heat Flux (W/m2)
+Qg:           0  W/m2    DN   1 0 0 1 155 10      # Ground Heat Flux (W/m2)
+Qf:           0  W/m2    S2L  1 0 0 1 229 10      # Energy of fusion (W/m2)
+Qv:           0  W/m2    S2V  1 0 0 1 134 10      # Energy of sublimation (W/m2)
+Qa:           0  W/m2    DN   1 0 0 1 136 10      # Advective Energy (W/m2)
+Qtau:         0  N/m2    DN   1 0 0 1 135 10      # Momentum flux (N/m2)
+DelSurfHeat:  0  J/m2    INC  1 0 0 1 137 10      # Change in surface heat storage (J/m2)
+DelColdCont:  0  J/m2    INC  1 0 0 1 138 10      # Change in snow cold content (J/m2)
+BR:           0  -       -    1 0 1 1 256 10      # Bowen ratio
+EF:           0  -       -    1 0 1 1 256 10      # Evaporative fraction
+
+#Water balance components
+Snowf:        0  kg/m2s  DN   1 0 0 1 161 10000   # Snowfall rate (kg/m2s)
+Rainf:        0  kg/m2s  DN   1 0 0 1 162 10000   # Rainfall rate (kg/m2s)
+RainfConv:    0  kg/m2s  DN   1 0 0 1 163 10000   # Convective Rainfall rate (kg/m2s)
+TotalPrecip:  0  kg/m2s  DN   1 0 0 1 164 10000   # Total Precipitation rate (kg/m2s)
+Evap:         0  kg/m2s  UP   1 0 0 1  57 10000   # Total Evapotranspiration (kg/m2s)
+Qs:           0  kg/m2s  OUT  1 0 0 1 235 10000   # Surface runoff (kg/m2s)
+Qrec:         0  kg/m2s  IN   1 0 0 1 143 10000   # Recharge (kg/m2s)
+Qsb:          0  kg/m2s  OUT  1 0 0 1 254 10000   # Subsurface runoff (kg/m2s)
+Qsm:          0  kg/m2s  S2L  1 0 0 1  99 10000   # Snowmelt (kg/m2s)
+Qfz:          0  kg/m2s  L2S  1 0 0 1 146 10000   # Refreezing of water in the snowpack (kg/m2s)
+Qst:          0  kg/m2s  -    1 0 0 1 147 10000   # Snow throughfall (kg/m2s)
+DelSoilMoist: 0  kg/m2   INC  0 0 0 1 148 10000   # Change in soil moisture (kg/m2)
+DelSWE:       0  kg/m2   INC  0 0 0 1 149 1000    # Change in snow water equivalent (kg/m2)
+DelSurfStor:  0  kg/m2   INC  1 0 0 1 150 1000    # Change in surface water storage (kg/m2)
+DelIntercept: 0  kg/m2   INC  1 0 0 1 151 1000    # Change in interception storage (kg/m2)
+RHMin:        0   -      -    1 0 0 1  51 10      # Minimum 2 meter relative humidity (-)
+
+#Surface state variables
+SnowT:        0  K       -    1 0 0 1 152 10      # Snow surface temperature (K)
+VegT:         0  K       -    1 0 0 1 153 10      # Vegetation canopy temperature (K)
+BareSoilT:    0  K       -    1 0 0 1 154 10      # Temperature of bare soil (K)
+AvgSurfT:     0  K       -    1 0 0 1 148 10      # Average surface temperature (K)
+RadT:         0  K       -    1 1 0 1 156 10      # Surface Radiative Temperature (K)
+Albedo:       0  -       -    1 0 0 1  84 100     # Surface Albedo (-)
+SWE:          0  kg/m2   -    1 0 0 1  65 1000    # Snow Water Equivalent (kg/m2)
+SWEVeg:       0  kg/m2   -    1 0 0 1 159 1000    # SWE intercepted by vegetation (kg/m2)
+SurfStor:     0  kg/m2   -    1 0 0 1 160 1000    # Surface water storage (kg/m2)
+TWS:          0  mm      -    1 0 0 1 160 1000    # Terrestrial water storage (mm)
+GWS:          0  mm      -    1 0 0 1 176 100     # Ground water storage (mm)
+WaterTableD:  0  m       -    1 0 0 1 174 1       # Water table depth (m)
+SWS:          0  mm      -    1 0 0 1 333 10      # Surface water storage
+
+#Subsurface state variables
+SoilMoist:    0  m3/m3   -    1 0 0 4  86 1000    # Average layer soil moisture (kg/m2)
+SoilTemp:     0  K       -    1 0 0 4  85 1000    # Average layer soil temperature (K)
+SmLiqFrac:    0  -       -    1 0 0 4  85 100     # Average layer fraction of liquid moisture (-)
+SmFrozFrac:   0  -       -    1 0 0 4  85 100     # Average layer fraction of frozen moisture (-)
+SoilWet:      0  -       -    0 0 0 1  85 100     # Total soil wetness (-)
+RelSMC:       0  m3/m3   -    0 0 0 1  86 1000    # Relative soil moisture
+RootTemp:     0  K       -    0 0 0 1  85 1000    # Rootzone temperature (K)
+
+#Evaporation components
+PotEvap:      0  kg/m2s  UP   1 0 0 1 166 1       # Potential Evapotranspiration (kg/m2s)
+ECanop:       0  kg/m2s  UP   1 0 0 1 200 1       # Interception evaporation (kg/m2s)
+TVeg:         0  kg/m2s  UP   1 0 0 1 210 1       # Vegetation transpiration (kg/m2s)
+ESoil:        0  kg/m2s  UP   1 0 0 1 199 1       # Bare soil evaporation (kg/m2s)
+EWater:       0  kg/m2s  UP   1 0 0 1 170 1       # Open water evaporation (kg/m2s)
+RootMoist:    0  kg/m2   -    0 0 0 1 171 1       # Root zone soil moisture (kg/m2)
+CanopInt:     0  kg/m2   -    1 0 0 1 223 1000    # Total canopy water storage (kg/m2)
+EvapSnow:     0  kg/m2s  -    1 0 0 1 173 1000    # Snow evaporation (kg/m2s)
+SubSnow:      0  kg/m2s  -    1 0 0 1 198 1000    # Snow sublimation (kg/m2s)
+SubSurf:      0  kg/m2s  -    1 0 0 1 175 1000    # Sublimation of the snow free area (kg/m2s)
+ACond:        0  m/s     -    1 0 0 1 179 100000  # Aerodynamic conductance
+CCond:        0  m/s     -    1 0 0 1 179 1000000 # Canopy conductance
+
+#Cold season processes
+Snowcover:    0  -       -    1 0 0 1  66 100     # Snow Cover (-)
+SnowDepth:    0  m       -    1 0 0 1  66 1000    # Snow Depth (m)
+SLiqFrac:     0  -       -    0 0 0 1  65 1000    # Fraction of SWE in the liquid phase
+
+#Forcings
+Wind_f:       0  m/s     -    1 0 0 1 177 10      # Near Surface Wind (m/s)
+Rainf_f:      0  kg/m2s  DN   1 0 0 1 162 1000    # Average rainfall rate
+Snowf_f:      0  kg/m2s  DN   1 0 0 1 161 1000    # Average snowfall rate
+Tair_f:       1  K       -    1 0 0 1  11 10      # Near surface air temperature
+Qair_f:       1  kg/kg   -    1 0 0 1  51 1000    # Near surface specific humidity
+Psurf_f:      1  Pa      -    1 0 0 1   1 10      # Surface pressure
+SWdown_f:     0  W/m2    DN   1 0 0 1 204 10      # Surface incident shortwave radiation
+LWdown_f:     1  W/m2    DN   1 0 0 1 205 10      # Surface incident longwave radiation
+
+#Additional forcings
+DirectSW_f:   0  W/m2    -    0 0 0 1 256 10      # Surface direct incident shortwave radiation
+DiffuseSW_f:  0  W/m2    -    0 0 0 1 256 10      # Surface diffuse incident shortwave radiation
+NWind_f:      0  m/s     N    0 0 0 1 256 10      # Northward wind
+EWind_f:      0  m/s     E    0 0 0 1 256 10      # Eastward wind
+FHeight_f:    0  m       -    0 0 0 1 256 10      # Height of forcing variables
+CH_f:         0  -       -    0 0 0 1 256 10      # Surface exchange coefficient for heat
+CM_f:         0  -       -    0 0 0 1 256 10      # Surface Exchange Coefficient for momentum
+Emiss_f:      0  -       -    0 0 0 1 256 10      # Surface emissivity
+MixRatio_f:   0  kg/kg   -    0 0 0 1 256 10      # Surface mixing ration
+CosZenith_f:  0  -       -    0 0 0 1 256 10      # Cosine of zenith angle
+Albedo_f:     0  -       -    0 0 0 1 256 10      # Surface albedo
+
+#Parameters
+Landmask:     0  -       -    0 0 0 1  81 1       # Land Mask (0 - Water, 1- Land)
+Landcover:    0  -       -    0 0 0 1 186 1       # Land cover
+Soiltype:     0  -       -    0 0 0 1 187 1       # Soil type
+SandFrac:     0  -       -    0 0 0 1 999 1       # Sand fraction
+ClayFrac:     0  -       -    0 0 0 1 999 1       # Clay fraction
+SiltFrac:     0  -       -    0 0 0 1 999 1       # Silt fraction
+Porosity:     0  -       -    3 0 0 1 999 1       # Porosity
+Soilcolor:    0  -       -    0 0 0 1 188 1       # Soil color
+Elevation:    0  m       -    0 0 0 1 189 10      # Elevation
+Slope:        0  -       -    0 0 0 1 999 10      # Slope
+LAI:          0  -       -    1 0 0 1 190 100     # LAI
+SAI:          0  -       -    0 0 0 1 191 100     # SAI
+Snfralbedo:   0  -       -    0 0 0 1 192 100     # Snow fraction albedo
+Mxsnalbedo:   0  -       -    0 0 0 1 192 100     # Maximum snow albedo
+Greenness:    0  -       -    0 0 0 1  87 100     # Greenness
+Tempbot:      0  -       -    0 0 0 1 194 10      # Bottom soil temperature
+
+#RoutingStreamflow:      1 m3/s    -     1 0 0 1 333 10      #Streamflow
+Streamflow:      0 m3/s    -     1 0 0 1 333 10      #Streamflow
+RiverDepth:      0 m       -     1 0 0 1 333 10      #RiverDepth
+RiverVelocity:   0 m/s     -     1 0 0 1 333 10      #RiverVelocity
+FloodQ:          0 m3/s    -     1 0 0 1 333 10      #FloodDischarge
+FloodEvap:       0 m3      -     1 0 0 1 333 10      #FloodEvap
+FloodStor:       0 m3      -     1 0 0 1 333 10      #FloodStorage
+FloodDepth:      0 m       -     1 0 0 1 333 10      #FloodDepth
+FloodVelocity:   0 m/s     -     1 0 0 1 333 10      #FloodVelocity
+FloodedFrac:     0 -       -     1 0 0 1 333 10      #FloodedFrac
+FloodedArea:     0 m2      -     1 0 0 1 333 10      #FloodedArea
+SurfElev:        0 m       -     1 0 0 1 333 10      #SurfElev
+RunoffStor:      0 m3      -     1 0 0 1 333 10      #RunoffStor
+BaseflowStor:    0 m3      -     1 0 0 1 333 10      #BaseflowStor
+
+#
+GPP:          0  g/m2s   IN   1 0 0 1 256 1       # Gross Primary Production
+NEE:          0  g/m2s   OUT  1 0 0 1 256 1       # Net Ecosystem Exchange
+
+#Irrigation
+Irrigated water:   0 kg/m2s    -     1 0 0 1 333 10      #Irrigation amount
+
+#Lapse rate
+Lapserate:    1  K/km    UP   1 0 0 1 255 10      # Lapse rate

--- a/lis/testcases/metforcing/merra2bias/README
+++ b/lis/testcases/metforcing/merra2bias/README
@@ -1,0 +1,80 @@
+MERRA2bias Dynamic Lapse-Rate Forcing Test Case
+
+This test case performs a 1-km simulation over central California using
+the TEMPLATE LSM option from 2026-01-31 01:00 UTC through 2026-01-31
+06:00 UTC to test the processing of MERRA2bias forcing data and
+dynamic lapse-rate downscaling within the NASA Land Information System
+(LIS). The testcase uses dynamic lapse-rate fields generated from
+MERRA-2 air-temperature fields following the methodology described by
+Whitney et al. (2025).
+
+The test case uses:
+
+(a) MERRA2bias forcing data containing MERRA-2 near-surface air
+    temperature, near-surface specific humidity, and surface pressure,
+    and bias-corrected downward longwave radiation.
+
+(b) Dynamic lapse-rate downscaling within LIS.
+
+(c) The TEMPLATE LSM option, which serves as a placeholder land surface
+    model and outputs the processed forcing fields.
+
+(d) A 1-km domain over central California.
+
+(e) Dynamic lapse-rate fields generated from MERRA2bias air-temperature
+    inputs using the methodology of Whitney et al. (2025).
+
+MERRA2bias forcings are generated upstream of LIS by combining native
+MERRA-2 near-surface air temperature, near-surface specific humidity,
+and surface pressure with bias-corrected downward longwave radiation.
+The longwave radiation field is bias corrected using monthly
+climatological reference datasets generated outside of LIS. The
+resulting MERRA2bias forcing fields are provided as input to LIS
+through the input/MERRA2BIAS directory.
+
+The dynamic lapse-rate fields used by this test case are provided
+through the input/dynlapserates_merra2bias directory. These lapse rates
+are generated from MERRA-2 air-temperature fields using the
+methodology described by Whitney et al. (2025) and are used by LIS to
+perform elevation-based downscaling of air temperature.
+
+This directory contains:
+
+* this README file.
+* the ldt.config file used to generate the LIS parameter file.
+* the lis.config file used for this test case.
+* the MODEL_OUTPUT_LIST.TBL file used to specify output variables.
+* a sample GrADS control file that can be used to visualize the LIS
+  parameter file (input.ctl).
+* a sample GrADS control file that can be used to visualize the model
+  output (output.ctl).
+* a sample GrADS control file that can be used to visualize the target
+  output (testcase.ctl).
+
+To run this test case:
+
+* Generate the LIS executable.
+* Run the LIS executable using the supplied lis.config file and the
+  testcase input data.
+* Compare the generated output against the supplied target output.
+* View the output using the provided GrADS control files.
+
+Notes
+
+Additional information regarding the dynamic lapse-rate generation
+workflow used for NLDAS-3 forcing production can be found in:
+
+  lis/utils/nldas-3_forcing/dynamic_lapse_rates
+
+The dynamic lapse-rate methodology follows the framework of Rouf et al.
+(2020) with modifications described by Whitney et al. (2025). The
+associated workflow documentation and implementation are maintained in
+the dynamic_lapse_rates directory.
+
+References
+
+Whitney, K. M., Kumar, S. V., Mocko, D., Pflug, J., Bolten, J. D.,
+Maina, F. Z., Wrzesien, M. L., and Hain, C. R., 2025:
+Quantifying the Impacts of Dynamic Lapse Regimes on Snow Simulations.
+Journal of Hydrometeorology, 26(10), 1525–1560.
+https://doi.org/10.1175/JHM-D-25-0021.1

--- a/lis/testcases/metforcing/merra2bias/input.ctl
+++ b/lis/testcases/metforcing/merra2bias/input.ctl
@@ -1,0 +1,94 @@
+dset ^lis_input_testcase.d01.nc
+dtype netcdf
+options template
+undef -9999
+xdef 101 linear -122.5 0.01
+ydef 101 linear 36.0 0.01
+zdef 1 linear 1 1
+* dummy tdef
+tdef 1 linear 00z01jan2026 1hr
+vars 83
+DOMAINMASK=>DOMAINMASK 1 y,x description
+LANDMASK=>LANDMASK 1 y,x description
+SURFACETYPE=>SURFACETYPE1 0 0,y,x description
+SURFACETYPE=>SURFACETYPE2 0 1,y,x description
+SURFACETYPE=>SURFACETYPE3 0 2,y,x description
+SURFACETYPE=>SURFACETYPE4 0 3,y,x description
+SURFACETYPE=>SURFACETYPE5 0 4,y,x description
+SURFACETYPE=>SURFACETYPE6 0 5,y,x description
+SURFACETYPE=>SURFACETYPE7 0 6,y,x description
+SURFACETYPE=>SURFACETYPE8 0 7,y,x description
+SURFACETYPE=>SURFACETYPE9 0 8,y,x description
+SURFACETYPE=>SURFACETYPE10 0 9,y,x description
+SURFACETYPE=>SURFACETYPE11 0 10,y,x description
+SURFACETYPE=>SURFACETYPE12 0 11,y,x description
+SURFACETYPE=>SURFACETYPE13 0 12,y,x description
+SURFACETYPE=>SURFACETYPE14 0 13,y,x description
+SURFACETYPE=>SURFACETYPE15 0 14,y,x description
+SURFACETYPE=>SURFACETYPE16 0 15,y,x description
+SURFACETYPE=>SURFACETYPE17 0 16,y,x description
+SURFACETYPE=>SURFACETYPE18 0 17,y,x description
+SURFACETYPE=>SURFACETYPE19 0 18,y,x description
+SURFACETYPE=>SURFACETYPE20 0 19,y,x description
+LANDCOVER=>LANDCOVER1 0 0,y,x description
+LANDCOVER=>LANDCOVER2 0 1,y,x description
+LANDCOVER=>LANDCOVER3 0 2,y,x description
+LANDCOVER=>LANDCOVER4 0 3,y,x description
+LANDCOVER=>LANDCOVER5 0 4,y,x description
+LANDCOVER=>LANDCOVER6 0 5,y,x description
+LANDCOVER=>LANDCOVER7 0 6,y,x description
+LANDCOVER=>LANDCOVER8 0 7,y,x description
+LANDCOVER=>LANDCOVER9 0 8,y,x description
+LANDCOVER=>LANDCOVER10 0 9,y,x description
+LANDCOVER=>LANDCOVER11 0 10,y,x description
+LANDCOVER=>LANDCOVER12 0 11,y,x description
+LANDCOVER=>LANDCOVER13 0 12,y,x description
+LANDCOVER=>LANDCOVER14 0 13,y,x description
+LANDCOVER=>LANDCOVER15 0 14,y,x description
+LANDCOVER=>LANDCOVER16 0 15,y,x description
+LANDCOVER=>LANDCOVER17 0 16,y,x description
+LANDCOVER=>LANDCOVER18 0 17,y,x description
+LANDCOVER=>LANDCOVER19 0 18,y,x description
+LANDCOVER=>LANDCOVER20 0 19,y,x description
+TEXTURE=>TEXTURE1 0 0,y,x description
+TEXTURE=>TEXTURE2 0 1,y,x description
+TEXTURE=>TEXTURE3 0 2,y,x description
+TEXTURE=>TEXTURE4 0 3,y,x description
+TEXTURE=>TEXTURE5 0 4,y,x description
+TEXTURE=>TEXTURE6 0 5,y,x description
+TEXTURE=>TEXTURE7 0 6,y,x description
+TEXTURE=>TEXTURE8 0 7,y,x description
+TEXTURE=>TEXTURE9 0 8,y,x description
+TEXTURE=>TEXTURE10 0 9,y,x description
+TEXTURE=>TEXTURE11 0 10,y,x description
+TEXTURE=>TEXTURE12 0 11,y,x description
+TEXTURE=>TEXTURE13 0 12,y,x description
+TEXTURE=>TEXTURE14 0 13,y,x description
+TEXTURE=>TEXTURE15 0 14,y,x description
+TEXTURE=>TEXTURE16 0 15,y,x description
+ELEVFGRD=>ELEVFGRD 1 y,x description
+ELEVATION=>ELEVATION 1 y,x description
+SLOPEFGRD=>SLOPEFGRD 1 y,x description
+SLOPE=>SLOPE 1 y,x description
+ASPECTFGRD=>ASPECTFGRD 1 y,x description
+ASPECT=>ASPECT 1 y,x description
+GREENNESS=>GREENNESS1 0 0,y,x description
+GREENNESS=>GREENNESS2 0 1,y,x description
+GREENNESS=>GREENNESS3 0 2,y,x description
+GREENNESS=>GREENNESS4 0 3,y,x description
+GREENNESS=>GREENNESS5 0 4,y,x description
+GREENNESS=>GREENNESS6 0 5,y,x description
+GREENNESS=>GREENNESS7 0 6,y,x description
+GREENNESS=>GREENNESS8 0 7,y,x description
+GREENNESS=>GREENNESS9 0 8,y,x description
+GREENNESS=>GREENNESS10 0 9,y,x description
+GREENNESS=>GREENNESS11 0 10,y,x description
+GREENNESS=>GREENNESS12 0 11,y,x description
+SHDMIN=>SHDMIN 1 y,x description
+SHDMAX=>SHDMAX 1 y,x description
+TBOT=>TBOT 1 y,x description
+NOAHMP36_PBLH=>NOAHMP36_PBLH 1 y,x description
+ELEV_MERRA2=>ELEV_MERRA2 1 y,x description
+lat=>lat 1 y,x description
+lon=>lon 1 y,x description
+endvars

--- a/lis/testcases/metforcing/merra2bias/ldt.config
+++ b/lis/testcases/metforcing/merra2bias/ldt.config
@@ -1,0 +1,131 @@
+#Overall driver options
+LDT running mode:                       "LSM parameter processing"
+Processed LSM parameter filename:       ./lis_input_testcase.d01.nc
+LIS number of nests:                    1
+Number of surface model types:          1
+Surface model types:                    "LSM"
+Land surface model:                     "Noah-MP.4.0.1"
+Routing model:                          none
+Lake model:                             none
+Water fraction cutoff value:            0.5
+Incorporate crop information:           .false.
+Number of met forcing sources:          1
+Met forcing sources:                    "MERRA2"
+Met spatial transform methods:          bilinear
+Topographic correction method (met forcing):  "lapse-rate"
+Temporal interpolation method (met forcing):  none
+LDT diagnostic file:                    ldtlog_testcase
+Mask-parameter fill diagnostic file:    MaskParamFill.lis_input_testcase.d01.log
+LDT output directory:                   OUTPUT
+Undefined value:                        -9999.0
+
+#LIS domain
+Map projection of the LIS domain:       latlon
+LL run domain lower left lat: 36.000
+LL run domain lower left lon: -122.500
+LL run domain upper right lat: 37.000
+LL run domain upper right lon: -121.500
+LL run domain resolution (dx): 0.01
+LL run domain resolution (dy): 0.01
+
+Number of processors along x:           4
+Number of processors along y:           4
+
+#Landcover parameter inputs
+Landcover data source:                  "MODIS_Native"
+Landcover classification:               "IGBPNCEP"
+Landcover file:                         ./input/LS_PARAMETERS/noah_2dparms/igbp.bin
+Landcover spatial transform:            neighbor
+Landcover map projection:               latlon
+Landcover fill option:                  neighbor
+Landcover fill radius:                  5
+Landcover fill value:                   6
+
+#Landmask parameter inputs
+Create or readin landmask:              "create"
+Landmask data source:                   "MODIS_Native"
+
+#Soil parameter inputs
+Soil fraction data source:              none
+Soils spatial transform:                none
+Soils map projection:                   latlon
+Soils fill option:                      none
+Porosity data source:                   none
+Porosity map:                           none
+
+#Soil texture inputs
+Soil texture data source:               "ISRIC"
+Soil texture map:                       ./input/LS_PARAMETERS/soil_parms/ISRIC/v2017/TEXMHT_M_sl1_250m.tif
+Soil texture spatial transform:         mode
+Soil texture map projection:            latlon
+Soil texture fill option:               neighbor
+Soil texture fill radius:               5
+Soil texture fill value:                6
+Soil texture force exclusion of water points during fill:  .true.
+
+#Topography parameter inputs
+Elevation data source:                  "MERIT_1K"
+Elevation number of bands:              1
+Elevation map:                          ./input/LS_PARAMETERS/topo_parms/MERIT
+Elevation fill option:                  neighbor
+Elevation fill radius:                  5
+Elevation fill value:                   0.0
+
+Slope data source:                      "MERIT_1K"
+Slope number of bands:                  1
+Slope map:                              ./input/LS_PARAMETERS/topo_parms/MERIT
+Slope fill option:                      neighbor
+Slope fill radius:                      5
+Slope fill value:                       0.0
+
+Aspect data source:                     "MERIT_1K"
+Aspect number of bands:                 1
+Aspect map:                             ./input/LS_PARAMETERS/topo_parms/MERIT
+Aspect fill option:                     neighbor
+Aspect fill radius:                     5
+Aspect fill value:                      3.14159
+
+Topography spatial transform:           average
+Topography map projection:              latlon
+
+#Albedo inputs
+Albedo data source:                     none
+
+#Maximum snow albedo inputs
+Max snow albedo data source:            none
+
+#Greenness inputs
+Greenness data source:                  "NCEP_Native"
+Greenness fraction map:                 ./input/LS_PARAMETERS/noah_2dparms/gfrac
+Greenness climatology interval:         monthly
+Calculate min-max greenness fraction:   .true.
+Greenness spatial transform:            "budget-bilinear"
+Greenness map projection:               latlon
+Greenness fill option:                  neighbor
+Greenness fill radius:                  5
+Greenness fill value:                   0.3
+Greenness maximum fill value:           1.0
+Greenness minimum fill value:           0.0
+
+#Slope type inputs
+Slope type data source:                 none
+
+#Bottom temperature inputs
+Bottom temperature data source:         "ISLSCP1"
+Bottom temperature map:                 ./input/LS_PARAMETERS/noah_2dparms/SOILTEMP.60
+Bottom temperature spatial transform:   "budget-bilinear"
+Bottom temperature map projection:      latlon
+Bottom temperature fill option:         average
+Bottom temperature fill radius:         5
+Bottom temperature fill value:          287.0
+Bottom temperature topographic downscaling:  "lapse-rate"
+
+#Noah-MP LSM inputs
+Noah-MP PBL Height Value:               900.
+
+#Forcing-based parameter inputs
+MERRA2 forcing directory:                  ./input/MET_FORCING/MERRA2
+MERRA2 use lowest model level forcing:     1
+MERRA2 use corrected total precipitation:  1
+MERRA2 geopotential terrain height file:   ./input/MET_FORCING/MERRA2/MERRA2_all/MERRA2.const_2d_asm_Nx.00000000.nc4
+

--- a/lis/testcases/metforcing/merra2bias/lis.config
+++ b/lis/testcases/metforcing/merra2bias/lis.config
@@ -1,0 +1,161 @@
+#Overall driver options
+Running mode:                           retrospective
+Map projection of the LIS domain:       latlon
+Number of nests:                        1
+Number of surface model types:          1
+Surface model types:                    LSM
+Surface model output interval:          1hr
+Land surface model:                     none
+Open water model:                       none
+Number of met forcing sources:          1
+Blending method for forcings:           overlay
+Met forcing sources:                    "MERRA2bias"
+Met forcing chosen ensemble member:     1
+Topographic correction method (met forcing):  "lapse-rate"
+Enable spatial downscaling of precipitation:  0
+Spatial upscaling method (met forcing):       none
+Spatial interpolation method (met forcing):   bilinear 
+Temporal interpolation method (met forcing):  "linear"
+
+#Runtime options
+Forcing variables list file:            ./input/forcing_variables.txt
+Output methodology:                     "2d gridspace" # "none" for spinup, "2d gridspace" for model runs
+Output model restart files:             0
+Output data format:                     netcdf #netcdf #binary
+Output naming style:                    "3 level hierarchy"
+Enable output statistics:               .false.
+Start mode:                             coldstart
+Starting year:                          2026
+Starting month:                         01
+Starting day:                           31
+Starting hour:                          00 
+Starting minute:                        00 
+Starting second:                        00
+Ending year:                            2026 
+Ending month:                           01
+Ending day:                             31
+Ending hour:                            06
+Ending minute:                          00
+Ending second:                          00
+Undefined value:                       -9999
+Output directory:                       'OUTPUT'
+Diagnostic output file:                 lislog
+Number of ensembles per tile:           1
+
+#The following options are used for subgrid tiling based on vegetation
+Maximum number of surface type tiles per grid:    1
+Minimum cutoff percentage (surface type tiles):   0.05
+Maximum number of soil texture tiles per grid:    1
+Minimum cutoff percentage (soil texture tiles):   0.05
+Maximum number of soil fraction tiles per grid:   1
+Minimum cutoff percentage (soil fraction tiles):  0.05
+Maximum number of elevation bands per grid:       1
+Minimum cutoff percentage (elevation bands):      0.05
+Maximum number of slope bands per grid:           1
+Minimum cutoff percentage (slope bands):          0.05
+Maximum number of aspect bands per grid:          1
+Minimum cutoff percentage (aspect bands):         0.05
+
+#Processor layout
+#Should match the total number of processors used
+Number of processors along x:        1
+Number of processors along y:        1
+Halo size along x:                      0
+Halo size along y:                      0
+
+#Sub-models
+Radiative transfer model:               none
+Number of application models:           0
+
+#HYMAP router
+Routing model:                           "none"
+
+#---------------------DATA ASSIMILATION ----------------------------------
+#Data assimilation options
+
+Number of data assimilation instances:               0
+Data assimilation algorithm:                         none
+Data assimilation set:                               none
+
+Apply perturbation bias correction:        0
+Bias estimation algorithm:                "none"  "none"
+Bias estimation attributes file:          "none"  "none"
+Data assimilation number of observation types:       1
+Data assimilation output ensemble spread:            0
+Data assimilation scaling strategy:                  "none"
+Data assimilation output processed observations:     1
+Data assimilation output innovations:                0
+Data assimilation use a trained forward model: 0
+Data assimilation trained forward model output file: none
+
+#Perturbation options
+Perturbations start mode:                  coldstart
+Perturbations restart output interval:     1mo
+Perturbations restart filename:            none
+Forcing perturbation algorithm:            none
+Forcing perturbation frequency:            1hr
+Forcing attributes file:                   none
+Forcing perturbation attributes file:      none
+State perturbation algorithm:              none
+State perturbation frequency:              3hr
+State attributes file:                     none
+State perturbation attributes file:        none
+Observation perturbation algorithm:        none
+Observation perturbation frequency:        6hr
+Observation attributes file:               none
+Observation perturbation attributes file:  none
+
+#------------------------DOMAIN SPECIFICATION--------------------------
+#The following options list the choice of parameter maps to be used
+LIS domain and parameter data file:     ./lis_input_testcase.d01.nc
+Landmask data source:                   LDT
+Landcover data source:                  LDT
+Soil texture data source:               LDT
+Soil fraction data source:              none
+Soil color data source:                 none
+Elevation data source:                  LDT
+Slope data source:                      LDT
+Aspect data source:                     LDT
+Curvature data source:                  none
+LAI data source:                        none
+SAI data source:                        none
+Albedo data source:                     none
+Max snow albedo data source:            none
+Greenness data source:                  LDT
+Roughness data source:                  none
+Porosity data source:                   none
+Ksat data source:                       none
+B parameter data source:                none
+Quartz data source:                     none
+Emissivity data source:                 none
+
+TBOT lag skin temperature update option:  0
+TBOT skin temperature lag days:           
+
+#--------------------------------FORCINGS----------------------------------
+MERRA2bias forcing directory:       ./input/MERRA2BIAS/
+MERRA2bias dynamic lapse rate filename prefix: MERRA2.lapse_rate.hourly.
+MERRA2bias dynamic lapse rate filename suffix: .nldas3.nc
+MERRA2bias apply dynamic lapse rates:          1
+MERRA2bias dynamic lapse rate data directory:  ./input/dynlapserates_merra2bias/
+MERRA2bias apply double-sided dynamic lapse rate cutoff:  1
+
+#------------------------------IRRIGATION-------------------------
+Irrigation scheme:            "none"
+
+#-----------------------LAND SURFACE MODELS--------------------------
+Template open water timestep:                1hr
+TEMPLATE model timestep:                     1hr
+
+#---------------------------MODEL OUTPUT CONFIGURATION-----------------------
+#Specify the list of ALMA variables that need to be featured in the
+#LSM model output
+Output start year:
+Output start month:
+Output start day:
+Output start hour:
+Output start minutes:
+Output start seconds:
+Time Average option:  1
+Number of dimensions in the lat/lon output fields:  "1D"
+Model output attributes file:           ./MODEL_OUTPUT_LIST.TBL

--- a/lis/testcases/metforcing/merra2bias/output.ctl
+++ b/lis/testcases/metforcing/merra2bias/output.ctl
@@ -1,0 +1,16 @@
+DSET ^OUTPUT/SURFACEMODEL/202601/LIS_HIST_%y4%m2%d2%h2%n2.d01.nc
+DTYPE netcdf
+OPTIONS template
+TITLE LIS output
+UNDEF -9999.0
+XDEF 101 LINEAR -122.5 0.01
+YDEF 101 LINEAR 36.0 0.01
+ZDEF 1 LINEAR 1 1
+TDEF 6 LINEAR 01:00Z31dec2023 1hr
+VARS 5
+Tair_f_tavg       1 99 ** air temperature K
+Qair_f_tavg       1 99 ** specific humidity kg/kg
+Psurf_f_tavg      1 99 ** surface pressure Pa
+LWdown_f_tavg     1 99 ** downward longwave radiation W/m2
+Lapserate_tavg    1 99 ** lapse rate K/km
+ENDVARS

--- a/lis/testcases/metforcing/merra2bias/testcase.ctl
+++ b/lis/testcases/metforcing/merra2bias/testcase.ctl
@@ -1,0 +1,16 @@
+DSET ^TARGET_OUTPUT/SURFACEMODEL/202601/LIS_HIST_%y4%m2%d2%h2%n2.d01.nc
+DTYPE netcdf
+OPTIONS template
+TITLE LIS output
+UNDEF -9999.0
+XDEF 101 LINEAR -122.5 0.01
+YDEF 101 LINEAR 36.0 0.01
+ZDEF 1 LINEAR 1 1
+TDEF 6 LINEAR 01:00Z31dec2023 1hr
+VARS 5
+Tair_f_tavg       1 99 ** air temperature K
+Qair_f_tavg       1 99 ** specific humidity kg/kg
+Psurf_f_tavg      1 99 ** surface pressure Pa
+LWdown_f_tavg     1 99 ** downward longwave radiation W/m2
+Lapserate_tavg    1 99 ** lapse rate K/km
+ENDVARS


### PR DESCRIPTION
This pull request adds support for the MERRA2bias meteorological forcing
dataset within LIS.

The implementation builds upon the framework introduced in Issue #1760
(Add GEOS-IT bias meteorological forcing and extend MERRA-2 lapse rate
support), while adapting the reader for the MERRA2bias forcing dataset
used in the NLDAS-3 retrospective forcing workflow.

The MERRA2bias forcing dataset consists of native MERRA-2 near-surface
air temperature, near-surface specific humidity, and surface pressure,
together with bias-corrected downward longwave radiation generated
upstream of LIS.

The bias correction is applied using monthly MERRA-2 downward longwave
radiation climatologies, consistent with the approach used for the
CERES-based retrospective forcing record prior to 2026. Beginning in
2026, when CERES downward longwave radiation is no longer available,
the MERRA2bias dataset provides a continuous transition in the NLDAS-3
retrospective forcing workflow while preserving consistency with the
earlier CERES-based record.

Changes include:

- Added a new `merra2bias` meteorological forcing reader.
- Added support for MERRA2bias within the LIS metforcing plugin
  infrastructure.
- Added support for dynamic lapse-rate downscaling using MERRA-2-derived
  dynamic lapse-rate fields.
- Added documentation for the new forcing source.
- Added a functional testcase.

**Functional testcase input files**

Additional input files required to run the functional testcase are available at:

`/discover/nobackup/projects/eis_freshwater/kwhitney/SHARE/merra2bias_testcase/`

Resolves #1833


