### PR TITLE
Move external mpi defs to LIS_mpiMod.F90

### DIFF
--- a/lis/core/LIS_mpiMod.F90
+++ b/lis/core/LIS_mpiMod.F90
@@ -20,6 +20,11 @@ module LIS_mpiMod
 #if (defined SPMD)
 #if (defined USE_INCLUDE_MPI)
   include 'mpif.h' 
+  external :: MPI_ALLGATHER
+  external :: MPI_ALLGATHERV
+  external :: MPI_ALLREDUCE
+  external :: MPI_BCAST
+  external :: MPI_GATHERV
 #else
   use mpi
 #endif

--- a/lis/core/LIS_routingMod.F90
+++ b/lis/core/LIS_routingMod.F90
@@ -109,11 +109,6 @@ contains
 
     external :: routinginit
 
-#if (defined SPMD)
-    external :: MPI_GATHERV
-    external :: MPI_Bcast
-#endif
-
     call ESMF_ConfigGetAttribute(LIS_config, LIS_rc%routingmodel, &
          label="Routing model:",default="none", rc=rc)
 

--- a/lis/routing/HYMAP3_router/HYMAP3_model.F90
+++ b/lis/routing/HYMAP3_router/HYMAP3_model.F90
@@ -173,10 +173,6 @@ subroutine HYMAP3_model(n, mis, nx, ny, yr, mo, da, hr, mn, ss, &
 
   external :: HYMAP3_model_core
 
-#if (defined SPMD)
-  external :: mpi_allreduce
-#endif
-
   !ag(03Jun2020)
   if(HYMAP3_routing_struc(n)%enable2waycpl==1)then
      do ic=1,nseqall

--- a/lis/routing/HYMAP3_router/HYMAP3_model_core.F90
+++ b/lis/routing/HYMAP3_router/HYMAP3_model_core.F90
@@ -219,10 +219,6 @@ subroutine HYMAP3_model_core(n, it, mis, nseqall, nz, time, dt,  &
   !ag (5Apr2025)
   real, allocatable    :: sfcelv_glb(:)
 
-#if (defined SPMD)
-  external :: MPI_BCAST
-#endif
-
   ! ================================================
   !convert units [kg m-2 sec-1] to [m3 sec-1] and aggregate surface
   !runoff and baseflow

--- a/lis/routing/HYMAP3_router/HYMAP3_routingMod.F90
+++ b/lis/routing/HYMAP3_router/HYMAP3_routingMod.F90
@@ -419,13 +419,6 @@ contains
     external :: perturbinit
     external :: perturbsetup
 
-#if (defined SPMD)
-    external :: MPI_ALLREDUCE
-    external :: MPI_ALLGATHER
-    external :: MPI_BCAST
-    external :: MPI_ALLGATHERV
-#endif
-
     allocate(HYMAP3_routing_struc(LIS_rc%nnest))
 
     HYMAP3_logunit = LIS_getNextUnitNumber()
@@ -3846,10 +3839,6 @@ contains
     integer        :: status
 
 #if (defined SPMD)
-    external :: MPI_ALLGATHERV
-#endif
-
-#if (defined SPMD)
     call MPI_ALLGATHERV(var,&
          LIS_rc%nroutinggrid(n),&
          MPI_REAL,tmpvar,&
@@ -3899,10 +3888,6 @@ contains
     real           :: tmpvar(LIS_rc%glbnroutinggrid(n))
     integer        :: i,l,ix,iy,ix1,iy1
     integer        :: status
-
-#if (defined SPMD)
-    external :: MPI_ALLGATHERV
-#endif
 
 #if (defined SPMD)
     call MPI_ALLGATHERV(var,&

--- a/lis/routing/HYMAP3_router/HYMAP3_routing_writerst.F90
+++ b/lis/routing/HYMAP3_router/HYMAP3_routing_writerst.F90
@@ -701,10 +701,6 @@ subroutine HYMAP3_writevar_restart(ftn, n, var, varid)
   integer           :: l,i,ix,iy,ix1,iy1
   integer :: ierr
 
-#if (defined SPMD)
-  external :: MPI_GATHERV
-#endif
-
   if(LIS_masterproc) then
      allocate(gtmp(LIS_rc%glbnroutinggrid(n)))
      allocate(gtmp1(LIS_rc%glbnroutinggrid(n)))
@@ -788,10 +784,6 @@ subroutine HYMAP3_writevar_restart_ens(ftn, n, var, varid)
   integer           :: m
   integer           :: l,i,ix,iy,ix1,iy1
   integer :: ierr
-
-#if (defined SPMD)
-  external :: MPI_GATHERV
-#endif
 
   if(LIS_masterproc) then
      allocate(gtmp(LIS_rc%glbnroutinggrid(n)*LIS_rc%nensem(n)))


### PR DESCRIPTION
* wrap external mpi defs in USE_INCLUDE_MPI
* fixes 'cannot change attributes of USE-associated symbol'

### Description

I'm seeing a compiler error when compiling with gfortran@13.3 and mpich@5.0 within a ubuntu@24.04 container. The error says "cannot change attributes of USE-associated symbol" but because each file here includes `use LIS_mpiMod` these external definitions aren't needed because the compiler reads the `mpi.mod` file to define these procedures. This PR moves the `external :: MPI_` definitions into the `LIS_mpiMod.F90 `file and sets them only when the compiler links using `include 'mpif.h'`

Resolves #1835 

I'm not really sure if there is robust testing or a use case for -DUSE_INCLUDE_MPI but I did compile successfully with and without this flag. I think these changes could use a little more structured testing though.

### Testcase
Including a container that was used to build LIS.
[nlc_container.tar.gz](https://github.com/user-attachments/files/30060179/nlc_container.tar.gz)



