### PR TITLE
Updated LIS7.8 S2S Docs

### DIFF
--- a/env/hpc11/lisf_7.6_prgenv_cray_8.6.0_cpe_25.03_cce_19.0.0_afw3.13-202605
+++ b/env/hpc11/lisf_7.6_prgenv_cray_8.6.0_cpe_25.03_cce_19.0.0_afw3.13-202605
@@ -207,15 +207,7 @@ prepend-path   PATH   "$def_lis_netcdf/bin:$def_lis_eccodes/bin"
 # Latest AFW Python Builds:
 module use /sw/afw_sw/modulefiles
 
-# Check for optional CYLC environment override
-set use_cylc_env [info exists env(USE_CYLC_ENV)]
-if { $use_cylc_env && $env(USE_CYLC_ENV) == "1" } {
-    # CYLC-specific environment
-    module load cylc/8.5.0
-    puts stderr "Using CYLC environment: cylc/8.5.0"
-} else {
-    # Default AFW environment
-    module load afw-python/3.11-202511
-    puts stderr "Using default S2S environment: afw-python/3.11-202511"
-}
+# Latest production S2S environment
+module load afw-python/3.13-202605
+
 

--- a/lis/utils/usaf/S2S/docs/README_GHI-S2S_LIS7.8
+++ b/lis/utils/usaf/S2S/docs/README_GHI-S2S_LIS7.8
@@ -3,7 +3,7 @@
   Subseasonal-to-Seasonal (S2S) End-to-End System (E2ES) Master Doc
 
   NASA/GSFC GHI-S2S Team 
-  Last Modified 27 Apr 2026
+  Last Modified 17 Aug 2026
 
 		TABLE OF CONTENTS
 		_________________
@@ -62,23 +62,24 @@
     grib configuration settings), and netCDF4.
 
 * For running on Discover, you will load the following module:
-  LISF/env/discover/lisf_7.8_intel_2023.2.1_s2s
+  LISF/env/discover/lisf_7.5_intel_2023.2.1_s2s
 
-* Python 3.11, with the following extra libraries installed:
+   -- This module loads a Python 3.11 version.
+
+* For Python 3.13, includes the installed libraries:
                 NCCS        HPC
-  - Cartopy     0.24.0      0.25.0
-  - cfgrib      0.9.15.0    0.9.15.1
-  - dask        2024.8.1    2024.8.1
-  - dateutil    2.9.0.post0 2.9.0.post0
-  - GDAL/OSGEO  3.9.1       3.9.2
-  - Matplotlib  3.8.4       3.9.4
-  - NetCDF4     1.7.2       1.7.2
-  - numpy       1.26.4      1.26.4
-  - pandas      2.2.3       2.3.3
-  - PyYAML      6.0.2       6.0.3
-  - rasterio    1.3.10      1.4.1
-  - xarray      2025.1.1    2025.6.1
-  - xesmf       0.8.8       0.8.10
+  - Cartopy     0.25.0      0.25.0
+  - cfgrib      0.9.15.1    0.9.15.1
+  - dask        2026.3.0    2026.3.0
+  - GDAL/OSGEO  3.12.3      3.12.3
+  - Matplotlib  3.10.9      3.10.9
+  - NetCDF4     1.7.4       1.7.4
+  - numpy       2.3.5       2.3.5 
+  - pandas      3.0.3       3.0.3
+  - PyYAML      6.0.3       6.0.3
+  - rasterio    1.5.0       1.5.0
+  - xarray      2026.4.0    2026.4.0
+  - xesmf       0.9.2       0.9.2
 
   ** Note:  Updates to the above libraries and modules
         could get updated as frequent as every 3- to
@@ -145,13 +146,12 @@
   nmme_download_dir: [DIRECTORY_PATH_WHERE_NMME_FORECAST_FILES_ARE_DOWNLOADED]
   ... 
 
- ** NEW OPTIONS WITH LISV7.8 RP2 **
+ ** NEW OPTIONS WITH LISV7.8 RP3 **
  
   The Columbia/IRI source for NMME files will be "sunsetted" by late
    summer of 2026, so new NMME data source options are now offered.
-   These include:
+   They include:
 
-  - CCSR (replacement to IRI)   ==> Set precip: ccsr-nmme
   - NOAA (being made available) ==> Set precip: noaa-nmme
 
   Then ensure updates to the "nmme_download_dir" pairs with
@@ -485,7 +485,7 @@
 
   4.1 DOWNLOADING FORECAST INPUT FORCINGS
 
-    * NOTE: Aim to have all forecast files downloaded by the 9th
+    * NOTE: Aim to have all forecast files downloaded by the 8th
             of each month.  More information below.
 
     4.1.1 Downloading CFSv2 forcing files
@@ -523,9 +523,6 @@
 
        Precipitation forecasts are available for only 2 NMME models (GEOS5v2 CESM1). 
        Do you want to continue (Y/N)?
-
-      We recommend the user to wait until all files are available on the IRI/Columbia
-       University server before proceeding with the remaining E2E steps. 
 
 
   4.2 Global USAF Forcing generation ("S2S_Daily")
@@ -603,7 +600,7 @@
   - This step preprocesses CFSv2 (non-precip) and 6 separate NMME
     forecast model precipitation data for driving the models offline in LIS.
     The forecasts are for the 557 WW ~25KM global domain, bias-corrected
-    using the USAF-LIS7.8-S2S (e.g., NAFPA precipitation) dataset, and covers
+    using the USAF-LIS7.5-S2S (e.g., NAFPA precipitation) dataset, and covers
     up to 9 months of forecast as input data to LIS.
 
   - This step occurs now just before the LIS FCST step and runs
@@ -669,14 +666,9 @@
       varies per model as well.  The recommended settings for the
       9-lead months are:
 
-      JOB_SEGMENTS:
-      - CanESM5: 3
-        CESM1: 3
-        GNEMO52: 3
-        GEOSv2: 2
-        CFSv2: 5
-        GFDL: 9
-
+     JOB_SEGMENTS: {CanESM5: 5, CESM1: 5, GNEMO52: 5, GEOSv2: 2, CFSv2: 5,
+                    CCSM4: 5, GFDL: 9}
+   
       Note: Number of segments per model can also vary based on
              compute cluster type and number of lead months.
              For example a 6-lead month run, would require less

--- a/lis/utils/usaf/S2S/docs/README_ghis2s-cylc.md
+++ b/lis/utils/usaf/S2S/docs/README_ghis2s-cylc.md
@@ -29,6 +29,7 @@ The `S2Srun` class provides the following functionality:
 2. **Workflow Generation**: Writes the `flow.cylc` file for Cylc workflow management based on ([for example](https://github.com/NASA-LIS/LISF/tree/support/lisf-557ww-7.8/lis/utils/usaf/S2S/docs/flow.cylc_example)):
    - Selected NMME models 
    - Requirements specified in the forecast configuration file
+   - Full paths to key S2S config and code that are placed at the top of `flow.cylc` to allow it to be portable.
      
    **Note:** The flow.cylc file uses [this global.cylc](https://github.com/NASA-LIS/LISF/tree/support/lisf-557ww-7.8/lis/utils/usaf/S2S/ghis2s/cylc_script/global.cylc) configuration file, as an example.
 
@@ -198,7 +199,7 @@ Each month requires customized LIS input/configuration files, job script argumen
   
 No. As stated above, monthly differences in input files and configurations require that **ghis2s_program.py** be executed each time. The **ghis2s** package programmatically generates the 1500 to 2000 line flow.cylc file to minimize human error and improve efficiency.  
 
-However, one new feature in LISFV7.8 RP3 removes the main hard-coded paths throughout the automatically constructed flow.cylc file by placing the paths at the top of the file defined as Jinja2 variables. This allows the flow.cylc file to be portable across different users and forecast months, given the core forecast configuration does not change (the paths come from your s2s_config_global_fcast). Those new variables point to your GHI S2S scratch run directory, your LISF GHI S2S python scripts path, and your LISF-based private module path.
+However, one new feature in LISFV7.8 RP3 removes the main hard-coded paths throughout the new automatically constructed ([flow.cylc example](https://github.com/NASA-LIS/LISF/tree/support/lisf-557ww-7.8/lis/utils/usaf/S2S/docs/flow.cylc_example)) file by placing the paths at the top of the file defined as Jinja2 variables. This allows the flow.cylc file to be portable across different users and forecast months, given the core forecast configuration does not change (the paths come from your s2s_config_global_fcast). Those new variables point to your GHI S2S scratch run directory, your LISF GHI S2S python scripts path, and your LISF-based private module path.
   
 **c) Why is [[dependencies]] → [[[R1]]] necessary?**  
   

--- a/lis/utils/usaf/S2S/docs/README_ghis2s-cylc.md
+++ b/lis/utils/usaf/S2S/docs/README_ghis2s-cylc.md
@@ -196,7 +196,9 @@ Each month requires customized LIS input/configuration files, job script argumen
   
 **b) Can the same flow.cylc file be reused each month?**  
   
-No. As stated above, monthly differences in input files and configurations require that **ghis2s_program.py** be executed each time. The **ghis2s** package programmatically generates the 800+ line flow.cylc file to minimize human error and improve efficiency.  
+No. As stated above, monthly differences in input files and configurations require that **ghis2s_program.py** be executed each time. The **ghis2s** package programmatically generates the 1500 to 2000 line flow.cylc file to minimize human error and improve efficiency.  
+
+However, one new feature in LISFV7.8 RP3 removes the main hard-coded paths throughout the automatically constructed flow.cylc file by placing the paths at the top of the file defined as Jinja2 variables. This allows the flow.cylc file to be portable across different users and forecast months, given the core forecast configuration does not change (the paths come from your s2s_config_global_fcast). Those new variables point to your GHI S2S scratch run directory, your LISF GHI S2S python scripts path, and your LISF-based private module path.
   
 **c) Why is [[dependencies]] → [[[R1]]] necessary?**  
   
@@ -222,8 +224,7 @@ That said, ghis2s includes a feature to generate fully system-agnostic shell scr
 
 **e) How does ghis2s differ from other GHI subsystems (GHI-NRT, GHI-MR)?**  
   
-Although the GHI-S2S workflow includes over 150 tasks and is more complex than other subsystems, **the main script of the ghis2s software tool, [*s2s_run.py*](https://github.com/NASA-LIS/LISF/tree/support/lisf-557ww-7.8/lis/utils/usaf/S2S/ghis2s/s2s_app/s2s_run.py)**, simplifies execution by consolidating all tasks into a single command driven by a unified configuration file.  
+Although the GHI-S2S workflow includes hundreds of tasks and is more complex than other subsystems, **the main script of the ghis2s software tool, [*s2s_run.py*](https://github.com/NASA-LIS/LISF/tree/support/lisf-557ww-7.8/lis/utils/usaf/S2S/ghis2s/s2s_app/s2s_run.py)**, simplifies execution by consolidating all tasks into a single command driven by a unified configuration file.  
 The script automates the execution of all tasks based on their dependencies, effectively eliminating the need for manual intervention.
   
-
 

--- a/lis/utils/usaf/S2S/docs/flow.cylc_example
+++ b/lis/utils/usaf/S2S/docs/flow.cylc_example
@@ -1,9 +1,13 @@
 #!jinja2
+{% set SCRATCH_ROOT = '/lustre/typhoon/nwp601/proj-shared/[username]/LISV7.8RP3_test/scratch/202510' %}
+{% set PYTHONPATH_ROOT = '/lustre/typhoon/nwp601/proj-shared/[username]/LISF78p3_src/lis/utils/usaf/S2S/' %}
+{% set MODULEPATH_ROOT = '/lustre/typhoon/nwp601/proj-shared/[username]/LISF78p3_src/env/hpc11/' %}
+
 # S2S Forecast Workflow
   
 [meta]
     title = S2S Forecast Workflow
-    description = S2S Forecast Initialized on 2025-12
+    description = S2S Forecast Initialized on 2025-10
   
 [scheduler]
     UTC mode = True
@@ -19,7 +23,6 @@
   
     [[graph]]
         R1 = """
-                lisda_run => ldtics_run
                 mf_regrid_01_run & mf_regrid_02_run & mf_regrid_03_run & mf_regrid_04_run & mf_regrid_05_run & mf_regrid_06_run => mf_biascorr_01_run
                 mf_regrid_01_run & mf_regrid_02_run & mf_regrid_03_run & mf_regrid_04_run & mf_regrid_05_run & mf_regrid_06_run => mf_biascorr_02_run
                 mf_regrid_01_run & mf_regrid_02_run & mf_regrid_03_run & mf_regrid_04_run & mf_regrid_05_run & mf_regrid_06_run => mf_biascorr_03_run
@@ -27,13 +30,13 @@
                 mf_regrid_01_run & mf_regrid_02_run & mf_regrid_03_run & mf_regrid_04_run & mf_regrid_05_run & mf_regrid_06_run => mf_biascorr_05_run
                 mf_regrid_01_run & mf_regrid_02_run & mf_regrid_03_run & mf_regrid_04_run & mf_regrid_05_run & mf_regrid_06_run => mf_biascorr_06_run
                 mf_regrid_01_run & mf_regrid_02_run & mf_regrid_03_run & mf_regrid_04_run & mf_regrid_05_run & mf_regrid_06_run => mf_biascorr_07_run
+                mf_biascorr_01_run & mf_biascorr_02_run & mf_biascorr_03_run & mf_biascorr_04_run & mf_biascorr_05_run & mf_biascorr_06_run & mf_biascorr_07_run => mf_tempdis_01_run
+                mf_biascorr_01_run & mf_biascorr_02_run & mf_biascorr_03_run & mf_biascorr_04_run & mf_biascorr_05_run & mf_biascorr_06_run & mf_biascorr_07_run => mf_tempdis_02_run
                 pr_regrid_run => pr_biascorr_01_run
                 pr_regrid_run => pr_biascorr_02_run
                 pr_regrid_run => pr_biascorr_03_run
                 pr_regrid_run => pr_biascorr_04_run
                 pr_regrid_run => pr_biascorr_05_run
-                mf_biascorr_01_run & mf_biascorr_02_run & mf_biascorr_03_run & mf_biascorr_04_run & mf_biascorr_05_run & mf_biascorr_06_run & mf_biascorr_07_run => mf_tempdis_01_run
-                mf_biascorr_01_run & mf_biascorr_02_run & mf_biascorr_03_run & mf_biascorr_04_run & mf_biascorr_05_run & mf_biascorr_06_run & mf_biascorr_07_run => mf_tempdis_02_run
                 mf_regrid_01_run & mf_regrid_02_run & mf_regrid_03_run & mf_regrid_04_run & mf_regrid_05_run & mf_regrid_06_run & pr_biascorr_01_run & pr_biascorr_02_run & pr_biascorr_03_run & pr_biascorr_04_run & pr_biascorr_05_run => pr_tempdis_01_run
                 mf_regrid_01_run & mf_regrid_02_run & mf_regrid_03_run & mf_regrid_04_run & mf_regrid_05_run & mf_regrid_06_run & pr_biascorr_01_run & pr_biascorr_02_run & pr_biascorr_03_run & pr_biascorr_04_run & pr_biascorr_05_run => pr_tempdis_02_run
                 mf_regrid_01_run & mf_regrid_02_run & mf_regrid_03_run & mf_regrid_04_run & mf_regrid_05_run & mf_regrid_06_run & pr_biascorr_01_run & pr_biascorr_02_run & pr_biascorr_03_run & pr_biascorr_04_run & pr_biascorr_05_run => pr_tempdis_03_run
@@ -41,9 +44,13 @@
                 ldtics_run & combine_files_run & pr_tempdis_01_run & pr_tempdis_02_run & pr_tempdis_03_run => lis_fcst_CanESM5_00_run
                 lis_fcst_CanESM5_00_run => lis_fcst_CanESM5_01_run
                 lis_fcst_CanESM5_01_run => lis_fcst_CanESM5_02_run
+                lis_fcst_CanESM5_02_run => lis_fcst_CanESM5_03_run
+                lis_fcst_CanESM5_03_run => lis_fcst_CanESM5_04_run
                 ldtics_run & combine_files_run & pr_tempdis_01_run & pr_tempdis_02_run & pr_tempdis_03_run => lis_fcst_CESM1_00_run
                 lis_fcst_CESM1_00_run => lis_fcst_CESM1_01_run
                 lis_fcst_CESM1_01_run => lis_fcst_CESM1_02_run
+                lis_fcst_CESM1_02_run => lis_fcst_CESM1_03_run
+                lis_fcst_CESM1_03_run => lis_fcst_CESM1_04_run
                 ldtics_run & combine_files_run & pr_tempdis_01_run & pr_tempdis_02_run & pr_tempdis_03_run => lis_fcst_CFSv2_00_run
                 lis_fcst_CFSv2_00_run => lis_fcst_CFSv2_01_run
                 lis_fcst_CFSv2_01_run => lis_fcst_CFSv2_02_run
@@ -54,8 +61,10 @@
                 ldtics_run & combine_files_run & pr_tempdis_01_run & pr_tempdis_02_run & pr_tempdis_03_run => lis_fcst_GNEMO52_00_run
                 lis_fcst_GNEMO52_00_run => lis_fcst_GNEMO52_01_run
                 lis_fcst_GNEMO52_01_run => lis_fcst_GNEMO52_02_run
-                lis_fcst_CanESM5_02_run & lis_fcst_CESM1_02_run & lis_fcst_CFSv2_04_run & lis_fcst_GEOSv2_01_run & lis_fcst_GNEMO52_02_run => s2spost_01_run
-                lis_fcst_CanESM5_02_run & lis_fcst_CESM1_02_run & lis_fcst_CFSv2_04_run & lis_fcst_GEOSv2_01_run & lis_fcst_GNEMO52_02_run => s2spost_02_run
+                lis_fcst_GNEMO52_02_run => lis_fcst_GNEMO52_03_run
+                lis_fcst_GNEMO52_03_run => lis_fcst_GNEMO52_04_run
+                lis_fcst_CanESM5_04_run & lis_fcst_CESM1_04_run & lis_fcst_CFSv2_04_run & lis_fcst_GEOSv2_01_run & lis_fcst_GNEMO52_04_run => s2spost_01_run
+                lis_fcst_CanESM5_04_run & lis_fcst_CESM1_04_run & lis_fcst_CFSv2_04_run & lis_fcst_GEOSv2_01_run & lis_fcst_GNEMO52_04_run => s2spost_02_run
                 s2spost_01_run & s2spost_02_run => s2spost_mon_01_run
                 s2spost_01_run & s2spost_02_run => s2spost_mon_02_run
                 s2spost_01_run & s2spost_02_run => s2spost_mon_03_run
@@ -64,25 +73,31 @@
                 s2spost_01_run & s2spost_02_run => s2spost_mon_06_run
                 s2spost_01_run & s2spost_02_run => s2spost_mon_07_run
                 s2spost_01_run & s2spost_02_run => s2spost_mon_08_run
+                s2spost_01_run & s2spost_02_run => s2spost_mon_09_run
+                s2spost_01_run & s2spost_02_run => s2spost_mon_10_run
+                s2spost_01_run & s2spost_02_run => s2spost_mon_11_run
+                s2spost_01_run & s2spost_02_run => s2spost_mon_12_run
                 s2spost_01_run & s2spost_02_run => s2spost_weekly_01_run
                 s2spost_01_run & s2spost_02_run => s2spost_weekly_02_run
-                s2spost_mon_01_run & s2spost_mon_02_run & s2spost_mon_03_run & s2spost_mon_04_run & s2spost_mon_05_run & s2spost_mon_06_run & s2spost_mon_07_run & s2spost_mon_08_run => s2smetric_01_run
-                s2spost_mon_01_run & s2spost_mon_02_run & s2spost_mon_03_run & s2spost_mon_04_run & s2spost_mon_05_run & s2spost_mon_06_run & s2spost_mon_07_run & s2spost_mon_08_run => s2smetric_02_run
-                s2spost_mon_01_run & s2spost_mon_02_run & s2spost_mon_03_run & s2spost_mon_04_run & s2spost_mon_05_run & s2spost_mon_06_run & s2spost_mon_07_run & s2spost_mon_08_run => s2smetric_03_run
-                s2spost_mon_01_run & s2spost_mon_02_run & s2spost_mon_03_run & s2spost_mon_04_run & s2spost_mon_05_run & s2spost_mon_06_run & s2spost_mon_07_run & s2spost_mon_08_run => s2smetric_04_run
-                s2spost_mon_01_run & s2spost_mon_02_run & s2spost_mon_03_run & s2spost_mon_04_run & s2spost_mon_05_run & s2spost_mon_06_run & s2spost_mon_07_run & s2spost_mon_08_run => s2smetric_05_run
-                s2spost_weekly_01_run & s2spost_weekly_02_run => s2smetric_weekly_01_run
-                s2spost_weekly_01_run & s2spost_weekly_02_run => s2smetric_weekly_02_run
-                s2spost_weekly_01_run & s2spost_weekly_02_run => s2smetric_weekly_03_run
-                s2spost_weekly_01_run & s2spost_weekly_02_run => s2smetric_weekly_04_run
-                s2spost_weekly_01_run & s2spost_weekly_02_run => s2smetric_weekly_05_run
+                s2spost_01_run & s2spost_02_run => s2spost_weekly_03_run
+                s2spost_mon_01_run & s2spost_mon_02_run & s2spost_mon_03_run & s2spost_mon_04_run & s2spost_mon_05_run & s2spost_mon_06_run & s2spost_mon_07_run & s2spost_mon_08_run & s2spost_mon_09_run & s2spost_mon_10_run & s2spost_mon_11_run & s2spost_mon_12_run => s2smetric_01_run
+                s2spost_mon_01_run & s2spost_mon_02_run & s2spost_mon_03_run & s2spost_mon_04_run & s2spost_mon_05_run & s2spost_mon_06_run & s2spost_mon_07_run & s2spost_mon_08_run & s2spost_mon_09_run & s2spost_mon_10_run & s2spost_mon_11_run & s2spost_mon_12_run => s2smetric_02_run
+                s2spost_mon_01_run & s2spost_mon_02_run & s2spost_mon_03_run & s2spost_mon_04_run & s2spost_mon_05_run & s2spost_mon_06_run & s2spost_mon_07_run & s2spost_mon_08_run & s2spost_mon_09_run & s2spost_mon_10_run & s2spost_mon_11_run & s2spost_mon_12_run => s2smetric_03_run
+                s2spost_mon_01_run & s2spost_mon_02_run & s2spost_mon_03_run & s2spost_mon_04_run & s2spost_mon_05_run & s2spost_mon_06_run & s2spost_mon_07_run & s2spost_mon_08_run & s2spost_mon_09_run & s2spost_mon_10_run & s2spost_mon_11_run & s2spost_mon_12_run => s2smetric_04_run
+                s2spost_mon_01_run & s2spost_mon_02_run & s2spost_mon_03_run & s2spost_mon_04_run & s2spost_mon_05_run & s2spost_mon_06_run & s2spost_mon_07_run & s2spost_mon_08_run & s2spost_mon_09_run & s2spost_mon_10_run & s2spost_mon_11_run & s2spost_mon_12_run => s2smetric_05_run
+                s2spost_weekly_01_run & s2spost_weekly_02_run & s2spost_weekly_03_run => s2smetric_weekly_01_run
+                s2spost_weekly_01_run & s2spost_weekly_02_run & s2spost_weekly_03_run => s2smetric_weekly_02_run
+                s2spost_weekly_01_run & s2spost_weekly_02_run & s2spost_weekly_03_run => s2smetric_weekly_03_run
+                s2spost_weekly_01_run & s2spost_weekly_02_run & s2spost_weekly_03_run => s2smetric_weekly_04_run
+                s2spost_weekly_01_run & s2spost_weekly_02_run & s2spost_weekly_03_run => s2smetric_weekly_05_run
                 s2smetric_01_run & s2smetric_02_run & s2smetric_03_run & s2smetric_04_run & s2smetric_05_run => s2smetric_tiff_run
                 s2smetric_weekly_01_run & s2smetric_weekly_02_run & s2smetric_weekly_03_run & s2smetric_weekly_04_run & s2smetric_weekly_05_run => s2smetric_weekly_tiff_run
                 s2smetric_tiff_run & s2smetric_weekly_tiff_run => s2splots_01_run
                 s2smetric_tiff_run & s2smetric_weekly_tiff_run => s2splots_02_run
                 s2smetric_tiff_run & s2smetric_weekly_tiff_run => s2splots_03_run
                 s2smetric_tiff_run & s2smetric_weekly_tiff_run => s2splots_04_run
-                s2splots_01_run & s2splots_02_run & s2splots_03_run & s2splots_04_run => final_log_collect => stop_log_monitor
+                s2smetric_tiff_run & s2smetric_weekly_tiff_run => s2splots_05_run
+                s2splots_01_run & s2splots_02_run & s2splots_03_run & s2splots_04_run & s2splots_05_run => final_log_collect => stop_log_monitor
                 stop_log_monitor => !log_monitor
         """
   
@@ -94,24 +109,23 @@
     [[root]]
         platform = slurm-ghi
         pre-script = """
-            source /etc/profile.d/modules.sh
-            module load lisf_7.5_intel_2023.2.1_s2s
+            module load lisf_7.6_prgenv_cray_8.6.0_cpe_25.03_cce_19.0.0_afw3.13-202605
         """
         [[[environment]]]
             USE_CYLC_ENV = 1
-            MODULEPATH = /discover/nobackup/projects/ghilis/karsenau/LISF_7.7/env/discover/:$MODULEPATH
-            PYTHONPATH = /discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            MODULEPATH = {{ MODULEPATH_ROOT }}:$MODULEPATH
+            PYTHONPATH = {{ PYTHONPATH_ROOT }}
         [[[mail]]]
-            to = kristi.r.arsenault@nasa.gov
+            to = sarith.p.mahanama@nasa.gov
         [[[events]]]
             mail events = failed
   
     [[log_monitor]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/ghis2s_log.sh
+        script = {{ SCRATCH_ROOT }}/ghis2s_log.sh
         platform = localhost-ghi
   
     [[final_log_collect]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/ghis2s_log.sh
+        script = {{ SCRATCH_ROOT }}/ghis2s_log.sh
         platform = localhost-ghi
   
     [[stop_log_monitor]]
@@ -120,1187 +134,1671 @@
             cylc stop $CYLC_WORKFLOW_ID --now
         """
   
-    [[lisda_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_darun/lisda_run.sh
-        [[[directives]]]
-            --account=s1189
-            --time=300
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
-            --job-name=lisda_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_darun/logs/lisda_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_darun/logs/lisda_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
     [[ldtics_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/ldt_ics/ldtics_run.sh
+        script = {{ SCRATCH_ROOT }}/ldt_ics/ldtics_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks-per-node=1
             --time=120
-            --constraint=mil
-            --mem-per-cpu=40GB
-            --partition=packable
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=ldtics_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/ldt_ics/logs/ldtics_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/ldt_ics/logs/ldtics_%j.err
+            --output={{ SCRATCH_ROOT }}/ldt_ics/logs/ldtics_%j.out
+            --error={{ SCRATCH_ROOT }}/ldt_ics/logs/ldtics_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=ldtics_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_regrid_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_regrid_01_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_regrid_01_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks-per-node=18
             --time=60
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=14GB
-            --cpus-per-task=1
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_regrid_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_regrid_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_regrid_01_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_regrid_01_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_regrid_01_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_regrid_01_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=1
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_regrid_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_regrid_02_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_regrid_02_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks-per-node=18
             --time=60
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=14GB
-            --cpus-per-task=1
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_regrid_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_regrid_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_regrid_02_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_regrid_02_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_regrid_02_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_regrid_02_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=1
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_regrid_03_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_regrid_03_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_regrid_03_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks-per-node=18
             --time=60
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=14GB
-            --cpus-per-task=1
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_regrid_03_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_regrid_03_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_regrid_03_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_regrid_03_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_regrid_03_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_regrid_03_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=1
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_regrid_04_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_regrid_04_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_regrid_04_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks-per-node=18
             --time=60
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=14GB
-            --cpus-per-task=1
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_regrid_04_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_regrid_04_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_regrid_04_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_regrid_04_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_regrid_04_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_regrid_04_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=1
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_regrid_05_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_regrid_05_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_regrid_05_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks-per-node=18
             --time=60
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=14GB
-            --cpus-per-task=1
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_regrid_05_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_regrid_05_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_regrid_05_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_regrid_05_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_regrid_05_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_regrid_05_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=1
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_regrid_06_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_regrid_06_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_regrid_06_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks-per-node=18
             --time=60
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=14GB
-            --cpus-per-task=1
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_regrid_06_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_regrid_06_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_regrid_06_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_regrid_06_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_regrid_06_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_regrid_06_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=1
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[pr_regrid_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/pr_regrid_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/pr_regrid_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks-per-node=5
             --time=180
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=48GB
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=pr_regrid_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_regrid_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_regrid_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_regrid_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_regrid_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=pr_regrid_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_biascorr_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_biascorr_01_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_biascorr_01_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
             --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_biascorr_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_01_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_01_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_01_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_biascorr_01_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=120
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_biascorr_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_biascorr_02_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_biascorr_02_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
             --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_biascorr_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_02_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_02_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_02_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_biascorr_02_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=120
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_biascorr_03_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_biascorr_03_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_biascorr_03_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
             --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_biascorr_03_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_03_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_03_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_03_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_03_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_biascorr_03_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=120
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_biascorr_04_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_biascorr_04_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_biascorr_04_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
             --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_biascorr_04_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_04_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_04_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_04_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_04_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_biascorr_04_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=120
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_biascorr_05_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_biascorr_05_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_biascorr_05_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
             --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_biascorr_05_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_05_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_05_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_05_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_05_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_biascorr_05_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=120
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_biascorr_06_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_biascorr_06_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_biascorr_06_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
             --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_biascorr_06_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_06_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_06_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_06_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_06_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_biascorr_06_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=120
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_biascorr_07_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_biascorr_07_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_biascorr_07_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
             --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_biascorr_07_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_07_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_biascorr_07_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_07_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_biascorr_07_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_biascorr_07_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=120
-    [[pr_biascorr_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/pr_biascorr_01_run.sh
-        [[[directives]]]
-            --account=s1189
-            --nodes=1
-            --ntasks=1
-            --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=120
-            --job-name=pr_biascorr_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_biascorr_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_biascorr_01_%j.err
-        [[[environment]]]
-            USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
-            SCRIPT_NAME=pr_biascorr_01_run.j
-            NUM_WORKERS=120
-    [[pr_biascorr_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/pr_biascorr_02_run.sh
-        [[[directives]]]
-            --account=s1189
-            --nodes=1
-            --ntasks=1
-            --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=120
-            --job-name=pr_biascorr_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_biascorr_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_biascorr_02_%j.err
-        [[[environment]]]
-            USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
-            SCRIPT_NAME=pr_biascorr_02_run.j
-            NUM_WORKERS=120
-    [[pr_biascorr_03_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/pr_biascorr_03_run.sh
-        [[[directives]]]
-            --account=s1189
-            --nodes=1
-            --ntasks=1
-            --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=120
-            --job-name=pr_biascorr_03_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_biascorr_03_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_biascorr_03_%j.err
-        [[[environment]]]
-            USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
-            SCRIPT_NAME=pr_biascorr_03_run.j
-            NUM_WORKERS=120
-    [[pr_biascorr_04_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/pr_biascorr_04_run.sh
-        [[[directives]]]
-            --account=s1189
-            --nodes=1
-            --ntasks=1
-            --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=120
-            --job-name=pr_biascorr_04_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_biascorr_04_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_biascorr_04_%j.err
-        [[[environment]]]
-            USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
-            SCRIPT_NAME=pr_biascorr_04_run.j
-            NUM_WORKERS=120
-    [[pr_biascorr_05_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/pr_biascorr_05_run.sh
-        [[[directives]]]
-            --account=s1189
-            --nodes=1
-            --ntasks=1
-            --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=120
-            --job-name=pr_biascorr_05_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_biascorr_05_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_biascorr_05_%j.err
-        [[[environment]]]
-            USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
-            SCRIPT_NAME=pr_biascorr_05_run.j
-            NUM_WORKERS=120
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_tempdis_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_tempdis_01_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_tempdis_01_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=3
             --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=12
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_tempdis_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_tempdis_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_tempdis_01_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_tempdis_01_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_tempdis_01_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_tempdis_01_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=12
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[mf_tempdis_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/mf_tempdis_02_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/mf_tempdis_02_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=3
             --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=12
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=mf_tempdis_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_tempdis_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/mf_tempdis_02_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_tempdis_02_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/mf_tempdis_02_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=mf_tempdis_02_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=12
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[pr_biascorr_01_run]]
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/pr_biascorr_01_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --nodes=1
+            --ntasks=1
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=pr_biascorr_01_
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_biascorr_01_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_biascorr_01_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=pr_biascorr_01_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            NUM_WORKERS=120
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[pr_biascorr_02_run]]
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/pr_biascorr_02_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --nodes=1
+            --ntasks=1
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=pr_biascorr_02_
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_biascorr_02_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_biascorr_02_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=pr_biascorr_02_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            NUM_WORKERS=120
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[pr_biascorr_03_run]]
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/pr_biascorr_03_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --nodes=1
+            --ntasks=1
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=pr_biascorr_03_
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_biascorr_03_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_biascorr_03_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=pr_biascorr_03_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            NUM_WORKERS=120
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[pr_biascorr_04_run]]
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/pr_biascorr_04_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --nodes=1
+            --ntasks=1
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=pr_biascorr_04_
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_biascorr_04_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_biascorr_04_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=pr_biascorr_04_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            NUM_WORKERS=120
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[pr_biascorr_05_run]]
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/pr_biascorr_05_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --nodes=1
+            --ntasks=1
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=pr_biascorr_05_
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_biascorr_05_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_biascorr_05_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=pr_biascorr_05_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            NUM_WORKERS=120
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[pr_tempdis_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/pr_tempdis_01_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/pr_tempdis_01_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=2
             --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=15
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=pr_tempdis_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_tempdis_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_tempdis_01_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_tempdis_01_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_tempdis_01_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=pr_tempdis_01_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=15
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[pr_tempdis_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/pr_tempdis_02_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/pr_tempdis_02_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=2
             --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=15
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=pr_tempdis_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_tempdis_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_tempdis_02_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_tempdis_02_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_tempdis_02_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=pr_tempdis_02_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=15
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[pr_tempdis_03_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/pr_tempdis_03_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/pr_tempdis_03_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
             --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=15
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=pr_tempdis_03_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_tempdis_03_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/pr_tempdis_03_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_tempdis_03_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/pr_tempdis_03_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=pr_tempdis_03_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=15
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[combine_files_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/combine_files_run.sh
+        script = {{ SCRATCH_ROOT }}/bcsd_fcst/combine_files_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
             --time=360
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=12
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=combine_files_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/combine_files_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/bcsd_fcst/logs/combine_files_%j.err
+            --output={{ SCRATCH_ROOT }}/bcsd_fcst/logs/combine_files_%j.out
+            --error={{ SCRATCH_ROOT }}/bcsd_fcst/logs/combine_files_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=combine_files_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=12
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[lis_fcst_CanESM5_00_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_CanESM5_00_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CanESM5_00_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_CanESM5_00_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CanESM5_00_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CanESM5_00_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CanESM5_00_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CanESM5_00_%j.err
     [[lis_fcst_CanESM5_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_CanESM5_01_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CanESM5_01_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_CanESM5_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CanESM5_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CanESM5_01_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CanESM5_01_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CanESM5_01_%j.err
     [[lis_fcst_CanESM5_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_CanESM5_02_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CanESM5_02_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_CanESM5_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CanESM5_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CanESM5_02_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CanESM5_02_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CanESM5_02_%j.err
+    [[lis_fcst_CanESM5_03_run]]
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CanESM5_03_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
+            --job-name=lis_fcst_CanESM5_03_
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CanESM5_03_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CanESM5_03_%j.err
+    [[lis_fcst_CanESM5_04_run]]
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CanESM5_04_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
+            --job-name=lis_fcst_CanESM5_04_
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CanESM5_04_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CanESM5_04_%j.err
     [[lis_fcst_CESM1_00_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_CESM1_00_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CESM1_00_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_CESM1_00_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CESM1_00_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CESM1_00_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CESM1_00_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CESM1_00_%j.err
     [[lis_fcst_CESM1_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_CESM1_01_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CESM1_01_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_CESM1_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CESM1_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CESM1_01_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CESM1_01_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CESM1_01_%j.err
     [[lis_fcst_CESM1_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_CESM1_02_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CESM1_02_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_CESM1_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CESM1_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CESM1_02_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CESM1_02_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CESM1_02_%j.err
+    [[lis_fcst_CESM1_03_run]]
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CESM1_03_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
+            --job-name=lis_fcst_CESM1_03_
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CESM1_03_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CESM1_03_%j.err
+    [[lis_fcst_CESM1_04_run]]
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CESM1_04_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
+            --job-name=lis_fcst_CESM1_04_
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CESM1_04_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CESM1_04_%j.err
     [[lis_fcst_CFSv2_00_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_CFSv2_00_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CFSv2_00_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_CFSv2_00_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CFSv2_00_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CFSv2_00_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CFSv2_00_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CFSv2_00_%j.err
     [[lis_fcst_CFSv2_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_CFSv2_01_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CFSv2_01_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_CFSv2_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CFSv2_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CFSv2_01_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CFSv2_01_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CFSv2_01_%j.err
     [[lis_fcst_CFSv2_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_CFSv2_02_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CFSv2_02_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_CFSv2_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CFSv2_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CFSv2_02_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CFSv2_02_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CFSv2_02_%j.err
     [[lis_fcst_CFSv2_03_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_CFSv2_03_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CFSv2_03_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_CFSv2_03_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CFSv2_03_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CFSv2_03_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CFSv2_03_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CFSv2_03_%j.err
     [[lis_fcst_CFSv2_04_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_CFSv2_04_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_CFSv2_04_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_CFSv2_04_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CFSv2_04_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_CFSv2_04_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CFSv2_04_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_CFSv2_04_%j.err
     [[lis_fcst_GEOSv2_00_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_GEOSv2_00_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_GEOSv2_00_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_GEOSv2_00_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_GEOSv2_00_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_GEOSv2_00_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GEOSv2_00_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GEOSv2_00_%j.err
     [[lis_fcst_GEOSv2_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_GEOSv2_01_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_GEOSv2_01_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_GEOSv2_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_GEOSv2_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_GEOSv2_01_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GEOSv2_01_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GEOSv2_01_%j.err
     [[lis_fcst_GNEMO52_00_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_GNEMO52_00_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_GNEMO52_00_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_GNEMO52_00_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_GNEMO52_00_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_GNEMO52_00_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GNEMO52_00_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GNEMO52_00_%j.err
     [[lis_fcst_GNEMO52_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_GNEMO52_01_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_GNEMO52_01_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_GNEMO52_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_GNEMO52_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_GNEMO52_01_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GNEMO52_01_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GNEMO52_01_%j.err
     [[lis_fcst_GNEMO52_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/lis_fcst_GNEMO52_02_run.sh
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_GNEMO52_02_run.sh
         [[[directives]]]
-            --account=s1189
-            --time=420
-            --constraint=mil
-            --ntasks=288 --ntasks-per-socket=48 --ntasks-per-core=1
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
             --job-name=lis_fcst_GNEMO52_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_GNEMO52_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/lis_fcst/logs/lis_fcst_GNEMO52_02_%j.err
-        [[[environment]]]
-            I_MPI_PMI_LIBRARY=/usr/slurm/lib64/libpmi2.so
-            I_MPI_PMI_VALUE_LENGTH_MAX=288
-    [[s2spost_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/s2spost_01_run.sh
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GNEMO52_02_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GNEMO52_02_%j.err
+    [[lis_fcst_GNEMO52_03_run]]
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_GNEMO52_03_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
+            --job-name=lis_fcst_GNEMO52_03_
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GNEMO52_03_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GNEMO52_03_%j.err
+    [[lis_fcst_GNEMO52_04_run]]
+        script = {{ SCRATCH_ROOT }}/lis_fcst/lis_fcst_GNEMO52_04_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --time=360
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --nodes=12
+            --ntasks-per-node=24
+            --job-name=lis_fcst_GNEMO52_04_
+            --output={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GNEMO52_04_%j.out
+            --error={{ SCRATCH_ROOT }}/lis_fcst/logs/lis_fcst_GNEMO52_04_%j.err
+    [[s2spost_01_run]]
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_01_run.sh
+        [[[directives]]]
+            --account=NWP601
             --nodes=1
             --ntasks-per-node=27
             --time=240
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=9GB
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2spost_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_01_%j.err
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_01_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_01_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2spost_01_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2spost_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/s2spost_02_run.sh
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_02_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks-per-node=18
             --time=240
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=14GB
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2spost_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_02_%j.err
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_02_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_02_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2spost_02_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2spost_mon_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/s2spost_mon_01_run.sh
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_mon_01_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
-            --ntasks-per-node=6
+            --ntasks-per-node=4
             --time=180
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=40GB
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2spost_mon_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_01_%j.err
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_01_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_01_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2spost_mon_01_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2spost_mon_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/s2spost_mon_02_run.sh
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_mon_02_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
-            --ntasks-per-node=6
+            --ntasks-per-node=4
             --time=180
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=40GB
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2spost_mon_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_02_%j.err
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_02_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_02_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2spost_mon_02_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2spost_mon_03_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/s2spost_mon_03_run.sh
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_mon_03_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
-            --ntasks-per-node=6
+            --ntasks-per-node=4
             --time=180
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=40GB
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2spost_mon_03_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_03_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_03_%j.err
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_03_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_03_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2spost_mon_03_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2spost_mon_04_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/s2spost_mon_04_run.sh
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_mon_04_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
-            --ntasks-per-node=6
+            --ntasks-per-node=4
             --time=180
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=40GB
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2spost_mon_04_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_04_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_04_%j.err
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_04_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_04_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2spost_mon_04_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2spost_mon_05_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/s2spost_mon_05_run.sh
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_mon_05_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
-            --ntasks-per-node=6
+            --ntasks-per-node=4
             --time=180
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=40GB
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2spost_mon_05_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_05_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_05_%j.err
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_05_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_05_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2spost_mon_05_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2spost_mon_06_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/s2spost_mon_06_run.sh
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_mon_06_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
-            --ntasks-per-node=6
+            --ntasks-per-node=4
             --time=180
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=40GB
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2spost_mon_06_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_06_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_06_%j.err
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_06_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_06_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2spost_mon_06_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2spost_mon_07_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/s2spost_mon_07_run.sh
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_mon_07_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
-            --ntasks-per-node=6
+            --ntasks-per-node=4
             --time=180
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=40GB
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2spost_mon_07_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_07_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_07_%j.err
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_07_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_07_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2spost_mon_07_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2spost_mon_08_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/s2spost_mon_08_run.sh
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_mon_08_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
-            --ntasks-per-node=3
+            --ntasks-per-node=4
             --time=180
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=80GB
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2spost_mon_08_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_08_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_mon_08_%j.err
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_08_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_08_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2spost_mon_08_run.j
-    [[s2spost_weekly_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/s2spost_weekly_01_run.sh
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2spost_mon_09_run]]
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_mon_09_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
-            --ntasks-per-node=18
-            --time=60
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=14GB
-            --job-name=s2spost_weekly_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_weekly_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_weekly_01_%j.err
+            --ntasks-per-node=4
+            --time=180
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=s2spost_mon_09_
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_09_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_09_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
-            SCRIPT_NAME=s2spost_weekly_01_run.j
-    [[s2spost_weekly_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/s2spost_weekly_02_run.sh
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=s2spost_mon_09_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2spost_mon_10_run]]
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_mon_10_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
+            --nodes=1
+            --ntasks-per-node=4
+            --time=180
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=s2spost_mon_10_
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_10_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_10_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=s2spost_mon_10_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2spost_mon_11_run]]
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_mon_11_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --nodes=1
+            --ntasks-per-node=4
+            --time=180
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=s2spost_mon_11_
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_11_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_11_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=s2spost_mon_11_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2spost_mon_12_run]]
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_mon_12_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --nodes=1
+            --ntasks-per-node=1
+            --time=180
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=s2spost_mon_12_
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_12_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_mon_12_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=s2spost_mon_12_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2spost_weekly_01_run]]
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_weekly_01_run.sh
+        [[[directives]]]
+            --account=NWP601
             --nodes=1
             --ntasks-per-node=12
             --time=60
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=20GB
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=s2spost_weekly_01_
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_weekly_01_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_weekly_01_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=s2spost_weekly_01_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2spost_weekly_02_run]]
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_weekly_02_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --nodes=1
+            --ntasks-per-node=12
+            --time=60
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2spost_weekly_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_weekly_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2spost/logs/s2spost_weekly_02_%j.err
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_weekly_02_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_weekly_02_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2spost_weekly_02_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2spost_weekly_03_run]]
+        script = {{ SCRATCH_ROOT }}/s2spost/s2spost_weekly_03_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --nodes=1
+            --ntasks-per-node=6
+            --time=60
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=s2spost_weekly_03_
+            --output={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_weekly_03_%j.out
+            --error={{ SCRATCH_ROOT }}/s2spost/logs/s2spost_weekly_03_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=s2spost_weekly_03_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2smetric_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/s2smetric_01_run.sh
+        script = {{ SCRATCH_ROOT }}/s2smetric/s2smetric_01_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
-            --time=60
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=16
+            --time=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2smetric_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_01_%j.err
+            --output={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_01_%j.out
+            --error={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_01_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2smetric_01_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=16
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2smetric_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/s2smetric_02_run.sh
+        script = {{ SCRATCH_ROOT }}/s2smetric/s2smetric_02_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
-            --time=60
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=16
+            --time=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2smetric_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_02_%j.err
+            --output={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_02_%j.out
+            --error={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_02_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2smetric_02_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=16
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2smetric_03_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/s2smetric_03_run.sh
+        script = {{ SCRATCH_ROOT }}/s2smetric/s2smetric_03_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
-            --time=60
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=16
+            --time=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2smetric_03_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_03_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_03_%j.err
+            --output={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_03_%j.out
+            --error={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_03_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2smetric_03_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=16
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2smetric_04_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/s2smetric_04_run.sh
+        script = {{ SCRATCH_ROOT }}/s2smetric/s2smetric_04_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
-            --time=60
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=16
+            --time=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2smetric_04_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_04_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_04_%j.err
+            --output={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_04_%j.out
+            --error={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_04_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2smetric_04_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=16
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2smetric_05_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/s2smetric_05_run.sh
+        script = {{ SCRATCH_ROOT }}/s2smetric/s2smetric_05_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
-            --time=60
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=16
+            --time=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2smetric_05_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_05_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_05_%j.err
+            --output={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_05_%j.out
+            --error={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_05_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2smetric_05_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=16
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2smetric_weekly_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/s2smetric_weekly_01_run.sh
+        script = {{ SCRATCH_ROOT }}/s2smetric/s2smetric_weekly_01_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
-            --time=60
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=10
+            --time=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2smetric_weekly_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_weekly_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_weekly_01_%j.err
+            --output={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_weekly_01_%j.out
+            --error={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_weekly_01_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2smetric_weekly_01_run.j
-            NUM_WORKERS=10
-    [[s2smetric_weekly_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/s2smetric_weekly_02_run.sh
-        [[[directives]]]
-            --account=s1189
-            --nodes=1
-            --ntasks=1
-            --time=60
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=10
-            --job-name=s2smetric_weekly_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_weekly_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_weekly_02_%j.err
-        [[[environment]]]
-            USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
-            SCRIPT_NAME=s2smetric_weekly_02_run.j
-            NUM_WORKERS=10
-    [[s2smetric_weekly_03_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/s2smetric_weekly_03_run.sh
-        [[[directives]]]
-            --account=s1189
-            --nodes=1
-            --ntasks=1
-            --time=60
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=10
-            --job-name=s2smetric_weekly_03_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_weekly_03_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_weekly_03_%j.err
-        [[[environment]]]
-            USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
-            SCRIPT_NAME=s2smetric_weekly_03_run.j
-            NUM_WORKERS=10
-    [[s2smetric_weekly_04_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/s2smetric_weekly_04_run.sh
-        [[[directives]]]
-            --account=s1189
-            --nodes=1
-            --ntasks=1
-            --time=60
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=10
-            --job-name=s2smetric_weekly_04_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_weekly_04_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_weekly_04_%j.err
-        [[[environment]]]
-            USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
-            SCRIPT_NAME=s2smetric_weekly_04_run.j
-            NUM_WORKERS=10
-    [[s2smetric_weekly_05_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/s2smetric_weekly_05_run.sh
-        [[[directives]]]
-            --account=s1189
-            --nodes=1
-            --ntasks=1
-            --time=60
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=10
-            --job-name=s2smetric_weekly_05_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_weekly_05_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_weekly_05_%j.err
-        [[[environment]]]
-            USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
-            SCRIPT_NAME=s2smetric_weekly_05_run.j
-            NUM_WORKERS=10
-    [[s2smetric_tiff_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/s2smetric_tiff_run.sh
-        [[[directives]]]
-            --account=s1189
-            --nodes=1
-            --ntasks=1
-            --time=60
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=16
-            --job-name=s2smetric_tiff_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_tiff_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_tiff_%j.err
-        [[[environment]]]
-            USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
-            SCRIPT_NAME=s2smetric_tiff_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=16
-    [[s2smetric_weekly_tiff_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/s2smetric_weekly_tiff_run.sh
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2smetric_weekly_02_run]]
+        script = {{ SCRATCH_ROOT }}/s2smetric/s2smetric_weekly_02_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
+            --nodes=1
+            --ntasks=1
+            --time=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=s2smetric_weekly_02_
+            --output={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_weekly_02_%j.out
+            --error={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_weekly_02_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=s2smetric_weekly_02_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            NUM_WORKERS=16
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2smetric_weekly_03_run]]
+        script = {{ SCRATCH_ROOT }}/s2smetric/s2smetric_weekly_03_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --nodes=1
+            --ntasks=1
+            --time=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=s2smetric_weekly_03_
+            --output={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_weekly_03_%j.out
+            --error={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_weekly_03_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=s2smetric_weekly_03_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            NUM_WORKERS=16
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2smetric_weekly_04_run]]
+        script = {{ SCRATCH_ROOT }}/s2smetric/s2smetric_weekly_04_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --nodes=1
+            --ntasks=1
+            --time=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=s2smetric_weekly_04_
+            --output={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_weekly_04_%j.out
+            --error={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_weekly_04_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=s2smetric_weekly_04_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            NUM_WORKERS=16
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2smetric_weekly_05_run]]
+        script = {{ SCRATCH_ROOT }}/s2smetric/s2smetric_weekly_05_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --nodes=1
+            --ntasks=1
+            --time=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=s2smetric_weekly_05_
+            --output={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_weekly_05_%j.out
+            --error={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_weekly_05_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=s2smetric_weekly_05_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            NUM_WORKERS=16
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2smetric_tiff_run]]
+        script = {{ SCRATCH_ROOT }}/s2smetric/s2smetric_tiff_run.sh
+        [[[directives]]]
+            --account=NWP601
             --nodes=1
             --ntasks=1
             --time=60
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=10
-            --job-name=s2smetric_weekly_tiff_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_weekly_tiff_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2smetric/logs/s2smetric_weekly_tiff_%j.err
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=s2smetric_tiff_
+            --output={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_tiff_%j.out
+            --error={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_tiff_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
-            SCRIPT_NAME=s2smetric_weekly_tiff_run.j
-            NUM_WORKERS=10
-    [[s2splots_01_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2splots/s2splots_01_run.sh
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=s2smetric_tiff_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            NUM_WORKERS=16
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2smetric_weekly_tiff_run]]
+        script = {{ SCRATCH_ROOT }}/s2smetric/s2smetric_weekly_tiff_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
+            --nodes=1
+            --ntasks=1
+            --time=60
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=s2smetric_weekly_tiff_
+            --output={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_weekly_tiff_%j.out
+            --error={{ SCRATCH_ROOT }}/s2smetric/logs/s2smetric_weekly_tiff_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=s2smetric_weekly_tiff_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            NUM_WORKERS=16
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2splots_01_run]]
+        script = {{ SCRATCH_ROOT }}/s2splots/s2splots_01_run.sh
+        [[[directives]]]
+            --account=NWP601
             --nodes=1
             --ntasks-per-node=4
             --time=120
-            --constraint=mil
-            --partition=packable
-            --mem-per-cpu=60GB
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2splots_01_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2splots/logs/s2splots_01_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2splots/logs/s2splots_01_%j.err
+            --output={{ SCRATCH_ROOT }}/s2splots/logs/s2splots_01_%j.out
+            --error={{ SCRATCH_ROOT }}/s2splots/logs/s2splots_01_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2splots_01_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2splots_02_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2splots/s2splots_02_run.sh
+        script = {{ SCRATCH_ROOT }}/s2splots/s2splots_02_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
             --time=120
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=7
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2splots_02_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2splots/logs/s2splots_02_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2splots/logs/s2splots_02_%j.err
+            --output={{ SCRATCH_ROOT }}/s2splots/logs/s2splots_02_%j.out
+            --error={{ SCRATCH_ROOT }}/s2splots/logs/s2splots_02_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2splots_02_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=7
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2splots_03_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2splots/s2splots_03_run.sh
+        script = {{ SCRATCH_ROOT }}/s2splots/s2splots_03_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
             --time=120
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=7
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2splots_03_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2splots/logs/s2splots_03_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2splots/logs/s2splots_03_%j.err
+            --output={{ SCRATCH_ROOT }}/s2splots/logs/s2splots_03_%j.out
+            --error={{ SCRATCH_ROOT }}/s2splots/logs/s2splots_03_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2splots_03_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=7
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
     [[s2splots_04_run]]
-        script = /discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2splots/s2splots_04_run.sh
+        script = {{ SCRATCH_ROOT }}/s2splots/s2splots_04_run.sh
         [[[directives]]]
-            --account=s1189
+            --account=NWP601
             --nodes=1
             --ntasks=1
             --time=120
-            --constraint=mil
-            --mem=240GB
-            --cpus-per-task=5
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
             --job-name=s2splots_04_
-            --output=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2splots/logs/s2splots_04_%j.out
-            --error=/discover/nobackup/projects/ghilis/karsenau/E2ES_7.7_CYLC_12012025/scratch/202512/s2splots/logs/s2splots_04_%j.err
+            --output={{ SCRATCH_ROOT }}/s2splots/logs/s2splots_04_%j.out
+            --error={{ SCRATCH_ROOT }}/s2splots/logs/s2splots_04_%j.err
         [[[environment]]]
             USE_CYLC_ENV=0
-            PYTHONPATH=/discover/nobackup/projects/ghilis/karsenau/LISF_7.7/lis/utils/usaf/S2S/
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
             SCRIPT_NAME=s2splots_04_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
             NUM_WORKERS=5
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"
+    [[s2splots_05_run]]
+        script = {{ SCRATCH_ROOT }}/s2splots/s2splots_05_run.sh
+        [[[directives]]]
+            --account=NWP601
+            --nodes=1
+            --ntasks=1
+            --time=120
+            --cluster-constraint=blue
+            --partition=batch
+            --exclusive=
+            --mem=0
+            --job-name=s2splots_05_
+            --output={{ SCRATCH_ROOT }}/s2splots/logs/s2splots_05_%j.out
+            --error={{ SCRATCH_ROOT }}/s2splots/logs/s2splots_05_%j.err
+        [[[environment]]]
+            USE_CYLC_ENV=0
+            PYTHONPATH={{ PYTHONPATH_ROOT }}
+            SCRIPT_NAME=s2splots_05_run.j
+            HDF5_USE_FILE_LOCKING=FALSE
+            NUM_WORKERS=7
+            USER_CACHE_DIR="//lustre/typhoon/nwp601/scratch/[username]//ghis2s_python_cache_$$"
+            MPLCONFIGDIR="$USER_CACHE_DIR"
+            XDG_CACHE_HOME="$USER_CACHE_DIR"

--- a/lis/utils/usaf/S2S/ghis2s/s2s_app/s2s_config_global_fcast
+++ b/lis/utils/usaf/S2S/ghis2s/s2s_app/s2s_config_global_fcast
@@ -5,8 +5,8 @@
 #######################################################################
 
 SETUP:
-  E2ESDIR: /discover/nobackup/projects/ghilis/S2S/GLOBAL/E2ES_557ww-7.5/
-  LISFDIR: /discover/nobackup/projects/ghilis/S2S/LISF/
+  E2ESDIR: /discover/nobackup/projects/ghilis/S2S/GLOBAL/E2ES_557ww-7.8/
+  LISFDIR: /discover/nobackup/projects/ghilis/S2S/LISF_557ww_7.8.3/
   LISFMOD: lisf_7.5_intel_2023.2.1_s2s
   METFORC: /discover/nobackup/projects/usaf_lis/USAF_FORCING/
   supplementarydir: /discover/nobackup/projects/usaf_lis/GHI_S2S/supplementary_files/
@@ -26,20 +26,21 @@ EXP:
   routing_model: {model: hymap2, subdomains: false}
   pertmode: restart
   lead_months: 9
-  NMME_models: [CanESM5, CESM1, CFSv2, GEOSv2, GFDL, GNEMO52]
+  NMME_models: [CanESM5, CESM1, CFSv2, GEOSv2, GFDL, GNEMO52, CCSM4]
 
 #######################################################################
 #              Bias Correction and Spatial Downscaling (BCSD)
 #######################################################################
-
+# NMME Precip source options: "IRI": nmme, "NOAA": "noaa-nmme"
+#
 BCSD:
-  fcst_download_dir: /discover/nobackup/projects/lis/MET_FORCING/CFSv2/
-  nmme_download_dir: /discover/nobackup/projects/usaf_lis/GHI_S2S/NMME/
+  source: {metforce: CFSv2, precip: noaa-nmme, obs: USAF-LIS7.3rc8}
+  nof_raw_ens: 12
+  fcst_download_dir: /lustre/typhoon/nwp601/proj-shared/karsenau/GHI_S2S/JUL2026_INPUT/CFSv2/
+  nmme_download_dir: /lustre/typhoon/nwp601/proj-shared/karsenau/GHI_S2S/JUL2026_INPUT/NOAA_NMME/
   clim_start_year: 1991
   clim_end_year: 2020
-  nof_raw_ens: 12
-  source: {metforce: CFSv2, precip: nmme, obs: USAF-LIS7.3rc8}
-  force_corr: {lapserate: false, aspect: false}
+  force_corr: {lapsrate: false, aspect: false}
 
 #######################################################################
 #                            LIS Forecast
@@ -49,7 +50,7 @@ FCST:
   numprocx: 4
   numprocy: 72
   JOB_SEGMENTS: {CanESM5: 5, CESM1: 5, GNEMO52: 5, GEOSv2: 2, CFSv2: 5,
-                 GFDL: 9}
+                 CCSM4: 5, GFDL: 9}
   
 #######################################################################
 #                          Post-processor

--- a/lis/utils/usaf/S2S/ghis2s/s2s_app/s2s_config_global_fcast
+++ b/lis/utils/usaf/S2S/ghis2s/s2s_app/s2s_config_global_fcast
@@ -36,8 +36,8 @@ EXP:
 BCSD:
   source: {metforce: CFSv2, precip: noaa-nmme, obs: USAF-LIS7.3rc8}
   nof_raw_ens: 12
-  fcst_download_dir: /lustre/typhoon/nwp601/proj-shared/karsenau/GHI_S2S/JUL2026_INPUT/CFSv2/
-  nmme_download_dir: /lustre/typhoon/nwp601/proj-shared/karsenau/GHI_S2S/JUL2026_INPUT/NOAA_NMME/
+  fcst_download_dir: /discover/nobackup/projects/lis/MET_FORCING/CFSv2/
+  nmme_download_dir: /discover/nobackup/projects/usaf_lis/GHI_S2S/NOAA_NMME/netcdf/realtime/
   clim_start_year: 1991
   clim_end_year: 2020
   force_corr: {lapsrate: false, aspect: false}


### PR DESCRIPTION
The following updates have been made to the LISFV7.8 557 WW support
  branch S2S docs:
 - main LISFV7.8 S2S Readme files to reflect latest changes associated with V7.8 RP3
 - flow.cylc_example file to capture new path variables at top of file
 - s2s_config_global_fcast file to reflect latest NMME data option (NOAA)
 - renamed/modified S2S-related LISF private module to reflect latest Python production baselin version.