### PR TITLE
Support/lisf 557ww 7.8 p2b

### DIFF
--- a/lis/utils/usaf/S2S/ghis2s/cylc_script/ghis2s_program.py
+++ b/lis/utils/usaf/S2S/ghis2s/cylc_script/ghis2s_program.py
@@ -284,15 +284,42 @@ class Ghis2sProgram():
         with config_file.open('r', encoding="utf-8") as file:
             filedata = file.read()
 
+        # set global env variables
+        scr_root = (
+            f"{self.env['E2ESDIR']}/scratch/"
+            f"{self.env['FORECAST_YEAR']:04d}{self.env['FORECAST_MONTH']:02d}"
+        ).replace('//', '/')
+        pythonpath_root = self.env["PYTHONPATH"].replace('//', '/')
+        modulepath_root = ""
+        for line in filedata.splitlines():
+            if "MODULEPATH" in line and ":$MODULEPATH" in line:
+                modulepath_root = line.split("=")[1].split(":$MODULEPATH")[0].strip()
+                break
+
+        # Replace hardcoded paths with Jinja2 variables in flow.cylc
+        filedata = filedata.replace(scr_root, '{{ SCRATCH_ROOT }}')
+        filedata = filedata.replace(pythonpath_root, '{{ PYTHONPATH_ROOT }}')
+        filedata = filedata.replace(modulepath_root, '{{ MODULEPATH_ROOT }}')
+
         # Replace placeholders
         filedata = filedata.replace('USEREMAIL', self.env["USER_EMAIL"])
         filedata = filedata.replace('YYYY-MM', self.forecast_date)
         filedata = filedata.replace('--output ', '--output=')
         filedata = filedata.replace('--error ', '--error=')
         filedata = filedata.replace('--exclusive', '--exclusive=')
+        filedata = filedata.replace('--no-requeue', '--no-requeue=')
         filedata = filedata.replace('-N ', '--nodes=')
         filedata = filedata.replace('PF_SLURM', self.env["PF_SLURM"])
         filedata = filedata.replace('PF_LHOST', self.env["PF_LHOST"])
+
+        # Update Jinja2 env vaiables at the top
+        jinja_injection = (
+            f"#!jinja2\n"
+            f"{{% set SCRATCH_ROOT = '{scr_root}' %}}\n"
+            f"{{% set PYTHONPATH_ROOT = '{pythonpath_root}' %}}\n"
+            f"{{% set MODULEPATH_ROOT = '{modulepath_root}' %}}\n"
+        )
+        filedata = filedata.replace("#!jinja2", jinja_injection, 1)
 
         with config_file.open('w', encoding="utf-8") as file:
             file.write(filedata)

--- a/lis/utils/usaf/S2S/ghis2s/main/experiment_setup.py
+++ b/lis/utils/usaf/S2S/ghis2s/main/experiment_setup.py
@@ -1874,7 +1874,7 @@ class S2Srun(DownloadForecasts):
         # processing monthlies multi tasks per job
         jobname='s2spost_mon_'
         prev = sorted(glob.glob("s2spost_0*_run.j"))
-        l_sub = 6
+        l_sub = 4 
         slurm_sub = self.split_list(monthly_commands, l_sub)
         for i, sub_val in enumerate(slurm_sub):
             tfile = self.sublist_to_file(sub_val, cwd)
@@ -1894,7 +1894,7 @@ class S2Srun(DownloadForecasts):
 
         # processing dailies multi tasks per job
         jobname='s2spost_weekly_'
-        l_sub = 18
+        l_sub = 12
         slurm_sub = self.split_list(weekly_commands, l_sub)
         for i, sub_val in enumerate(slurm_sub):
             tfile = self.sublist_to_file(sub_val, cwd)

--- a/lis/utils/usaf/S2S/ghis2s/s2spost/temporal_aggregate.py
+++ b/lis/utils/usaf/S2S/ghis2s/s2spost/temporal_aggregate.py
@@ -40,6 +40,7 @@ import yaml
 
 # Third-party libraries
 import xarray as xr
+import dask
 import numpy as np
 from ghis2s.shared.utils import write_ncfile, load_ncdata
 # pylint: disable=f-string-without-interpolation,too-many-positional-arguments,too-many-arguments,too-many-locals
@@ -265,7 +266,6 @@ def _create_time_aggregated_file_xarray(varlists, input_dir, output_dir, fcstdat
                                 coords='minimal',
                                 parallel=False,
                                 data_vars=time_varying_vars,
-                                dask_lazy=False,
                                 decode_cf=False))
 
     # Process accumulation variables (sum over time)
@@ -379,12 +379,13 @@ def _create_time_aggregated_file_xarray(varlists, input_dir, output_dir, fcstdat
                                          enddate, model_forcing, config["EXP"]["DOMAIN"])
 
     logger.info(f"Writing: {outfile}", subtask=subtask)
-    write_ncfile(monthly_ds, outfile, encoding, [logger, subtask])
+    with dask.config.set(scheduler='single-threaded'):
+        write_ncfile(monthly_ds, outfile, encoding, [logger, subtask])
 
     try:
         ds_all.close()
     except RuntimeError as e:
-        # Ignore "NetCDF: Not a valid ID" errors on close, as it means the 
+        # Ignore "NetCDF: Not a valid ID" errors on close, as it means the
         # file descriptor was already cleaned up by xarray/Dask.
         if "Not a valid ID" not in str(e):
             logger.error("Closing daily files failed", subtask=subtask)


### PR DESCRIPTION
1) temporal_aggregate.py randomly hung while writing the output file. 
Forced Dask to write sequentially by adding with dask.config.set(scheduler='single-threaded'): (Line 382).
2)  main/experiment_setup.py: GFDL ran out of memory in s2spost thus reduced the workload per job.
3) Updated ghis2s_program.py to make the ghis2s-generated flow.cylc fully portable across different users and forecast months with no hard-coded paths. So a given forecast configuration, in other words as long as the s2s_config_global_fcast file remains unchanged, this flow.cylc file can be used anywhere by anyone in any month. 

@karsenau 